### PR TITLE
Fix console output in print_failure_details to use print instead of rule

### DIFF
--- a/python/timbal/evals/display.py
+++ b/python/timbal/evals/display.py
@@ -160,7 +160,7 @@ def print_failure_details(result: EvalResult) -> None:
     name = result.eval.name
 
     console.print()
-    console.rule(f"[red]FAILED[/red] {path}::{name}", style="red")
+    console.print(f"[red]FAILED[/red] {path}::{name}", style="red")
 
     if result.captured_stdout:
         console.print(


### PR DESCRIPTION
Path in failure details was not fully visible. It was cut and if the path was long you would not see the name of the eval.