### PR TITLE
Rename TIMBAL_PLATFORM_TRACES to TIMBAL_SYNC_TRACES

### DIFF
--- a/python/tests/state/test_config_loader.py
+++ b/python/tests/state/test_config_loader.py
@@ -8,48 +8,48 @@ from timbal.state.config import PlatformAuth, PlatformAuthType, PlatformConfig, 
 from timbal.state.config_loader import load_file_config, resolve_platform_config
 
 
-def _write_minimal_config(tmp_path: Path, platform_traces_line: str) -> None:
+def _write_minimal_config(tmp_path: Path, sync_traces_line: str) -> None:
     (tmp_path / "config").write_text(
         "[default]\n"
         "base_url = https://api.example.com\n"
         "org = org-from-file\n"
-        f"{platform_traces_line}",
+        f"{sync_traces_line}",
         encoding="utf-8",
     )
 
 
 @pytest.mark.parametrize(
-    ("platform_traces_line", "expected"),
+    ("sync_traces_line", "expected"),
     [
         ("", None),
-        ("platform_traces = 1\n", True),
-        ("platform_traces = true\n", True),
-        ("platform_traces = TRUE\n", True),
-        ("platform_traces = t\n", True),
-        ("platform_traces = y\n", True),
-        ("platform_traces = yes\n", True),
-        ("platform_traces = enabled\n", True),
-        ("platform_traces = on\n", True),
-        ("platform_traces = 0\n", False),
-        ("platform_traces = false\n", False),
-        ("platform_traces = bogus\n", False),
+        ("sync_traces = 1\n", True),
+        ("sync_traces = true\n", True),
+        ("sync_traces = TRUE\n", True),
+        ("sync_traces = t\n", True),
+        ("sync_traces = y\n", True),
+        ("sync_traces = yes\n", True),
+        ("sync_traces = enabled\n", True),
+        ("sync_traces = on\n", True),
+        ("sync_traces = 0\n", False),
+        ("sync_traces = false\n", False),
+        ("sync_traces = bogus\n", False),
     ],
 )
-def test_load_file_config_platform_traces_truthy_list(
+def test_load_file_config_sync_traces_truthy_list(
     tmp_path: Path,
-    platform_traces_line: str,
+    sync_traces_line: str,
     expected: bool | None,
 ) -> None:
-    _write_minimal_config(tmp_path, platform_traces_line)
+    _write_minimal_config(tmp_path, sync_traces_line)
     fc = load_file_config(profile="default", config_dir=tmp_path)
-    assert fc.platform_traces_enabled == expected
+    assert fc.sync_traces_enabled == expected
 
 
-def test_resolve_platform_traces_from_env(
+def test_resolve_sync_traces_from_env(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.delenv("TIMBAL_PLATFORM_TRACES", raising=False)
+    monkeypatch.delenv("TIMBAL_SYNC_TRACES", raising=False)
     creds = tmp_path / "credentials"
     creds.write_text(
         "[default]\napi_key = secret-key\n",
@@ -61,26 +61,45 @@ def test_resolve_platform_traces_from_env(
         encoding="utf-8",
     )
     monkeypatch.setenv("TIMBAL_APP_ID", "app1")
-    monkeypatch.setenv("TIMBAL_PLATFORM_TRACES", "0")
+    monkeypatch.setenv("TIMBAL_SYNC_TRACES", "0")
 
     pc = resolve_platform_config(profile="default", config_dir=tmp_path)
     assert pc is not None
-    assert pc.platform_traces_enabled is False
+    assert pc.sync_traces_enabled is False
     assert pc.subject is not None
     assert pc.subject.app_id == "app1"
 
 
-def test_resolve_platform_traces_explicit_wins_over_env(
+def test_resolve_sync_traces_explicit_wins_over_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("TIMBAL_PLATFORM_TRACES", "0")
+    monkeypatch.setenv("TIMBAL_SYNC_TRACES", "0")
     existing = PlatformConfig(
         host="h",
         auth=PlatformAuth(type=PlatformAuthType.BEARER, token=SecretStr("t")),
         subject=PlatformSubject(org_id="o", app_id="a"),
-        platform_traces_enabled=True,
+        sync_traces_enabled=True,
     )
     pc = resolve_platform_config(platform_config=existing)
     assert pc is not None
-    assert pc.platform_traces_enabled is True
+    assert pc.sync_traces_enabled is True
 
+
+def test_resolve_sync_traces_defaults_to_true(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("TIMBAL_SYNC_TRACES", raising=False)
+    creds = tmp_path / "credentials"
+    creds.write_text(
+        "[default]\napi_key = secret-key\n",
+        encoding="utf-8",
+    )
+    cfg = tmp_path / "config"
+    cfg.write_text(
+        "[default]\nbase_url = https://api.example.com\norg = o1\n",
+        encoding="utf-8",
+    )
+    pc = resolve_platform_config(profile="default", config_dir=tmp_path)
+    assert pc is not None
+    assert pc.sync_traces_enabled is True

--- a/python/timbal/state/config.py
+++ b/python/timbal/state/config.py
@@ -71,12 +71,12 @@ class PlatformConfig(BaseModel):
     """Platform authentication configuration."""
     subject: PlatformSubject | None = None
     """Platform subject configuration. i.e. this is the agent/workflow platform identifiers context."""
-    platform_traces_enabled: bool | None = None
+    sync_traces_enabled: bool | None = None
     """When True, persist run traces to the platform (requires org + app subject).
 
-    When False, use in-memory tracing even if subject is set. When None, use platform
-    tracing whenever subject includes app_id (legacy default). Resolved from
-    ``TIMBAL_PLATFORM_TRACES`` / ``platform_traces`` in ~/.timbal/config when unset here.
+    When False, use in-memory tracing even if subject is set. Resolved from
+    ``TIMBAL_SYNC_TRACES`` / ``sync_traces`` in ~/.timbal/config when unset here.
+    Defaults to True when not explicitly configured.
     """
 
     @model_validator(mode="before")

--- a/python/timbal/state/config_loader.py
+++ b/python/timbal/state/config_loader.py
@@ -12,7 +12,7 @@ logger = structlog.get_logger("timbal.state.config_loader")
 
 TIMBAL_CONFIG_DIR = Path.home() / ".timbal"
 
-# Shared with TIMBAL_PLATFORM_TRACES and ~/.timbal/config platform_traces option.
+# Shared with TIMBAL_SYNC_TRACES and ~/.timbal/config sync_traces option.
 _TRUTHY_STRINGS = frozenset({"true", "1", "t", "yes", "y", "enabled", "on"})
 
 
@@ -26,7 +26,7 @@ class FileConfig(NamedTuple):
     base_url: str | None
     api_key: SecretStr | None
     org: str | None
-    platform_traces_enabled: bool | None
+    sync_traces_enabled: bool | None
 
 
 def _resolve_section_name(profile: str) -> str:
@@ -64,7 +64,7 @@ def load_file_config(
     base_url: str | None = None
     org: str | None = None
     api_key: SecretStr | None = None
-    platform_traces_enabled: bool | None = None
+    sync_traces_enabled: bool | None = None
 
     if config_path.is_file():
         config = configparser.ConfigParser()
@@ -73,10 +73,10 @@ def load_file_config(
             if config.has_section(section):
                 base_url = config.get(section, "base_url", fallback=None)
                 org = config.get(section, "org", fallback=None)
-                if config.has_option(section, "platform_traces"):
-                    platform_traces_enabled = _is_truthy_string(config.get(section, "platform_traces"))
+                if config.has_option(section, "sync_traces"):
+                    sync_traces_enabled = _is_truthy_string(config.get(section, "sync_traces"))
                 else:
-                    platform_traces_enabled = None
+                    sync_traces_enabled = None
             else:
                 logger.debug(
                     f"Profile section '{section}' not found in config file.",
@@ -115,29 +115,32 @@ def load_file_config(
         base_url=base_url,
         api_key=api_key,
         org=org,
-        platform_traces_enabled=platform_traces_enabled,
+        sync_traces_enabled=sync_traces_enabled,
     )
 
 
-def _merge_platform_traces_enabled(platform_config: PlatformConfig, file_config: FileConfig) -> None:
-    """Fill platform_traces_enabled from env then file when not set on platform_config."""
-    if platform_config.platform_traces_enabled is not None:
+def _merge_sync_traces_enabled(platform_config: PlatformConfig, file_config: FileConfig) -> None:
+    """Fill sync_traces_enabled from env then file then default (True) when not set on platform_config."""
+    if platform_config.sync_traces_enabled is not None:
         return
-    if "TIMBAL_PLATFORM_TRACES" in os.environ:
-        platform_config.platform_traces_enabled = _is_truthy_string(
-            os.getenv("TIMBAL_PLATFORM_TRACES", "false"),
+    if "TIMBAL_SYNC_TRACES" in os.environ:
+        platform_config.sync_traces_enabled = _is_truthy_string(
+            os.getenv("TIMBAL_SYNC_TRACES", "true"),
         )
         logger.debug(
-            "Resolved platform_traces_enabled from TIMBAL_PLATFORM_TRACES.",
-            value=platform_config.platform_traces_enabled,
+            "Resolved sync_traces_enabled from TIMBAL_SYNC_TRACES.",
+            value=platform_config.sync_traces_enabled,
         )
         return
-    if file_config.platform_traces_enabled is not None:
-        platform_config.platform_traces_enabled = file_config.platform_traces_enabled
+    if file_config.sync_traces_enabled is not None:
+        platform_config.sync_traces_enabled = file_config.sync_traces_enabled
         logger.debug(
-            "Resolved platform_traces_enabled from config file.",
-            value=file_config.platform_traces_enabled,
+            "Resolved sync_traces_enabled from config file.",
+            value=file_config.sync_traces_enabled,
         )
+        return
+    platform_config.sync_traces_enabled = True
+    logger.debug("Defaulted sync_traces_enabled to True.")
 
 
 def _strip_scheme(url: str) -> str:
@@ -161,12 +164,9 @@ def resolve_platform_config(
     2. Environment variables
     3. ~/.timbal/ config and credentials files
 
-    Platform trace persistence uses ``platform_traces_enabled`` on ``PlatformConfig``.
-    When that field is unset, ``TIMBAL_PLATFORM_TRACES`` is parsed with the same truthy rules as
-    ``platform_traces`` in the config file, but only if ``TIMBAL_PLATFORM_TRACES`` is set in the
-    environment; otherwise the ``platform_traces`` option in ~/.timbal/config is used.
-    ``None`` on the model keeps legacy behavior: use the platform tracing provider when
-    org and app subject are present.
+    Sync trace persistence uses ``sync_traces_enabled`` on ``PlatformConfig``.
+    When that field is unset, ``TIMBAL_SYNC_TRACES`` is checked first, then the ``sync_traces``
+    option in ~/.timbal/config, then defaults to True.
 
     Args:
         platform_config: Existing config to fill in missing fields for.
@@ -224,7 +224,7 @@ def resolve_platform_config(
 
     if not org_id:
         logger.debug("No org_id found, skipping subject resolution.")
-        _merge_platform_traces_enabled(platform_config, file_config)
+        _merge_sync_traces_enabled(platform_config, file_config)
         return platform_config
 
     app_id = None
@@ -246,5 +246,5 @@ def resolve_platform_config(
     )
     logger.debug("Resolved platform subject.", org_id=org_id, app_id=app_id, version_id=version_id)
 
-    _merge_platform_traces_enabled(platform_config, file_config)
+    _merge_sync_traces_enabled(platform_config, file_config)
     return platform_config

--- a/python/timbal/state/context.py
+++ b/python/timbal/state/context.py
@@ -90,7 +90,7 @@ class RunContext(BaseModel):
 
         self._trace = Trace()
         if self.platform_config:
-            use_platform_traces = self.platform_config.platform_traces_enabled is not False
+            use_platform_traces = self.platform_config.sync_traces_enabled is not False
             if (
                 use_platform_traces
                 and self.platform_config.subject
@@ -104,9 +104,9 @@ class RunContext(BaseModel):
                 )
                 self._tracing_provider = PlatformTracingProvider
                 return
-            if self.platform_config.platform_traces_enabled is False:
+            if self.platform_config.sync_traces_enabled is False:
                 _get_logger().info(
-                    "Platform traces disabled (platform_traces_enabled=False). Using in-memory tracing provider.",
+                    "Sync traces disabled (sync_traces_enabled=False). Using in-memory tracing provider.",
                     event_name="tracing_setup",
                     run_id=self.id,
                 )


### PR DESCRIPTION
## Summary

- Renames env var `TIMBAL_PLATFORM_TRACES` → `TIMBAL_SYNC_TRACES`
- Renames config file key `platform_traces` → `sync_traces`
- Renames model field `platform_traces_enabled` → `sync_traces_enabled` on `PlatformConfig` and `FileConfig`
- Changes default to `True` (explicitly set when neither env var nor config file is present)

## Test plan

- [x] All 15 existing tests pass with updated names
- [x] New test `test_resolve_sync_traces_defaults_to_true` covers the explicit `True` default