### PR TITLE
Add human-in-the-loop approval gates

### DIFF
--- a/docs/agents/index.mdx
+++ b/docs/agents/index.mdx
@@ -110,6 +110,95 @@ async for event in agent(prompt="Hello"):
     print(event)
 ```
 
+### Approval-Required Tools
+
+Any runnable can require approval before it executes. This is most useful for tools that send emails, charge cards, deploy code, delete data, or call external systems with side effects.
+
+```python
+from timbal import Agent, Tool
+from timbal.types.events import ApprovalEvent
+
+
+def refund_customer(amount: int) -> str:
+    return f"refunded ${amount}"
+
+
+refund = Tool(
+    handler=refund_customer,
+    requires_approval=lambda amount: amount > 100,
+    approval_prompt=lambda amount: f"Approve refunding ${amount}?",
+)
+
+agent = Agent(
+    name="support_agent",
+    model="openai/gpt-5",
+    tools=[refund],
+)
+
+events = []
+async for event in agent(prompt="Refund $250"):
+    events.append(event)
+    if isinstance(event, ApprovalEvent):
+        approval_id = event.approval_id
+```
+
+If approval is required, Timbal emits an `ApprovalEvent` and the run ends with `status.code == "cancelled"` and `status.reason == "approval_required"`. Resume by calling the runnable again with `approval_decisions`:
+
+```python
+result = await agent(
+    prompt="Refund $250",
+    approval_decisions={approval_id: True},
+).collect()
+```
+
+Use a structured decision to deny with a reason:
+
+```python
+result = await agent(
+    prompt="Refund $250",
+    approval_decisions={
+        approval_id: {
+            "approved": False,
+            "reason": "Refund exceeds policy limit.",
+        }
+    },
+).collect()
+```
+
+For direct tool calls, denial returns `status.reason == "approval_denied"` and the handler does not run. For agent tool calls, denial is converted into a tool result so the model can explain what happened or choose another path.
+
+#### `approval_id` semantics
+
+The `approval_id` is derived from `(runnable_path, validated_input)`: the same path + input shares one decision, so a decision survives retries of the same call. Treat the id as **opaque** — the derivation is an internal contract and may change across SDK versions, so don't persist it across deploys.
+
+For irreversible operations (money movement, destructive deletes) where every call must require a fresh decision, include a unique value in the input (e.g. an `idempotency_key=uuid4()` arg) so each call derives a distinct `approval_id`.
+
+#### Time-limited decisions
+
+Pass an `expires_at` (Unix-ms) on a resolution to bound how long it stays valid. When the gate sees an expired decision it ignores it, emits a fresh `ApprovalEvent`, and surfaces `metadata["approval"]["expired"] == True`:
+
+```python
+from timbal.types.approval import ApprovalResolution
+import time
+
+decision = ApprovalResolution(
+    approved=True,
+    expires_at=int(time.time() * 1000) + 60_000,  # valid for 60s
+)
+result = await agent(
+    prompt="Refund $250",
+    approval_decisions={approval_id: decision},
+).collect()
+```
+
+#### Enumerating pending approvals
+
+When a run cancels with `approval_required` and you have multiple concurrent tool calls, every pending gate emits its own `ApprovalEvent`. To enumerate them server-side, walk the trace via `RunContext.pending_approvals()` (works against in-memory, JSONL, and SQLite traces — `span.status` may be a dict after reload, the helper handles both shapes).
+
+#### Policy errors
+
+If your callable `requires_approval` or `approval_prompt` raises, the runnable does **not** silently approve nor execute. Instead it ends with `status.code == "error"` and a dedicated `status.reason == "approval_policy_error"` so dashboards can distinguish policy bugs from handler bugs.
+
 ## Input
 
 Agents communicate through `Message` objects - Timbal's data structure that standardizes both input and output.

--- a/docs/agents/index.mdx
+++ b/docs/agents/index.mdx
@@ -151,27 +151,78 @@ result = await agent(
 ).collect()
 ```
 
-Use a structured decision to deny with a reason:
+Use a structured decision to include audit fields or deny with a reason:
 
 ```python
+from timbal.types.approval import ApprovalResolution
+
 result = await agent(
     prompt="Refund $250",
     approval_decisions={
-        approval_id: {
-            "approved": False,
-            "reason": "Refund exceeds policy limit.",
-        }
+        approval_id: ApprovalResolution(
+            approved=False,
+            reason="Refund exceeds policy limit.",
+            approver_id="user_42",
+            comment="Customer is outside the refund window.",
+        )
     },
 ).collect()
 ```
 
 For direct tool calls, denial returns `status.reason == "approval_denied"` and the handler does not run. For agent tool calls, denial is converted into a tool result so the model can explain what happened or choose another path.
 
+#### Redacting approval input
+
+Approval input is shown to humans and written to traces. If a gated runnable receives secrets or PII, redact the public approval snapshot:
+
+```python
+rotate_key = Tool(
+    handler=rotate_key_impl,
+    requires_approval=True,
+    approval_prompt="Rotate this API key?",
+    approval_redact_keys=["api_key", "password"],
+)
+```
+
+For custom logic, use `approval_redactor`. It receives the validated input dict and returns the public snapshot:
+
+```python
+rotate_key = Tool(
+    handler=rotate_key_impl,
+    requires_approval=True,
+    approval_redactor=lambda input: {
+        **input,
+        "api_key": "***",
+        "customer_email": input["customer_email"].split("@")[0] + "@***",
+    },
+)
+```
+
+The redacted snapshot is used for `ApprovalEvent.input`, `span.input` while the gate is pending, `span.metadata["approval"]["input"]`, and `OutputEvent.metadata["pending_approvals"]`. The handler still receives the original unredacted input when the approval is resumed.
+
 #### `approval_id` semantics
 
 The `approval_id` is derived from `(runnable_path, validated_input)`: the same path + input shares one decision, so a decision survives retries of the same call. Treat the id as **opaque** — the derivation is an internal contract and may change across SDK versions, so don't persist it across deploys.
 
 For irreversible operations (money movement, destructive deletes) where every call must require a fresh decision, include a unique value in the input (e.g. an `idempotency_key=uuid4()` arg) so each call derives a distinct `approval_id`.
+
+#### Duplicate resume protection
+
+When resuming from a durable trace store, Timbal claims `(parent_id, approval_id)` before executing the approved or denied resolution. If two workers try to resume the same pending approval, only the first worker can execute the gated handler. Later duplicates stop before handler execution with `status.reason == "approval_already_claimed"`.
+
+This protection is implemented by `JsonlTracingProvider` and `SqliteTracingProvider`. Custom tracing providers should override `claim_approval(parent_id, approval_id, run_id)` to get the same durable locking behavior.
+
+```python
+result = await agent(
+    prompt="Refund $250",
+    parent_id=paused_run_id,
+    approval_decisions={approval_id: True},
+).collect()
+
+if result.status.reason == "approval_already_claimed":
+    # Another worker already consumed this approval.
+    pass
+```
 
 #### Time-limited decisions
 
@@ -183,6 +234,8 @@ import time
 
 decision = ApprovalResolution(
     approved=True,
+    approver_id="user_42",
+    comment="Approved from the support console.",
     expires_at=int(time.time() * 1000) + 60_000,  # valid for 60s
 )
 result = await agent(
@@ -191,9 +244,30 @@ result = await agent(
 ).collect()
 ```
 
+#### Audit trail and usage counters
+
+`ApprovalResolution` audit fields are persisted under `span.metadata["approval"]["resolution"]`:
+
+```python
+ApprovalResolution(
+    approved=True,
+    approver_id="user_42",
+    comment="Reviewed invoice and customer history.",
+)
+```
+
+`decided_at` is set automatically to the decision construction time unless you pass an explicit Unix-ms timestamp.
+
+Timbal also records approval lifecycle counters in `OutputEvent.usage`:
+
+- `approvals:required` — a gate emitted an `ApprovalEvent`
+- `approvals:approved` — a valid approved resolution was consumed
+- `approvals:denied` — a valid denied resolution was consumed
+- `approvals:expired` — an expired resolution was ignored and the gate re-emitted
+
 #### Enumerating pending approvals
 
-When a run cancels with `approval_required` and you have multiple concurrent tool calls, every pending gate emits its own `ApprovalEvent`. To enumerate them server-side, walk the trace via `RunContext.pending_approvals()` (works against in-memory, JSONL, and SQLite traces — `span.status` may be a dict after reload, the helper handles both shapes).
+When a run cancels with `approval_required` and you have multiple concurrent tool calls, every pending gate emits its own `ApprovalEvent`. To enumerate them server-side for a loaded run, walk the trace via `RunContext.pending_approvals()` (works against in-memory, JSONL, and SQLite traces — `span.status` may be a dict after reload, the helper handles both shapes). Returned entries use the redacted approval input snapshot.
 
 #### Policy errors
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ dev = [
   "pyngrok>=7.2.3",
   "pytest>=8.3.4",
   "pytest-asyncio>=0.25.2",
+  "pytest-cov>=7.0.0",
   "yappi>=1.7.6",
 ]
 

--- a/python/tests/core/test_approval.py
+++ b/python/tests/core/test_approval.py
@@ -16,6 +16,7 @@ import warnings
 import pytest
 from timbal import Agent, Tool, Workflow
 from timbal.core.test_model import TestModel
+from timbal.state import get_run_context
 from timbal.types.approval import ApprovalPolicyDecision, ApprovalResolution
 from timbal.types.content import ToolUseContent
 from timbal.types.events import ApprovalEvent, OutputEvent
@@ -861,18 +862,15 @@ class TestPendingApprovalsSurface:
             .step(Tool(name="step_a", handler=step_a, requires_approval=True))
             .step(Tool(name="step_b", handler=step_b, requires_approval=True))
         )
-        seen_ctx = {}
 
-        # Capture the run_context via post_hook would not run on cancel; instead
-        # we collect approval_ids from emitted events and compare them against
-        # what a downstream consumer would discover by reading the trace.
         events = [e async for e in wf(x=1, y=2)]
         emitted_ids = {a.approval_id for a in _approval_events(events)}
         assert len(emitted_ids) == 2
 
-        # A consumer would inspect the cancelled OutputEvent's path/metadata —
-        # we additionally verify the consumer-visible approval_ids match the
-        # set surfaced by emitted events, which is the actual contract.
         cancelled = _final_output(events)
         assert cancelled.status.reason == "approval_required"
-        assert seen_ctx == {}  # marker: nothing leaked through hooks
+
+        ctx = get_run_context()
+        assert ctx is not None
+        pending_ids = {entry["approval_id"] for entry in ctx.pending_approvals()}
+        assert pending_ids == emitted_ids

--- a/python/tests/core/test_approval.py
+++ b/python/tests/core/test_approval.py
@@ -1,0 +1,878 @@
+"""End-to-end lifecycle tests for the human-in-the-loop approval gate.
+
+Each lifecycle test drives the full user flow:
+
+    1. invoke without decision → assert ApprovalEvent + cancelled OutputEvent
+    2. resume with decision     → assert handler ran (or denial path)
+
+Tests organised by *user-facing scenario* (tool, agent, workflow, nested,
+parallel) rather than implementation surface, so a regression in any layer
+fails the test that exercises the corresponding flow.
+"""
+
+import time
+import warnings
+
+import pytest
+from timbal import Agent, Tool, Workflow
+from timbal.core.test_model import TestModel
+from timbal.types.approval import ApprovalDecision, ApprovalResolution
+from timbal.types.content import ToolUseContent
+from timbal.types.events import ApprovalEvent, OutputEvent
+from timbal.types.message import Message
+
+
+def _approval_event(events) -> ApprovalEvent:
+    return next(e for e in events if isinstance(e, ApprovalEvent))
+
+
+def _approval_events(events) -> list[ApprovalEvent]:
+    return [e for e in events if isinstance(e, ApprovalEvent)]
+
+
+def _final_output(events) -> OutputEvent:
+    """Return the OUTPUT event of the outermost runnable (the final OUTPUT in stream order)."""
+    return next(e for e in reversed(events) if isinstance(e, OutputEvent))
+
+
+# ---------------------------------------------------------------------------
+# Tool-level lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestToolApprovalLifecycle:
+    @pytest.mark.asyncio
+    async def test_full_cycle_static_policy(self):
+        """Default scope: gate → approve → handler runs on resume."""
+        calls: list[str] = []
+
+        def delete_file(path: str) -> str:
+            calls.append(path)
+            return f"deleted {path}"
+
+        tool = Tool(
+            name="delete_file",
+            handler=delete_file,
+            requires_approval=True,
+            approval_prompt="Approve file deletion?",
+        )
+
+        events = [e async for e in tool(path="/tmp/a.txt")]
+        approval = _approval_event(events)
+        cancelled = _final_output(events)
+
+        assert approval.approval_id
+        assert approval.prompt == "Approve file deletion?"
+        assert approval.input == {"path": "/tmp/a.txt"}
+        assert cancelled.status.code == "cancelled"
+        assert cancelled.status.reason == "approval_required"
+        assert calls == [], "handler must not run before approval"
+
+        approved = await tool(
+            path="/tmp/a.txt",
+            approval_decisions={approval.approval_id: True},
+        ).collect()
+
+        assert approved.status.code == "success"
+        assert approved.output == "deleted /tmp/a.txt"
+        assert calls == ["/tmp/a.txt"], "handler must run after approval"
+
+    @pytest.mark.asyncio
+    async def test_denial_skips_handler_and_carries_reason(self):
+        calls: list[int] = []
+
+        def charge_card(amount: int) -> str:
+            calls.append(amount)
+            return "charged"
+
+        tool = Tool(name="charge_card", handler=charge_card, requires_approval=True)
+
+        events = [e async for e in tool(amount=100)]
+        approval = _approval_event(events)
+
+        denied = await tool(
+            amount=100,
+            approval_decisions={approval.approval_id: {"approved": False, "reason": "too much"}},
+        ).collect()
+
+        assert denied.status.code == "cancelled"
+        assert denied.status.reason == "approval_denied"
+        assert denied.output["reason"] == "too much"
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_callable_policy_uses_validated_input_and_full_cycle(self):
+        calls: list[int] = []
+
+        def transfer(amount: int) -> str:
+            calls.append(amount)
+            return "transferred"
+
+        tool = Tool(
+            name="transfer",
+            handler=transfer,
+            requires_approval=lambda amount: amount > 100,
+            approval_prompt=lambda amount: f"Approve transfer of {amount}?",
+        )
+
+        # Below threshold → no gate, handler runs immediately
+        ok = await tool(amount=50).collect()
+        assert ok.status.code == "success"
+        assert calls == [50]
+
+        # Above threshold → gate
+        events = [e async for e in tool(amount=150)]
+        approval = _approval_event(events)
+        assert approval.prompt == "Approve transfer of 150?"
+
+        # Resume → handler runs with full validated input
+        approved = await tool(
+            amount=150,
+            approval_decisions={approval.approval_id: True},
+        ).collect()
+        assert approved.status.code == "success"
+        assert calls == [50, 150]
+
+    @pytest.mark.asyncio
+    async def test_same_input_shares_approval_id_across_invocations(self):
+        """Default semantics: a single decision approves any retry/replay of
+        the same path+input within a session. Used after transient failures."""
+        calls: list[int] = []
+
+        def op(x: int) -> str:
+            calls.append(x)
+            return f"x={x}"
+
+        tool = Tool(name="op", handler=op, requires_approval=True)
+        first = await tool(x=1).collect()
+        approval_id = first.metadata["approval"]["id"]
+
+        a = await tool(x=1, approval_decisions={approval_id: True}).collect()
+        b = await tool(x=1, approval_decisions={approval_id: True}).collect()
+
+        assert a.status.code == "success" and b.status.code == "success"
+        assert calls == [1, 1]
+
+    @pytest.mark.asyncio
+    async def test_idempotency_key_pattern_for_per_call_approval(self):
+        """For irreversible ops where each call must require its own decision,
+        users add an idempotency_key arg so the input hash differs per call.
+        This is the documented replacement for the dropped scope='call'."""
+        import uuid
+
+        calls: list[tuple[int, str]] = []
+
+        def transfer(amount: int, idempotency_key: str) -> str:
+            calls.append((amount, idempotency_key))
+            return "ok"
+
+        tool = Tool(name="transfer", handler=transfer, requires_approval=True)
+
+        k1 = str(uuid.uuid4())
+        first = await tool(amount=500, idempotency_key=k1).collect()
+        first_id = first.metadata["approval"]["id"]
+
+        k2 = str(uuid.uuid4())
+        second = await tool(amount=500, idempotency_key=k2).collect()
+        second_id = second.metadata["approval"]["id"]
+
+        assert first_id != second_id, "different idempotency_key → different approval_id"
+
+        # First decision does not authorise the second call
+        retry = await tool(
+            amount=500,
+            idempotency_key=k2,
+            approval_decisions={first_id: True},
+        ).collect()
+        assert retry.status.reason == "approval_required"
+        assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# Agent lifecycle (tool calls, slash commands, denial-as-tool-result)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentApprovalLifecycle:
+    @pytest.mark.asyncio
+    async def test_tool_call_full_cycle(self):
+        calls: list[int] = []
+
+        def wire_money(amount: int) -> str:
+            calls.append(amount)
+            return "wired"
+
+        tool = Tool(name="wire_money", handler=wire_money, requires_approval=True)
+        agent = Agent(
+            name="approval_agent",
+            model=TestModel(
+                responses=[
+                    Message(
+                        role="assistant",
+                        content=[ToolUseContent(id="call_1", name="wire_money", input={"amount": 500})],
+                        stop_reason="tool_use",
+                    ),
+                    "done",
+                ]
+            ),
+            tools=[tool],
+        )
+
+        events = [e async for e in agent(prompt="wire 500")]
+        approval = _approval_event(events)
+        cancelled = _final_output(events)
+
+        assert approval.runnable_path == "approval_agent.wire_money"
+        assert cancelled.path == "approval_agent"
+        assert cancelled.status.code == "cancelled"
+        assert cancelled.status.reason == "approval_required"
+        assert calls == []
+
+        approved = await agent(
+            prompt="wire 500",
+            approval_decisions={approval.approval_id: True},
+        ).collect()
+
+        assert approved.status.code == "success"
+        assert calls == [500], "handler must execute after resume"
+
+    @pytest.mark.asyncio
+    async def test_denial_becomes_tool_result_for_llm(self):
+        calls: list[int] = []
+
+        def wire_money(amount: int) -> str:
+            calls.append(amount)
+            return "wired"
+
+        tool = Tool(name="wire_money", handler=wire_money, requires_approval=True)
+        agent = Agent(
+            name="denial_agent",
+            model=TestModel(
+                responses=[
+                    Message(
+                        role="assistant",
+                        content=[ToolUseContent(id="call_1", name="wire_money", input={"amount": 500})],
+                        stop_reason="tool_use",
+                    ),
+                    "I will not wire the money.",
+                ]
+            ),
+            tools=[tool],
+        )
+
+        events = [e async for e in agent(prompt="wire 500")]
+        approval = _approval_event(events)
+
+        denied = await agent(
+            prompt="wire 500",
+            approval_decisions={approval.approval_id: {"approved": False, "reason": "not allowed"}},
+        ).collect()
+
+        assert denied.status.code == "success"
+        assert denied.output.collect_text() == "I will not wire the money."
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_slash_command_full_cycle(self):
+        calls: list[str] = []
+
+        def delete_target(target: str) -> str:
+            calls.append(target)
+            return f"deleted {target}"
+
+        tool = Tool(
+            name="delete_target",
+            handler=delete_target,
+            command="/delete",
+            requires_approval=True,
+        )
+        agent = Agent(name="command_agent", model=TestModel(), tools=[tool])
+
+        events = [e async for e in agent(prompt="/delete prod-db")]
+        approval = _approval_event(events)
+        cancelled = _final_output(events)
+        assert approval.input == {"target": "prod-db"}
+        assert cancelled.status.reason == "approval_required"
+        assert calls == []
+
+        approved = await agent(
+            prompt="/delete prod-db",
+            approval_decisions={approval.approval_id: True},
+        ).collect()
+        assert approved.status.code == "success"
+        assert calls == ["prod-db"]
+
+
+# ---------------------------------------------------------------------------
+# Workflow lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowApprovalLifecycle:
+    @pytest.mark.asyncio
+    async def test_step_full_cycle(self):
+        calls: list[str] = []
+
+        def deploy(env: str) -> str:
+            calls.append(env)
+            return f"deployed {env}"
+
+        step = Tool(name="deploy", handler=deploy, requires_approval=True)
+        workflow = Workflow(name="deploy_workflow").step(step)
+
+        events = [e async for e in workflow(env="prod")]
+        approval = _approval_event(events)
+        cancelled = _final_output(events)
+
+        assert approval.runnable_path == "deploy_workflow.deploy"
+        assert cancelled.path == "deploy_workflow"
+        assert cancelled.status.reason == "approval_required"
+        assert calls == []
+
+        approved = await workflow(
+            env="prod",
+            approval_decisions={approval.approval_id: True},
+        ).collect()
+        assert approved.status.code == "success"
+        assert calls == ["prod"]
+
+
+# ---------------------------------------------------------------------------
+# Parallel approval gates
+# ---------------------------------------------------------------------------
+
+
+class TestParallelApprovalGates:
+    @pytest.mark.asyncio
+    async def test_agent_with_multiple_concurrent_tool_calls(self):
+        """Drain regression: every parallel tool finishes its gate so callers
+        see one ApprovalEvent per tool, then a single cancel from the agent."""
+        calls: list[str] = []
+
+        def op_a(n: int) -> str:
+            calls.append(f"a={n}")
+            return "a"
+
+        def op_b(n: int) -> str:
+            calls.append(f"b={n}")
+            return "b"
+
+        t_a = Tool(name="op_a", handler=op_a, requires_approval=True)
+        t_b = Tool(name="op_b", handler=op_b, requires_approval=True)
+        agent = Agent(
+            name="multi",
+            model=TestModel(
+                responses=[
+                    Message(
+                        role="assistant",
+                        content=[
+                            ToolUseContent(id="c1", name="op_a", input={"n": 1}),
+                            ToolUseContent(id="c2", name="op_b", input={"n": 2}),
+                        ],
+                        stop_reason="tool_use",
+                    ),
+                    "summary",
+                ]
+            ),
+            tools=[t_a, t_b],
+        )
+
+        events = [e async for e in agent(prompt="run both")]
+        approvals = _approval_events(events)
+        assert len(approvals) == 2, "every concurrent tool must emit its approval event"
+        paths = {a.runnable_path for a in approvals}
+        assert paths == {"multi.op_a", "multi.op_b"}
+        assert calls == []
+
+        decisions = {a.approval_id: True for a in approvals}
+        resumed = await agent(prompt="run both", approval_decisions=decisions).collect()
+        assert resumed.status.code == "success"
+        assert sorted(calls) == ["a=1", "b=2"], "both handlers must run after resuming with both decisions"
+
+    @pytest.mark.asyncio
+    async def test_workflow_with_multiple_independent_gating_steps(self):
+        """Workflow drain regression: parallel independent steps both gate;
+        the workflow does not short-circuit on the first ApprovalRequired."""
+        calls: list[str] = []
+
+        def step_a(x: int) -> str:
+            calls.append(f"a={x}")
+            return "a"
+
+        def step_b(y: int) -> str:
+            calls.append(f"b={y}")
+            return "b"
+
+        a = Tool(name="step_a", handler=step_a, requires_approval=True)
+        b = Tool(name="step_b", handler=step_b, requires_approval=True)
+        wf = Workflow(name="parallel_wf").step(a).step(b)
+
+        events = [e async for e in wf(x=1, y=2)]
+        approvals = _approval_events(events)
+        assert len(approvals) == 2, "every parallel step must emit its approval event"
+        paths = {a.runnable_path for a in approvals}
+        assert paths == {"parallel_wf.step_a", "parallel_wf.step_b"}
+
+        cancelled = _final_output(events)
+        assert cancelled.path == "parallel_wf"
+        assert cancelled.status.reason == "approval_required"
+        assert calls == []
+
+        decisions = {a.approval_id: True for a in approvals}
+        resumed = await wf(x=1, y=2, approval_decisions=decisions).collect()
+        assert resumed.status.code == "success"
+        assert sorted(calls) == ["a=1", "b=2"]
+
+    @pytest.mark.asyncio
+    async def test_workflow_partial_resume_only_executes_approved_steps(self):
+        """If only one of two parallel decisions is supplied, the other gates
+        again. Caught a class of bug where a later step incorrectly inherits
+        its sibling's resolution."""
+        calls: list[str] = []
+
+        def step_a(x: int) -> str:
+            calls.append(f"a={x}")
+            return "a"
+
+        def step_b(y: int) -> str:
+            calls.append(f"b={y}")
+            return "b"
+
+        a = Tool(name="step_a", handler=step_a, requires_approval=True)
+        b = Tool(name="step_b", handler=step_b, requires_approval=True)
+        wf = Workflow(name="parallel_wf").step(a).step(b)
+
+        events = [e async for e in wf(x=1, y=2)]
+        approvals = {ev.runnable_path: ev for ev in _approval_events(events)}
+
+        decisions = {approvals["parallel_wf.step_a"].approval_id: True}
+        partial_events = [e async for e in wf(x=1, y=2, approval_decisions=decisions)]
+        partial_final = _final_output(partial_events)
+        partial_approvals = _approval_events(partial_events)
+
+        assert calls == ["a=1"], "only the approved step ran"
+        assert partial_final.status.code == "cancelled"
+        assert partial_final.status.reason == "approval_required"
+        assert len(partial_approvals) == 1
+        assert partial_approvals[0].runnable_path == "parallel_wf.step_b"
+
+
+# ---------------------------------------------------------------------------
+# Nested lifecycles
+# ---------------------------------------------------------------------------
+
+
+class TestNestedApprovalLifecycle:
+    @pytest.mark.asyncio
+    async def test_subagent_as_tool_full_cycle(self):
+        calls: list[int] = []
+
+        def wire_money(amount: int) -> str:
+            calls.append(amount)
+            return f"wired {amount}"
+
+        money_tool = Tool(name="wire_money", handler=wire_money, requires_approval=True)
+        inner = Agent(
+            name="finance_subagent",
+            model=TestModel(
+                responses=[
+                    Message(
+                        role="assistant",
+                        content=[ToolUseContent(id="ic1", name="wire_money", input={"amount": 999})],
+                        stop_reason="tool_use",
+                    ),
+                    "wire complete",
+                ]
+            ),
+            tools=[money_tool],
+        )
+        outer = Agent(
+            name="orchestrator",
+            model=TestModel(
+                responses=[
+                    Message(
+                        role="assistant",
+                        content=[ToolUseContent(id="oc1", name="finance_subagent", input={"prompt": "wire 999"})],
+                        stop_reason="tool_use",
+                    ),
+                    "all done",
+                ]
+            ),
+            tools=[inner],
+        )
+
+        events = [e async for e in outer(prompt="run finance flow")]
+        approval = _approval_event(events)
+        cancelled = _final_output(events)
+        assert approval.runnable_path == "orchestrator.finance_subagent.wire_money"
+        assert cancelled.path == "orchestrator"
+        assert cancelled.status.reason == "approval_required"
+        assert calls == []
+
+        resumed = await outer(
+            prompt="run finance flow",
+            approval_decisions={approval.approval_id: True},
+        ).collect()
+        assert resumed.status.code == "success"
+        assert calls == [999]
+
+    @pytest.mark.asyncio
+    async def test_workflow_with_agent_step_full_cycle(self):
+        calls: list[str] = []
+
+        def shutdown(target: str) -> str:
+            calls.append(target)
+            return f"shut down {target}"
+
+        risky = Tool(name="shutdown", handler=shutdown, requires_approval=True)
+        sub_agent = Agent(
+            name="ops_agent",
+            model=TestModel(
+                responses=[
+                    Message(
+                        role="assistant",
+                        content=[ToolUseContent(id="t1", name="shutdown", input={"target": "prod"})],
+                        stop_reason="tool_use",
+                    ),
+                    "ops done",
+                ]
+            ),
+            tools=[risky],
+        )
+        wf = Workflow(name="incident").step(sub_agent)
+
+        events = [e async for e in wf(prompt="restart prod")]
+        approval = _approval_event(events)
+        cancelled = _final_output(events)
+        assert approval.runnable_path == "incident.ops_agent.shutdown"
+        assert cancelled.path == "incident"
+        assert cancelled.status.reason == "approval_required"
+        assert calls == []
+
+        resumed = await wf(
+            prompt="restart prod",
+            approval_decisions={approval.approval_id: True},
+        ).collect()
+        assert resumed.status.code == "success"
+        assert calls == ["prod"]
+
+
+# ---------------------------------------------------------------------------
+# TTL
+# ---------------------------------------------------------------------------
+
+
+class TestApprovalTTL:
+    @pytest.mark.asyncio
+    async def test_expired_resolution_re_emits_event_and_full_cycle_with_fresh(self):
+        calls: list[str] = []
+
+        def delete_file(path: str) -> str:
+            calls.append(path)
+            return f"deleted {path}"
+
+        tool = Tool(name="delete_file", handler=delete_file, requires_approval=True)
+        events = [e async for e in tool(path="/tmp/a.txt")]
+        approval = _approval_event(events)
+
+        stale = ApprovalResolution(approved=True, expires_at=int(time.time() * 1000) - 1)
+        retry_events = [
+            e
+            async for e in tool(
+                path="/tmp/a.txt",
+                approval_decisions={approval.approval_id: stale},
+            )
+        ]
+        retry_approval = _approval_event(retry_events)
+        retry_cancelled = _final_output(retry_events)
+
+        assert retry_approval.approval_id == approval.approval_id
+        assert retry_cancelled.status.reason == "approval_required"
+        assert retry_cancelled.metadata["approval"]["expired"] is True
+        assert calls == [], "expired decision must NOT execute the handler"
+
+        # Resume with a fresh decision and assert handler runs.
+        fresh = ApprovalResolution(approved=True, expires_at=int(time.time() * 1000) + 60_000)
+        resumed = await tool(
+            path="/tmp/a.txt",
+            approval_decisions={approval.approval_id: fresh},
+        ).collect()
+        assert resumed.status.code == "success"
+        assert calls == ["/tmp/a.txt"]
+
+    def test_is_expired_helper(self):
+        now = int(time.time() * 1000)
+        assert ApprovalResolution(approved=True).is_expired() is False
+        assert ApprovalResolution(approved=True, expires_at=now - 1).is_expired() is True
+        assert ApprovalResolution(approved=True, expires_at=now + 60_000).is_expired() is False
+        assert ApprovalResolution(approved=True, expires_at=now + 60_000).is_expired(now_ms=now + 100_000) is True
+
+
+# ---------------------------------------------------------------------------
+# Adversarial policy returns — every wrong shape must surface as
+# approval_policy_error, never a generic handler error and never silently
+# approve. This exercises the wrap-the-whole-function contract.
+# ---------------------------------------------------------------------------
+
+
+def _policy_raises(x: int) -> bool:  # noqa: ARG001
+    raise RuntimeError("policy is on fire")
+
+
+def _policy_returns_str(x: int):  # noqa: ARG001
+    return "yes please"
+
+
+def _policy_returns_int(x: int):  # noqa: ARG001
+    return 1
+
+
+def _policy_returns_list(x: int):  # noqa: ARG001
+    return []
+
+
+def _policy_returns_none(x: int):  # noqa: ARG001
+    return None
+
+
+def _policy_returns_dict_missing_required(x: int):  # noqa: ARG001
+    return {"prompt": "no required field"}
+
+
+def _policy_returns_dict_wrong_type(x: int):  # noqa: ARG001
+    """Pydantic rejects list-as-bool — this exercises the validation wrap."""
+    return {"required": [1, 2]}
+
+
+class TestApprovalPolicyErrors:
+    @staticmethod
+    def _tool(policy, prompt=None) -> Tool:
+        def handler(x: int) -> str:  # noqa: ARG001
+            return "should not run"
+
+        kwargs = {"name": "risky", "handler": handler, "requires_approval": policy}
+        if prompt is not None:
+            kwargs["approval_prompt"] = prompt
+        return Tool(**kwargs)
+
+    @pytest.mark.parametrize(
+        "policy,err_substr",
+        [
+            (_policy_raises, "policy is on fire"),
+            (_policy_returns_str, "must be a bool or callable"),
+            (_policy_returns_int, "must be a bool or callable"),
+            (_policy_returns_list, "must be a bool or callable"),
+            (_policy_returns_none, "must be a bool or callable"),
+            (_policy_returns_dict_missing_required, "required"),
+            (_policy_returns_dict_wrong_type, ""),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_invalid_policy_returns_become_policy_error(self, policy, err_substr):
+        tool = self._tool(policy)
+        out = await tool(x=1).collect()
+        assert out.status.code == "error"
+        assert out.status.reason == "approval_policy_error"
+        assert out.error is not None
+        if err_substr:
+            assert err_substr.lower() in out.error["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_callable_prompt_exception_also_caught(self):
+        def prompt(x: int) -> str:  # noqa: ARG001
+            raise ValueError("prompt blew up")
+
+        tool = self._tool(True, prompt=prompt)
+        out = await tool(x=1).collect()
+        assert out.status.code == "error"
+        assert out.status.reason == "approval_policy_error"
+        assert "prompt blew up" in out.error["message"]
+
+    @pytest.mark.asyncio
+    async def test_async_policy_supported_and_errors_wrapped(self):
+        async def bad(x: int):  # noqa: ARG001
+            raise RuntimeError("async boom")
+
+        tool = self._tool(bad)
+        out = await tool(x=1).collect()
+        assert out.status.code == "error"
+        assert out.status.reason == "approval_policy_error"
+        assert "async boom" in out.error["message"]
+
+    @pytest.mark.asyncio
+    async def test_decision_object_with_invalid_metadata_type_also_wrapped(self):
+        """ApprovalDecision currently has metadata: dict; passing a non-dict
+        should be a policy error, not a handler error."""
+
+        def bad(x: int):  # noqa: ARG001
+            # bypass type checker on purpose: simulate user code returning an invalid dict
+            return {"required": True, "metadata": "not-a-dict"}
+
+        tool = self._tool(bad)
+        out = await tool(x=1).collect()
+        assert out.status.code == "error"
+        assert out.status.reason == "approval_policy_error"
+
+    @pytest.mark.asyncio
+    async def test_valid_decision_object_works(self):
+        def policy(x: int) -> ApprovalDecision:  # noqa: ARG001
+            return ApprovalDecision(required=True, prompt="approve?")
+
+        tool = self._tool(policy)
+        events = [e async for e in tool(x=1)]
+        approval = _approval_event(events)
+        assert approval.prompt == "approve?"
+
+
+# ---------------------------------------------------------------------------
+# Deprecation
+# ---------------------------------------------------------------------------
+
+
+class TestApprovalDeprecation:
+    @pytest.mark.asyncio
+    async def test_approvals_kwarg_emits_warning_but_still_works(self):
+        def handler() -> str:
+            return "ok"
+
+        tool = Tool(name="t", handler=handler, requires_approval=True)
+        first = await tool().collect()
+        approval_id = first.metadata["approval"]["id"]
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            out = await tool(approvals={approval_id: True}).collect()
+
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert deprecations, "expected DeprecationWarning for `approvals=`"
+        assert "approval_decisions" in str(deprecations[0].message)
+        assert out.status.code == "success"
+
+    @pytest.mark.asyncio
+    async def test_approval_decisions_takes_precedence_when_both_passed(self):
+        def handler() -> str:
+            return "ok"
+
+        tool = Tool(name="t", handler=handler, requires_approval=True)
+        first = await tool().collect()
+        approval_id = first.metadata["approval"]["id"]
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            out = await tool(
+                approval_decisions={approval_id: True},
+                approvals={approval_id: False},
+            ).collect()
+        assert out.status.code == "success"
+
+
+# ---------------------------------------------------------------------------
+# RunContext.pending_approvals
+# ---------------------------------------------------------------------------
+
+
+class TestPendingApprovalsSurface:
+    def test_lists_every_cancelled_approval_span_with_metadata(self):
+        from timbal.state.context import RunContext
+        from timbal.state.tracing.span import Span
+        from timbal.types.run_status import RunStatus
+
+        ctx = RunContext()
+        ctx._trace["root"] = Span(
+            path="agent",
+            call_id="root",
+            t0=0,
+            status=RunStatus(code="cancelled", reason="approval_required", message=None),
+            metadata={},
+        )
+        ctx._trace["a"] = Span(
+            path="agent.op_a",
+            call_id="a",
+            parent_call_id="root",
+            t0=0,
+            metadata={"approval": {"id": "id-a", "prompt": "approve a?"}},
+            status=RunStatus(code="cancelled", reason="approval_required", message=None),
+        )
+        ctx._trace["b"] = Span(
+            path="agent.op_b",
+            call_id="b",
+            parent_call_id="root",
+            t0=0,
+            metadata={
+                "approval": {
+                    "id": "id-b",
+                    "prompt": "approve b?",
+                    "expired": True,
+                    "expired_at": 12345,
+                },
+            },
+            status=RunStatus(code="cancelled", reason="approval_required", message=None),
+        )
+        ctx._trace["c"] = Span(
+            path="agent.completed",
+            call_id="c",
+            parent_call_id="root",
+            t0=0,
+            status=RunStatus(code="success", reason=None, message=None),
+        )
+        ctx._trace["d"] = Span(
+            path="agent.denied",
+            call_id="d",
+            parent_call_id="root",
+            t0=0,
+            metadata={"approval": {"id": "id-d"}},
+            status=RunStatus(code="cancelled", reason="approval_denied", message=None),
+        )
+
+        pending = ctx.pending_approvals()
+        by_id = {p["approval_id"]: p for p in pending}
+        # Only spans with cancelled/approval_required AND an approval_id
+        assert set(by_id) == {"id-a", "id-b"}
+        assert by_id["id-a"]["path"] == "agent.op_a"
+        assert by_id["id-b"]["expired"] is True
+        assert by_id["id-b"]["expired_at"] == 12345
+        # Non-expired approvals must not include expired keys
+        assert "expired" not in by_id["id-a"]
+
+    def test_handles_dict_status_after_reload(self):
+        from timbal.state.context import RunContext
+        from timbal.state.tracing.span import Span
+
+        ctx = RunContext()
+        span = Span(path="x", call_id="x", t0=0, metadata={"approval": {"id": "id-x"}})
+        span.status = {"code": "cancelled", "reason": "approval_required"}
+        ctx._trace["x"] = span
+        pending = ctx.pending_approvals()
+        assert [p["approval_id"] for p in pending] == ["id-x"]
+
+    @pytest.mark.asyncio
+    async def test_after_real_parallel_run_lists_every_pending_id(self):
+        """Behavioural check: drive an actual parallel-gating workflow, then
+        assert pending_approvals enumerates exactly the approval_ids emitted."""
+
+        def step_a(x: int) -> str:  # noqa: ARG001
+            return "a"
+
+        def step_b(y: int) -> str:  # noqa: ARG001
+            return "b"
+
+        wf = (
+            Workflow(name="wf")
+            .step(Tool(name="step_a", handler=step_a, requires_approval=True))
+            .step(Tool(name="step_b", handler=step_b, requires_approval=True))
+        )
+        seen_ctx = {}
+
+        # Capture the run_context via post_hook would not run on cancel; instead
+        # we collect approval_ids from emitted events and compare them against
+        # what a downstream consumer would discover by reading the trace.
+        events = [e async for e in wf(x=1, y=2)]
+        emitted_ids = {a.approval_id for a in _approval_events(events)}
+        assert len(emitted_ids) == 2
+
+        # A consumer would inspect the cancelled OutputEvent's path/metadata —
+        # we additionally verify the consumer-visible approval_ids match the
+        # set surfaced by emitted events, which is the actual contract.
+        cancelled = _final_output(events)
+        assert cancelled.status.reason == "approval_required"
+        assert seen_ctx == {}  # marker: nothing leaked through hooks

--- a/python/tests/core/test_approval.py
+++ b/python/tests/core/test_approval.py
@@ -16,7 +16,7 @@ import warnings
 import pytest
 from timbal import Agent, Tool, Workflow
 from timbal.core.test_model import TestModel
-from timbal.types.approval import ApprovalDecision, ApprovalResolution
+from timbal.types.approval import ApprovalPolicyDecision, ApprovalResolution
 from timbal.types.content import ToolUseContent
 from timbal.types.events import ApprovalEvent, OutputEvent
 from timbal.types.message import Message
@@ -701,7 +701,7 @@ class TestApprovalPolicyErrors:
 
     @pytest.mark.asyncio
     async def test_decision_object_with_invalid_metadata_type_also_wrapped(self):
-        """ApprovalDecision currently has metadata: dict; passing a non-dict
+        """ApprovalPolicyDecision currently has metadata: dict; passing a non-dict
         should be a policy error, not a handler error."""
 
         def bad(x: int):  # noqa: ARG001
@@ -715,8 +715,8 @@ class TestApprovalPolicyErrors:
 
     @pytest.mark.asyncio
     async def test_valid_decision_object_works(self):
-        def policy(x: int) -> ApprovalDecision:  # noqa: ARG001
-            return ApprovalDecision(required=True, prompt="approve?")
+        def policy(x: int) -> ApprovalPolicyDecision:  # noqa: ARG001
+            return ApprovalPolicyDecision(required=True, prompt="approve?")
 
         tool = self._tool(policy)
         events = [e async for e in tool(x=1)]

--- a/python/tests/core/test_approval_audit_and_metrics.py
+++ b/python/tests/core/test_approval_audit_and_metrics.py
@@ -1,0 +1,619 @@
+# ruff: noqa: ARG001, ARG005 — test handlers declare params for schema, do not consume them
+"""Approver audit trail + observability counters.
+
+Two production gaps closed here:
+
+1. **Audit trail.** Today ``ApprovalResolution`` carries only ``approved``,
+   ``reason``, ``expires_at``, and a free-form ``metadata`` dict. SOC2 /
+   compliance / "who approved this $1M wire on Tuesday?" require a typed
+   ``approver_id`` + ``comment`` + ``decided_at`` (Unix ms) that traces
+   serialize verbatim and resume surfaces verbatim. Free-form metadata stays
+   for orgs that need extra structure on top.
+
+2. **Observability counters.** Every gate emits one of four lifecycle
+   events: ``required`` (human hasn't decided yet), ``approved``,
+   ``denied``, ``expired`` (decision was given but stale at resume time).
+   These are auto-incremented into ``RunContext.update_usage`` so they
+   propagate up through agent / workflow spans and ship through
+   ``OutputEvent.usage`` and any tracing exporter (OTel, etc.) without
+   extra wiring on the user's side.
+
+Invariants we enforce:
+
+- Counters are emitted from the **gate site** (the runnable that owns
+  ``requires_approval``), not from parents — so ``span.usage`` on the tool
+  span is the source of truth, while parents see them via the standard
+  propagation chain.
+- ``decided_at`` defaults to ``int(time.time() * 1000)`` if not provided,
+  but explicit values are preserved (idempotent replay).
+- Backward compat: old callers passing only ``approved=True`` still work;
+  new typed fields are ``None``.
+- JSONL/SQLite round-trip preserves all typed fields verbatim — auditors
+  can query ``span.metadata.approval.resolution.approver_id`` from disk.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+from timbal import Agent, Tool, Workflow
+from timbal.core.test_model import TestModel
+from timbal.state.tracing.providers.jsonl import JsonlTracingProvider
+from timbal.state.tracing.providers.sqlite import SqliteTracingProvider
+from timbal.types.approval import ApprovalResolution
+from timbal.types.content import ToolUseContent
+from timbal.types.events import ApprovalEvent, OutputEvent
+from timbal.types.message import Message
+
+
+def _approval_event(events) -> ApprovalEvent:
+    return next(e for e in events if isinstance(e, ApprovalEvent))
+
+
+def _final_output(events) -> OutputEvent:
+    return next(e for e in reversed(events) if isinstance(e, OutputEvent))
+
+
+# ---------------------------------------------------------------------------
+# Typed fields on ApprovalResolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolutionTypedFields:
+    def test_typed_fields_are_accepted(self):
+        r = ApprovalResolution(
+            approved=True,
+            approver_id="user_42",
+            comment="Looks legitimate",
+            decided_at=1777250000000,
+        )
+        assert r.approver_id == "user_42"
+        assert r.comment == "Looks legitimate"
+        assert r.decided_at == 1777250000000
+
+    def test_decided_at_defaults_to_now_ms(self):
+        before = int(time.time() * 1000)
+        r = ApprovalResolution(approved=True)
+        after = int(time.time() * 1000)
+        assert r.decided_at is not None
+        assert before <= r.decided_at <= after
+
+    def test_explicit_decided_at_preserved(self):
+        r = ApprovalResolution(approved=False, decided_at=42)
+        assert r.decided_at == 42
+
+    def test_backward_compat_minimal_resolution(self):
+        r = ApprovalResolution(approved=True)
+        assert r.approved is True
+        assert r.approver_id is None
+        assert r.comment is None
+        assert r.metadata == {}
+
+
+# ---------------------------------------------------------------------------
+# Resolution fields appear in span.metadata['approval']['resolution']
+# ---------------------------------------------------------------------------
+
+
+class TestResolutionPersistedToSpanMetadata:
+    @pytest.mark.asyncio
+    async def test_approved_resolution_serialized(self):
+        seen: list[str] = []
+        tool = Tool(
+            name="op",
+            handler=lambda x: seen.append("ran") or "ok",
+            requires_approval=True,
+        )
+
+        events = [e async for e in tool(x=1)]
+        approval = _approval_event(events)
+
+        out = await tool(
+            x=1,
+            approval_decisions={
+                approval.approval_id: ApprovalResolution(
+                    approved=True,
+                    approver_id="user_42",
+                    comment="vetted",
+                    decided_at=42,
+                )
+            },
+        ).collect()
+        assert out.status.code == "success"
+
+        resolution = (out.metadata or {}).get("approval", {}).get("resolution")
+        assert resolution is not None, (
+            "span.metadata['approval']['resolution'] must carry the typed snapshot"
+        )
+        assert resolution["approved"] is True
+        assert resolution["approver_id"] == "user_42"
+        assert resolution["comment"] == "vetted"
+        assert resolution["decided_at"] == 42
+
+    @pytest.mark.asyncio
+    async def test_denied_resolution_serialized_with_audit_fields(self):
+        tool = Tool(
+            name="op",
+            handler=lambda x: "ok",
+            requires_approval=True,
+        )
+
+        events = [e async for e in tool(x=1)]
+        approval = _approval_event(events)
+
+        out = await tool(
+            x=1,
+            approval_decisions={
+                approval.approval_id: ApprovalResolution(
+                    approved=False,
+                    reason="suspicious origin",
+                    approver_id="user_99",
+                    comment="flagged for review",
+                )
+            },
+        ).collect()
+        assert out.status.code == "cancelled"
+        assert out.status.reason == "approval_denied"
+
+        resolution = (out.metadata or {}).get("approval", {}).get("resolution")
+        assert resolution is not None
+        assert resolution["approved"] is False
+        assert resolution["approver_id"] == "user_99"
+        assert resolution["comment"] == "flagged for review"
+
+    @pytest.mark.asyncio
+    async def test_jsonl_roundtrip_preserves_audit_fields(self, tmp_path: Path):
+        traces = tmp_path / "traces.jsonl"
+        provider = JsonlTracingProvider.configured(_path=traces)
+
+        tool = Tool(
+            name="op",
+            handler=lambda x: "ok",
+            requires_approval=True,
+            tracing_provider=provider,
+        )
+
+        events1 = [e async for e in tool(x=1)]
+        approval = _approval_event(events1)
+        gate_run_id = _final_output(events1).run_id
+
+        await tool(
+            x=1,
+            parent_id=gate_run_id,
+            approval_decisions={
+                approval.approval_id: ApprovalResolution(
+                    approved=True,
+                    approver_id="user_42",
+                    comment="ok",
+                    decided_at=12345,
+                )
+            },
+        ).collect()
+
+        records = [json.loads(line) for line in traces.read_text().splitlines() if line.strip()]
+        # The resume run's parent_id is the gate run's id.
+        approved_record = next(r for r in records if r.get("parent_id") == gate_run_id)
+        op_span = next(s for s in approved_record["spans"] if s["path"] == "op")
+        resolution = op_span["metadata"]["approval"]["resolution"]
+        assert resolution["approver_id"] == "user_42"
+        assert resolution["comment"] == "ok"
+        assert resolution["decided_at"] == 12345
+
+
+# ---------------------------------------------------------------------------
+# Usage counters: approvals:required / :approved / :denied / :expired
+# ---------------------------------------------------------------------------
+
+
+class TestApprovalUsageCounters:
+    @pytest.mark.asyncio
+    async def test_required_counter_on_first_gate(self):
+        tool = Tool(
+            name="op",
+            handler=lambda x: "ok",
+            requires_approval=True,
+        )
+
+        out = await tool(x=1).collect()
+        assert out.status.code == "cancelled"
+        assert out.usage.get("approvals:required") == 1
+        assert "approvals:approved" not in out.usage
+        assert "approvals:denied" not in out.usage
+        assert "approvals:expired" not in out.usage
+
+    @pytest.mark.asyncio
+    async def test_approved_counter_on_resume(self):
+        tool = Tool(
+            name="op",
+            handler=lambda x: "ok",
+            requires_approval=True,
+        )
+
+        events = [e async for e in tool(x=1)]
+        approval = _approval_event(events)
+
+        out = await tool(x=1, approval_decisions={approval.approval_id: True}).collect()
+        assert out.status.code == "success"
+        assert out.usage.get("approvals:approved") == 1
+        assert "approvals:required" not in out.usage
+
+    @pytest.mark.asyncio
+    async def test_denied_counter_on_resume(self):
+        tool = Tool(
+            name="op",
+            handler=lambda x: "ok",
+            requires_approval=True,
+        )
+
+        events = [e async for e in tool(x=1)]
+        approval = _approval_event(events)
+
+        out = await tool(
+            x=1,
+            approval_decisions={
+                approval.approval_id: ApprovalResolution(approved=False, reason="nope")
+            },
+        ).collect()
+        assert out.status.code == "cancelled"
+        assert out.usage.get("approvals:denied") == 1
+
+    @pytest.mark.asyncio
+    async def test_expired_counter_then_required_on_resume(self):
+        tool = Tool(
+            name="op",
+            handler=lambda x: "ok",
+            requires_approval=True,
+        )
+
+        events = [e async for e in tool(x=1)]
+        approval = _approval_event(events)
+
+        # Expired resolution: gate must re-fire AND we must increment
+        # both ``expired`` (the resolution we threw away) and ``required``
+        # (the new gate emitted as a result).
+        out = await tool(
+            x=1,
+            approval_decisions={
+                approval.approval_id: ApprovalResolution(
+                    approved=True,
+                    expires_at=int(time.time() * 1000) - 1000,
+                )
+            },
+        ).collect()
+        assert out.status.code == "cancelled"
+        assert out.status.reason == "approval_required"
+        assert out.usage.get("approvals:expired") == 1
+        assert out.usage.get("approvals:required") == 1
+
+    @pytest.mark.asyncio
+    async def test_counters_propagate_through_workflow(self):
+        wf = (
+            Workflow(name="wf")
+            .step(
+                Tool(
+                    name="op_a",
+                    handler=lambda x: "ok",
+                    requires_approval=True,
+                )
+            )
+            .step(
+                Tool(
+                    name="op_b",
+                    handler=lambda x: "ok",
+                    requires_approval=True,
+                ),
+                x=1,
+            )
+        )
+
+        out = await wf(x=1).collect()
+        # Two parallel gates fire; both increment :required on the
+        # workflow's aggregated usage via the standard propagation chain.
+        assert out.usage.get("approvals:required") == 2
+
+    @pytest.mark.asyncio
+    async def test_counters_propagate_through_agent_tool_call(self):
+        tool = Tool(
+            name="wire",
+            handler=lambda amount: "wired",
+            requires_approval=True,
+        )
+        agent = Agent(
+            name="bank",
+            model=TestModel(
+                responses=[
+                    Message(
+                        role="assistant",
+                        content=[ToolUseContent(id="t1", name="wire", input={"amount": 100})],
+                        stop_reason="tool_use",
+                    ),
+                    "done",
+                ]
+            ),
+            tools=[tool],
+        )
+
+        events = [e async for e in agent(prompt="wire 100")]
+        gate_out = _final_output(events)
+        approval = _approval_event(events)
+        assert gate_out.usage.get("approvals:required") == 1
+
+        out = await agent(
+            prompt="wire 100",
+            approval_decisions={approval.approval_id: True},
+        ).collect()
+        assert out.status.code == "success"
+        assert out.usage.get("approvals:approved") == 1
+
+
+# ---------------------------------------------------------------------------
+# Resolution snapshot completeness — every typed field is round-tripped
+# ---------------------------------------------------------------------------
+
+
+class TestResolutionSnapshotCompleteness:
+    @pytest.mark.asyncio
+    async def test_full_resolution_snapshot_shape(self):
+        """All seven keys must land on the snapshot — anything missing
+        means a downstream consumer can't reconstruct the audit row."""
+        tool = Tool(name="op", handler=lambda x: "ok", requires_approval=True)
+
+        events = [e async for e in tool(x=1)]
+        approval = _approval_event(events)
+
+        # Use a far-future expires_at so the resolution isn't expired —
+        # otherwise the gate discards it and emits a fresh ApprovalEvent
+        # without writing the snapshot.
+        future = int(time.time() * 1000) + 10_000_000
+        out = await tool(
+            x=1,
+            approval_decisions={
+                approval.approval_id: ApprovalResolution(
+                    approved=True,
+                    reason="trusted source",
+                    approver_id="user_42",
+                    comment="vetted via SSO",
+                    decided_at=42,
+                    expires_at=future,
+                    metadata={"sso_provider": "google", "ip": "10.0.0.1"},
+                )
+            },
+        ).collect()
+
+        snapshot = out.metadata["approval"]["resolution"]
+        assert snapshot == {
+            "approved": True,
+            "reason": "trusted source",
+            "approver_id": "user_42",
+            "comment": "vetted via SSO",
+            "decided_at": 42,
+            "expires_at": future,
+            "metadata": {"sso_provider": "google", "ip": "10.0.0.1"},
+        }
+
+    @pytest.mark.asyncio
+    async def test_bool_shorthand_produces_complete_snapshot(self):
+        """``approval_decisions={id: True}`` is the most common form. The
+        framework must still produce a fully-typed snapshot with
+        ``decided_at`` defaulted (so the audit trail isn't blank)."""
+        tool = Tool(name="op", handler=lambda x: "ok", requires_approval=True)
+
+        events = [e async for e in tool(x=1)]
+        approval = _approval_event(events)
+
+        before = int(time.time() * 1000)
+        out = await tool(
+            x=1, approval_decisions={approval.approval_id: True}
+        ).collect()
+        after = int(time.time() * 1000)
+
+        snapshot = out.metadata["approval"]["resolution"]
+        assert snapshot["approved"] is True
+        assert snapshot["approver_id"] is None
+        assert snapshot["comment"] is None
+        assert snapshot["reason"] is None
+        assert snapshot["expires_at"] is None
+        assert snapshot["metadata"] == {}
+        assert before <= snapshot["decided_at"] <= after, (
+            "decided_at must be auto-populated even from the bool shorthand"
+        )
+
+    @pytest.mark.asyncio
+    async def test_dict_shorthand_preserves_audit_fields(self):
+        """``approval_decisions={id: {"approved": True, "approver_id": ...}}``
+        should round-trip every typed field; unknown keys would surface as
+        a validation error from ``ApprovalResolution.model_validate``."""
+        tool = Tool(name="op", handler=lambda x: "ok", requires_approval=True)
+
+        events = [e async for e in tool(x=1)]
+        approval = _approval_event(events)
+
+        out = await tool(
+            x=1,
+            approval_decisions={
+                approval.approval_id: {
+                    "approved": True,
+                    "approver_id": "user_42",
+                    "comment": "ok",
+                    "decided_at": 1234,
+                }
+            },
+        ).collect()
+
+        snapshot = out.metadata["approval"]["resolution"]
+        assert snapshot["approver_id"] == "user_42"
+        assert snapshot["comment"] == "ok"
+        assert snapshot["decided_at"] == 1234
+
+
+# ---------------------------------------------------------------------------
+# Mixed counter states + gate-site invariant
+# ---------------------------------------------------------------------------
+
+
+class TestCounterMixedStates:
+    @pytest.mark.asyncio
+    async def test_mixed_approve_and_deny_counters_sum_correctly(self):
+        """Two parallel steps, one resolved approved, one resolved denied.
+        Counters at the workflow level must reflect both decisions
+        independently."""
+        wf = (
+            Workflow(name="wf")
+            .step(Tool(name="op_a", handler=lambda x: "ok", requires_approval=True))
+            .step(Tool(name="op_b", handler=lambda x: "ok", requires_approval=True), x=1)
+        )
+
+        events = [e async for e in wf(x=1)]
+        approvals = [e for e in events if isinstance(e, ApprovalEvent)]
+        assert len(approvals) == 2
+        # Map approval_id by step name for stable resolution wiring.
+        ids = {a.runnable_path.split(".")[-1]: a.approval_id for a in approvals}
+
+        out = await wf(
+            x=1,
+            approval_decisions={
+                ids["op_a"]: True,
+                ids["op_b"]: ApprovalResolution(approved=False, reason="nope"),
+            },
+        ).collect()
+
+        assert out.usage.get("approvals:approved") == 1
+        assert out.usage.get("approvals:denied") == 1
+        assert out.usage.get("approvals:required", 0) == 0
+
+    @pytest.mark.asyncio
+    async def test_counter_emitted_at_gate_site_span(self):
+        """Source-of-truth invariant: the gate's own span.usage has the
+        counter; parents see it via update_usage propagation."""
+        wf = Workflow(name="wf").step(
+            Tool(name="op", handler=lambda x: "ok", requires_approval=True)
+        )
+
+        out = await wf(x=1).collect()
+        assert out.status.code == "cancelled"
+
+        # The OutputEvent's usage reflects propagation up the chain. Both
+        # the workflow and its gated step must agree on the count.
+        assert out.usage.get("approvals:required") == 1
+
+
+# ---------------------------------------------------------------------------
+# SQLite round-trip parity — must match JSONL behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestSqliteRoundtripParity:
+    @pytest.mark.asyncio
+    async def test_sqlite_preserves_audit_fields(self, tmp_path: Path):
+        db = tmp_path / "traces.db"
+        provider = SqliteTracingProvider.configured(_path=db)
+
+        tool = Tool(
+            name="op",
+            handler=lambda x: "ok",
+            requires_approval=True,
+            tracing_provider=provider,
+        )
+
+        events1 = [e async for e in tool(x=1)]
+        approval = _approval_event(events1)
+        gate_run_id = _final_output(events1).run_id
+
+        out = await tool(
+            x=1,
+            parent_id=gate_run_id,
+            approval_decisions={
+                approval.approval_id: ApprovalResolution(
+                    approved=True,
+                    approver_id="user_99",
+                    comment="cross-provider audit",
+                    decided_at=98765,
+                )
+            },
+        ).collect()
+        assert out.status.code == "success"
+
+        # Read back via raw sqlite so we test on-disk deserialization,
+        # not just the in-memory metadata.
+        import sqlite3
+
+        conn = sqlite3.connect(db)
+        rows = conn.execute("SELECT run_id, parent_id, spans FROM runs").fetchall()
+        conn.close()
+
+        approved_record = next(
+            json.loads(spans) for run_id, parent_id, spans in rows if parent_id == gate_run_id
+        )
+        op_span = next(s for s in approved_record if s["path"] == "op")
+        snapshot = op_span["metadata"]["approval"]["resolution"]
+        assert snapshot["approver_id"] == "user_99"
+        assert snapshot["comment"] == "cross-provider audit"
+        assert snapshot["decided_at"] == 98765
+
+
+# ---------------------------------------------------------------------------
+# Cross-process audit trail: process A writes audit, process B reads it
+# ---------------------------------------------------------------------------
+
+
+class TestCrossProcessAuditTrail:
+    @pytest.mark.asyncio
+    async def test_audit_trail_recoverable_after_disk_roundtrip(self, tmp_path: Path):
+        """Approver fields written by the resume turn must be readable
+        from disk by a new RunContext (e.g. an audit dashboard reading
+        the trace store after the original process exited)."""
+        traces = tmp_path / "traces.jsonl"
+        provider = JsonlTracingProvider.configured(_path=traces)
+
+        tool = Tool(
+            name="op",
+            handler=lambda x: "ok",
+            requires_approval=True,
+            tracing_provider=provider,
+        )
+
+        events1 = [e async for e in tool(x=1)]
+        approval = _approval_event(events1)
+        gate_run_id = _final_output(events1).run_id
+
+        # Resume in the same process, but the assertions read disk state
+        # only — proving an audit dashboard with no in-memory state can
+        # reconstruct the full audit row.
+        await tool(
+            x=1,
+            parent_id=gate_run_id,
+            approval_decisions={
+                approval.approval_id: ApprovalResolution(
+                    approved=True,
+                    approver_id="user_777",
+                    comment="approved by oncall",
+                    decided_at=11111,
+                )
+            },
+        ).collect()
+
+        records = [json.loads(line) for line in traces.read_text().splitlines() if line.strip()]
+        approved_record = next(r for r in records if r.get("parent_id") == gate_run_id)
+        op_span = next(s for s in approved_record["spans"] if s["path"] == "op")
+
+        # Audit row reconstructed entirely from disk:
+        snapshot = op_span["metadata"]["approval"]["resolution"]
+        audit_row = {
+            "approval_id": op_span["metadata"]["approval"]["id"],
+            "path": op_span["path"],
+            "approver_id": snapshot["approver_id"],
+            "comment": snapshot["comment"],
+            "decided_at": snapshot["decided_at"],
+            "approved": snapshot["approved"],
+        }
+        assert audit_row == {
+            "approval_id": approval.approval_id,
+            "path": "op",
+            "approver_id": "user_777",
+            "comment": "approved by oncall",
+            "decided_at": 11111,
+            "approved": True,
+        }

--- a/python/tests/core/test_approval_cross_process.py
+++ b/python/tests/core/test_approval_cross_process.py
@@ -1,0 +1,574 @@
+"""Cross-process / cross-restart proof for the human-in-the-loop approval gate.
+
+Real HITL is:
+
+    1. process A runs the agent, persists trace to durable storage,
+       hits a gate, exits.
+    2. some external system (queue, DB, UI) holds the ``approval_id``.
+    3. process B starts fresh, asks the trace store for pending
+       approvals, then calls the runnable again with
+       ``approval_decisions=...`` and ``parent_id=...``.
+
+If that flow doesn't work, the whole feature is an in-memory toy.
+
+The tests in this file pin the contract by using on-disk providers
+(:class:`JsonlTracingProvider` and :class:`SqliteTracingProvider`) as
+the only path between turns. The autouse fixture in ``conftest`` clears
+``InMemoryTracingProvider._storage`` between tests, so any silent
+reliance on shared in-memory state would fail here.
+
+Every test is parametrised across both providers via the ``backend``
+fixture. The final test boots a real subprocess to literally prove the
+resume loop works across Python processes — not just across
+``RunContext`` instances within one interpreter.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+from timbal import Agent, Tool, Workflow
+from timbal.core.test_model import TestModel
+from timbal.state.tracing.providers.jsonl import JsonlTracingProvider
+from timbal.state.tracing.providers.sqlite import SqliteTracingProvider
+from timbal.types.approval import ApprovalResolution
+from timbal.types.content import ToolUseContent
+from timbal.types.events import ApprovalEvent, OutputEvent
+from timbal.types.message import Message
+
+
+def _approval_events(events) -> list[ApprovalEvent]:
+    return [e for e in events if isinstance(e, ApprovalEvent)]
+
+
+def _final_output(events) -> OutputEvent:
+    return next(e for e in reversed(events) if isinstance(e, OutputEvent))
+
+
+# ---------------------------------------------------------------------------
+# Backend-agnostic durable-store fixture
+# ---------------------------------------------------------------------------
+
+
+class _Backend:
+    """Provider + raw-record reader, abstracted over backend storage."""
+
+    def __init__(self, name: str, path: Path, provider, load_records, script_setup: str):
+        self.name = name
+        self.path = path
+        self.provider = provider
+        self._load_records = load_records
+        self.script_setup = script_setup  # python snippet for subprocess scripts
+
+    def load_records(self) -> list[dict]:
+        """Return [{run_id, parent_id, spans}, ...] regardless of backend."""
+        return self._load_records()
+
+
+def _make_jsonl_backend(tmp_path: Path) -> _Backend:
+    path = tmp_path / "traces.jsonl"
+    provider = JsonlTracingProvider.configured(_path=path)
+
+    def load() -> list[dict]:
+        if not path.exists():
+            return []
+        return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+    script_setup = textwrap.dedent(
+        f"""
+        from pathlib import Path
+        from timbal.state.tracing.providers.jsonl import JsonlTracingProvider
+        TRACE_PATH = Path(r"{path}")
+        provider = JsonlTracingProvider.configured(_path=TRACE_PATH)
+        """
+    ).strip()
+    return _Backend("jsonl", path, provider, load, script_setup)
+
+
+def _make_sqlite_backend(tmp_path: Path) -> _Backend:
+    path = tmp_path / "traces.db"
+    provider = SqliteTracingProvider.configured(_path=path)
+
+    def load() -> list[dict]:
+        if not path.exists():
+            return []
+        conn = sqlite3.connect(str(path))
+        try:
+            rows = conn.execute(
+                "SELECT run_id, parent_id, spans FROM runs"
+            ).fetchall()
+        except sqlite3.OperationalError:
+            return []
+        finally:
+            conn.close()
+        return [
+            {"run_id": r[0], "parent_id": r[1], "spans": json.loads(r[2])}
+            for r in rows
+        ]
+
+    script_setup = textwrap.dedent(
+        f"""
+        from pathlib import Path
+        from timbal.state.tracing.providers.sqlite import SqliteTracingProvider
+        TRACE_PATH = Path(r"{path}")
+        provider = SqliteTracingProvider.configured(_path=TRACE_PATH)
+        """
+    ).strip()
+    return _Backend("sqlite", path, provider, load, script_setup)
+
+
+@pytest.fixture(params=["jsonl", "sqlite"])
+def backend(request, tmp_path) -> _Backend:
+    return {
+        "jsonl": _make_jsonl_backend,
+        "sqlite": _make_sqlite_backend,
+    }[request.param](tmp_path)
+
+
+def _agent_with_tool(provider, *, responses, tool_name, handler, requires_approval=True):
+    tool = Tool(name=tool_name, handler=handler, requires_approval=requires_approval)
+    return Agent(
+        name="cross_process_agent",
+        model=TestModel(responses=responses),
+        tools=[tool],
+        tracing_provider=provider,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Single tool gate
+# ---------------------------------------------------------------------------
+
+
+class TestSingleToolGate:
+    @pytest.mark.asyncio
+    async def test_gate_persists_then_resumes_from_durable_store(self, backend):
+        """Turn 1 hits the gate, turn 2 resumes via parent_id + decision.
+
+        The provider's ``get()`` only reads from disk/SQLite, so the second
+        run cannot rely on any in-memory state from turn 1.
+        """
+        calls: list[int] = []
+
+        def wire(amount: int) -> str:
+            calls.append(amount)
+            return f"wired {amount}"
+
+        agent = _agent_with_tool(
+            backend.provider,
+            responses=[
+                Message(
+                    role="assistant",
+                    content=[ToolUseContent(id="t1", name="wire", input={"amount": 500})],
+                    stop_reason="tool_use",
+                ),
+                "done",
+            ],
+            tool_name="wire",
+            handler=wire,
+        )
+
+        events1 = [e async for e in agent(prompt="wire 500")]
+        approvals = _approval_events(events1)
+        out1 = _final_output(events1)
+
+        assert out1.status.code == "cancelled"
+        assert out1.status.reason == "approval_required"
+        assert len(approvals) == 1
+        assert calls == []
+
+        # Sanity: trace really hit durable storage before we resume.
+        assert backend.path.exists()
+        records = backend.load_records()
+        assert any(r["run_id"] == out1.run_id for r in records)
+
+        out2 = await agent(
+            prompt="wire 500",
+            parent_id=out1.run_id,
+            approval_decisions={approvals[0].approval_id: True},
+        ).collect()
+
+        assert out2.status.code == "success", out2.error
+        assert calls == [500], "tool must execute exactly once after resume"
+
+    @pytest.mark.asyncio
+    async def test_denial_persists(self, backend):
+        calls: list[int] = []
+
+        def charge(amount: int) -> str:
+            calls.append(amount)
+            return "charged"
+
+        agent = _agent_with_tool(
+            backend.provider,
+            responses=[
+                Message(
+                    role="assistant",
+                    content=[ToolUseContent(id="t1", name="charge", input={"amount": 999})],
+                    stop_reason="tool_use",
+                ),
+                "I will not charge $999.",
+            ],
+            tool_name="charge",
+            handler=charge,
+        )
+
+        events1 = [e async for e in agent(prompt="charge 999")]
+        approval = _approval_events(events1)[0]
+        out1 = _final_output(events1)
+        assert out1.status.reason == "approval_required"
+
+        out2 = await agent(
+            prompt="charge 999",
+            parent_id=out1.run_id,
+            approval_decisions={
+                approval.approval_id: {"approved": False, "reason": "policy"},
+            },
+        ).collect()
+
+        assert out2.status.code == "success", out2.error
+        assert "will not charge" in out2.output.collect_text().lower()
+        assert calls == [], "denied tool must never execute"
+
+    @pytest.mark.asyncio
+    async def test_pending_approval_recoverable_from_storage_only(self, backend):
+        """A 'queue worker' should be able to discover the pending approval
+        without ever importing the original RunContext — just by reading the
+        durable store and pulling ``metadata['approval']``."""
+
+        def deploy(env: str) -> str:
+            return f"deployed {env}"
+
+        tool = Tool(
+            name="deploy",
+            handler=deploy,
+            requires_approval=True,
+            approval_prompt="Promote to prod?",
+            approval_description="Production deploy",
+        )
+        wf = Workflow(name="deploy_wf", tracing_provider=backend.provider).step(tool)
+
+        events1 = [e async for e in wf(env="prod")]
+        out1 = _final_output(events1)
+        assert out1.status.reason == "approval_required"
+
+        records = backend.load_records()
+        run_record = next(r for r in records if r["run_id"] == out1.run_id)
+        approval_spans = [
+            s for s in run_record["spans"]
+            if (s.get("metadata") or {}).get("approval", {}).get("id")
+        ]
+        assert len(approval_spans) == 1
+        approval_meta = approval_spans[0]["metadata"]["approval"]
+        assert approval_meta["prompt"] == "Promote to prod?"
+        assert approval_meta["description"] == "Production deploy"
+
+        ev_id = _approval_events(events1)[0].approval_id
+        assert approval_meta["id"] == ev_id
+
+
+# ---------------------------------------------------------------------------
+# Expired-resolution
+# ---------------------------------------------------------------------------
+
+
+class TestExpiredResolution:
+    @pytest.mark.asyncio
+    async def test_expired_decision_emits_fresh_event(self, backend):
+        calls: list[int] = []
+
+        def transfer(amount: int) -> str:
+            calls.append(amount)
+            return "ok"
+
+        agent = _agent_with_tool(
+            backend.provider,
+            responses=[
+                Message(
+                    role="assistant",
+                    content=[ToolUseContent(id="t1", name="transfer", input={"amount": 50})],
+                    stop_reason="tool_use",
+                ),
+                Message(
+                    role="assistant",
+                    content=[ToolUseContent(id="t2", name="transfer", input={"amount": 50})],
+                    stop_reason="tool_use",
+                ),
+                "done",
+            ],
+            tool_name="transfer",
+            handler=transfer,
+        )
+
+        events1 = [e async for e in agent(prompt="transfer 50")]
+        approval = _approval_events(events1)[0]
+        out1 = _final_output(events1)
+        assert out1.status.reason == "approval_required"
+
+        already_expired = ApprovalResolution(
+            approved=True,
+            expires_at=int(time.time() * 1000) - 1,
+        )
+        events2 = [
+            e async for e in agent(
+                prompt="transfer 50",
+                parent_id=out1.run_id,
+                approval_decisions={approval.approval_id: already_expired},
+            )
+        ]
+        approvals2 = _approval_events(events2)
+        out2 = _final_output(events2)
+
+        assert out2.status.reason == "approval_required", "expired decision must NOT execute"
+        assert calls == []
+        assert len(approvals2) >= 1
+        assert approvals2[0].approval_id == approval.approval_id
+
+        records = backend.load_records()
+        run2 = next(r for r in records if r["run_id"] == out2.run_id)
+        approval_meta = next(
+            (s["metadata"] or {}).get("approval", {})
+            for s in run2["spans"]
+            if (s.get("metadata") or {}).get("approval", {}).get("id")
+        )
+        assert approval_meta.get("expired") is True
+
+
+# ---------------------------------------------------------------------------
+# Parallel gates
+# ---------------------------------------------------------------------------
+
+
+class TestParallelGatesResume:
+    @pytest.mark.asyncio
+    async def test_workflow_two_parallel_steps_resume_via_storage(self, backend):
+        calls: list[str] = []
+
+        def step_a(x: int) -> str:
+            calls.append(f"a={x}")
+            return "a"
+
+        def step_b(y: int) -> str:
+            calls.append(f"b={y}")
+            return "b"
+
+        a = Tool(name="step_a", handler=step_a, requires_approval=True)
+        b = Tool(name="step_b", handler=step_b, requires_approval=True)
+        wf = Workflow(name="parallel_wf", tracing_provider=backend.provider).step(a).step(b)
+
+        events1 = [e async for e in wf(x=1, y=2)]
+        approvals = _approval_events(events1)
+        out1 = _final_output(events1)
+
+        assert len(approvals) == 2
+        assert out1.status.reason == "approval_required"
+        assert calls == []
+
+        decisions = {a.approval_id: True for a in approvals}
+        out2 = await wf(
+            x=1, y=2,
+            parent_id=out1.run_id,
+            approval_decisions=decisions,
+        ).collect()
+
+        assert out2.status.code == "success", out2.error
+        assert sorted(calls) == ["a=1", "b=2"], "both gated steps must execute on resume"
+
+    @pytest.mark.asyncio
+    async def test_workflow_partial_resume_persists_remaining_gate(self, backend):
+        calls: list[str] = []
+
+        def step_a(x: int) -> str:
+            calls.append(f"a={x}")
+            return "a"
+
+        def step_b(y: int) -> str:
+            calls.append(f"b={y}")
+            return "b"
+
+        a = Tool(name="step_a", handler=step_a, requires_approval=True)
+        b = Tool(name="step_b", handler=step_b, requires_approval=True)
+        wf = Workflow(name="parallel_wf", tracing_provider=backend.provider).step(a).step(b)
+
+        events1 = [e async for e in wf(x=1, y=2)]
+        approvals = {e.runnable_path: e for e in _approval_events(events1)}
+        out1 = _final_output(events1)
+
+        events2 = [
+            e async for e in wf(
+                x=1, y=2,
+                parent_id=out1.run_id,
+                approval_decisions={approvals["parallel_wf.step_a"].approval_id: True},
+            )
+        ]
+        out2 = _final_output(events2)
+        approvals2 = _approval_events(events2)
+
+        assert calls == ["a=1"], "only the approved step must run"
+        assert out2.status.reason == "approval_required"
+
+        records = backend.load_records()
+        run2 = next(r for r in records if r["run_id"] == out2.run_id)
+        pending = [
+            (s.get("metadata") or {}).get("approval", {}).get("id")
+            for s in run2["spans"]
+            if (
+                isinstance(s.get("status"), dict)
+                and s["status"].get("code") == "cancelled"
+                and s["status"].get("reason") == "approval_required"
+            )
+        ]
+        assert approvals["parallel_wf.step_b"].approval_id in pending
+        assert {a.approval_id for a in approvals2} == {
+            approvals["parallel_wf.step_b"].approval_id
+        }
+
+
+# ---------------------------------------------------------------------------
+# True process restart — second Python interpreter resumes through storage.
+# ---------------------------------------------------------------------------
+
+
+_GATE_BODY = textwrap.dedent(
+    """
+    import asyncio, json, sys
+    from pathlib import Path
+    from timbal import Agent, Tool
+    from timbal.core.test_model import TestModel
+    from timbal.types.content import ToolUseContent
+    from timbal.types.events import ApprovalEvent
+    from timbal.types.message import Message
+
+    SIDE_EFFECT_FILE = Path(sys.argv[1])
+
+    def wire(amount: int) -> str:
+        SIDE_EFFECT_FILE.write_text(f"wired {amount}")
+        return f"wired {amount}"
+
+    agent = Agent(
+        name="cp_agent",
+        model=TestModel(responses=[
+            Message(
+                role="assistant",
+                content=[ToolUseContent(id="t1", name="wire", input={"amount": 42})],
+                stop_reason="tool_use",
+            ),
+            "done",
+        ]),
+        tools=[Tool(name="wire", handler=wire, requires_approval=True)],
+        tracing_provider=provider,
+    )
+
+    async def main():
+        approval_id = None
+        run_id = None
+        async for event in agent(prompt="wire 42"):
+            if isinstance(event, ApprovalEvent):
+                approval_id = event.approval_id
+                run_id = event.run_id
+        sys.stdout.write(
+            "<<<RESULT>>>"
+            + json.dumps({"approval_id": approval_id, "run_id": run_id})
+            + "<<<END>>>"
+        )
+
+    asyncio.run(main())
+    """
+).strip()
+
+
+_RESUME_BODY = textwrap.dedent(
+    """
+    import asyncio, sys
+    from pathlib import Path
+    from timbal import Agent, Tool
+    from timbal.core.test_model import TestModel
+    from timbal.types.content import ToolUseContent
+    from timbal.types.message import Message
+
+    SIDE_EFFECT_FILE = Path(sys.argv[1])
+    RUN_ID = sys.argv[2]
+    APPROVAL_ID = sys.argv[3]
+
+    def wire(amount: int) -> str:
+        SIDE_EFFECT_FILE.write_text(f"wired {amount}")
+        return f"wired {amount}"
+
+    agent = Agent(
+        name="cp_agent",
+        model=TestModel(responses=[
+            Message(
+                role="assistant",
+                content=[ToolUseContent(id="t1", name="wire", input={"amount": 42})],
+                stop_reason="tool_use",
+            ),
+            "done",
+        ]),
+        tools=[Tool(name="wire", handler=wire, requires_approval=True)],
+        tracing_provider=provider,
+    )
+
+    async def main():
+        out = await agent(
+            prompt="wire 42",
+            parent_id=RUN_ID,
+            approval_decisions={APPROVAL_ID: True},
+        ).collect()
+        sys.stdout.write("<<<RESULT>>>" + out.status.code + "<<<END>>>")
+
+    asyncio.run(main())
+    """
+).strip()
+
+
+def _extract_result(stdout: str) -> str:
+    start = stdout.find("<<<RESULT>>>")
+    end = stdout.find("<<<END>>>")
+    assert start != -1 and end != -1, f"sentinel not found in stdout:\n{stdout}"
+    return stdout[start + len("<<<RESULT>>>"):end]
+
+
+class TestRealSubprocessResume:
+    """Hard proof: gate happens in process A, resume happens in process B.
+
+    Parametrised across both durable-store backends.
+    """
+
+    def test_gate_in_one_process_resume_in_another(self, backend, tmp_path):
+        side_effect = tmp_path / "side_effect.txt"
+        gate_script = backend.script_setup + "\n" + _GATE_BODY
+        resume_script = backend.script_setup + "\n" + _RESUME_BODY
+
+        gate = subprocess.run(  # noqa: S603
+            [sys.executable, "-c", gate_script, str(side_effect)],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        payload = json.loads(_extract_result(gate.stdout))
+        assert payload["approval_id"], gate.stderr
+        assert payload["run_id"], gate.stderr
+        assert backend.path.exists(), gate.stderr
+        assert not side_effect.exists(), "tool must NOT have run before approval"
+
+        resume = subprocess.run(  # noqa: S603
+            [
+                sys.executable, "-c", resume_script,
+                str(side_effect),
+                payload["run_id"], payload["approval_id"],
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert _extract_result(resume.stdout) == "success", resume.stderr
+        assert side_effect.read_text() == "wired 42", "tool must run after cross-process resume"

--- a/python/tests/core/test_approval_double_resume.py
+++ b/python/tests/core/test_approval_double_resume.py
@@ -1,0 +1,194 @@
+# ruff: noqa: ARG001, ARG005 — test handlers declare params for schema, do not consume them
+"""Double-resume protection for approval gates.
+
+The dangerous race is:
+
+    1. process A hits approval_required and persists the parent trace
+    2. two queue workers both receive the same approval_id
+    3. both call the runnable with parent_id=<gate_run_id> and approved=True
+
+Without a durable claim on ``(parent_id, approval_id)``, both workers execute
+the gated handler. For irreversible tools (charge card, delete data, deploy)
+that defeats the point of HITL.
+
+These tests pin the provider contract for durable tracing providers:
+
+- first resume claims the approval and executes
+- later/concurrent duplicate resumes stop before the handler
+- claim works through agent-mediated pending tool execution, not just direct tools
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+from timbal import Agent, Tool
+from timbal.core.test_model import TestModel
+from timbal.state.tracing.providers.jsonl import JsonlTracingProvider
+from timbal.state.tracing.providers.sqlite import SqliteTracingProvider
+from timbal.types.content import ToolUseContent
+from timbal.types.events import ApprovalEvent, OutputEvent
+from timbal.types.message import Message
+
+
+class _Backend:
+    def __init__(self, name: str, path: Path, provider):
+        self.name = name
+        self.path = path
+        self.provider = provider
+
+
+@pytest.fixture(params=["jsonl", "sqlite"])
+def backend(request, tmp_path) -> _Backend:
+    if request.param == "jsonl":
+        path = tmp_path / "traces.jsonl"
+        return _Backend("jsonl", path, JsonlTracingProvider.configured(_path=path))
+    path = tmp_path / "traces.db"
+    return _Backend("sqlite", path, SqliteTracingProvider.configured(_path=path))
+
+
+def _approval_event(events) -> ApprovalEvent:
+    return next(e for e in events if isinstance(e, ApprovalEvent))
+
+
+def _final_output(events) -> OutputEvent:
+    return next(e for e in reversed(events) if isinstance(e, OutputEvent))
+
+
+def _claim_count(backend: _Backend) -> int:
+    if backend.name == "jsonl":
+        claims_path = backend.path.with_suffix(backend.path.suffix + ".approval_claims.json")
+        if not claims_path.exists():
+            return 0
+        return len(json.loads(claims_path.read_text() or "{}"))
+
+    conn = sqlite3.connect(backend.path)
+    try:
+        return conn.execute("SELECT COUNT(*) FROM approval_claims").fetchone()[0]
+    finally:
+        conn.close()
+
+
+class TestDirectToolDoubleResume:
+    @pytest.mark.asyncio
+    async def test_second_resume_does_not_execute_handler(self, backend):
+        calls: list[int] = []
+
+        def charge(amount: int) -> str:
+            calls.append(amount)
+            return f"charged {amount}"
+
+        tool = Tool(
+            name="charge",
+            handler=charge,
+            requires_approval=True,
+            tracing_provider=backend.provider,
+        )
+
+        events = [e async for e in tool(amount=100)]
+        approval = _approval_event(events)
+        parent_id = _final_output(events).run_id
+
+        first = await tool(
+            amount=100,
+            parent_id=parent_id,
+            approval_decisions={approval.approval_id: True},
+        ).collect()
+        second = await tool(
+            amount=100,
+            parent_id=parent_id,
+            approval_decisions={approval.approval_id: True},
+        ).collect()
+
+        assert first.status.code == "success"
+        assert second.status.code == "cancelled"
+        assert second.status.reason == "approval_already_claimed"
+        assert calls == [100]
+        assert _claim_count(backend) == 1
+
+    @pytest.mark.asyncio
+    async def test_concurrent_resumes_only_execute_once(self, backend):
+        calls: list[int] = []
+
+        async def charge(amount: int) -> str:
+            calls.append(amount)
+            await asyncio.sleep(0.05)
+            return f"charged {amount}"
+
+        tool = Tool(
+            name="charge",
+            handler=charge,
+            requires_approval=True,
+            tracing_provider=backend.provider,
+        )
+
+        events = [e async for e in tool(amount=200)]
+        approval = _approval_event(events)
+        parent_id = _final_output(events).run_id
+
+        async def resume_once():
+            return await tool(
+                amount=200,
+                parent_id=parent_id,
+                approval_decisions={approval.approval_id: True},
+            ).collect()
+
+        out_a, out_b = await asyncio.gather(resume_once(), resume_once())
+        reasons = sorted((out_a.status.reason, out_b.status.reason), key=lambda x: x or "")
+        codes = sorted((out_a.status.code, out_b.status.code))
+
+        assert calls == [200]
+        assert codes == ["cancelled", "success"]
+        assert reasons == [None, "approval_already_claimed"]
+        assert _claim_count(backend) == 1
+
+
+class TestAgentToolDoubleResume:
+    @pytest.mark.asyncio
+    async def test_duplicate_agent_resume_does_not_execute_tool_twice(self, backend):
+        calls: list[int] = []
+
+        def charge(amount: int) -> str:
+            calls.append(amount)
+            return f"charged {amount}"
+
+        tool = Tool(name="charge", handler=charge, requires_approval=True)
+        agent = Agent(
+            name="agent",
+            model=TestModel(
+                responses=[
+                    Message(
+                        role="assistant",
+                        content=[ToolUseContent(id="t1", name="charge", input={"amount": 300})],
+                        stop_reason="tool_use",
+                    ),
+                    "done",
+                ]
+            ),
+            tools=[tool],
+            tracing_provider=backend.provider,
+        )
+
+        events = [e async for e in agent(prompt="charge 300")]
+        approval = _approval_event(events)
+        parent_id = _final_output(events).run_id
+
+        first = await agent(
+            prompt="charge 300",
+            parent_id=parent_id,
+            approval_decisions={approval.approval_id: True},
+        ).collect()
+        second = await agent(
+            prompt="charge 300",
+            parent_id=parent_id,
+            approval_decisions={approval.approval_id: True},
+        ).collect()
+
+        assert first.status.code == "success"
+        assert second.status.code == "success"
+        assert calls == [300]
+        assert _claim_count(backend) == 1

--- a/python/tests/core/test_approval_redaction.py
+++ b/python/tests/core/test_approval_redaction.py
@@ -1,0 +1,398 @@
+# ruff: noqa: ARG001, ARG005 — test handlers declare params for schema, do not consume them
+"""Approval input redaction.
+
+A tool gated on a sensitive input (password, api_key, PII, etc.) currently
+leaks the raw input through three public surfaces:
+
+    1. :class:`ApprovalEvent.input` — sent to UI / queue worker.
+    2. :attr:`Span.input` (and ``span._input_dump``) — written to disk by
+       every tracing provider, forwarded to OTel/Langfuse exporters.
+    3. ``span.metadata['approval']['input']`` — the human-facing snapshot
+       a UI uses to render "Approve this action?".
+
+Redaction must:
+
+- Apply only when the runnable goes through the approval gate. Non-gated
+  runs are untouched (handler still gets the full input verbatim).
+- Apply to **all** public surfaces above. Any one leak defeats the point.
+- Survive a JSONL/SQLite round-trip — the persisted trace must contain
+  only redacted values.
+- **Not** affect the ``approval_id``: it stays derived from the unredacted
+  validated input so that resume calls (which carry the full input)
+  match the original gate's id.
+- **Not** affect the handler invocation on resume — the handler always
+  receives the full validated input.
+
+Two ways to opt in:
+
+- ``approval_redactor=callable`` — full control; receives validated input,
+  returns a redacted dict.
+- ``approval_redact_keys=["api_key", ...]`` — ergonomic shortcut; listed
+  keys are masked with ``"***"``.
+
+When both are set, the callable wins.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from timbal import Agent, Tool, Workflow
+from timbal.core.test_model import TestModel
+from timbal.state.tracing.providers.jsonl import JsonlTracingProvider
+from timbal.types.content import ToolUseContent
+from timbal.types.events import ApprovalEvent, OutputEvent
+from timbal.types.message import Message
+
+
+def _approval_event(events) -> ApprovalEvent:
+    return next(e for e in events if isinstance(e, ApprovalEvent))
+
+
+def _final_output(events) -> OutputEvent:
+    return next(e for e in reversed(events) if isinstance(e, OutputEvent))
+
+
+# ---------------------------------------------------------------------------
+# Tool-level redaction
+# ---------------------------------------------------------------------------
+
+
+class TestToolRedactor:
+    @pytest.mark.asyncio
+    async def test_redactor_masks_event_and_span_input(self):
+        seen: list[dict] = []
+
+        def rotate(api_key: str, env: str) -> str:
+            seen.append({"api_key": api_key, "env": env})
+            return "rotated"
+
+        tool = Tool(
+            name="rotate",
+            handler=rotate,
+            requires_approval=True,
+            approval_redactor=lambda inp: {**inp, "api_key": "***"},
+        )
+
+        events = [e async for e in tool(api_key="SECRET_KEY", env="prod")]
+        approval = _approval_event(events)
+        gated = _final_output(events)
+
+        # 1. Event surface
+        assert approval.input == {"api_key": "***", "env": "prod"}, (
+            f"ApprovalEvent.input must be redacted, got {approval.input}"
+        )
+
+        # 2. Span surface: cancelled gate persists redacted input
+        assert "SECRET_KEY" not in json.dumps(gated.input, default=str), (
+            "OutputEvent.input must not leak the secret"
+        )
+
+        # 3. Resume passes full input, handler runs with full input
+        approved = await tool(
+            api_key="SECRET_KEY",
+            env="prod",
+            approval_decisions={approval.approval_id: True},
+        ).collect()
+        assert approved.status.code == "success"
+        assert seen == [{"api_key": "SECRET_KEY", "env": "prod"}], (
+            "handler must receive the full unredacted input"
+        )
+
+    @pytest.mark.asyncio
+    async def test_redact_keys_shortcut_masks_listed_keys(self):
+        def op(amount: int, api_key: str, password: str) -> str:
+            return "ok"
+
+        tool = Tool(
+            name="op",
+            handler=op,
+            requires_approval=True,
+            approval_redact_keys=["api_key", "password"],
+        )
+
+        events = [e async for e in tool(amount=42, api_key="K", password="P")]
+        approval = _approval_event(events)
+
+        assert approval.input == {"amount": 42, "api_key": "***", "password": "***"}
+
+    @pytest.mark.asyncio
+    async def test_redactor_does_not_change_approval_id(self):
+        """approval_id must stay derived from the unredacted input so the
+        resume call (which carries the full input) matches."""
+        tool_unredacted = Tool(
+            name="t",
+            handler=lambda secret: "ok",
+            requires_approval=True,
+        )
+        tool_redacted = Tool(
+            name="t",
+            handler=lambda secret: "ok",
+            requires_approval=True,
+            approval_redactor=lambda inp: {"secret": "***"},
+        )
+
+        events_a = [e async for e in tool_unredacted(secret="foo")]
+        events_b = [e async for e in tool_redacted(secret="foo")]
+
+        id_a = _approval_event(events_a).approval_id
+        id_b = _approval_event(events_b).approval_id
+        assert id_a == id_b, "redaction must not change approval_id"
+
+    @pytest.mark.asyncio
+    async def test_redactor_exception_falls_back_safely(self):
+        """A buggy redactor must not crash the gate — fall back to a
+        placeholder so the secret still doesn't leak."""
+
+        def boom(_inp):
+            raise RuntimeError("redactor blew up")
+
+        tool = Tool(
+            name="op",
+            handler=lambda api_key: "ok",
+            requires_approval=True,
+            approval_redactor=boom,
+        )
+
+        events = [e async for e in tool(api_key="LEAK_ME")]
+        approval = _approval_event(events)
+
+        assert "LEAK_ME" not in json.dumps(approval.input, default=str), (
+            "buggy redactor must NOT cause secret to leak"
+        )
+
+    @pytest.mark.asyncio
+    async def test_redactor_returning_non_dict_falls_back_safely(self):
+        tool = Tool(
+            name="op",
+            handler=lambda api_key: "ok",
+            requires_approval=True,
+            approval_redactor=lambda _inp: "not a dict",  # type: ignore[arg-type]
+        )
+
+        events = [e async for e in tool(api_key="LEAK_ME")]
+        approval = _approval_event(events)
+
+        assert "LEAK_ME" not in json.dumps(approval.input, default=str)
+
+    @pytest.mark.asyncio
+    async def test_redactor_takes_precedence_over_redact_keys(self):
+        tool = Tool(
+            name="op",
+            handler=lambda a, b: "ok",
+            requires_approval=True,
+            approval_redactor=lambda inp: {"only": "callable_won"},
+            approval_redact_keys=["a", "b"],
+        )
+
+        events = [e async for e in tool(a="x", b="y")]
+        approval = _approval_event(events)
+        assert approval.input == {"only": "callable_won"}
+
+    @pytest.mark.asyncio
+    async def test_no_redaction_without_requires_approval(self):
+        """Redaction is a property of the gate. If the runnable doesn't
+        gate, span.input keeps the full input (the redactor is inert)."""
+        tool = Tool(
+            name="op",
+            handler=lambda x: "ok",
+            requires_approval=False,
+            approval_redactor=lambda inp: {"x": "***"},
+        )
+
+        out = await tool(x="visible").collect()
+        assert out.status.code == "success"
+        # No approval event was emitted; nothing to assert on event input.
+        # Span input on an ungated run is left alone.
+        assert "visible" in json.dumps(out.input, default=str)
+
+
+# ---------------------------------------------------------------------------
+# Span / metadata / pending_approvals surface
+# ---------------------------------------------------------------------------
+
+
+class TestSpanAndMetadataRedaction:
+    @pytest.mark.asyncio
+    async def test_span_metadata_approval_carries_redacted_input(self):
+        """``span.metadata['approval']['input']`` is the snapshot a UI
+        renders — it must NOT contain the secret."""
+        tool = Tool(
+            name="op",
+            handler=lambda token: "ok",
+            requires_approval=True,
+            approval_redact_keys=["token"],
+        )
+        wf = Workflow(name="wf").step(tool)
+
+        out = await wf(token="LEAK_ME").collect()
+
+        # OutputEvent.metadata.pending_approvals is what `.collect()` exposes.
+        pending = (out.metadata or {}).get("pending_approvals", [])
+        assert pending, "expected at least one pending approval"
+        for entry in pending:
+            assert "LEAK_ME" not in json.dumps(entry, default=str), (
+                f"pending_approvals leaked secret: {entry}"
+            )
+            assert entry["input"] == {"token": "***"}
+
+    @pytest.mark.asyncio
+    async def test_jsonl_persisted_span_input_is_redacted(self, tmp_path: Path):
+        """Calling the gated tool directly (no workflow wrapper) so the
+        only span that sees the secret is the tool's, and redaction must
+        scrub that specific span before disk write.
+
+        Wrapping in a workflow would persist the workflow's own span.input
+        unredacted (the caller passed the secret to the workflow directly);
+        that's a separate concern from gate-surface redaction."""
+        traces = tmp_path / "traces.jsonl"
+        provider = JsonlTracingProvider.configured(_path=traces)
+
+        tool = Tool(
+            name="op",
+            handler=lambda api_key, env: "ok",
+            requires_approval=True,
+            approval_redact_keys=["api_key"],
+            tracing_provider=provider,
+        )
+
+        await tool(api_key="LEAK_ME", env="prod").collect()
+
+        raw = traces.read_text()
+        assert raw, "expected JSONL to be written"
+        assert "LEAK_ME" not in raw, (
+            "secret leaked into the JSONL trace; redaction must apply to "
+            "span.input (and span._input_dump) not just the in-memory event"
+        )
+        record = json.loads(raw.splitlines()[-1])
+        op_span = next(s for s in record["spans"] if s["path"] == "op")
+        assert op_span["input"] == {"api_key": "***", "env": "prod"}
+
+
+# ---------------------------------------------------------------------------
+# Agent-mediated tool calls
+# ---------------------------------------------------------------------------
+
+
+class TestAgentToolRedaction:
+    @pytest.mark.asyncio
+    async def test_agent_tool_call_redacts_event_and_span_but_handler_gets_full(self):
+        seen: list[dict] = []
+
+        def wire(amount: int, account: str, api_key: str) -> str:
+            seen.append({"amount": amount, "account": account, "api_key": api_key})
+            return "wired"
+
+        tool = Tool(
+            name="wire",
+            handler=wire,
+            requires_approval=True,
+            approval_redact_keys=["api_key"],
+        )
+        agent = Agent(
+            name="bank_agent",
+            model=TestModel(
+                responses=[
+                    Message(
+                        role="assistant",
+                        content=[
+                            ToolUseContent(
+                                id="t1",
+                                name="wire",
+                                input={"amount": 500, "account": "A1", "api_key": "K"},
+                            ),
+                        ],
+                        stop_reason="tool_use",
+                    ),
+                    "done",
+                ]
+            ),
+            tools=[tool],
+        )
+
+        events = [e async for e in agent(prompt="please wire 500")]
+        approval = _approval_event(events)
+        assert approval.input == {"amount": 500, "account": "A1", "api_key": "***"}
+
+        approved = await agent(
+            prompt="please wire 500",
+            approval_decisions={approval.approval_id: True},
+        ).collect()
+        assert approved.status.code == "success"
+        assert seen == [{"amount": 500, "account": "A1", "api_key": "K"}]
+
+
+# ---------------------------------------------------------------------------
+# Cross-process: secret must not survive disk round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestCrossProcessRedaction:
+    @pytest.mark.asyncio
+    async def test_secret_never_lands_on_disk_then_resumes_via_jsonl(self, tmp_path: Path):
+        traces = tmp_path / "traces.jsonl"
+        provider = JsonlTracingProvider.configured(_path=traces)
+
+        seen: list[dict] = []
+
+        def rotate(api_key: str, env: str) -> str:
+            seen.append({"api_key": api_key, "env": env})
+            return f"rotated {env}"
+
+        tool = Tool(
+            name="rotate",
+            handler=rotate,
+            requires_approval=True,
+            approval_redact_keys=["api_key"],
+        )
+        agent = Agent(
+            name="ops_agent",
+            model=TestModel(
+                responses=[
+                    Message(
+                        role="assistant",
+                        content=[
+                            ToolUseContent(
+                                id="t1",
+                                name="rotate",
+                                input={"api_key": "TOPSECRET", "env": "prod"},
+                            ),
+                        ],
+                        stop_reason="tool_use",
+                    ),
+                    "done",
+                ]
+            ),
+            tools=[tool],
+            tracing_provider=provider,
+        )
+
+        events1 = [e async for e in agent(prompt="rotate prod")]
+        approval = _approval_event(events1)
+        out1 = _final_output(events1)
+
+        # Disk must not contain the secret in the gated tool's span.input.
+        raw = traces.read_text()
+        assert raw
+        op_record = json.loads(
+            next(line for line in raw.splitlines()
+                 if json.loads(line)["run_id"] == out1.run_id)
+        )
+        op_span = next(s for s in op_record["spans"] if s["path"] == "ops_agent.rotate")
+        assert op_span["input"] == {"api_key": "***", "env": "prod"}, (
+            f"persisted span.input leaked secret: {op_span['input']}"
+        )
+        assert "TOPSECRET" not in json.dumps(op_span, default=str)
+
+        # Resume from a separate parent_id; tool MUST run with full secret.
+        out2 = await agent(
+            prompt="rotate prod",
+            parent_id=out1.run_id,
+            approval_decisions={approval.approval_id: True},
+        ).collect()
+        assert out2.status.code == "success", out2.error
+        assert seen == [{"api_key": "TOPSECRET", "env": "prod"}], (
+            "handler must run with full unredacted input on cross-process resume"
+        )

--- a/python/tests/core/test_approval_regressions.py
+++ b/python/tests/core/test_approval_regressions.py
@@ -1,0 +1,669 @@
+"""Regression tests for the human-in-the-loop approval gate.
+
+Each test in this file targets a *specific* known bug or API gap in the
+current HITL implementation. They are written to **fail** on the current
+code and pass once the corresponding fix is applied. Keep them isolated:
+one bug per test, with assertion messages that explain the failure.
+
+Order roughly matches severity — critical correctness bugs first, then
+UX/observability gaps.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from timbal import Agent, Tool, Workflow
+from timbal.core.test_model import TestModel
+from timbal.state.tracing.providers.in_memory import InMemoryTracingProvider
+from timbal.types.content import ToolUseContent
+from timbal.types.events import ApprovalEvent, OutputEvent
+from timbal.types.message import Message
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _approval_event(events) -> ApprovalEvent:
+    return next(e for e in events if isinstance(e, ApprovalEvent))
+
+
+def _approval_events(events) -> list[ApprovalEvent]:
+    return [e for e in events if isinstance(e, ApprovalEvent)]
+
+
+def _final_output(events) -> OutputEvent:
+    return next(e for e in reversed(events) if isinstance(e, OutputEvent))
+
+
+def _stored_span(run_id: str):
+    """Return the root span for ``run_id`` from the in-memory provider."""
+    trace = InMemoryTracingProvider._storage[run_id]
+    # Root span has parent_call_id None.
+    for span in trace.values():
+        if span.parent_call_id is None:
+            return span
+    raise AssertionError(f"No root span for run_id={run_id!r}")
+
+
+def _span_at_path(run_id: str, path: str):
+    trace = InMemoryTracingProvider._storage[run_id]
+    matches = [s for s in trace.values() if s.path == path]
+    assert matches, f"No span at path={path!r} for run_id={run_id!r}"
+    assert len(matches) == 1, f"Multiple spans at path={path!r}: {matches}"
+    return matches[0]
+
+
+# ---------------------------------------------------------------------------
+# 1. Critical: breaking the stream after ApprovalEvent corrupts stored status
+# ---------------------------------------------------------------------------
+
+
+class TestStreamBreakPreservesApprovalStatus:
+    """Real consumers `break` after seeing ApprovalEvent. The stored span
+    must still report status=cancelled/approval_required so consumers and
+    OTel dashboards can identify pending approvals via the trace alone."""
+
+    @pytest.mark.asyncio
+    async def test_tool_break_on_approval_event(self):
+        def dangerous(x: int) -> int:
+            return x
+
+        tool = Tool(name="dangerous", handler=dangerous, requires_approval=True)
+
+        run_id: str | None = None
+        async for event in tool(x=1):
+            if event.type == "START":
+                run_id = event.run_id
+            if isinstance(event, ApprovalEvent):
+                break
+
+        assert run_id is not None
+        # Give the generator-finalisation path time to run.
+        await asyncio.sleep(0.05)
+
+        span = _stored_span(run_id)
+        assert span.status.code == "cancelled", (
+            f"Expected stored span code 'cancelled', got {span.status.code!r}"
+        )
+        assert span.status.reason == "approval_required", (
+            f"Expected stored span reason 'approval_required' after stream break, "
+            f"got {span.status.reason!r}. Status is set *after* the yield, so "
+            f"GeneratorExit clobbers it with 'interrupted'."
+        )
+        # The metadata side already records approval info correctly — the bug
+        # is purely in span.status.
+        assert span.metadata["approval"]["required"] is True
+
+    @pytest.mark.asyncio
+    async def test_agent_break_on_approval_event(self):
+        """Same bug surfaces at agent level when a tool gates."""
+        tool = Tool(
+            name="risky",
+            handler=lambda x: f"did {x}",
+            requires_approval=True,
+        )
+        agent = Agent(
+            name="agent",
+            model=TestModel(
+                responses=[
+                    Message(
+                        role="assistant",
+                        content=[ToolUseContent(id="c1", name="risky", input={"x": 1})],
+                        stop_reason="tool_use",
+                    ),
+                ],
+            ),
+            tools=[tool],
+        )
+
+        run_id: str | None = None
+        async for event in agent(prompt="run"):
+            if event.type == "START" and event.path == "agent":
+                run_id = event.run_id
+            if isinstance(event, ApprovalEvent):
+                break
+
+        assert run_id is not None
+        await asyncio.sleep(0.05)
+
+        span = _stored_span(run_id)
+        assert span.status.reason == "approval_required", (
+            f"Agent root span lost approval_required status on stream break: "
+            f"{span.status!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_workflow_break_propagates_approval_status_to_step_span(self):
+        """Workflow with one gating step: break on the step's ApprovalEvent and
+        verify the *step* span (not just root) records approval_required."""
+        wf = Workflow(name="wf").step(
+            Tool(name="step_a", handler=lambda x: x, requires_approval=True),
+            x=1,
+        )
+
+        run_id: str | None = None
+        async for event in wf():
+            if event.type == "START" and event.path == "wf":
+                run_id = event.run_id
+            if isinstance(event, ApprovalEvent):
+                break
+
+        assert run_id is not None
+        await asyncio.sleep(0.05)
+
+        step_span = _span_at_path(run_id, "wf.step_a")
+        assert step_span.status.reason == "approval_required", (
+            f"Step span at wf.step_a lost approval_required after break: "
+            f"{step_span.status!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_break_does_not_clear_approval_metadata(self):
+        """Even on break, span.metadata['approval'] must record the id+prompt
+        so a server can reconstruct the approval from the trace alone."""
+        tool = Tool(
+            name="t",
+            handler=lambda x: x,
+            requires_approval=True,
+            approval_prompt="ok?",
+        )
+        approval_id_seen = None
+        run_id = None
+        async for event in tool(x=42):
+            if event.type == "START":
+                run_id = event.run_id
+            if isinstance(event, ApprovalEvent):
+                approval_id_seen = event.approval_id
+                break
+
+        assert approval_id_seen is not None
+        await asyncio.sleep(0.05)
+
+        span = _stored_span(run_id)
+        assert span.metadata["approval"]["id"] == approval_id_seen
+        assert span.metadata["approval"]["prompt"] == "ok?"
+        assert span.status.code == "cancelled"
+        assert span.status.reason == "approval_required"
+
+
+# ---------------------------------------------------------------------------
+# 2. Critical: multi-turn agent loses memory + tool never executes on resume
+# ---------------------------------------------------------------------------
+
+
+class TestMultiTurnApprovalResume:
+    """Resuming an agent with parent_id + approval_decisions must run the
+    gated tool *with* the prior conversation history intact. Currently the
+    early-return in resolve_memory drops all memory and the LLM may never
+    re-emit the same tool call."""
+
+    @pytest.mark.asyncio
+    async def test_resume_executes_gated_tool_after_multi_turn_history(self):
+        calls: list[int] = []
+
+        def risky(x: int) -> str:
+            calls.append(x)
+            return f"did {x}"
+
+        tool = Tool(name="risky", handler=risky, requires_approval=True)
+
+        agent = Agent(
+            name="agent",
+            model=TestModel(
+                responses=[
+                    # Turn 1: plain reply (sets up history).
+                    "hello back",
+                    # Turn 2: emit tool_use that will gate.
+                    Message(
+                        role="assistant",
+                        content=[
+                            ToolUseContent(id="c1", name="risky", input={"x": 7})
+                        ],
+                        stop_reason="tool_use",
+                    ),
+                    # Turn 3 resume: any non-tool reply once the tool has run.
+                    "ok done",
+                ],
+            ),
+            tools=[tool],
+        )
+
+        out1 = await agent(prompt="hi").collect()
+        assert out1.status.code == "success"
+
+        events2 = [e async for e in agent(prompt="run risky", parent_id=out1.run_id)]
+        approval = _approval_event(events2)
+        out2 = _final_output(events2)
+        assert out2.status.reason == "approval_required"
+
+        out3 = await agent(
+            prompt="run risky",
+            parent_id=out2.run_id,
+            approval_decisions={approval.approval_id: True},
+        ).collect()
+
+        assert calls == [7], (
+            f"Gated tool must run on resume. Got calls={calls}. The agent "
+            f"loses memory on resume because resolve_memory short-circuits "
+            f"when prev reason=='approval_required', so the LLM never "
+            f"re-emits the tool_use."
+        )
+
+        # And history must still be present in the resumed memory so the LLM
+        # has the original conversation context.
+        span3 = _stored_span(out3.run_id)
+        roles = [m.role for m in span3.memory]
+        assert roles[:2] == ["user", "assistant"], (
+            f"Expected resumed memory to contain prior turn(s), got roles={roles}."
+        )
+
+    @pytest.mark.asyncio
+    async def test_resume_preserves_first_turn_user_prompt_in_memory(self):
+        """Stronger assertion: the actual *user prompt* from turn 1 must
+        survive into turn 3's memory after approval-resume.
+
+        Using the user prompt as the canary makes this test robust against
+        TestModel's response-cycling — only memory loading can put it back.
+        """
+        def risky(x: int) -> str:
+            return f"did {x}"
+
+        tool = Tool(name="risky", handler=risky, requires_approval=True)
+        agent = Agent(
+            name="agent",
+            model=TestModel(
+                responses=[
+                    "ack",
+                    Message(
+                        role="assistant",
+                        content=[ToolUseContent(id="c1", name="risky", input={"x": 1})],
+                        stop_reason="tool_use",
+                    ),
+                    "all done",
+                ],
+            ),
+            tools=[tool],
+        )
+
+        UNIQUE_PROMPT = "ALPHA-UNIQUE-USER-PROMPT-12345"
+        out1 = await agent(prompt=UNIQUE_PROMPT).collect()
+        events2 = [e async for e in agent(prompt="now risky", parent_id=out1.run_id)]
+        approval = _approval_event(events2)
+        out2 = _final_output(events2)
+
+        out3 = await agent(
+            prompt="now risky",
+            parent_id=out2.run_id,
+            approval_decisions={approval.approval_id: True},
+        ).collect()
+
+        span3 = _stored_span(out3.run_id)
+        joined = " ".join(m.collect_text() for m in span3.memory)
+        assert UNIQUE_PROMPT in joined, (
+            f"Turn 1 user prompt missing from resumed memory — memory was "
+            f"reset to just the turn-3 prompt. Memory contents: {joined!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_resume_passes_full_history_to_llm(self):
+        """The strongest possible assertion of this bug: inspect the LLM
+        span on the resumed turn and verify the messages it received contain
+        prior conversation. Today the LLM input on resume is just the new
+        prompt — no history.
+        """
+        def risky(x: int) -> str:
+            return f"did {x}"
+
+        tool = Tool(name="risky", handler=risky, requires_approval=True)
+        agent = Agent(
+            name="agent",
+            model=TestModel(
+                responses=[
+                    "ack",
+                    Message(
+                        role="assistant",
+                        content=[ToolUseContent(id="c1", name="risky", input={"x": 1})],
+                        stop_reason="tool_use",
+                    ),
+                    "done",
+                ],
+            ),
+            tools=[tool],
+        )
+
+        UNIQUE = "BETA-PROMPT-CANARY-XYZ"
+        out1 = await agent(prompt=UNIQUE).collect()
+        events2 = [e async for e in agent(prompt="run risky", parent_id=out1.run_id)]
+        approval = _approval_event(events2)
+        out2 = _final_output(events2)
+
+        out3 = await agent(
+            prompt="run risky",
+            parent_id=out2.run_id,
+            approval_decisions={approval.approval_id: True},
+        ).collect()
+
+        # Find the *first* LLM call in turn 3's trace.
+        trace = InMemoryTracingProvider._storage[out3.run_id]
+        llm_spans = sorted(
+            (s for s in trace.values() if s.path == "agent.llm"),
+            key=lambda s: s.t0,
+        )
+        assert llm_spans, "Expected at least one LLM call on resume."
+        first_llm = llm_spans[0]
+        msgs = first_llm.input["messages"]
+        flat = repr(msgs)
+        assert UNIQUE in flat, (
+            f"Resumed LLM call must receive prior history; got messages "
+            f"that don't contain the turn-1 user prompt. Messages: {msgs}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. pre_hook fires on every gated attempt
+# ---------------------------------------------------------------------------
+
+
+class TestPreHookSemanticsUnderApproval:
+    """pre_hook is supposed to be a stable place for cross-cutting concerns
+    (auth, rate limiting, billing). Today it runs on the *gated* attempt as
+    well as the resumed attempt, so external side effects double-fire for
+    every approval cycle."""
+
+    @pytest.mark.asyncio
+    async def test_pre_hook_runs_only_once_per_logical_call(self):
+        hook_calls: list[int] = []
+
+        def pre() -> None:
+            hook_calls.append(1)
+
+        def handler(x: int) -> int:
+            return x
+
+        tool = Tool(
+            name="t",
+            handler=handler,
+            requires_approval=True,
+            pre_hook=pre,
+        )
+
+        events = [e async for e in tool(x=1)]
+        approval = _approval_event(events)
+        gated_count = len(hook_calls)
+
+        await tool(x=1, approval_decisions={approval.approval_id: True}).collect()
+
+        assert gated_count == 0, (
+            f"pre_hook should not run on the gated attempt (no real work "
+            f"happens), got {gated_count} call(s)."
+        )
+        assert len(hook_calls) == 1, (
+            f"pre_hook should run exactly once across the gate→resume cycle; "
+            f"got {len(hook_calls)} total calls."
+        )
+
+    @pytest.mark.asyncio
+    async def test_pre_hook_does_not_run_when_decision_denies(self):
+        """If the policy denies, pre_hook should not have side-effected. The
+        gated path must short-circuit before pre_hook."""
+        hook_calls: list[int] = []
+
+        def pre() -> None:
+            hook_calls.append(1)
+
+        tool = Tool(
+            name="t",
+            handler=lambda x: x,
+            requires_approval=True,
+            pre_hook=pre,
+        )
+
+        events = [e async for e in tool(x=1)]
+        approval = _approval_event(events)
+
+        await tool(x=1, approval_decisions={approval.approval_id: False}).collect()
+
+        assert hook_calls == [], (
+            f"pre_hook ran on a denied gate cycle — that's an external side "
+            f"effect for an action the user explicitly rejected. Got "
+            f"{len(hook_calls)} call(s)."
+        )
+
+    @pytest.mark.asyncio
+    async def test_pre_hook_runs_once_for_agent_gated_tool(self):
+        """pre_hook on a tool inside an agent should not double-fire when the
+        tool gates and the agent re-runs to resume it."""
+        hook_calls: list[int] = []
+
+        def pre() -> None:
+            hook_calls.append(1)
+
+        tool = Tool(
+            name="risky",
+            handler=lambda x: f"did {x}",
+            requires_approval=True,
+            pre_hook=pre,
+        )
+        agent = Agent(
+            name="agent",
+            model=TestModel(
+                responses=[
+                    Message(
+                        role="assistant",
+                        content=[ToolUseContent(id="c1", name="risky", input={"x": 1})],
+                        stop_reason="tool_use",
+                    ),
+                    "done",
+                ],
+            ),
+            tools=[tool],
+        )
+
+        events = [e async for e in agent(prompt="go")]
+        approval = _approval_event(events)
+
+        await agent(
+            prompt="go",
+            approval_decisions={approval.approval_id: True},
+        ).collect()
+
+        assert len(hook_calls) == 1, (
+            f"Tool pre_hook fired {len(hook_calls)} times across the "
+            f"agent→tool gate→resume cycle. Should be 1."
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. .collect() only surfaces ONE pending approval in concurrent scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestCollectExposesAllPendingApprovals:
+    """A workflow with multiple parallel gating steps emits multiple
+    ApprovalEvents on the stream, but ``.collect()`` consumers see only
+    one approval_id in the OutputEvent.output dict. They have no way to
+    discover the second pending approval without re-running the workflow."""
+
+    @pytest.mark.asyncio
+    async def test_workflow_collect_lists_all_pending_approvals(self):
+        wf = Workflow(name="wf").step(
+            Tool(name="step_a", handler=lambda: "a", requires_approval=True)
+        ).step(
+            Tool(name="step_b", handler=lambda: "b", requires_approval=True)
+        )
+
+        result = await wf().collect()
+        assert result.status.reason == "approval_required"
+
+        pending = None
+        # Accept either output-level or metadata-level surfacing — whichever
+        # the maintainers prefer. Both currently absent.
+        if isinstance(result.output, dict) and "pending_approvals" in result.output:
+            pending = result.output["pending_approvals"]
+        elif "pending_approvals" in (result.metadata or {}):
+            pending = result.metadata["pending_approvals"]
+
+        assert pending is not None, (
+            "OutputEvent must expose all pending approvals when "
+            "status.reason == 'approval_required'. Today only the first "
+            "approval shows up in output, hidden inside a flat dict."
+        )
+        assert len(pending) == 2, (
+            f"Expected 2 pending approvals (step_a, step_b), got {len(pending)}: {pending}"
+        )
+        ids = {entry["approval_id"] if isinstance(entry, dict) else entry.approval_id for entry in pending}
+        assert len(ids) == 2, f"Expected 2 distinct approval_ids, got {ids}"
+
+    @pytest.mark.asyncio
+    async def test_agent_collect_lists_all_concurrent_tool_approvals(self):
+        """Agent multiplexes 2 tool calls in one LLM turn, both gate. The
+        OutputEvent from .collect() should expose both approval_ids; today
+        only the first is reachable from the result."""
+        tool_a = Tool(name="tool_a", handler=lambda: "a", requires_approval=True)
+        tool_b = Tool(name="tool_b", handler=lambda: "b", requires_approval=True)
+        agent = Agent(
+            name="agent",
+            model=TestModel(
+                responses=[
+                    Message(
+                        role="assistant",
+                        content=[
+                            ToolUseContent(id="c1", name="tool_a", input={}),
+                            ToolUseContent(id="c2", name="tool_b", input={}),
+                        ],
+                        stop_reason="tool_use",
+                    ),
+                ],
+            ),
+            tools=[tool_a, tool_b],
+        )
+
+        result = await agent(prompt="parallel").collect()
+        assert result.status.reason == "approval_required"
+
+        pending = None
+        if isinstance(result.output, dict) and "pending_approvals" in result.output:
+            pending = result.output["pending_approvals"]
+        elif "pending_approvals" in (result.metadata or {}):
+            pending = result.metadata["pending_approvals"]
+
+        assert pending is not None and len(pending) == 2, (
+            f"Agent .collect() must expose every concurrent pending approval; "
+            f"got pending={pending}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. ApprovalEvent has no timestamp — SLA tracking impossible from the event
+# ---------------------------------------------------------------------------
+
+
+class TestApprovalEventMetadata:
+    @pytest.mark.asyncio
+    async def test_approval_event_has_request_timestamp(self):
+        tool = Tool(name="t", handler=lambda x: x, requires_approval=True)
+
+        events = [e async for e in tool(x=1)]
+        approval = _approval_event(events)
+
+        timestamp = getattr(approval, "t0", None) or getattr(approval, "requested_at", None)
+        assert timestamp is not None, (
+            "ApprovalEvent should carry a request timestamp so consumers "
+            "can drive SLA timers without joining against the trace store."
+        )
+        assert isinstance(timestamp, int) and timestamp > 0
+
+    @pytest.mark.asyncio
+    async def test_concurrent_approval_event_timestamps_are_ordered(self):
+        """Each ApprovalEvent should carry its *own* timestamp so a UI can
+        sort/group them. Without it they're indistinguishable in time."""
+        wf = (
+            Workflow(name="wf")
+            .step(Tool(name="step_a", handler=lambda: "a", requires_approval=True))
+            .step(Tool(name="step_b", handler=lambda: "b", requires_approval=True))
+        )
+
+        events = [e async for e in wf()]
+        approvals = _approval_events(events)
+        assert len(approvals) == 2
+
+        timestamps = [
+            getattr(a, "t0", None) or getattr(a, "requested_at", None) for a in approvals
+        ]
+        assert all(t is not None for t in timestamps), (
+            f"All ApprovalEvents should carry timestamps; got {timestamps}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 6. Unrecognised approval_decisions are silently dropped
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownApprovalDecisionsAreSurfaced:
+    """If a caller passes an approval_id that doesn't match any gate in the
+    run (typo, stale id replayed against a new trace, mismatched input
+    after a retry), the run still cancels with a fresh ApprovalEvent and
+    the bad id is silently swallowed. Make this debuggable."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_approval_id_logs_warning(self, capfd):
+        """A decision dict with an id that doesn't match any gate should
+        emit a warning so users can detect typos / stale ids.
+
+        The codebase emits via structlog (stderr); capfd grabs both streams.
+        """
+        tool = Tool(name="t", handler=lambda x: x, requires_approval=True)
+
+        events = [e async for e in tool(x=1, approval_decisions={"definitely-not-a-real-id": True})]
+
+        captured = capfd.readouterr()
+        log_text = captured.out + captured.err
+
+        approval = _approval_event(events)
+        assert approval.approval_id != "definitely-not-a-real-id"
+
+        assert (
+            "definitely-not-a-real-id" in log_text
+            or "Unrecognized approval_decisions" in log_text
+        ), (
+            "An approval_decisions entry that matched no gate should produce "
+            "a WARNING. Otherwise typos/stale ids fail silently. "
+            f"Captured output:\n{log_text!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unknown_id_in_mixed_decisions_warns_only_for_unused(self, capfd):
+        """One valid + one invalid decision → only the unused id should warn."""
+        tool = Tool(name="t", handler=lambda x: x, requires_approval=True)
+
+        events = [e async for e in tool(x=1)]
+        approval = _approval_event(events)
+        capfd.readouterr()  # drain the gating call's logs so we only assert the resume call
+
+        result = await tool(
+            x=1,
+            approval_decisions={
+                approval.approval_id: True,
+                "stale-other-id": True,
+            },
+        ).collect()
+
+        captured = capfd.readouterr()
+        log_text = captured.out + captured.err
+
+        assert result.status.code == "success"
+        assert "stale-other-id" in log_text, (
+            "Unused decision ('stale-other-id') should produce a WARNING "
+            "even when other decisions in the same call were valid. "
+            f"Captured output:\n{log_text!r}"
+        )
+        # And conversely the matched id must not be reported as unused.
+        unused_lines = [line for line in log_text.splitlines() if "unused_approval_ids" in line]
+        assert all(approval.approval_id not in line for line in unused_lines), (
+            f"Matched approval_id ({approval.approval_id}) was wrongly "
+            f"flagged as unused. Captured output:\n{log_text!r}"
+        )

--- a/python/tests/core/test_jsonl_tracing_provider.py
+++ b/python/tests/core/test_jsonl_tracing_provider.py
@@ -337,6 +337,27 @@ class TestMemoryDumpJsonlIntegration:
         assert stored_memory == expected, "_memory_dump stored on disk does not match full re-dump"
 
     @pytest.mark.asyncio
+    async def test_jsonl_reloaded_root_span_uses_dict_status_for_memory_chain(self, tmp_path):
+        """Regression: JSONL get() builds Span with status as a dict, not RunStatus;
+        parent_id + turn 2 must not raise (AttributeError) and must succeed.
+
+        (Previously resolve_memory read previous_span.status.code and crashed.)"""
+        from timbal import Agent
+        from timbal.core.test_model import TestModel
+
+        traces_path = tmp_path / "traces.jsonl"
+        provider = JsonlTracingProvider.configured(_path=traces_path)
+        agent = Agent(
+            name="chain_agent",
+            model=TestModel(responses=["r1", "r2"]),
+            tracing_provider=provider,
+        )
+        out1 = await agent(prompt="m0").collect()
+        out2 = await agent(prompt="m1", parent_id=out1.run_id).collect()
+        assert out2.status.code == "success", out2.error
+        assert out2.error is None
+
+    @pytest.mark.asyncio
     async def test_memory_grows_correctly_across_turns(self, tmp_path):
         """Each turn adds exactly 2 messages (user + assistant) to the stored memory."""
         from timbal import Agent

--- a/python/tests/core/test_otel_exporter.py
+++ b/python/tests/core/test_otel_exporter.py
@@ -15,6 +15,7 @@ from timbal.state.tracing.span import Span
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_span(
     call_id: str = "c1",
     path: str = "agent.step",
@@ -25,6 +26,8 @@ def _make_span(
     usage: dict | None = None,
     input_dump=None,
     output_dump=None,
+    metadata: dict | None = None,
+    status=None,
 ) -> Span:
     span = Span(
         path=path,
@@ -34,7 +37,10 @@ def _make_span(
         t1=t1,
         error=error,
         usage=usage or {},
+        metadata=metadata or {},
     )
+    if status is not None:
+        span.status = status
     span._input_dump = input_dump
     span._output_dump = output_dump
     span._memory_dump = None
@@ -74,6 +80,7 @@ async def _drain(exporter: OTelExporter) -> None:
 # ID helpers
 # ---------------------------------------------------------------------------
 
+
 class TestIds:
     def test_trace_id_is_32_hex_chars(self):
         tid = OTelExporter._trace_id("run-abc")
@@ -102,6 +109,7 @@ class TestIds:
 # Time conversion
 # ---------------------------------------------------------------------------
 
+
 class TestTimeConversion:
     def test_ms_to_ns(self):
         assert OTelExporter._ms_to_ns(1_000) == "1000000000"
@@ -116,6 +124,7 @@ class TestTimeConversion:
 # ---------------------------------------------------------------------------
 # Payload construction
 # ---------------------------------------------------------------------------
+
 
 class TestBuildPayload:
     def _exporter(self, service_name="my-svc") -> OTelExporter:
@@ -242,6 +251,74 @@ class TestBuildPayload:
         parsed = json.loads(attr["value"]["stringValue"])
         assert parsed == {"nested": [1, 2]}
 
+    def test_metadata_attribute_present_when_non_empty(self):
+        ctx = _make_run_context(spans=[_make_span(metadata={"type": "Tool"})])
+        payload = self._exporter()._build_payload(ctx)
+        otel_span = payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        attr = {a["key"]: a["value"] for a in otel_span["attributes"]}
+        assert "timbal.metadata" in attr
+        parsed = json.loads(attr["timbal.metadata"]["stringValue"])
+        assert parsed["type"] == "Tool"
+
+    def test_metadata_attribute_absent_when_empty(self):
+        ctx = _make_run_context(spans=[_make_span(metadata={})])
+        payload = self._exporter()._build_payload(ctx)
+        otel_span = payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        keys = {a["key"] for a in otel_span["attributes"]}
+        assert "timbal.metadata" not in keys
+
+    def test_approval_metadata_lifts_to_dedicated_attributes(self):
+        approval_meta = {"approval": {"id": "abc123", "required": True}}
+        ctx = _make_run_context(spans=[_make_span(metadata=approval_meta)])
+        payload = self._exporter()._build_payload(ctx)
+        otel_span = payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        attr = {a["key"]: a["value"]["stringValue"] for a in otel_span["attributes"]}
+        assert attr.get("timbal.approval.id") == "abc123"
+
+    def test_approval_expired_flag_lifts_to_dedicated_attribute(self):
+        approval_meta = {"approval": {"id": "abc123", "expired": True, "expired_at": 12345}}
+        ctx = _make_run_context(spans=[_make_span(metadata=approval_meta)])
+        payload = self._exporter()._build_payload(ctx)
+        otel_span = payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        bool_attr = next(a for a in otel_span["attributes"] if a["key"] == "timbal.approval.expired")
+        assert bool_attr["value"]["boolValue"] is True
+
+    def test_status_code_and_reason_exposed_as_attributes(self):
+        from timbal.types.run_status import RunStatus
+
+        status = RunStatus(code="cancelled", reason="approval_required", message=None)
+        ctx = _make_run_context(spans=[_make_span(status=status)])
+        payload = self._exporter()._build_payload(ctx)
+        otel_span = payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        attr = {a["key"]: a["value"]["stringValue"] for a in otel_span["attributes"]}
+        assert attr["timbal.status.code"] == "cancelled"
+        assert attr["timbal.status.reason"] == "approval_required"
+        # cancelled spans must NOT pollute error dashboards
+        assert otel_span["status"]["code"] == 0
+
+    def test_status_handles_dict_after_reload(self):
+        ctx = _make_run_context(spans=[_make_span(status={"code": "cancelled", "reason": "approval_denied"})])
+        payload = self._exporter()._build_payload(ctx)
+        otel_span = payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        attr = {a["key"]: a["value"]["stringValue"] for a in otel_span["attributes"]}
+        assert attr["timbal.status.reason"] == "approval_denied"
+
+    def test_approval_policy_error_status_is_error(self):
+        from timbal.types.run_status import RunStatus
+
+        ctx = _make_run_context(
+            spans=[
+                _make_span(
+                    status=RunStatus(code="error", reason="approval_policy_error", message="boom"),
+                )
+            ]
+        )
+        payload = self._exporter()._build_payload(ctx)
+        otel_span = payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        attr = {a["key"]: a["value"]["stringValue"] for a in otel_span["attributes"]}
+        assert attr["timbal.status.reason"] == "approval_policy_error"
+        assert otel_span["status"]["code"] == 2  # ERROR
+
     def test_t1_none_falls_back_to_t0(self):
         span = Span(path="p", call_id="c", t0=5_000, t1=None)
         span._input_dump = None
@@ -257,6 +334,7 @@ class TestBuildPayload:
 # ---------------------------------------------------------------------------
 # Resource attributes
 # ---------------------------------------------------------------------------
+
 
 class TestResourceAttributes:
     def test_includes_service_name(self):
@@ -286,6 +364,7 @@ class TestResourceAttributes:
 # Fire-and-forget + client lifecycle
 # ---------------------------------------------------------------------------
 
+
 class TestFireAndForget:
     @pytest.mark.asyncio
     async def test_export_returns_before_post_completes(self):
@@ -293,6 +372,7 @@ class TestFireAndForget:
 
         async def slow_post(*args, **kwargs):
             import asyncio as _asyncio
+
             await _asyncio.sleep(0.05)
             posted.append(True)
             r = MagicMock()
@@ -390,6 +470,7 @@ class TestFireAndForget:
 # Retry logic
 # ---------------------------------------------------------------------------
 
+
 class TestRetry:
     @pytest.mark.asyncio
     async def test_succeeds_on_first_attempt(self):
@@ -450,6 +531,7 @@ class TestRetry:
 # ---------------------------------------------------------------------------
 # HTTP export
 # ---------------------------------------------------------------------------
+
 
 class TestExport:
     @pytest.mark.asyncio

--- a/python/tests/core/test_sqlite_tracing_provider.py
+++ b/python/tests/core/test_sqlite_tracing_provider.py
@@ -462,3 +462,84 @@ class TestSqliteMemoryIntegration:
         assert trace is not None
         agent_span = next(s for s in trace.as_records() if s.path == "chain_agent")
         assert len(agent_span.memory) == 4
+
+    @pytest.mark.asyncio
+    async def test_sqlite_reloaded_root_span_uses_dict_status_for_memory_chain(self, tmp_path):
+        """Regression: SQLite get() builds Span with status as a dict, not RunStatus;
+        parent_id + turn 2 must not raise (AttributeError) and must succeed.
+
+        Mirrors the JSONL regression (resolve_memory previously read
+        previous_span.status.code and crashed when status was a dict).
+        Same risk applies to SQLite: spans are stored as JSON in the spans
+        column, so the reload path also produces dict-shaped status."""
+        from timbal import Agent
+        from timbal.core.test_model import TestModel
+
+        provider = SqliteTracingProvider.configured(_path=tmp_path / "traces.db")
+        agent = Agent(
+            name="chain_agent",
+            model=TestModel(responses=["r1", "r2"]),
+            tracing_provider=provider,
+        )
+        out1 = await agent(prompt="m0").collect()
+        out2 = await agent(prompt="m1", parent_id=out1.run_id).collect()
+        assert out2.status.code == "success", out2.error
+        assert out2.error is None
+
+    @pytest.mark.asyncio
+    async def test_memory_dump_correct_after_sqlite_reload(self, tmp_path):
+        """_memory_dump on turn 2 must equal a fresh dump of the full memory.
+
+        Mirrors the JSONL ``test_memory_dump_correct_after_jsonl_reload``:
+        proves the incremental ``_prev_memory_dump`` optimisation in
+        ``Agent.resolve_memory`` is transparent when spans are reconstructed
+        from the SQLite ``spans`` JSON column rather than carried in memory.
+        """
+        import sqlite3 as _sqlite3
+
+        from timbal import Agent
+        from timbal.core.test_model import TestModel
+        from timbal.types.message import Message
+        from timbal.utils import dump
+
+        db_path = tmp_path / "traces.db"
+        provider = SqliteTracingProvider.configured(_path=db_path)
+
+        turn_count = 0
+
+        def counting_handler(messages):  # noqa: ARG001 — TestModel handler signature
+            nonlocal turn_count
+            turn_count += 1
+            return f"response {turn_count}"
+
+        agent = Agent(
+            name="sqlite_memdump",
+            model=TestModel(handler=counting_handler),
+            tracing_provider=provider,
+        )
+
+        out1 = await agent(prompt="message 0").collect()
+        assert db_path.exists(), "SQLite db should be created after turn 1"
+
+        out2 = await agent(prompt="message 1", parent_id=out1.run_id).collect()
+
+        conn = _sqlite3.connect(str(db_path))
+        try:
+            row = conn.execute(
+                "SELECT spans FROM runs WHERE run_id = ?",
+                (out2.run_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None, "turn 2 row should exist in SQLite"
+        spans = json.loads(row[0])
+        agent_span = next(s for s in spans if s["path"] == "sqlite_memdump")
+        stored_memory = agent_span.get("memory")
+
+        assert stored_memory is not None, "memory should be persisted in turn 2 span"
+        assert len(stored_memory) == 4, (
+            f"Expected 4 messages (user0, assistant0, user1, assistant1), got {len(stored_memory)}"
+        )
+
+        expected = await dump([Message.validate(m) for m in stored_memory])
+        assert stored_memory == expected, "_memory_dump stored in SQLite does not match full re-dump"

--- a/python/timbal/collectors/impl/timbal.py
+++ b/python/timbal/collectors/impl/timbal.py
@@ -8,6 +8,7 @@ except ImportError:
 
 import structlog
 
+from ...types.events.approval import ApprovalEvent as TimbalApprovalEvent
 from ...types.events.base import BaseEvent as TimbalBaseEvent
 from ...types.events.delta import DeltaEvent as TimbalDeltaEvent
 from ...types.events.output import OutputEvent as TimbalOutputEvent
@@ -24,7 +25,12 @@ class TimbalCollector(BaseCollector):
 
     def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)
-        self._output_event = None
+        self._output_event: TimbalOutputEvent | None = None
+        # Capture every approval gate that fires during the stream so callers
+        # of .collect() can react to all pending approvals — not just the
+        # first one — when concurrent runnables (parallel workflow steps,
+        # multiplexed tools) gate on the same iteration.
+        self._pending_approvals: list[dict[str, Any]] = []
 
     @classmethod
     @override
@@ -38,13 +44,41 @@ class TimbalCollector(BaseCollector):
             return event
         elif isinstance(event, TimbalDeltaEvent):
             return event
+        elif isinstance(event, TimbalApprovalEvent):
+            self._pending_approvals.append({
+                "approval_id": event.approval_id,
+                "runnable_path": event.runnable_path,
+                "runnable_name": event.runnable_name,
+                "runnable_type": event.runnable_type,
+                "input": event.input,
+                "prompt": event.prompt,
+                "description": event.description,
+                "metadata": event.metadata,
+                "t0": event.t0,
+                "call_id": event.call_id,
+                "parent_call_id": event.parent_call_id,
+            })
+            return event
         elif isinstance(event, TimbalOutputEvent):
             self._output_event = event
+            return event
+        elif isinstance(event, TimbalBaseEvent):
             return event
         else:
             logger.warning("Unknown Timbal event type", event_type=type(event), event=event)
 
     @override
     def result(self) -> Any:
-        """Returns the output of the last output event received."""
+        """Returns the final OutputEvent enriched with pending_approvals.
+
+        When concurrent runnables gate, the OutputEvent only references the
+        *first* pending approval through ``status``/``output``. We attach the
+        full list under ``metadata['pending_approvals']`` so consumers driving
+        the resume loop can see every gate from one ``.collect()`` call.
+        """
+        if self._output_event is not None and self._pending_approvals:
+            self._output_event.metadata = {
+                **(self._output_event.metadata or {}),
+                "pending_approvals": list(self._pending_approvals),
+            }
         return self._output_event

--- a/python/timbal/core/agent.py
+++ b/python/timbal/core/agent.py
@@ -26,7 +26,7 @@ from pydantic import (
 )
 from uuid_extensions import uuid7
 
-from ..errors import InterruptError, bail
+from ..errors import ApprovalRequired, InterruptError, bail
 from ..state import get_run_context
 from ..types.content import CustomContent, FileContent, TextContent, ToolResultContent, ToolUseContent
 from ..types.events import BaseEvent, OutputEvent
@@ -195,12 +195,14 @@ class Agent(Runnable):
 
         # Build default params for the internal LLM tool from individual fields
         _llm_default_params = {
-            k: v for k, v in [
+            k: v
+            for k, v in [
                 ("max_tokens", self.max_tokens),
                 ("temperature", self.temperature),
                 ("base_url", self.base_url),
                 ("api_key", self.api_key),
-            ] if v is not None
+            ]
+            if v is not None
         }
         if self.model_params:
             _llm_default_params["provider_params"] = self.model_params
@@ -338,6 +340,37 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
 
         return system_prompt
 
+    def _find_pending_tool_uses(self, memory: list[Message]) -> list[ToolUseContent]:
+        """Return any tool_uses in the most recent assistant message that
+        still have no matching tool_result anywhere later in memory.
+
+        Used on approval-resume: the previous turn left tool_uses unresolved
+        because the user hadn't approved yet. Now that we have a decision we
+        re-execute those gated tool_uses directly without re-calling the LLM
+        (which would fail because most providers reject a request whose last
+        assistant message has unresolved tool_uses).
+        """
+        if not memory:
+            return []
+        for i in range(len(memory) - 1, -1, -1):
+            msg = memory[i]
+            if msg.role != "assistant":
+                continue
+            tool_uses = [
+                c for c in msg.content
+                if isinstance(c, ToolUseContent) and not c.is_server_tool_use
+            ]
+            if not tool_uses:
+                # Most recent assistant message has no tool_uses to resume.
+                return []
+            fulfilled: set[str] = set()
+            for later in memory[i + 1:]:
+                for c in later.content:
+                    if isinstance(c, ToolResultContent):
+                        fulfilled.add(c.id)
+            return [tu for tu in tool_uses if tu.id not in fulfilled]
+        return []
+
     def _synthesize_missing_tool_results(self, memory: list[Message]) -> None:
         """Append synthetic error results for any tool_use blocks that were interrupted.
 
@@ -435,13 +468,28 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
             return
 
         previous_span = self_spans[0]
-
+        prev_status = previous_span.status
+        if isinstance(prev_status, dict):
+            prev_code = prev_status.get("code")
+            prev_reason = prev_status.get("reason")
+        elif prev_status is not None:
+            prev_code = prev_status.code
+            prev_reason = prev_status.reason
+        else:
+            prev_code = None
+            prev_reason = None
         if not isinstance(previous_span.memory, list):
             return
         memory = [Message.validate(m) for m in previous_span.memory]
 
-        # Ensure interrupted tool calls have corresponding results before resuming.
-        self._synthesize_missing_tool_results(memory)
+        # On approval-required resume the gated tool_uses will be re-executed
+        # by the agent loop (see _find_pending_tool_uses), so we must NOT
+        # inject synthetic "tool failed" results for them. Without this guard
+        # the LLM would see fake failures and probably skip retrying the
+        # gated calls, silently dropping the user's approval decisions.
+        is_approval_resume = prev_code == "cancelled" and prev_reason == "approval_required"
+        if not is_approval_resume:
+            self._synthesize_missing_tool_results(memory)
         current_span.memory = memory + current_span.memory
 
         # Cache the already-serialized previous memory so handler() can skip re-dumping.
@@ -472,9 +520,7 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
                     )
                     should_compact = True
                 elif previous_span.usage:
-                    prev_input_tokens = sum(
-                        v for k, v in previous_span.usage.items() if ":input" in k and "token" in k
-                    )
+                    prev_input_tokens = sum(v for k, v in previous_span.usage.items() if ":input" in k and "token" in k)
                     prev_output_tokens = sum(
                         v for k, v in previous_span.usage.items() if ":output" in k and "token" in k
                     )
@@ -495,9 +541,7 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
 
             if should_compact:
                 compactors = (
-                    [self.memory_compaction]
-                    if not isinstance(self.memory_compaction, list)
-                    else self.memory_compaction
+                    [self.memory_compaction] if not isinstance(self.memory_compaction, list) else self.memory_compaction
                 )
                 compaction_steps = []
                 for compactor in compactors:
@@ -509,11 +553,13 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
                         current_span.memory = await compactor(current_span.memory)
                     else:
                         current_span.memory = compactor(current_span.memory)
-                    compaction_steps.append({
-                        "compactor": getattr(compactor, "__name__", repr(compactor)),
-                        "before": before,
-                        "after": len(current_span.memory),
-                    })
+                    compaction_steps.append(
+                        {
+                            "compactor": getattr(compactor, "__name__", repr(compactor)),
+                            "before": before,
+                            "after": len(current_span.memory),
+                        }
+                    )
                 current_span.metadata["compaction"] = {
                     "triggered": True,
                     "utilization": round(utilization, 4) if utilization is not None else None,
@@ -537,6 +583,9 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
             tools_names.add(tool.name)
             if tool.command:
                 commands[tool.command] = tool
+                stripped = tool.command.strip("/")
+                if stripped:
+                    commands[stripped] = tool
 
         for t in self.tools:
             if isinstance(t, ToolSet):
@@ -632,7 +681,7 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
             # Reuse the already-serialized previous messages; only dump new ones
             # (prompt + any synthetic tool results added by _synthesize_missing_tool_results).
             # If compaction ran it rewrites memory, invalidating the cached dump.
-            new_messages = current_span.memory[len(prev_dump):]
+            new_messages = current_span.memory[len(prev_dump) :]
             current_span._memory_dump = prev_dump + await dump(new_messages)
         else:
             current_span._memory_dump = await dump(current_span.memory)
@@ -649,10 +698,15 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
             """Helper to process tool output events and create tool results."""
             if not isinstance(event, OutputEvent) or event.path.count(".") != self._path.count(".") + 1:
                 return
+            if event.status.code == "cancelled" and event.status.reason == "approval_required":
+                return
             if event.status.code == "cancelled" and event.status.reason == "early_exit":
                 bail(event.status.message)
             content = None
-            if event.status.code == "cancelled" and event.status.reason == "early_exit_local":
+            if event.status.code == "cancelled" and event.status.reason == "approval_denied":
+                msg = event.status.message or "The tool call was denied."
+                content = f"[Approval denied] {msg}"
+            elif event.status.code == "cancelled" and event.status.reason == "early_exit_local":
                 msg = event.status.message or "The tool exited early."
                 content = f"[Cancelled] {msg}"
             elif event.error is not None:
@@ -713,7 +767,12 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
                                     {
                                         "role": "assistant",
                                         "content": [
-                                            {"type": "tool_use", "id": tool_use_id, "name": tool.name, "input": tool_input}
+                                            {
+                                                "type": "tool_use",
+                                                "id": tool_use_id,
+                                                "name": tool.name,
+                                                "input": tool_input,
+                                            }
                                         ],
                                     }
                                 )
@@ -721,6 +780,12 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
                                 async for event in tool(**tool_input):
                                     await _process_tool_event(event, tool_use_id, append_to_messages=False)
                                     if isinstance(event, OutputEvent) and event.output is not None:
+                                        if (
+                                            event.status.code == "cancelled"
+                                            and event.status.reason == "approval_required"
+                                        ):
+                                            yield event
+                                            raise ApprovalRequired(event)
                                         current_span.memory.append(
                                             Message.validate(
                                                 {
@@ -731,6 +796,32 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
                                         )
                                     yield event
                                 return
+
+                # Resume path: if the trailing assistant message has tool_uses
+                # that were left unresolved by an earlier approval gate, run
+                # them directly. Skipping the LLM call here is important —
+                # most providers reject a request whose conversation ends in
+                # an assistant message whose tool_uses have no matching
+                # tool_results.
+                pending_tool_uses = self._find_pending_tool_uses(current_span.memory)
+                if pending_tool_uses:
+                    _llm_memory_saved = True  # nothing to salvage; we never called the LLM
+                    tool_calls = pending_tool_uses
+                    first_pending_approval: OutputEvent | None = None
+                    async for tool_call, event in self._multiplex_tools(tools, tool_calls):
+                        await _process_tool_event(event, tool_call.id, append_to_messages=True)
+                        yield event
+                        if (
+                            isinstance(event, OutputEvent)
+                            and event.status.code == "cancelled"
+                            and event.status.reason == "approval_required"
+                            and first_pending_approval is None
+                        ):
+                            first_pending_approval = event
+                    if first_pending_approval is not None:
+                        raise ApprovalRequired(first_pending_approval)
+                    i += 1
+                    continue
 
                 async for event in self._llm(
                     model=model,
@@ -819,9 +910,19 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
                 if not tool_calls:
                     break
 
+                first_pending_approval: OutputEvent | None = None
                 async for tool_call, event in self._multiplex_tools(tools, tool_calls):
                     await _process_tool_event(event, tool_call.id, append_to_messages=True)
                     yield event
+                    if (
+                        isinstance(event, OutputEvent)
+                        and event.status.code == "cancelled"
+                        and event.status.reason == "approval_required"
+                        and first_pending_approval is None
+                    ):
+                        first_pending_approval = event
+                if first_pending_approval is not None:
+                    raise ApprovalRequired(first_pending_approval)
                 i += 1
         finally:
             if not _llm_memory_saved:

--- a/python/timbal/core/runnable.py
+++ b/python/timbal/core/runnable.py
@@ -40,7 +40,7 @@ from ..state.context import RunContext
 from ..state.dependency_analyzer import RunContextDependencyAnalyzer
 from ..state.tracing.providers import TRACING_UNSET
 from ..state.tracing.span import Span
-from ..types.approval import ApprovalDecision, ApprovalResolution
+from ..types.approval import ApprovalPolicyDecision, ApprovalResolution
 from ..types.events import (
     ApprovalEvent,
     BaseEvent,
@@ -120,7 +120,7 @@ def _timbal_collector_wrap(fn):
 ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"
 
 
-ApprovalPolicy = bool | Callable[..., bool | ApprovalDecision | dict[str, Any]]
+ApprovalPolicy = bool | Callable[..., bool | ApprovalPolicyDecision | dict[str, Any]]
 ApprovalPrompt = str | Callable[..., str | None] | None
 
 
@@ -192,7 +192,7 @@ class Runnable(ABC, BaseModel):
     """Whether this runnable invocation requires approval before handler execution.
 
     A callable receives the validated runnable input and may return a bool, dict,
-    or ApprovalDecision.
+    or ApprovalPolicyDecision.
     """
     approval_prompt: ApprovalPrompt = None
     """Optional approval prompt, or a callable that receives the validated runnable input."""
@@ -744,7 +744,7 @@ class Runnable(ABC, BaseModel):
 
         return await loop.run_in_executor(None, fn_with_ctx)
 
-    async def _resolve_approval_decision(self, validated_input: dict[str, Any]) -> ApprovalDecision:
+    async def _resolve_approval_decision(self, validated_input: dict[str, Any]) -> ApprovalPolicyDecision:
         """Normalize approval configuration for this invocation.
 
         Wraps **all** policy resolution errors — callable exceptions, invalid
@@ -761,15 +761,15 @@ class Runnable(ABC, BaseModel):
             else:
                 raw_decision = raw_policy
 
-            if isinstance(raw_decision, ApprovalDecision):
+            if isinstance(raw_decision, ApprovalPolicyDecision):
                 decision = raw_decision
             elif isinstance(raw_decision, bool):
-                decision = ApprovalDecision(required=raw_decision)
+                decision = ApprovalPolicyDecision(required=raw_decision)
             elif isinstance(raw_decision, dict):
-                decision = ApprovalDecision.model_validate(raw_decision)
+                decision = ApprovalPolicyDecision.model_validate(raw_decision)
             else:
                 raise TypeError(
-                    "requires_approval must be a bool or callable returning bool, dict, or ApprovalDecision; "
+                    "requires_approval must be a bool or callable returning bool, dict, or ApprovalPolicyDecision; "
                     f"got {type(raw_decision).__name__}."
                 )
 
@@ -780,7 +780,7 @@ class Runnable(ABC, BaseModel):
                 else:
                     prompt = self.approval_prompt
 
-            return ApprovalDecision(
+            return ApprovalPolicyDecision(
                 required=decision.required,
                 prompt=prompt,
                 description=decision.description or self.approval_description,

--- a/python/timbal/core/runnable.py
+++ b/python/timbal/core/runnable.py
@@ -1,7 +1,9 @@
 import ast
 import asyncio
 import contextvars
+import hashlib
 import inspect
+import json
 import os
 import secrets
 import time
@@ -25,7 +27,7 @@ from pydantic import (
 from uuid_extensions import uuid7
 
 from ..collectors import get_collector_registry
-from ..errors import EarlyExit, InterruptError
+from ..errors import ApprovalPolicyError, ApprovalRequired, EarlyExit, InterruptError
 from ..state import (
     get_call_id,
     get_parent_call_id,
@@ -38,7 +40,9 @@ from ..state.context import RunContext
 from ..state.dependency_analyzer import RunContextDependencyAnalyzer
 from ..state.tracing.providers import TRACING_UNSET
 from ..state.tracing.span import Span
+from ..types.approval import ApprovalDecision, ApprovalResolution
 from ..types.events import (
+    ApprovalEvent,
     BaseEvent,
     Event,
     OutputEvent,
@@ -116,7 +120,43 @@ def _timbal_collector_wrap(fn):
 ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"
 
 
-# TODO Add timeout
+ApprovalPolicy = bool | Callable[..., bool | ApprovalDecision | dict[str, Any]]
+ApprovalPrompt = str | Callable[..., str | None] | None
+
+
+def _normalize_approval_decisions(raw: Any) -> dict[str, ApprovalResolution]:
+    """Normalize caller-provided approval decisions keyed by approval_id."""
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise ValueError("approval_decisions must be a mapping of approval_id to approval result.")
+
+    decisions: dict[str, ApprovalResolution] = {}
+    for approval_id, value in raw.items():
+        if isinstance(value, ApprovalResolution):
+            resolution = value
+        elif isinstance(value, bool):
+            resolution = ApprovalResolution(approved=value)
+        elif isinstance(value, dict):
+            resolution = ApprovalResolution.model_validate(value)
+        else:
+            raise ValueError("approval_decisions values must be booleans, dicts, or ApprovalResolution instances.")
+        decisions[str(approval_id)] = resolution
+    return decisions
+
+
+def _approval_id_for(path: str, input_dump: Any) -> str:
+    """Compute a stable approval_id for an invocation.
+
+    Hashes ``(path, validated_input)`` so the same decision resumes any retry
+    of the same call. Treat the returned id as opaque: the derivation is an
+    internal contract and may change across SDK versions, so do not persist
+    ids beyond the lifetime of a single pending run.
+    """
+    payload = {"path": path, "input": input_dump}
+    return hashlib.sha256(json.dumps(payload, sort_keys=True, default=str).encode()).hexdigest()[:32]
+
+
 class Runnable(ABC, BaseModel):
     """Abstract base class for all runnable components in the Timbal framework.
 
@@ -148,6 +188,16 @@ class Runnable(ABC, BaseModel):
     """Optional description of what this runnable does, used in LLM tool schemas."""
     metadata: dict[str, Any] = {}
     """Optional metadata for this runnable."""
+    requires_approval: ApprovalPolicy = False
+    """Whether this runnable invocation requires approval before handler execution.
+
+    A callable receives the validated runnable input and may return a bool, dict,
+    or ApprovalDecision.
+    """
+    approval_prompt: ApprovalPrompt = None
+    """Optional approval prompt, or a callable that receives the validated runnable input."""
+    approval_description: str | None = None
+    """Optional approval description shown in ApprovalEvent."""
 
     schema_params_mode: Literal["all", "required"] = "all"
     """Parameter inclusion mode: 'all' includes all params, 'required' only required ones."""
@@ -161,8 +211,14 @@ class Runnable(ABC, BaseModel):
     These parameters are added to the handler's parameters when the handler is called."""
 
     pre_hook: Callable[[], Any] | None = None
-    """Pre-execution hook for runtime processing. Must be a parameterless callable.
-    Use get_run_context() to access execution state and data.
+    """Pre-execution hook: parameterless callable; use get_run_context() for state.
+
+    Runs after input resolution and before Pydantic validation, so the params
+    model can see in-place changes to ``span.input`` (e.g. STT, middleware). A
+    callable ``requires_approval`` policy is evaluated *after* validation, but
+    this hook still runs on the first attempt, including when the run later cancels
+    for ``approval_required``. Defer expensive work until after approval by using
+    the handler or a nested Runnable.
     """
     post_hook: Callable[[], Any] | None = None
     """Post-execution hook for runtime processing. Must be a parameterless callable.
@@ -669,6 +725,72 @@ class Runnable(ABC, BaseModel):
 
             return await loop.run_in_executor(None, fn_with_ctx)
 
+    async def _execute_approval_callable(self, fn: Callable[..., Any], validated_input: dict[str, Any]) -> Any:
+        """Execute an approval policy callable with matching validated input parameters."""
+        sig = inspect.signature(fn)
+        if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in sig.parameters.values()):
+            kwargs = validated_input
+        else:
+            kwargs = {name: validated_input[name] for name in sig.parameters if name in validated_input}
+
+        if inspect.iscoroutinefunction(fn):
+            return await fn(**kwargs)
+
+        loop = asyncio.get_running_loop()
+        ctx = contextvars.copy_context()
+
+        def fn_with_ctx():
+            return ctx.run(fn, **kwargs)
+
+        return await loop.run_in_executor(None, fn_with_ctx)
+
+    async def _resolve_approval_decision(self, validated_input: dict[str, Any]) -> ApprovalDecision:
+        """Normalize approval configuration for this invocation.
+
+        Wraps **all** policy resolution errors — callable exceptions, invalid
+        return types, malformed dicts that fail pydantic validation, prompt
+        callable exceptions — in :class:`ApprovalPolicyError` so the gate
+        surfaces a dedicated ``approval_policy_error`` reason rather than a
+        generic handler error. The wrapping spans the whole function so any
+        future code added here inherits the same contract.
+        """
+        try:
+            raw_policy = self.requires_approval
+            if callable(raw_policy):
+                raw_decision = await self._execute_approval_callable(raw_policy, validated_input)
+            else:
+                raw_decision = raw_policy
+
+            if isinstance(raw_decision, ApprovalDecision):
+                decision = raw_decision
+            elif isinstance(raw_decision, bool):
+                decision = ApprovalDecision(required=raw_decision)
+            elif isinstance(raw_decision, dict):
+                decision = ApprovalDecision.model_validate(raw_decision)
+            else:
+                raise TypeError(
+                    "requires_approval must be a bool or callable returning bool, dict, or ApprovalDecision; "
+                    f"got {type(raw_decision).__name__}."
+                )
+
+            prompt = decision.prompt
+            if decision.required and prompt is None and self.approval_prompt is not None:
+                if callable(self.approval_prompt):
+                    prompt = await self._execute_approval_callable(self.approval_prompt, validated_input)
+                else:
+                    prompt = self.approval_prompt
+
+            return ApprovalDecision(
+                required=decision.required,
+                prompt=prompt,
+                description=decision.description or self.approval_description,
+                metadata=decision.metadata,
+            )
+        except ApprovalPolicyError:
+            raise
+        except Exception as exc:
+            raise ApprovalPolicyError(self._path, exc) from exc
+
     async def _resolve_input_params(self, input: dict[str, Any] | None = None) -> dict[str, Any]:
         """Merge fixed defaults, runtime defaults (lambdas), and input. Input takes priority."""
         input = input or {}
@@ -802,6 +924,22 @@ class Runnable(ABC, BaseModel):
         else:
             run_in_background = False
 
+        approval_decisions: dict[str, ApprovalResolution] = {}
+        # Process the deprecated alias FIRST so that the canonical
+        # ``approval_decisions=`` always wins on overlapping keys.
+        if "approvals" in kwargs:
+            import warnings
+
+            warnings.warn(
+                "`approvals=` is deprecated; use `approval_decisions=` instead. "
+                "Both work for now but `approvals` will be removed in a future release.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            approval_decisions.update(_normalize_approval_decisions(kwargs.pop("approvals")))
+        if "approval_decisions" in kwargs:
+            approval_decisions.update(_normalize_approval_decisions(kwargs.pop("approval_decisions")))
+
         # Generate new context or reset it if appropriate
         _parent_call_id = get_parent_call_id()
         _call_id = get_call_id()
@@ -824,6 +962,8 @@ class Runnable(ABC, BaseModel):
             _parent_call_id = None
             _call_id = None
         await run_context.get_session()
+        previous_approval_decisions = dict(run_context._approval_decisions)
+        run_context._approval_decisions.update(approval_decisions)
         set_run_context(run_context)
 
         _new_parent_call_id = _call_id
@@ -881,13 +1021,91 @@ class Runnable(ABC, BaseModel):
             span.input = input
             span._input_dump = await dump(input)
 
+            # Pydantic model_validate() does not mutate the input dict
+            validated_input = dict(self.params_model.model_validate(input))
+
+            approval_decision = await self._resolve_approval_decision(validated_input)
+            if approval_decision.required:
+                input_dump = await dump(validated_input)
+                approval_id = _approval_id_for(span.path, input_dump)
+                span.metadata["approval"] = {
+                    "id": approval_id,
+                    "required": True,
+                    "prompt": approval_decision.prompt,
+                    "description": approval_decision.description,
+                    "metadata": approval_decision.metadata,
+                }
+                approval_resolution = run_context._approval_decisions.get(approval_id)
+                if approval_resolution is not None:
+                    run_context._used_approval_ids.add(approval_id)
+                if approval_resolution is not None and approval_resolution.is_expired():
+                    span.metadata["approval"]["expired"] = True
+                    span.metadata["approval"]["expired_at"] = approval_resolution.expires_at
+                    approval_resolution = None
+
+                if approval_resolution is None:
+                    # Status/output MUST be set BEFORE the yield. If the
+                    # consumer breaks the stream right after seeing the
+                    # ApprovalEvent, GeneratorExit fires at the yield and
+                    # we'd otherwise persist this span as 'interrupted'.
+                    span.status = RunStatus(
+                        code="cancelled",
+                        reason="approval_required",
+                        message="Approval required before runnable execution.",
+                    )
+                    span.output = {
+                        "approval_id": approval_id,
+                        "status": "approval_required",
+                        "prompt": approval_decision.prompt,
+                    }
+                    span._output_dump = await dump(span.output)
+
+                    approval_event = ApprovalEvent(
+                        run_id=run_context.id,
+                        parent_run_id=run_context.parent_id,
+                        path=span.path,
+                        call_id=span.call_id,
+                        parent_call_id=span.parent_call_id,
+                        t0=int(time.time() * 1000),
+                        approval_id=approval_id,
+                        runnable_path=span.path,
+                        runnable_name=self.name,
+                        runnable_type=self.metadata.get("type", self.__class__.__name__),
+                        input=validated_input,
+                        prompt=approval_decision.prompt,
+                        description=approval_decision.description,
+                        metadata=approval_decision.metadata,
+                    )
+                    if approval_event.type in self._log_events:
+                        _get_logger().info(approval_event.type, **approval_event.model_dump())
+                    yield approval_event
+                    _restore_context()
+                    return
+
+                span.metadata["approval"]["approved"] = approval_resolution.approved
+                span.metadata["approval"]["reason"] = approval_resolution.reason
+                span.metadata["approval"]["resolution_metadata"] = approval_resolution.metadata
+                if not approval_resolution.approved:
+                    span.status = RunStatus(
+                        code="cancelled",
+                        reason="approval_denied",
+                        message=approval_resolution.reason or "Approval denied.",
+                    )
+                    span.output = {
+                        "approval_id": approval_id,
+                        "status": "approval_denied",
+                        "reason": approval_resolution.reason,
+                    }
+                    span._output_dump = await dump(span.output)
+                    return
+
+            # pre_hook runs only when we're actually going to execute the
+            # handler. We deliberately defer it past the approval gate so
+            # external side-effects don't fire on gated/denied attempts.
             if self.pre_hook is not None:
                 await self._execute_runtime_callable(self.pre_hook, self._pre_hook_is_coroutine)
                 set_parent_call_id(_new_parent_call_id)
                 set_call_id(_new_call_id)
-
-            # Pydantic model_validate() does not mutate the input dict
-            validated_input = dict(self.params_model.model_validate(input))
 
             # Background task
             if run_in_background:
@@ -942,6 +1160,17 @@ class Runnable(ABC, BaseModel):
                     if handler_collector is not None:
                         collector = handler_collector
                     if event is not None:
+                        # If a child gates, set our own status BEFORE the yield
+                        # so that a consumer breaking the stream right after
+                        # the ApprovalEvent doesn't end up with our span
+                        # recorded as 'interrupted' (GeneratorExit clobbers
+                        # late-set status). See test_agent_break_on_approval_event.
+                        if isinstance(event, ApprovalEvent) and span.status is None:
+                            span.status = RunStatus(
+                                code="cancelled",
+                                reason="approval_required",
+                                message="Approval required before runnable execution.",
+                            )
                         yield event
                         _restore_context()
                     if final_output is not None:
@@ -976,9 +1205,13 @@ class Runnable(ABC, BaseModel):
 
         except GeneratorExit:
             _generator_closed = True
-            span.status = RunStatus(code="cancelled", reason="interrupted", message="")
-            if collector is not None:
-                span.output = _collector_output_on_interrupt(collector)
+            # Only overwrite status if no earlier branch (e.g. approval gate)
+            # already set it. This keeps approval_required, early_exit etc.
+            # intact when a consumer breaks the stream right after their event.
+            if span.status is None:
+                span.status = RunStatus(code="cancelled", reason="interrupted", message="")
+                if collector is not None:
+                    span.output = _collector_output_on_interrupt(collector)
             raise
 
         except EarlyExit as early_exit:
@@ -986,6 +1219,28 @@ class Runnable(ABC, BaseModel):
             span.status = RunStatus(code="cancelled", reason=reason, message=early_exit.message)
             span.output = None
             span._output_dump = None
+
+        except ApprovalRequired as approval_required:
+            output_event = approval_required.output_event
+            span.status = output_event.status
+            span.output = output_event.output
+            span._output_dump = (
+                output_event._output_dump if hasattr(output_event, "_output_dump") else await dump(span.output)
+            )
+
+        except ApprovalPolicyError as policy_err:
+            original = policy_err.original
+            span.status = RunStatus(
+                code="error",
+                reason="approval_policy_error",
+                message=str(original),
+            )
+            span.error = {
+                "type": type(original).__name__,
+                "message": str(original),
+                "traceback": "".join(traceback.format_exception(type(original), original, original.__traceback__)),
+                "runnable_path": policy_err.runnable_path,
+            }
 
         except (asyncio.CancelledError, InterruptError) as e:
             # Set status FIRST before any awaits. A second CancelledError can arrive
@@ -1066,6 +1321,23 @@ class Runnable(ABC, BaseModel):
             output_event._input_dump = span._input_dump
             output_event._output_dump = span._output_dump
             await run_context._save_trace()
+            # Warn about decisions that didn't match any gate so callers find
+            # typos / stale IDs instead of silently dropping their decisions.
+            # Only check the IDs introduced by THIS call; nested children
+            # don't re-introduce them.
+            if approval_decisions:
+                unused = [
+                    aid for aid in approval_decisions
+                    if aid not in run_context._used_approval_ids
+                ]
+                if unused:
+                    _get_logger().warning(
+                        "Unrecognized approval_decisions ignored — these IDs "
+                        "did not match any gate during this run.",
+                        unused_approval_ids=unused,
+                        runnable_path=self._path,
+                    )
+            run_context._approval_decisions = previous_approval_decisions
             set_parent_call_id(_parent_call_id)
             set_call_id(_call_id)
             if output_event.type in self._log_events:

--- a/python/timbal/core/runnable.py
+++ b/python/timbal/core/runnable.py
@@ -1113,6 +1113,9 @@ class Runnable(ABC, BaseModel):
                 if approval_resolution is not None and approval_resolution.is_expired():
                     span.metadata["approval"]["expired"] = True
                     span.metadata["approval"]["expired_at"] = approval_resolution.expires_at
+                    # Counter fires for the *expired* resolution. The gate
+                    # then re-emits below, which adds a fresh :required tick.
+                    run_context.update_usage("approvals:expired", 1)
                     approval_resolution = None
 
                 if approval_resolution is None:
@@ -1148,16 +1151,28 @@ class Runnable(ABC, BaseModel):
                         description=approval_decision.description,
                         metadata=approval_decision.metadata,
                     )
+                    run_context.update_usage("approvals:required", 1)
                     if approval_event.type in self._log_events:
                         _get_logger().info(approval_event.type, **approval_event.model_dump())
                     yield approval_event
                     _restore_context()
                     return
 
-                span.metadata["approval"]["approved"] = approval_resolution.approved
-                span.metadata["approval"]["reason"] = approval_resolution.reason
-                span.metadata["approval"]["resolution_metadata"] = approval_resolution.metadata
+                # Resolution found and not expired — capture the audit
+                # snapshot before deciding the gate's outcome. Typed fields
+                # are surfaced under ``resolution`` so trace consumers can
+                # query e.g. ``approval.resolution.approver_id`` directly.
+                span.metadata["approval"]["resolution"] = {
+                    "approved": approval_resolution.approved,
+                    "reason": approval_resolution.reason,
+                    "approver_id": approval_resolution.approver_id,
+                    "comment": approval_resolution.comment,
+                    "decided_at": approval_resolution.decided_at,
+                    "expires_at": approval_resolution.expires_at,
+                    "metadata": approval_resolution.metadata,
+                }
                 if not approval_resolution.approved:
+                    run_context.update_usage("approvals:denied", 1)
                     span.status = RunStatus(
                         code="cancelled",
                         reason="approval_denied",
@@ -1170,6 +1185,8 @@ class Runnable(ABC, BaseModel):
                     }
                     span._output_dump = await dump(span.output)
                     return
+
+                run_context.update_usage("approvals:approved", 1)
 
             # pre_hook runs only when we're actually going to execute the
             # handler. We deliberately defer it past the approval gate so

--- a/python/timbal/core/runnable.py
+++ b/python/timbal/core/runnable.py
@@ -198,6 +198,21 @@ class Runnable(ABC, BaseModel):
     """Optional approval prompt, or a callable that receives the validated runnable input."""
     approval_description: str | None = None
     """Optional approval description shown in ApprovalEvent."""
+    approval_redactor: Callable[[dict[str, Any]], dict[str, Any]] | None = None
+    """Optional callable to redact sensitive fields before they reach any
+    public approval surface (``ApprovalEvent.input``, persisted ``span.input``,
+    ``span.metadata['approval']['input']``, exporters).
+
+    Receives a copy of the validated input dict and must return a dict.
+    The handler still runs with the unredacted validated input on resume.
+    Takes precedence over ``approval_redact_keys`` when both are set.
+    A redactor that raises or returns a non-dict falls back to a placeholder
+    so the secret never leaks — see :meth:`_redact_validated_input`.
+    """
+    approval_redact_keys: list[str] | None = None
+    """Ergonomic shortcut for ``approval_redactor``: each listed key in the
+    validated input is replaced with ``"***"`` on the public approval
+    surfaces. The handler still receives the unredacted input."""
 
     schema_params_mode: Literal["all", "required"] = "all"
     """Parameter inclusion mode: 'all' includes all params, 'required' only required ones."""
@@ -791,6 +806,47 @@ class Runnable(ABC, BaseModel):
         except Exception as exc:
             raise ApprovalPolicyError(self._path, exc) from exc
 
+    def _redact_validated_input(self, validated_input: dict[str, Any]) -> dict[str, Any]:
+        """Apply ``approval_redactor`` / ``approval_redact_keys`` to produce
+        the public-facing input snapshot.
+
+        The original ``validated_input`` is never mutated. The returned dict
+        is what flows into :class:`ApprovalEvent`, ``span.input`` (when the
+        gate fires), and ``span.metadata['approval']['input']``. The handler
+        on resume keeps receiving the unredacted validated input.
+
+        Defensive: a redactor that raises or returns a non-dict is treated
+        as a config bug — we log and fall back to a placeholder so the
+        secret never reaches a public surface.
+        """
+        if self.approval_redactor is None and not self.approval_redact_keys:
+            return dict(validated_input)
+
+        if self.approval_redactor is not None:
+            try:
+                redacted = self.approval_redactor(dict(validated_input))
+            except Exception as exc:
+                _get_logger().warning(
+                    "approval_redactor raised; falling back to placeholder so the secret does not leak.",
+                    runnable_path=self._path,
+                    error=repr(exc),
+                )
+                return {"_approval_redaction_error": True}
+            if not isinstance(redacted, dict):
+                _get_logger().warning(
+                    "approval_redactor must return a dict; falling back to placeholder.",
+                    runnable_path=self._path,
+                    returned_type=type(redacted).__name__,
+                )
+                return {"_approval_redaction_error": True}
+            return redacted
+
+        redacted = dict(validated_input)
+        for key in self.approval_redact_keys or ():
+            if key in redacted:
+                redacted[key] = "***"
+        return redacted
+
     async def _resolve_input_params(self, input: dict[str, Any] | None = None) -> dict[str, Any]:
         """Merge fixed defaults, runtime defaults (lambdas), and input. Input takes priority."""
         input = input or {}
@@ -1026,14 +1082,30 @@ class Runnable(ABC, BaseModel):
 
             approval_decision = await self._resolve_approval_decision(validated_input)
             if approval_decision.required:
+                # ``approval_id`` MUST be derived from the unredacted input
+                # so the resume call (which carries the full input) lands
+                # on the same id as the original gate.
                 input_dump = await dump(validated_input)
                 approval_id = _approval_id_for(span.path, input_dump)
+
+                # Compute the redacted view once and use it for every
+                # public surface. The unredacted ``validated_input`` is
+                # still what the handler sees on resume.
+                redacted_input = self._redact_validated_input(validated_input)
+                redaction_active = (
+                    self.approval_redactor is not None or bool(self.approval_redact_keys)
+                )
+                if redaction_active:
+                    span.input = redacted_input
+                    span._input_dump = await dump(redacted_input)
+
                 span.metadata["approval"] = {
                     "id": approval_id,
                     "required": True,
                     "prompt": approval_decision.prompt,
                     "description": approval_decision.description,
                     "metadata": approval_decision.metadata,
+                    "input": redacted_input,
                 }
                 approval_resolution = run_context._approval_decisions.get(approval_id)
                 if approval_resolution is not None:
@@ -1071,7 +1143,7 @@ class Runnable(ABC, BaseModel):
                         runnable_path=span.path,
                         runnable_name=self.name,
                         runnable_type=self.metadata.get("type", self.__class__.__name__),
-                        input=validated_input,
+                        input=redacted_input,
                         prompt=approval_decision.prompt,
                         description=approval_decision.description,
                         metadata=approval_decision.metadata,

--- a/python/timbal/core/runnable.py
+++ b/python/timbal/core/runnable.py
@@ -995,13 +995,14 @@ class Runnable(ABC, BaseModel):
             approval_decisions.update(_normalize_approval_decisions(kwargs.pop("approvals")))
         if "approval_decisions" in kwargs:
             approval_decisions.update(_normalize_approval_decisions(kwargs.pop("approval_decisions")))
+        explicit_parent_id = kwargs.pop("parent_id", None)
 
         # Generate new context or reset it if appropriate
         _parent_call_id = get_parent_call_id()
         _call_id = get_call_id()
         run_context = get_run_context()
         if run_context is None:
-            run_context = RunContext(tracing_provider=self.tracing_provider)
+            run_context = RunContext(parent_id=explicit_parent_id, tracing_provider=self.tracing_provider)
             _parent_call_id = None
             _call_id = None
         elif "." not in self._path and run_context._trace:
@@ -1012,9 +1013,12 @@ class Runnable(ABC, BaseModel):
             # belongs to a concurrent sibling — create a fresh context.
             root = run_context.root_span()
             if root is not None and root.t1 is not None:
-                run_context = RunContext(parent_id=run_context.id, tracing_provider=self.tracing_provider)
+                run_context = RunContext(
+                    parent_id=explicit_parent_id or run_context.id,
+                    tracing_provider=self.tracing_provider,
+                )
             else:
-                run_context = RunContext(tracing_provider=self.tracing_provider)
+                run_context = RunContext(parent_id=explicit_parent_id, tracing_provider=self.tracing_provider)
             _parent_call_id = None
             _call_id = None
         await run_context.get_session()
@@ -1117,6 +1121,29 @@ class Runnable(ABC, BaseModel):
                     # then re-emits below, which adds a fresh :required tick.
                     run_context.update_usage("approvals:expired", 1)
                     approval_resolution = None
+
+                if approval_resolution is not None and run_context._tracing_provider is not None:
+                    claimed = await run_context._tracing_provider.claim_approval(
+                        str(run_context.parent_id) if run_context.parent_id else None,
+                        approval_id,
+                        str(run_context.id),
+                    )
+                    if not claimed:
+                        span.metadata["approval"]["claim"] = {
+                            "claimed": False,
+                            "parent_id": str(run_context.parent_id) if run_context.parent_id else None,
+                        }
+                        span.status = RunStatus(
+                            code="cancelled",
+                            reason="approval_already_claimed",
+                            message="Approval was already claimed by another resume run.",
+                        )
+                        span.output = {
+                            "approval_id": approval_id,
+                            "status": "approval_already_claimed",
+                        }
+                        span._output_dump = await dump(span.output)
+                        return
 
                 if approval_resolution is None:
                     # Status/output MUST be set BEFORE the yield. If the

--- a/python/timbal/core/workflow.py
+++ b/python/timbal/core/workflow.py
@@ -13,7 +13,7 @@ except ImportError:
 import structlog
 from pydantic import BaseModel, ConfigDict, PrivateAttr, computed_field, create_model
 
-from ..errors import InterruptError, SpanNotFound
+from ..errors import ApprovalRequired, InterruptError, SpanNotFound
 from ..state import get_call_id, get_parent_call_id, set_parent_call_id
 from ..types.events.output import OutputEvent
 from .runnable import Runnable, RunnableLike
@@ -229,6 +229,15 @@ class Workflow(Runnable):
         try:
             async for event in step(**resolved_input):
                 await queue.put(event)
+                if (
+                    isinstance(event, OutputEvent)
+                    and event.status.code == "cancelled"
+                    and event.status.reason in {"approval_required", "approval_denied"}
+                ):
+                    logger.info(f"Step {step.name} cancelled because approval is required or denied.")
+                    status.state = StepState.FAILED
+                    await queue.put(ApprovalRequired(event))
+                    return
                 if isinstance(event, OutputEvent) and event.error is not None:
                     logger.info(f"Step {step.name} completed with error.")
                     status.state = StepState.FAILED
@@ -246,7 +255,15 @@ class Workflow(Runnable):
         await queue.put(None)
 
     async def handler(self, **kwargs: Any) -> AsyncGenerator[Any, None]:
-        """Execute all steps concurrently, respecting dependencies."""
+        """Execute all steps concurrently, respecting dependencies.
+
+        When multiple parallel steps require approval, every gate is drained
+        (so each step emits its OutputEvent + ApprovalEvent) before the
+        workflow itself raises ``ApprovalRequired``. This lets a caller
+        collect every pending ``approval_id`` from a single run and resume
+        with all decisions at once. Mirrors the agent's tool-multiplexing
+        behaviour and prevents the first gate from cancelling later gates.
+        """
         queue = asyncio.Queue()
         statuses = {step_name: StepStatus() for step_name in self._steps.keys()}
         tasks = [
@@ -254,27 +271,38 @@ class Workflow(Runnable):
             for step in self._steps.values()
         ]
 
+        first_pending_approval: ApprovalRequired | None = None
+        first_pending_exception: Exception | None = None
+
         try:
             remaining = len(tasks)
             while remaining > 0:
                 event = await queue.get()
                 if isinstance(event, InterruptError):
-                    # Propagate interrupt error - will be handled by finally block
                     raise event
+                if isinstance(event, ApprovalRequired):
+                    if first_pending_approval is None:
+                        first_pending_approval = event
+                    remaining -= 1
+                    continue
                 if isinstance(event, Exception):
-                    raise event
-                elif event is None:
+                    if first_pending_exception is None:
+                        first_pending_exception = event
+                    remaining -= 1
+                    continue
+                if event is None:
                     remaining -= 1
                 else:
                     yield event
+            if first_pending_approval is not None:
+                raise first_pending_approval
+            if first_pending_exception is not None:
+                raise first_pending_exception
         except (asyncio.CancelledError, InterruptError):
-            # Cancellation or interrupt - clean up gracefully
             raise
         finally:
-            # Cancel all pending step tasks
             for task in tasks:
                 if not task.done():
                     task.cancel()
-            # Wait for all cancellations to complete, suppressing errors
             if tasks:
                 await asyncio.gather(*tasks, return_exceptions=True)

--- a/python/timbal/errors.py
+++ b/python/timbal/errors.py
@@ -56,6 +56,26 @@ class InterruptError(TimbalError):
         self.message = message
 
 
+class ApprovalRequired(TimbalError):
+    """Internal signal used to propagate approval-required child runs."""
+
+    def __init__(self, output_event: Any) -> None:
+        super().__init__("Approval required")
+        self.output_event = output_event
+
+
+class ApprovalPolicyError(TimbalError):
+    """Error raised when an approval policy callable (requires_approval or
+    approval_prompt) raises an exception. Surfaces as a span with status
+    ``error`` and reason ``approval_policy_error`` so operators can distinguish
+    policy bugs from runnable handler errors."""
+
+    def __init__(self, runnable_path: str, original: BaseException) -> None:
+        super().__init__(f"Approval policy raised in {runnable_path}: {original!r}")
+        self.runnable_path = runnable_path
+        self.original = original
+
+
 class ImageProcessingError(TimbalError):
     """Error raised when an image file cannot be processed."""
 

--- a/python/timbal/state/context.py
+++ b/python/timbal/state/context.py
@@ -7,12 +7,20 @@ from uuid_extensions import uuid7
 
 from ..errors import SpanNotFound
 from .config import PlatformConfig
-from .tracing.providers import TRACING_UNSET, InMemoryTracingProvider, PlatformTracingProvider, TracingProvider, _TracingProviderUnset
+from .tracing.providers import (
+    TRACING_UNSET,
+    InMemoryTracingProvider,
+    PlatformTracingProvider,
+    TracingProvider,
+    _TracingProviderUnset,
+)
 from .tracing.span import Span
 from .tracing.trace import Trace
 
+
 def _get_logger():
     import structlog
+
     return structlog.get_logger("timbal.state.context")
 
 
@@ -85,6 +93,47 @@ class RunContext(BaseModel):
     _trace: Trace = PrivateAttr()
     _tracing_provider: type[TracingProvider] = PrivateAttr()
     _session_data: dict[str, Any] | None = PrivateAttr(default=None)
+    _approval_decisions: dict[str, Any] = PrivateAttr(default_factory=dict)
+    """Active approval resolutions keyed by approval_id (values: ApprovalResolution).
+    Typed as ``Any`` to avoid an import cycle with ``..types.approval`` — the
+    invariant is enforced at write time by ``_normalize_approval_decisions``."""
+    _used_approval_ids: set[str] = PrivateAttr(default_factory=set)
+    """Approval IDs that matched a gate during this run. Used to warn about
+    unrecognized decisions (typos, stale IDs) at run completion."""
+
+    def pending_approvals(self) -> list[dict[str, Any]]:
+        """Return metadata for every span currently waiting on approval.
+
+        Useful when an OutputEvent's status is cancelled/approval_required and
+        the caller wants to enumerate every approval that needs a decision
+        before retrying the run with ``approval_decisions={...}``. Includes
+        ``expired``/``expired_at`` when the previous decision was rejected for
+        TTL reasons so a UI can flag stale approvals to the operator.
+
+        Tolerates both ``RunStatus`` instances and dicts, since traces loaded
+        from JSONL/SQLite providers carry status as a dict.
+        """
+        pending: list[dict[str, Any]] = []
+        for span in self._trace.values():
+            status = span.status
+            code = status.get("code") if isinstance(status, dict) else getattr(status, "code", None)
+            reason = status.get("reason") if isinstance(status, dict) else getattr(status, "reason", None)
+            if code == "cancelled" and reason == "approval_required":
+                approval = (span.metadata or {}).get("approval")
+                if approval and approval.get("id"):
+                    entry = {
+                        "approval_id": approval["id"],
+                        "path": span.path,
+                        "call_id": span.call_id,
+                        "prompt": approval.get("prompt"),
+                        "description": approval.get("description"),
+                        "metadata": approval.get("metadata", {}),
+                    }
+                    if approval.get("expired"):
+                        entry["expired"] = True
+                        entry["expired_at"] = approval.get("expired_at")
+                    pending.append(entry)
+        return pending
 
     def model_post_init(self, __context: Any) -> None:
         """Initialize the RunContext after Pydantic model creation.
@@ -103,8 +152,7 @@ class RunContext(BaseModel):
         # None means tracing is disabled; a class means use that provider.
         if not isinstance(self.tracing_provider, _TracingProviderUnset):
             if self.tracing_provider is not None and (
-                not isinstance(self.tracing_provider, type)
-                or not issubclass(self.tracing_provider, TracingProvider)
+                not isinstance(self.tracing_provider, type) or not issubclass(self.tracing_provider, TracingProvider)
             ):
                 raise TypeError(
                     f"tracing_provider must be a TracingProvider subclass, None, or TRACING_UNSET — "
@@ -119,11 +167,7 @@ class RunContext(BaseModel):
 
         if self.platform_config:
             use_platform_traces = self.platform_config.sync_traces_enabled is not False
-            if (
-                use_platform_traces
-                and self.platform_config.subject
-                and self.platform_config.subject.app_id
-            ):
+            if use_platform_traces and self.platform_config.subject and self.platform_config.subject.app_id:
                 _get_logger().info(
                     f"Platform configuration found (subject: {self.platform_config.subject}). "
                     "Using platform tracing provider.",

--- a/python/timbal/state/context.py
+++ b/python/timbal/state/context.py
@@ -128,6 +128,7 @@ class RunContext(BaseModel):
                         "prompt": approval.get("prompt"),
                         "description": approval.get("description"),
                         "metadata": approval.get("metadata", {}),
+                        "input": approval.get("input"),
                     }
                     if approval.get("expired"):
                         entry["expired"] = True

--- a/python/timbal/state/tracing/exporters/otel.py
+++ b/python/timbal/state/tracing/exporters/otel.py
@@ -159,37 +159,105 @@ class OTelExporter(Exporter):
         return str(ms * 1_000_000)
 
     @staticmethod
-    def _build_attributes(span: Span) -> list[dict[str, Any]]:
-        attrs = []
+    def _status_parts(span: Span) -> tuple[str | None, str | None]:
+        """Return (code, reason) for span.status, tolerating dict shape after reload."""
+        status = getattr(span, "status", None)
+        if status is None:
+            return None, None
+        if isinstance(status, dict):
+            return status.get("code"), status.get("reason")
+        return getattr(status, "code", None), getattr(status, "reason", None)
+
+    @classmethod
+    def _build_attributes(cls, span: Span) -> list[dict[str, Any]]:
+        attrs: list[dict[str, Any]] = []
         input_dump = getattr(span, "_input_dump", None)
         if input_dump is not None:
-            attrs.append({
-                "key": "timbal.input",
-                "value": {"stringValue": json.dumps(input_dump, default=str)},
-            })
+            attrs.append(
+                {
+                    "key": "timbal.input",
+                    "value": {"stringValue": json.dumps(input_dump, default=str)},
+                }
+            )
         output_dump = getattr(span, "_output_dump", None)
         if output_dump is not None:
-            attrs.append({
-                "key": "timbal.output",
-                "value": {"stringValue": json.dumps(output_dump, default=str)},
-            })
+            attrs.append(
+                {
+                    "key": "timbal.output",
+                    "value": {"stringValue": json.dumps(output_dump, default=str)},
+                }
+            )
         if span.error is not None:
-            attrs.append({
-                "key": "timbal.error",
-                "value": {"stringValue": str(span.error)},
-            })
+            attrs.append(
+                {
+                    "key": "timbal.error",
+                    "value": {"stringValue": str(span.error)},
+                }
+            )
         if span.usage:
-            attrs.append({
-                "key": "timbal.usage",
-                "value": {"stringValue": json.dumps(span.usage)},
-            })
+            attrs.append(
+                {
+                    "key": "timbal.usage",
+                    "value": {"stringValue": json.dumps(span.usage)},
+                }
+            )
+        code, reason = cls._status_parts(span)
+        if code:
+            attrs.append(
+                {
+                    "key": "timbal.status.code",
+                    "value": {"stringValue": str(code)},
+                }
+            )
+        if reason:
+            attrs.append(
+                {
+                    "key": "timbal.status.reason",
+                    "value": {"stringValue": str(reason)},
+                }
+            )
+        metadata = getattr(span, "metadata", None)
+        if metadata:
+            attrs.append(
+                {
+                    "key": "timbal.metadata",
+                    "value": {"stringValue": json.dumps(metadata, default=str)},
+                }
+            )
+            approval = metadata.get("approval") if isinstance(metadata, dict) else None
+            if approval:
+                approval_id = approval.get("id") if isinstance(approval, dict) else None
+                if approval_id:
+                    attrs.append(
+                        {
+                            "key": "timbal.approval.id",
+                            "value": {"stringValue": str(approval_id)},
+                        }
+                    )
+                if approval.get("expired"):
+                    attrs.append(
+                        {
+                            "key": "timbal.approval.expired",
+                            "value": {"boolValue": True},
+                        }
+                    )
         return attrs
 
-    @staticmethod
-    def _span_status(span: Span) -> dict[str, Any]:
-        # OTel StatusCode: 0=UNSET, 1=OK, 2=ERROR
+    @classmethod
+    def _span_status(cls, span: Span) -> dict[str, Any]:
+        """Map Timbal status to OTel StatusCode (0=UNSET, 1=OK, 2=ERROR).
+
+        ``approval_required``, ``approval_denied`` are surfaced as UNSET (so they
+        don't pollute error dashboards) but the Timbal reason is exposed via
+        the ``timbal.status.reason`` attribute set in :meth:`_build_attributes`.
+        """
         if span.error is not None:
             return {"code": 2, "message": str(span.error)}
+        code, reason = cls._status_parts(span)
+        if code == "error":
+            return {"code": 2, "message": str(reason) if reason else ""}
+        if code == "cancelled":
+            return {"code": 0, "message": str(reason) if reason else "cancelled"}
         return {"code": 1}
 
     def _resource_attributes(self) -> list[dict[str, Any]]:
@@ -233,13 +301,17 @@ class OTelExporter(Exporter):
             otel_spans.append(otel_span)
 
         return {
-            "resourceSpans": [{
-                "resource": {"attributes": self._resource_attributes()},
-                "scopeSpans": [{
-                    "scope": {"name": "timbal"},
-                    "spans": otel_spans,
-                }],
-            }]
+            "resourceSpans": [
+                {
+                    "resource": {"attributes": self._resource_attributes()},
+                    "scopeSpans": [
+                        {
+                            "scope": {"name": "timbal"},
+                            "spans": otel_spans,
+                        }
+                    ],
+                }
+            ]
         }
 
     # ------------------------------------------------------------------

--- a/python/timbal/state/tracing/providers/base.py
+++ b/python/timbal/state/tracing/providers/base.py
@@ -192,6 +192,22 @@ class TracingProvider(ABC):
                 pass
 
     @classmethod
+    async def claim_approval(cls, parent_id: str | None, approval_id: str, run_id: str) -> bool:
+        """Atomically claim an approval resolution before executing it.
+
+        Durable providers override this to prevent two workers from resuming
+        the same pending approval and executing the gated handler twice. The
+        claim key is ``(parent_id, approval_id)`` because duplicate-resume
+        races are about multiple child runs consuming the same parent gate.
+
+        The default is permissive so existing custom tracing providers keep
+        working, but they do not get duplicate-resume protection until they
+        implement this method.
+        """
+        _ = (parent_id, approval_id, run_id)
+        return True
+
+    @classmethod
     @abstractmethod
     async def _store(cls, run_context: "RunContext") -> None:
         """Persist the completed run's trace (provider-specific storage).

--- a/python/timbal/state/tracing/providers/jsonl.py
+++ b/python/timbal/state/tracing/providers/jsonl.py
@@ -1,5 +1,7 @@
 import asyncio
+import fcntl
 import json
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -74,6 +76,16 @@ class JsonlTracingProvider(TracingProvider):
         return cls._lock
 
     @classmethod
+    def _approval_claims_path(cls) -> Path:
+        assert cls._path is not None
+        return cls._path.with_suffix(cls._path.suffix + ".approval_claims.json")
+
+    @classmethod
+    def _approval_claims_lock_path(cls) -> Path:
+        assert cls._path is not None
+        return cls._path.with_suffix(cls._path.suffix + ".approval_claims.lock")
+
+    @classmethod
     @override
     async def get(cls, run_context: "RunContext") -> Trace | None:
         """Retrieve the parent run's trace from the JSONL file.
@@ -98,6 +110,58 @@ class JsonlTracingProvider(TracingProvider):
         except (OSError, json.JSONDecodeError):
             return None
         return None
+
+    @classmethod
+    @override
+    async def claim_approval(cls, parent_id: str | None, approval_id: str, run_id: str) -> bool:
+        """Claim ``(parent_id, approval_id)`` using a sidecar JSON file.
+
+        JSONL itself stores one record per run, so mutating the parent record
+        for a tiny approval-claim row would be awkward and race-prone. A
+        sidecar file keeps the trace format unchanged while still giving local
+        development and tests a durable cross-process lock via ``fcntl``.
+        """
+        if parent_id is None:
+            return True
+        if cls._path is None:
+            raise RuntimeError(
+                "JsonlTracingProvider._path is not set. "
+                "Use JsonlTracingProvider.configured(_path=Path(...)) to create a configured provider."
+            )
+
+        def _claim() -> bool:
+            claims_path = cls._approval_claims_path()
+            lock_path = cls._approval_claims_lock_path()
+            claims_path.parent.mkdir(parents=True, exist_ok=True)
+            lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+            with lock_path.open("a+", encoding="utf-8") as lock_file:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+                try:
+                    try:
+                        claims = json.loads(claims_path.read_text(encoding="utf-8")) if claims_path.exists() else {}
+                    except json.JSONDecodeError:
+                        claims = {}
+
+                    key = f"{parent_id}:{approval_id}"
+                    existing = claims.get(key)
+                    if existing is not None:
+                        return existing.get("claimed_by_run_id") == run_id
+
+                    claims[key] = {
+                        "parent_id": parent_id,
+                        "approval_id": approval_id,
+                        "claimed_by_run_id": run_id,
+                        "claimed_at": int(time.time() * 1000),
+                    }
+                    tmp_path = claims_path.with_suffix(claims_path.suffix + ".tmp")
+                    tmp_path.write_text(json.dumps(claims, sort_keys=True), encoding="utf-8")
+                    tmp_path.replace(claims_path)
+                    return True
+                finally:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+        return await asyncio.to_thread(_claim)
 
     @classmethod
     @override

--- a/python/timbal/state/tracing/providers/sqlite.py
+++ b/python/timbal/state/tracing/providers/sqlite.py
@@ -63,6 +63,27 @@ class SqliteTracingProvider(TracingProvider):
         return conn
 
     @classmethod
+    def _ensure_schema(cls, conn: sqlite3.Connection) -> None:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS runs (
+                run_id    TEXT    PRIMARY KEY,
+                parent_id TEXT,
+                spans     TEXT    NOT NULL,
+                stored_at INTEGER NOT NULL
+            )
+        """)
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_runs_parent_id ON runs (parent_id)")
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS approval_claims (
+                parent_id         TEXT    NOT NULL,
+                approval_id       TEXT    NOT NULL,
+                claimed_by_run_id TEXT    NOT NULL,
+                claimed_at        INTEGER NOT NULL,
+                PRIMARY KEY (parent_id, approval_id)
+            )
+        """)
+
+    @classmethod
     @override
     async def get(cls, run_context: "RunContext") -> Trace | None:
         """Retrieve the parent run's trace from the SQLite database.
@@ -102,6 +123,54 @@ class SqliteTracingProvider(TracingProvider):
 
     @classmethod
     @override
+    async def claim_approval(cls, parent_id: str | None, approval_id: str, run_id: str) -> bool:
+        """Atomically claim ``(parent_id, approval_id)``.
+
+        SQLite enforces the single-consumer invariant with a unique primary
+        key. ``INSERT OR IGNORE`` makes duplicate workers race safely: one row
+        wins, every other worker observes the existing claimant and stops
+        before executing the gated handler.
+        """
+        if parent_id is None:
+            return True
+        if cls._path is None:
+            raise RuntimeError(
+                "SqliteTracingProvider._path is not set. "
+                "Use SqliteTracingProvider.configured(_path=Path(...)) to create a configured provider."
+            )
+
+        def _claim() -> bool:
+            conn = cls._connect()
+            try:
+                cls._ensure_schema(conn)
+                claimed_at = int(time.time() * 1000)
+                cursor = conn.execute(
+                    """
+                    INSERT OR IGNORE INTO approval_claims
+                        (parent_id, approval_id, claimed_by_run_id, claimed_at)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (str(parent_id), approval_id, run_id, claimed_at),
+                )
+                conn.commit()
+                if cursor.rowcount == 1:
+                    return True
+                row = conn.execute(
+                    """
+                    SELECT claimed_by_run_id FROM approval_claims
+                    WHERE parent_id = ? AND approval_id = ?
+                    """,
+                    (str(parent_id), approval_id),
+                ).fetchone()
+                return bool(row and row[0] == run_id)
+            finally:
+                conn.close()
+
+        async with cls._get_lock():
+            return await asyncio.to_thread(_claim)
+
+    @classmethod
+    @override
     async def _store(cls, run_context: "RunContext") -> None:
         """Upsert the current run's trace into the SQLite database.
 
@@ -122,17 +191,9 @@ class SqliteTracingProvider(TracingProvider):
         def _write() -> None:
             conn = cls._connect()
             try:
-                # CREATE TABLE / INDEX are idempotent — SQLite caches the schema
-                # after the first call so these are effectively free on subsequent writes.
-                conn.execute("""
-                    CREATE TABLE IF NOT EXISTS runs (
-                        run_id    TEXT    PRIMARY KEY,
-                        parent_id TEXT,
-                        spans     TEXT    NOT NULL,
-                        stored_at INTEGER NOT NULL
-                    )
-                """)
-                conn.execute("CREATE INDEX IF NOT EXISTS idx_runs_parent_id ON runs (parent_id)")
+                # Schema operations are idempotent — SQLite caches the schema
+                # after the first call so this is effectively free later.
+                cls._ensure_schema(conn)
                 conn.execute(
                     "INSERT OR REPLACE INTO runs (run_id, parent_id, spans, stored_at) VALUES (?, ?, ?, ?)",
                     (run_id, parent_id, spans_json, stored_at),

--- a/python/timbal/types/__init__.py
+++ b/python/timbal/types/__init__.py
@@ -1,3 +1,4 @@
 # ruff: noqa: F401
+from .approval import ApprovalDecision, ApprovalResolution
 from .file import File
 from .message import Message

--- a/python/timbal/types/__init__.py
+++ b/python/timbal/types/__init__.py
@@ -1,4 +1,4 @@
 # ruff: noqa: F401
-from .approval import ApprovalDecision, ApprovalResolution
+from .approval import ApprovalPolicyDecision, ApprovalResolution
 from .file import File
 from .message import Message

--- a/python/timbal/types/approval.py
+++ b/python/timbal/types/approval.py
@@ -27,6 +27,11 @@ class ApprovalResolution(BaseModel):
 
     Resolutions can carry an optional ``expires_at`` (Unix ms). Stale resolutions
     are ignored at gate time and the gate emits a fresh ``ApprovalEvent``.
+
+    Audit fields (``approver_id``, ``comment``, ``decided_at``) are first-class
+    so traces serialize them verbatim and downstream queries
+    (``span.metadata.approval.resolution.approver_id``) work without grepping
+    a free-form ``metadata`` dict. ``metadata`` remains for org-specific extras.
     """
 
     approved: bool
@@ -37,7 +42,26 @@ class ApprovalResolution(BaseModel):
             "Optional Unix-ms timestamp after which this resolution is no longer honoured. None means never expires."
         ),
     )
+    approver_id: str | None = Field(
+        default=None,
+        description="Identifier of the human/caller who decided this resolution. Surfaced in trace audit.",
+    )
+    comment: str | None = Field(
+        default=None,
+        description="Free-form human reasoning for the decision. Surfaced in trace audit.",
+    )
+    decided_at: int | None = Field(
+        default=None,
+        description=(
+            "Unix-ms timestamp when the decision was made. Defaults to construction time when not given. "
+            "Pass an explicit value to preserve idempotency across replays."
+        ),
+    )
     metadata: dict[str, Any] = Field(default_factory=dict)
+
+    def model_post_init(self, __context: Any) -> None:
+        if self.decided_at is None:
+            self.decided_at = int(time.time() * 1000)
 
     def is_expired(self, now_ms: int | None = None) -> bool:
         if self.expires_at is None:

--- a/python/timbal/types/approval.py
+++ b/python/timbal/types/approval.py
@@ -6,7 +6,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 
-class ApprovalDecision(BaseModel):
+class ApprovalPolicyDecision(BaseModel):
     """Normalized approval policy decision for a runnable invocation.
 
     The ``approval_id`` is derived from ``(runnable_path, validated_input)``: a

--- a/python/timbal/types/approval.py
+++ b/python/timbal/types/approval.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ApprovalDecision(BaseModel):
+    """Normalized approval policy decision for a runnable invocation.
+
+    The ``approval_id`` is derived from ``(runnable_path, validated_input)``: a
+    single decision approves every invocation with the same path + input. For
+    irreversible operations (money movement, destructive deletes) include a
+    unique value in the input (e.g. ``idempotency_key=uuid4()``) so each call
+    derives a distinct ``approval_id`` and requires a fresh decision.
+    """
+
+    required: bool
+    prompt: str | None = None
+    description: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ApprovalResolution(BaseModel):
+    """Decision supplied by a human or caller to resume an approval gate.
+
+    Resolutions can carry an optional ``expires_at`` (Unix ms). Stale resolutions
+    are ignored at gate time and the gate emits a fresh ``ApprovalEvent``.
+    """
+
+    approved: bool
+    reason: str | None = None
+    expires_at: int | None = Field(
+        default=None,
+        description=(
+            "Optional Unix-ms timestamp after which this resolution is no longer honoured. None means never expires."
+        ),
+    )
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    def is_expired(self, now_ms: int | None = None) -> bool:
+        if self.expires_at is None:
+            return False
+        if now_ms is None:
+            now_ms = int(time.time() * 1000)
+        return now_ms >= self.expires_at

--- a/python/timbal/types/events/__init__.py
+++ b/python/timbal/types/events/__init__.py
@@ -3,6 +3,7 @@ from typing import Annotated
 
 from pydantic import Field
 
+from .approval import ApprovalEvent
 from .base import BaseEvent
 from .delta import DeltaEvent
 from .output import OutputEvent
@@ -11,6 +12,6 @@ from .start import StartEvent
 # Create a discriminated union of all possible event types.
 # Pydantic will use the 'type' field to determine which model to use.
 Event = Annotated[
-    StartEvent | OutputEvent | DeltaEvent,
+    StartEvent | OutputEvent | DeltaEvent | ApprovalEvent,
     Field(discriminator="type"),
 ]

--- a/python/timbal/types/events/approval.py
+++ b/python/timbal/types/events/approval.py
@@ -1,0 +1,30 @@
+from typing import Any, Literal
+
+from pydantic import Field
+
+from .base import BaseEvent
+
+
+class ApprovalEvent(BaseEvent):
+    """Event emitted when runnable execution is waiting on human approval."""
+
+    type: Literal["APPROVAL"] = "APPROVAL"
+
+    t0: int
+    """Unix-ms timestamp at which approval was requested. Useful for SLA timers."""
+    approval_id: str
+    """Stable identifier used to approve or deny this runnable invocation."""
+    runnable_path: str
+    """Full runnable path that requires approval."""
+    runnable_name: str
+    """Runnable name that requires approval."""
+    runnable_type: str
+    """Runnable class/type that requires approval."""
+    input: Any
+    """Validated input that would be passed to the runnable."""
+    prompt: str | None = None
+    """Optional human-readable prompt explaining what needs approval."""
+    description: str | None = None
+    """Optional runnable or policy description."""
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    """Additional policy metadata for future approval engines."""

--- a/uv.lock
+++ b/uv.lock
@@ -18,52 +18,6 @@ supported-markers = [
     "sys_platform == 'win32'",
 ]
 
-[manifest]
-members = [
-    "ace",
-    "timbal",
-]
-
-[[package]]
-name = "ace"
-source = { editable = "ace" }
-dependencies = [
-    { name = "anthropic", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "cachetools", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "google-genai", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "openai", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "psycopg", extra = ["binary", "pool"], marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "pydantic-settings", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "timbal", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "pytest-asyncio", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "pytest-cov", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "anthropic", specifier = ">=0.79.0" },
-    { name = "cachetools", specifier = ">=7.0.4" },
-    { name = "google-genai", specifier = ">=1.70.0" },
-    { name = "httpx" },
-    { name = "openai", specifier = ">=2.20.0" },
-    { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.3.3" },
-    { name = "pydantic-settings" },
-    { name = "timbal", editable = "." },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=9.0.2" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
-    { name = "pytest-cov", specifier = ">=7.0.0" },
-]
-
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
@@ -121,15 +75,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
-]
-
-[[package]]
-name = "cachetools"
-version = "7.0.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/dd/57fe3fdb6e65b25a5987fd2cdc7e22db0aef508b91634d2e57d22928d41b/cachetools-7.0.5.tar.gz", hash = "sha256:0cd042c24377200c1dcd225f8b7b12b0ca53cc2c961b43757e774ebe190fd990", size = 37367, upload-time = "2026-03-09T20:51:29.451Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/f3/39cf3367b8107baa44f861dc802cbf16263c945b62d8265d36034fc07bea/cachetools-7.0.5-py3-none-any.whl", hash = "sha256:46bc8ebefbe485407621d0a4264b23c080cedd913921bad7ac3ed2f26c183114", size = 13918, upload-time = "2026-03-09T20:51:27.33Z" },
 ]
 
 [[package]]
@@ -209,79 +154,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
     { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
     { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
-]
-
-[[package]]
-name = "charset-normalizer"
-version = "3.4.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/27/c6491ff4954e58a10f69ad90aca8a1b6fe9c5d3c6f380907af3c37435b59/charset_normalizer-3.4.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6e1fcf0720908f200cd21aa4e6750a48ff6ce4afe7ff5a79a90d5ed8a08296f8", size = 206988, upload-time = "2025-10-14T04:40:33.79Z" },
-    { url = "https://files.pythonhosted.org/packages/94/59/2e87300fe67ab820b5428580a53cad894272dbb97f38a7a814a2a1ac1011/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f819d5fe9234f9f82d75bdfa9aef3a3d72c4d24a6e57aeaebba32a704553aa0", size = 147324, upload-time = "2025-10-14T04:40:34.961Z" },
-    { url = "https://files.pythonhosted.org/packages/07/fb/0cf61dc84b2b088391830f6274cb57c82e4da8bbc2efeac8c025edb88772/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a59cb51917aa591b1c4e6a43c132f0cdc3c76dbad6155df4e28ee626cc77a0a3", size = 142742, upload-time = "2025-10-14T04:40:36.105Z" },
-    { url = "https://files.pythonhosted.org/packages/62/8b/171935adf2312cd745d290ed93cf16cf0dfe320863ab7cbeeae1dcd6535f/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8ef3c867360f88ac904fd3f5e1f902f13307af9052646963ee08ff4f131adafc", size = 160863, upload-time = "2025-10-14T04:40:37.188Z" },
-    { url = "https://files.pythonhosted.org/packages/09/73/ad875b192bda14f2173bfc1bc9a55e009808484a4b256748d931b6948442/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d9e45d7faa48ee908174d8fe84854479ef838fc6a705c9315372eacbc2f02897", size = 157837, upload-time = "2025-10-14T04:40:38.435Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/fc/de9cce525b2c5b94b47c70a4b4fb19f871b24995c728e957ee68ab1671ea/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:840c25fb618a231545cbab0564a799f101b63b9901f2569faecd6b222ac72381", size = 151550, upload-time = "2025-10-14T04:40:40.053Z" },
-    { url = "https://files.pythonhosted.org/packages/55/c2/43edd615fdfba8c6f2dfbd459b25a6b3b551f24ea21981e23fb768503ce1/charset_normalizer-3.4.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ca5862d5b3928c4940729dacc329aa9102900382fea192fc5e52eb69d6093815", size = 149162, upload-time = "2025-10-14T04:40:41.163Z" },
-    { url = "https://files.pythonhosted.org/packages/03/86/bde4ad8b4d0e9429a4e82c1e8f5c659993a9a863ad62c7df05cf7b678d75/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9c7f57c3d666a53421049053eaacdd14bbd0a528e2186fcb2e672effd053bb0", size = 150019, upload-time = "2025-10-14T04:40:42.276Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/86/a151eb2af293a7e7bac3a739b81072585ce36ccfb4493039f49f1d3cae8c/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:277e970e750505ed74c832b4bf75dac7476262ee2a013f5574dd49075879e161", size = 143310, upload-time = "2025-10-14T04:40:43.439Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/fe/43dae6144a7e07b87478fdfc4dbe9efd5defb0e7ec29f5f58a55aeef7bf7/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:31fd66405eaf47bb62e8cd575dc621c56c668f27d46a61d975a249930dd5e2a4", size = 162022, upload-time = "2025-10-14T04:40:44.547Z" },
-    { url = "https://files.pythonhosted.org/packages/80/e6/7aab83774f5d2bca81f42ac58d04caf44f0cc2b65fc6db2b3b2e8a05f3b3/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:0d3d8f15c07f86e9ff82319b3d9ef6f4bf907608f53fe9d92b28ea9ae3d1fd89", size = 149383, upload-time = "2025-10-14T04:40:46.018Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/e8/b289173b4edae05c0dde07f69f8db476a0b511eac556dfe0d6bda3c43384/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:9f7fcd74d410a36883701fafa2482a6af2ff5ba96b9a620e9e0721e28ead5569", size = 159098, upload-time = "2025-10-14T04:40:47.081Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/df/fe699727754cae3f8478493c7f45f777b17c3ef0600e28abfec8619eb49c/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ebf3e58c7ec8a8bed6d66a75d7fb37b55e5015b03ceae72a8e7c74495551e224", size = 152991, upload-time = "2025-10-14T04:40:48.246Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/86/584869fe4ddb6ffa3bd9f491b87a01568797fb9bd8933f557dba9771beaf/charset_normalizer-3.4.4-cp311-cp311-win32.whl", hash = "sha256:eecbc200c7fd5ddb9a7f16c7decb07b566c29fa2161a16cf67b8d068bd21690a", size = 99456, upload-time = "2025-10-14T04:40:49.376Z" },
-    { url = "https://files.pythonhosted.org/packages/65/f6/62fdd5feb60530f50f7e38b4f6a1d5203f4d16ff4f9f0952962c044e919a/charset_normalizer-3.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:5ae497466c7901d54b639cf42d5b8c1b6a4fead55215500d2f486d34db48d016", size = 106978, upload-time = "2025-10-14T04:40:50.844Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/9d/0710916e6c82948b3be62d9d398cb4fcf4e97b56d6a6aeccd66c4b2f2bd5/charset_normalizer-3.4.4-cp311-cp311-win_arm64.whl", hash = "sha256:65e2befcd84bc6f37095f5961e68a6f077bf44946771354a28ad434c2cce0ae1", size = 99969, upload-time = "2025-10-14T04:40:52.272Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/85/1637cd4af66fa687396e757dec650f28025f2a2f5a5531a3208dc0ec43f2/charset_normalizer-3.4.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0a98e6759f854bd25a58a73fa88833fba3b7c491169f86ce1180c948ab3fd394", size = 208425, upload-time = "2025-10-14T04:40:53.353Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/6a/04130023fef2a0d9c62d0bae2649b69f7b7d8d24ea5536feef50551029df/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b5b290ccc2a263e8d185130284f8501e3e36c5e02750fc6b6bdeb2e9e96f1e25", size = 148162, upload-time = "2025-10-14T04:40:54.558Z" },
-    { url = "https://files.pythonhosted.org/packages/78/29/62328d79aa60da22c9e0b9a66539feae06ca0f5a4171ac4f7dc285b83688/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74bb723680f9f7a6234dcf67aea57e708ec1fbdf5699fb91dfd6f511b0a320ef", size = 144558, upload-time = "2025-10-14T04:40:55.677Z" },
-    { url = "https://files.pythonhosted.org/packages/86/bb/b32194a4bf15b88403537c2e120b817c61cd4ecffa9b6876e941c3ee38fe/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f1e34719c6ed0b92f418c7c780480b26b5d9c50349e9a9af7d76bf757530350d", size = 161497, upload-time = "2025-10-14T04:40:57.217Z" },
-    { url = "https://files.pythonhosted.org/packages/19/89/a54c82b253d5b9b111dc74aca196ba5ccfcca8242d0fb64146d4d3183ff1/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2437418e20515acec67d86e12bf70056a33abdacb5cb1655042f6538d6b085a8", size = 159240, upload-time = "2025-10-14T04:40:58.358Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/10/d20b513afe03acc89ec33948320a5544d31f21b05368436d580dec4e234d/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11d694519d7f29d6cd09f6ac70028dba10f92f6cdd059096db198c283794ac86", size = 153471, upload-time = "2025-10-14T04:40:59.468Z" },
-    { url = "https://files.pythonhosted.org/packages/61/fa/fbf177b55bdd727010f9c0a3c49eefa1d10f960e5f09d1d887bf93c2e698/charset_normalizer-3.4.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac1c4a689edcc530fc9d9aa11f5774b9e2f33f9a0c6a57864e90908f5208d30a", size = 150864, upload-time = "2025-10-14T04:41:00.623Z" },
-    { url = "https://files.pythonhosted.org/packages/05/12/9fbc6a4d39c0198adeebbde20b619790e9236557ca59fc40e0e3cebe6f40/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:21d142cc6c0ec30d2efee5068ca36c128a30b0f2c53c1c07bd78cb6bc1d3be5f", size = 150647, upload-time = "2025-10-14T04:41:01.754Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/1f/6a9a593d52e3e8c5d2b167daf8c6b968808efb57ef4c210acb907c365bc4/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5dbe56a36425d26d6cfb40ce79c314a2e4dd6211d51d6d2191c00bed34f354cc", size = 145110, upload-time = "2025-10-14T04:41:03.231Z" },
-    { url = "https://files.pythonhosted.org/packages/30/42/9a52c609e72471b0fc54386dc63c3781a387bb4fe61c20231a4ebcd58bdd/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:5bfbb1b9acf3334612667b61bd3002196fe2a1eb4dd74d247e0f2a4d50ec9bbf", size = 162839, upload-time = "2025-10-14T04:41:04.715Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/5b/c0682bbf9f11597073052628ddd38344a3d673fda35a36773f7d19344b23/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:d055ec1e26e441f6187acf818b73564e6e6282709e9bcb5b63f5b23068356a15", size = 150667, upload-time = "2025-10-14T04:41:05.827Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/24/a41afeab6f990cf2daf6cb8c67419b63b48cf518e4f56022230840c9bfb2/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:af2d8c67d8e573d6de5bc30cdb27e9b95e49115cd9baad5ddbd1a6207aaa82a9", size = 160535, upload-time = "2025-10-14T04:41:06.938Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/e5/6a4ce77ed243c4a50a1fecca6aaaab419628c818a49434be428fe24c9957/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:780236ac706e66881f3b7f2f32dfe90507a09e67d1d454c762cf642e6e1586e0", size = 154816, upload-time = "2025-10-14T04:41:08.101Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/ef/89297262b8092b312d29cdb2517cb1237e51db8ecef2e9af5edbe7b683b1/charset_normalizer-3.4.4-cp312-cp312-win32.whl", hash = "sha256:5833d2c39d8896e4e19b689ffc198f08ea58116bee26dea51e362ecc7cd3ed26", size = 99694, upload-time = "2025-10-14T04:41:09.23Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/2d/1e5ed9dd3b3803994c155cd9aacb60c82c331bad84daf75bcb9c91b3295e/charset_normalizer-3.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:a79cfe37875f822425b89a82333404539ae63dbdddf97f84dcbc3d339aae9525", size = 107131, upload-time = "2025-10-14T04:41:10.467Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/d9/0ed4c7098a861482a7b6a95603edce4c0d9db2311af23da1fb2b75ec26fc/charset_normalizer-3.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:376bec83a63b8021bb5c8ea75e21c4ccb86e7e45ca4eb81146091b56599b80c3", size = 100390, upload-time = "2025-10-14T04:41:11.915Z" },
-    { url = "https://files.pythonhosted.org/packages/97/45/4b3a1239bbacd321068ea6e7ac28875b03ab8bc0aa0966452db17cd36714/charset_normalizer-3.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794", size = 208091, upload-time = "2025-10-14T04:41:13.346Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/62/73a6d7450829655a35bb88a88fca7d736f9882a27eacdca2c6d505b57e2e/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed", size = 147936, upload-time = "2025-10-14T04:41:14.461Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c5/adb8c8b3d6625bef6d88b251bbb0d95f8205831b987631ab0c8bb5d937c2/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72", size = 144180, upload-time = "2025-10-14T04:41:15.588Z" },
-    { url = "https://files.pythonhosted.org/packages/91/ed/9706e4070682d1cc219050b6048bfd293ccf67b3d4f5a4f39207453d4b99/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328", size = 161346, upload-time = "2025-10-14T04:41:16.738Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/0d/031f0d95e4972901a2f6f09ef055751805ff541511dc1252ba3ca1f80cf5/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede", size = 158874, upload-time = "2025-10-14T04:41:17.923Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/83/6ab5883f57c9c801ce5e5677242328aa45592be8a00644310a008d04f922/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894", size = 153076, upload-time = "2025-10-14T04:41:19.106Z" },
-    { url = "https://files.pythonhosted.org/packages/75/1e/5ff781ddf5260e387d6419959ee89ef13878229732732ee73cdae01800f2/charset_normalizer-3.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1", size = 150601, upload-time = "2025-10-14T04:41:20.245Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/57/71be810965493d3510a6ca79b90c19e48696fb1ff964da319334b12677f0/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490", size = 150376, upload-time = "2025-10-14T04:41:21.398Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/d5/c3d057a78c181d007014feb7e9f2e65905a6c4ef182c0ddf0de2924edd65/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44", size = 144825, upload-time = "2025-10-14T04:41:22.583Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/8c/d0406294828d4976f275ffbe66f00266c4b3136b7506941d87c00cab5272/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133", size = 162583, upload-time = "2025-10-14T04:41:23.754Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/24/e2aa1f18c8f15c4c0e932d9287b8609dd30ad56dbe41d926bd846e22fb8d/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3", size = 150366, upload-time = "2025-10-14T04:41:25.27Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/5b/1e6160c7739aad1e2df054300cc618b06bf784a7a164b0f238360721ab86/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e", size = 160300, upload-time = "2025-10-14T04:41:26.725Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/10/f882167cd207fbdd743e55534d5d9620e095089d176d55cb22d5322f2afd/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc", size = 154465, upload-time = "2025-10-14T04:41:28.322Z" },
-    { url = "https://files.pythonhosted.org/packages/89/66/c7a9e1b7429be72123441bfdbaf2bc13faab3f90b933f664db506dea5915/charset_normalizer-3.4.4-cp313-cp313-win32.whl", hash = "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac", size = 99404, upload-time = "2025-10-14T04:41:29.95Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/26/b9924fa27db384bdcd97ab83b4f0a8058d96ad9626ead570674d5e737d90/charset_normalizer-3.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14", size = 107092, upload-time = "2025-10-14T04:41:31.188Z" },
-    { url = "https://files.pythonhosted.org/packages/af/8f/3ed4bfa0c0c72a7ca17f0380cd9e4dd842b09f664e780c13cff1dcf2ef1b/charset_normalizer-3.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2", size = 100408, upload-time = "2025-10-14T04:41:32.624Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/35/7051599bd493e62411d6ede36fd5af83a38f37c4767b92884df7301db25d/charset_normalizer-3.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd", size = 207746, upload-time = "2025-10-14T04:41:33.773Z" },
-    { url = "https://files.pythonhosted.org/packages/10/9a/97c8d48ef10d6cd4fcead2415523221624bf58bcf68a802721a6bc807c8f/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb", size = 147889, upload-time = "2025-10-14T04:41:34.897Z" },
-    { url = "https://files.pythonhosted.org/packages/10/bf/979224a919a1b606c82bd2c5fa49b5c6d5727aa47b4312bb27b1734f53cd/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e", size = 143641, upload-time = "2025-10-14T04:41:36.116Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/33/0ad65587441fc730dc7bd90e9716b30b4702dc7b617e6ba4997dc8651495/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14", size = 160779, upload-time = "2025-10-14T04:41:37.229Z" },
-    { url = "https://files.pythonhosted.org/packages/67/ed/331d6b249259ee71ddea93f6f2f0a56cfebd46938bde6fcc6f7b9a3d0e09/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191", size = 159035, upload-time = "2025-10-14T04:41:38.368Z" },
-    { url = "https://files.pythonhosted.org/packages/67/ff/f6b948ca32e4f2a4576aa129d8bed61f2e0543bf9f5f2b7fc3758ed005c9/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838", size = 152542, upload-time = "2025-10-14T04:41:39.862Z" },
-    { url = "https://files.pythonhosted.org/packages/16/85/276033dcbcc369eb176594de22728541a925b2632f9716428c851b149e83/charset_normalizer-3.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6", size = 149524, upload-time = "2025-10-14T04:41:41.319Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/f2/6a2a1f722b6aba37050e626530a46a68f74e63683947a8acff92569f979a/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e", size = 150395, upload-time = "2025-10-14T04:41:42.539Z" },
-    { url = "https://files.pythonhosted.org/packages/60/bb/2186cb2f2bbaea6338cad15ce23a67f9b0672929744381e28b0592676824/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c", size = 143680, upload-time = "2025-10-14T04:41:43.661Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/a5/bf6f13b772fbb2a90360eb620d52ed8f796f3c5caee8398c3b2eb7b1c60d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090", size = 162045, upload-time = "2025-10-14T04:41:44.821Z" },
-    { url = "https://files.pythonhosted.org/packages/df/c5/d1be898bf0dc3ef9030c3825e5d3b83f2c528d207d246cbabe245966808d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152", size = 149687, upload-time = "2025-10-14T04:41:46.442Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/42/90c1f7b9341eef50c8a1cb3f098ac43b0508413f33affd762855f67a410e/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828", size = 160014, upload-time = "2025-10-14T04:41:47.631Z" },
-    { url = "https://files.pythonhosted.org/packages/76/be/4d3ee471e8145d12795ab655ece37baed0929462a86e72372fd25859047c/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec", size = 154044, upload-time = "2025-10-14T04:41:48.81Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/6f/8f7af07237c34a1defe7defc565a9bc1807762f672c0fde711a4b22bf9c0/charset_normalizer-3.4.4-cp314-cp314-win32.whl", hash = "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9", size = 99940, upload-time = "2025-10-14T04:41:49.946Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
-    { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
 ]
 
 [[package]]
@@ -543,45 +415,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e7/7b/f8e0211e9380f7195ba3f3d40c292594fd81ba8ec4629e3854c353aaca45/fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd", size = 394962, upload-time = "2026-03-01T18:18:29.369Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/72/42e900510195b23a56bde950d26a51f8b723846bfcaa0286e90287f0422b/fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e", size = 116999, upload-time = "2026-03-01T18:18:30.831Z" },
-]
-
-[[package]]
-name = "google-auth"
-version = "2.49.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "pyasn1-modules", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ea/80/6a696a07d3d3b0a92488933532f03dbefa4a24ab80fb231395b9a2a1be77/google_auth-2.49.1.tar.gz", hash = "sha256:16d40da1c3c5a0533f57d268fe72e0ebb0ae1cc3b567024122651c045d879b64", size = 333825, upload-time = "2026-03-12T19:30:58.135Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/eb/c6c2478d8a8d633460be40e2a8a6f8f429171997a35a96f81d3b680dec83/google_auth-2.49.1-py3-none-any.whl", hash = "sha256:195ebe3dca18eddd1b3db5edc5189b76c13e96f29e73043b923ebcf3f1a860f7", size = 240737, upload-time = "2026-03-12T19:30:53.159Z" },
-]
-
-[package.optional-dependencies]
-requests = [
-    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-]
-
-[[package]]
-name = "google-genai"
-version = "1.70.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "distro", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "google-auth", extra = ["requests"], marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "sniffio", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "tenacity", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "websockets", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/74/dd/28e4682904b183acbfad3fe6409f13a42f69bb8eab6e882d3bcbea1dde01/google_genai-1.70.0.tar.gz", hash = "sha256:36b67b0fc6f319e08d1f1efd808b790107b1809c8743a05d55dfcf9d9fad7719", size = 519550, upload-time = "2026-04-01T10:52:46.487Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/a3/d4564c8a9beaf6a3cef8d70fa6354318572cebfee65db4f01af0d41f45ba/google_genai-1.70.0-py3-none-any.whl", hash = "sha256:b74c24549d8b4208f4c736fd11857374788e1ffffc725de45d706e35c97fceee", size = 760584, upload-time = "2026-04-01T10:52:44.349Z" },
 ]
 
 [[package]]
@@ -1156,90 +989,6 @@ wheels = [
 ]
 
 [[package]]
-name = "psycopg"
-version = "3.3.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "(python_full_version < '3.13' and sys_platform == 'darwin') or (python_full_version < '3.13' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform == 'win32')" },
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/b6/379d0a960f8f435ec78720462fd94c4863e7a31237cf81bf76d0af5883bf/psycopg-3.3.3.tar.gz", hash = "sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9", size = 165624, upload-time = "2026-02-18T16:52:16.546Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/5b/181e2e3becb7672b502f0ed7f16ed7352aca7c109cfb94cf3878a9186db9/psycopg-3.3.3-py3-none-any.whl", hash = "sha256:f96525a72bcfade6584ab17e89de415ff360748c766f0106959144dcbb38c698", size = 212768, upload-time = "2026-02-18T16:46:27.365Z" },
-]
-
-[package.optional-dependencies]
-binary = [
-    { name = "psycopg-binary", marker = "(implementation_name != 'pypy' and sys_platform == 'darwin') or (implementation_name != 'pypy' and sys_platform == 'linux') or (implementation_name != 'pypy' and sys_platform == 'win32')" },
-]
-pool = [
-    { name = "psycopg-pool", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-]
-
-[[package]]
-name = "psycopg-binary"
-version = "3.3.3"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/c0/b389119dd754483d316805260f3e73cdcad97925839107cc7a296f6132b1/psycopg_binary-3.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a89bb9ee11177b2995d87186b1d9fa892d8ea725e85eab28c6525e4cc14ee048", size = 4609740, upload-time = "2026-02-18T16:47:51.093Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/e3/9976eef20f61840285174d360da4c820a311ab39d6b82fa09fbb545be825/psycopg_binary-3.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9f7d0cf072c6fbac3795b08c98ef9ea013f11db609659dcfc6b1f6cc31f9e181", size = 4676837, upload-time = "2026-02-18T16:47:55.523Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/f2/d28ba2f7404fd7f68d41e8a11df86313bd646258244cb12a8dd83b868a97/psycopg_binary-3.3.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:90eecd93073922f085967f3ed3a98ba8c325cbbc8c1a204e300282abd2369e13", size = 5497070, upload-time = "2026-02-18T16:47:59.929Z" },
-    { url = "https://files.pythonhosted.org/packages/de/2f/6c5c54b815edeb30a281cfcea96dc93b3bb6be939aea022f00cab7aa1420/psycopg_binary-3.3.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:dac7ee2f88b4d7bb12837989ca354c38d400eeb21bce3b73dac02622f0a3c8d6", size = 5172410, upload-time = "2026-02-18T16:48:05.665Z" },
-    { url = "https://files.pythonhosted.org/packages/51/75/8206c7008b57de03c1ada46bd3110cc3743f3fd9ed52031c4601401d766d/psycopg_binary-3.3.3-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b62cf8784eb6d35beaee1056d54caf94ec6ecf2b7552395e305518ab61eb8fd2", size = 6763408, upload-time = "2026-02-18T16:48:13.541Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/5a/ea1641a1e6c8c8b3454b0fcb43c3045133a8b703e6e824fae134088e63bd/psycopg_binary-3.3.3-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a39f34c9b18e8f6794cca17bfbcd64572ca2482318db644268049f8c738f35a6", size = 5006255, upload-time = "2026-02-18T16:48:22.176Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/fb/538df099bf55ae1637d52d7ccb6b9620b535a40f4c733897ac2b7bb9e14c/psycopg_binary-3.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:883d68d48ca9ff3cb3d10c5fdebea02c79b48eecacdddbf7cce6e7cdbdc216b8", size = 4532694, upload-time = "2026-02-18T16:48:27.338Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/d1/00780c0e187ea3c13dfc53bd7060654b2232cd30df562aac91a5f1c545ac/psycopg_binary-3.3.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:cab7bc3d288d37a80aa8c0820033250c95e40b1c2b5c57cf59827b19c2a8b69d", size = 4222833, upload-time = "2026-02-18T16:48:31.221Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/34/a07f1ff713c51d64dc9f19f2c32be80299a2055d5d109d5853662b922cb4/psycopg_binary-3.3.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:56c767007ca959ca32f796b42379fc7e1ae2ed085d29f20b05b3fc394f3715cc", size = 3952818, upload-time = "2026-02-18T16:48:35.869Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/67/d33f268a7759b4445f3c9b5a181039b01af8c8263c865c1be7a6444d4749/psycopg_binary-3.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:da2f331a01af232259a21573a01338530c6016dcfad74626c01330535bcd8628", size = 4258061, upload-time = "2026-02-18T16:48:41.365Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/3b/0d8d2c5e8e29ccc07d28c8af38445d9d9abcd238d590186cac82ee71fc84/psycopg_binary-3.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:19f93235ece6dbfc4036b5e4f6d8b13f0b8f2b3eeb8b0bd2936d406991bcdd40", size = 3558915, upload-time = "2026-02-18T16:48:46.679Z" },
-    { url = "https://files.pythonhosted.org/packages/90/15/021be5c0cbc5b7c1ab46e91cc3434eb42569f79a0592e67b8d25e66d844d/psycopg_binary-3.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6698dbab5bcef8fdb570fc9d35fd9ac52041771bfcfe6fd0fc5f5c4e36f1e99d", size = 4591170, upload-time = "2026-02-18T16:48:55.594Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/54/a60211c346c9a2f8c6b272b5f2bbe21f6e11800ce7f61e99ba75cf8b63e1/psycopg_binary-3.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:329ff393441e75f10b673ae99ab45276887993d49e65f141da20d915c05aafd8", size = 4670009, upload-time = "2026-02-18T16:49:03.608Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/53/ac7c18671347c553362aadbf65f92786eef9540676ca24114cc02f5be405/psycopg_binary-3.3.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:eb072949b8ebf4082ae24289a2b0fd724da9adc8f22743409d6fd718ddb379df", size = 5469735, upload-time = "2026-02-18T16:49:10.128Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/c3/4f4e040902b82a344eff1c736cde2f2720f127fe939c7e7565706f96dd44/psycopg_binary-3.3.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:263a24f39f26e19ed7fc982d7859a36f17841b05bebad3eb47bb9cd2dd785351", size = 5152919, upload-time = "2026-02-18T16:49:16.335Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/e7/d929679c6a5c212bcf738806c7c89f5b3d0919f2e1685a0e08d6ff877945/psycopg_binary-3.3.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5152d50798c2fa5bd9b68ec68eb68a1b71b95126c1d70adaa1a08cd5eefdc23d", size = 6738785, upload-time = "2026-02-18T16:49:22.687Z" },
-    { url = "https://files.pythonhosted.org/packages/69/b0/09703aeb69a9443d232d7b5318d58742e8ca51ff79f90ffe6b88f1db45e7/psycopg_binary-3.3.3-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d6a1e56dd267848edb824dbeb08cf5bac649e02ee0b03ba883ba3f4f0bd54f2", size = 4979008, upload-time = "2026-02-18T16:49:27.313Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/a6/e662558b793c6e13a7473b970fee327d635270e41eded3090ef14045a6a5/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73eaaf4bb04709f545606c1db2f65f4000e8a04cdbf3e00d165a23004692093e", size = 4508255, upload-time = "2026-02-18T16:49:31.575Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/7f/0f8b2e1d5e0093921b6f324a948a5c740c1447fbb45e97acaf50241d0f39/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:162e5675efb4704192411eaf8e00d07f7960b679cd3306e7efb120bb8d9456cc", size = 4189166, upload-time = "2026-02-18T16:49:35.801Z" },
-    { url = "https://files.pythonhosted.org/packages/92/ec/ce2e91c33bc8d10b00c87e2f6b0fb570641a6a60042d6a9ae35658a3a797/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:fab6b5e37715885c69f5d091f6ff229be71e235f272ebaa35158d5a46fd548a0", size = 3924544, upload-time = "2026-02-18T16:49:41.129Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/2f/7718141485f73a924205af60041c392938852aa447a94c8cbd222ff389a1/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a4aab31bd6d1057f287c96c0effca3a25584eb9cc702f282ecb96ded7814e830", size = 4235297, upload-time = "2026-02-18T16:49:46.726Z" },
-    { url = "https://files.pythonhosted.org/packages/57/f9/1add717e2643a003bbde31b1b220172e64fbc0cb09f06429820c9173f7fc/psycopg_binary-3.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:59aa31fe11a0e1d1bcc2ce37ed35fe2ac84cd65bb9036d049b1a1c39064d0f14", size = 3547659, upload-time = "2026-02-18T16:49:52.999Z" },
-    { url = "https://files.pythonhosted.org/packages/03/0a/cac9fdf1df16a269ba0e5f0f06cac61f826c94cadb39df028cdfe19d3a33/psycopg_binary-3.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:05f32239aec25c5fb15f7948cffdc2dc0dac098e48b80a140e4ba32b572a2e7d", size = 4590414, upload-time = "2026-02-18T16:50:01.441Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/c0/d8f8508fbf440edbc0099b1abff33003cd80c9e66eb3a1e78834e3fb4fb9/psycopg_binary-3.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7c84f9d214f2d1de2fafebc17fa68ac3f6561a59e291553dfc45ad299f4898c1", size = 4669021, upload-time = "2026-02-18T16:50:08.803Z" },
-    { url = "https://files.pythonhosted.org/packages/04/05/097016b77e343b4568feddf12c72171fc513acef9a4214d21b9478569068/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e77957d2ba17cada11be09a5066d93026cdb61ada7c8893101d7fe1c6e1f3925", size = 5467453, upload-time = "2026-02-18T16:50:14.985Z" },
-    { url = "https://files.pythonhosted.org/packages/91/23/73244e5feb55b5ca109cede6e97f32ef45189f0fdac4c80d75c99862729d/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:42961609ac07c232a427da7c87a468d3c82fee6762c220f38e37cfdacb2b178d", size = 5151135, upload-time = "2026-02-18T16:50:24.82Z" },
-    { url = "https://files.pythonhosted.org/packages/11/49/5309473b9803b207682095201d8708bbc7842ddf3f192488a69204e36455/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae07a3114313dd91fce686cab2f4c44af094398519af0e0f854bc707e1aeedf1", size = 6737315, upload-time = "2026-02-18T16:50:35.106Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/5d/03abe74ef34d460b33c4d9662bf6ec1dd38888324323c1a1752133c10377/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d257c58d7b36a621dcce1d01476ad8b60f12d80eb1406aee4cf796f88b2ae482", size = 4979783, upload-time = "2026-02-18T16:50:42.067Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/6c/3fbf8e604e15f2f3752900434046c00c90bb8764305a1b81112bff30ba24/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:07c7211f9327d522c9c47560cae00a4ecf6687f4e02d779d035dd3177b41cb12", size = 4509023, upload-time = "2026-02-18T16:50:50.116Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/6b/1a06b43b7c7af756c80b67eac8bfaa51d77e68635a8a8d246e4f0bb7604a/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:8e7e9eca9b363dbedeceeadd8be97149d2499081f3c52d141d7cd1f395a91f83", size = 4185874, upload-time = "2026-02-18T16:50:55.97Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/d3/bf49e3dcaadba510170c8d111e5e69e5ae3f981c1554c5bb71c75ce354bb/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:cb85b1d5702877c16f28d7b92ba030c1f49ebcc9b87d03d8c10bf45a2f1c7508", size = 3925668, upload-time = "2026-02-18T16:51:03.299Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/92/0aac830ed6a944fe334404e1687a074e4215630725753f0e3e9a9a595b62/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4d4606c84d04b80f9138d72f1e28c6c02dc5ae0c7b8f3f8aaf89c681ce1cd1b1", size = 4234973, upload-time = "2026-02-18T16:51:09.097Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/96/102244653ee5a143ece5afe33f00f52fe64e389dfce8dbc87580c6d70d3d/psycopg_binary-3.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:74eae563166ebf74e8d950ff359be037b85723d99ca83f57d9b244a871d6c13b", size = 3551342, upload-time = "2026-02-18T16:51:13.892Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/71/7a57e5b12275fe7e7d84d54113f0226080423a869118419c9106c083a21c/psycopg_binary-3.3.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:497852c5eaf1f0c2d88ab74a64a8097c099deac0c71de1cbcf18659a8a04a4b2", size = 4607368, upload-time = "2026-02-18T16:51:19.295Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/04/cb834f120f2b2c10d4003515ef9ca9d688115b9431735e3936ae48549af8/psycopg_binary-3.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:258d1ea53464d29768bf25930f43291949f4c7becc706f6e220c515a63a24edd", size = 4687047, upload-time = "2026-02-18T16:51:23.84Z" },
-    { url = "https://files.pythonhosted.org/packages/40/e9/47a69692d3da9704468041aa5ed3ad6fc7f6bb1a5ae788d261a26bbca6c7/psycopg_binary-3.3.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:111c59897a452196116db12e7f608da472fbff000693a21040e35fc978b23430", size = 5487096, upload-time = "2026-02-18T16:51:29.645Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/b6/0e0dd6a2f802864a4ae3dbadf4ec620f05e3904c7842b326aafc43e5f464/psycopg_binary-3.3.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:17bb6600e2455993946385249a3c3d0af52cd70c1c1cdbf712e9d696d0b0bf1b", size = 5168720, upload-time = "2026-02-18T16:51:36.499Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/0d/977af38ac19a6b55d22dff508bd743fd7c1901e1b73657e7937c7cccb0a3/psycopg_binary-3.3.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:642050398583d61c9856210568eb09a8e4f2fe8224bf3be21b67a370e677eead", size = 6762076, upload-time = "2026-02-18T16:51:43.167Z" },
-    { url = "https://files.pythonhosted.org/packages/34/40/912a39d48322cf86895c0eaf2d5b95cb899402443faefd4b09abbba6b6e1/psycopg_binary-3.3.3-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:533efe6dc3a7cba5e2a84e38970786bb966306863e45f3db152007e9f48638a6", size = 4997623, upload-time = "2026-02-18T16:51:47.707Z" },
-    { url = "https://files.pythonhosted.org/packages/98/0c/c14d0e259c65dc7be854d926993f151077887391d5a081118907a9d89603/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5958dbf28b77ce2033482f6cb9ef04d43f5d8f4b7636e6963d5626f000efb23e", size = 4532096, upload-time = "2026-02-18T16:51:51.421Z" },
-    { url = "https://files.pythonhosted.org/packages/39/21/8b7c50a194cfca6ea0fd4d1f276158307785775426e90700ab2eba5cd623/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a6af77b6626ce92b5817bf294b4d45ec1a6161dba80fc2d82cdffdd6814fd023", size = 4208884, upload-time = "2026-02-18T16:51:57.336Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/2c/a4981bf42cf30ebba0424971d7ce70a222ae9b82594c42fc3f2105d7b525/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:47f06fcbe8542b4d96d7392c476a74ada521c5aebdb41c3c0155f6595fc14c8d", size = 3944542, upload-time = "2026-02-18T16:52:04.266Z" },
-    { url = "https://files.pythonhosted.org/packages/60/e9/b7c29b56aa0b85a4e0c4d89db691c1ceef08f46a356369144430c155a2f5/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7800e6c6b5dc4b0ca7cc7370f770f53ac83886b76afda0848065a674231e856", size = 4254339, upload-time = "2026-02-18T16:52:10.444Z" },
-    { url = "https://files.pythonhosted.org/packages/98/5a/291d89f44d3820fffb7a04ebc8f3ef5dda4f542f44a5daea0c55a84abf45/psycopg_binary-3.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:165f22ab5a9513a3d7425ffb7fcc7955ed8ccaeef6d37e369d6cc1dff1582383", size = 3652796, upload-time = "2026-02-18T16:52:14.02Z" },
-]
-
-[[package]]
-name = "psycopg-pool"
-version = "3.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/56/9a/9470d013d0d50af0da9c4251614aeb3c1823635cab3edc211e3839db0bcf/psycopg_pool-3.3.0.tar.gz", hash = "sha256:fa115eb2860bd88fce1717d75611f41490dec6135efb619611142b24da3f6db5", size = 31606, upload-time = "2025-12-01T11:34:33.11Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/c3/26b8a0908a9db249de3b4169692e1c7c19048a9bc41a4d3209cee7dbb758/psycopg_pool-3.3.0-py3-none-any.whl", hash = "sha256:2e44329155c410b5e8666372db44276a8b1ebd8c90f1c3026ebba40d4bc81063", size = 39995, upload-time = "2025-12-01T11:34:29.761Z" },
-]
-
-[[package]]
 name = "pyarrow"
 version = "23.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1287,27 +1036,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/a3/d2c462d4ef313521eaf2eff04d204ac60775263f1fb08c374b543f79f610/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:46718a220d64677c93bc243af1d44b55998255427588e400677d7192671845c7", size = 48259435, upload-time = "2026-02-16T10:13:49.226Z" },
     { url = "https://files.pythonhosted.org/packages/cc/f1/11a544b8c3d38a759eb3fbb022039117fd633e9a7b19e4841cc3da091915/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690", size = 50629149, upload-time = "2026-02-16T10:13:57.238Z" },
     { url = "https://files.pythonhosted.org/packages/50/f2/c0e76a0b451ffdf0cf788932e182758eb7558953f4f27f1aff8e2518b653/pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce", size = 28365807, upload-time = "2026-02-16T10:14:03.892Z" },
-]
-
-[[package]]
-name = "pyasn1"
-version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
-]
-
-[[package]]
-name = "pyasn1-modules"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -1699,21 +1427,6 @@ wheels = [
 ]
 
 [[package]]
-name = "requests"
-version = "2.32.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "charset-normalizer", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "idna", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "urllib3", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
-]
-
-[[package]]
 name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1913,15 +1626,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tenacity"
-version = "9.1.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
-]
-
-[[package]]
 name = "timbal"
 source = { editable = "." }
 dependencies = [
@@ -1973,6 +1677,7 @@ dev = [
     { name = "pyngrok", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "pytest-asyncio", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pytest-cov", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "yappi", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
@@ -2015,6 +1720,7 @@ dev = [
     { name = "pyngrok", specifier = ">=7.2.3" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-asyncio", specifier = ">=0.25.2" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "yappi", specifier = ">=1.7.6" },
 ]
 
@@ -2103,15 +1809,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
-]
-
-[[package]]
-name = "tzdata"
-version = "2025.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add runnable-level human approval gates for tools, agents, workflows, and slash-command tools, including approval/denial resume flows.
- Harden HITL for production with durable JSONL/SQLite resume coverage, input redaction, typed audit metadata, lifecycle usage counters, and duplicate-resume locking.
- Document the approval API, redaction, audit fields, counters, pending approvals, and duplicate-resume behavior.

## Test plan
- `uv run pytest python/tests/core/test_approval.py python/tests/core/test_approval_regressions.py python/tests/core/test_approval_redaction.py python/tests/core/test_approval_audit_and_metrics.py python/tests/core/test_approval_double_resume.py python/tests/core/test_approval_cross_process.py python/tests/core/test_jsonl_tracing_provider.py python/tests/core/test_sqlite_tracing_provider.py python/tests/core/test_in_memory_tracing_provider.py python/tests/core/test_otel_exporter.py --no-header --tb=short -q`
- `uv run pytest python/tests/ --no-header --tb=line -q -m "not integration" --ignore=python/tests/types/test_file.py`
- `uv run ruff check python/timbal/state/tracing/providers/base.py python/timbal/state/tracing/providers/jsonl.py python/timbal/state/tracing/providers/sqlite.py python/timbal/core/runnable.py python/tests/core/test_approval_double_resume.py`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes core execution flow in `Runnable`, `Agent`, and `Workflow` (cancellation/interrupt semantics, tool execution/resume, tracing) and adds durable locking and redaction that affect side effects and observability.
> 
> **Overview**
> Introduces **human-in-the-loop approval gates** at the `Runnable` level (`requires_approval`, `approval_prompt`, `approval_decisions`) so tools/agents/workflows can cancel with `approval_required`, emit an `ApprovalEvent`, and later resume to execute (or deny) the gated handler.
> 
> Hardens approval for production: stable `approval_id` derivation, typed `ApprovalResolution` audit fields persisted to span metadata, lifecycle usage counters (`approvals:*`), **input redaction** for all public/tracing surfaces, durable **duplicate-resume protection** via `claim_approval` in JSONL/SQLite providers, and warnings for unused/unknown `approval_decisions`.
> 
> Fixes/extends runtime behavior around approvals: prevents `GeneratorExit` from clobbering approval status on stream breaks, enables agent resume by re-running pending tool uses without re-calling the LLM, drains parallel workflow steps before raising approval, and updates `.collect()` to expose **all** pending approvals via `OutputEvent.metadata['pending_approvals']` (plus OTel exporter attributes for metadata/approval/status).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd86f614e62de3da9fda172b4d453baede6e3e94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->