### PR TITLE
Resolve postponed tool annotations before schema serialization

### DIFF
--- a/python/tests/core/test_tool.py
+++ b/python/tests/core/test_tool.py
@@ -1,6 +1,7 @@
 import asyncio
+import json
 from functools import partial
-from typing import Any
+from typing import Any, Literal
 
 import pytest
 from pydantic import BaseModel
@@ -223,6 +224,58 @@ class TestToolExecution:
         output = await result.collect()
         assert isinstance(output, OutputEvent)
         assert output.error is not None  # Should have validation error
+
+    @pytest.mark.asyncio
+    async def test_literal_list_none_parameter_serializes_and_executes(self):
+        """Test Literal[...] | None params don't break schema or call serialization."""
+        def handler(
+            mode: Literal["auto", "manual"] | None = None,
+            modes: list[Literal["fast", "slow"]] | None = None,
+        ) -> str:
+            return f"{mode or ''}:{','.join(modes or [])}"
+
+        tool = Tool(handler=handler)
+
+        # Tool schemas are passed through provider clients, so they must remain JSON-serializable.
+        json.dumps(tool.openai_chat_completions_schema)
+        json.dumps(tool.anthropic_schema)
+
+        output = await tool(mode="auto", modes=["fast"]).collect()
+        assert_no_errors(output)
+        assert output.output == "auto:fast"
+        json.dumps(output.model_dump(mode="json"))
+
+        none_output = await tool(mode=None, modes=None).collect()
+        assert_no_errors(none_output)
+        assert none_output.output == ":"
+        json.dumps(none_output.model_dump(mode="json"))
+
+    @pytest.mark.asyncio
+    async def test_postponed_literal_parameter_annotations_serialize_and_execute(self):
+        """Test stringified Literal annotations resolve in generated params models."""
+        def search_catalogue(mode=None, fields=None) -> str:
+            return f"{mode or ''}:{','.join(fields or [])}"
+
+        search_catalogue.__annotations__ = {
+            "mode": 'Literal["auto", "manual"] | None',
+            "fields": 'list[Literal["brand", "color"]] | None',
+            "return": "str",
+        }
+
+        literal = globals().pop("Literal")
+        try:
+            tool = Tool(handler=search_catalogue)
+
+            json.dumps(tool.openai_chat_completions_schema)
+            json.dumps(tool.anthropic_schema)
+            json.dumps(tool.model_dump())
+
+            output = await tool(mode="manual", fields=["brand"]).collect()
+            assert_no_errors(output)
+            assert output.output == "manual:brand"
+            json.dumps(output.model_dump(mode="json"))
+        finally:
+            globals()["Literal"] = literal
 
 
 class TestToolSchemas:

--- a/python/timbal/utils/model.py
+++ b/python/timbal/utils/model.py
@@ -1,4 +1,5 @@
 import inspect
+import typing
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, create_model
@@ -9,6 +10,11 @@ from pydantic_core import PydanticUndefined
 def create_model_from_handler(name: str, handler: Any) -> BaseModel:
     """Create a dynamic pydantic model from the argspec of a function."""
     argspec = inspect.getfullargspec(handler)
+    try:
+        globalns = {**vars(typing), **getattr(handler, "__globals__", {})}
+        annotations = typing.get_type_hints(handler, globalns=globalns, include_extras=True)
+    except Exception:
+        annotations = argspec.annotations
 
     # If the handler is a bound method, we need to skip the first argument (normally self or cls)
     is_bound = inspect.ismethod(handler)
@@ -22,7 +28,7 @@ def create_model_from_handler(name: str, handler: Any) -> BaseModel:
         field_info = defaults.get(field_name, ...)  # Pydantic will use ... to mark this field as required.
         if not isinstance(field_info, FieldInfo):
             field_info = Field(field_info)
-        field_type = argspec.annotations.get(field_name, Any)
+        field_type = annotations.get(field_name, Any)
         fields[field_name] = (field_type, field_info)
     extra_mode = "allow" if argspec.varkw else "ignore"
     return create_model(name, __config__=ConfigDict(extra=extra_mode), **fields)


### PR DESCRIPTION
## Summary
- Resolve postponed/stringified handler annotations before building dynamic tool params models.
- Add regression coverage for `Literal[...] | None` and `list[Literal[...]] | None` tool params, including missing runtime `Literal` globals.

## Test plan
- `uv run pytest python/tests/core/test_tool.py::TestToolExecution::test_literal_list_none_parameter_serializes_and_executes python/tests/core/test_tool.py::TestToolExecution::test_postponed_literal_parameter_annotations_serialize_and_execute`
- `uv run ruff check --select I001,F401 python/tests/core/test_tool.py python/timbal/utils/model.py`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how tool parameter models are built by eagerly resolving type hints (including `Literal`/postponed annotations), which can affect runtime validation and provider schema generation for all tools.
> 
> **Overview**
> Fixes tool parameter model generation to resolve handler annotations via `typing.get_type_hints(..., include_extras=True)` (with a merged `typing` + handler globals namespace) before building the dynamic Pydantic params model, improving support for postponed/stringified annotations.
> 
> Adds regression tests ensuring `Literal[...] | None` and `list[Literal[...]] | None` parameters (including when `Literal` is missing from runtime globals) still produce JSON-serializable OpenAI/Anthropic tool schemas and execute correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9df51ad8c68dac2b8509d2b1773baef27f994a16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->