### PR TITLE
Add interactive controls to timbal start

### DIFF
--- a/cli/commands/start.zig
+++ b/cli/commands/start.zig
@@ -306,27 +306,7 @@ const LogFilterState = struct {
         }
     }
 
-    fn toggleMute(self: *LogFilterState, target: []const u8) !bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
-
-        if (std.mem.eql(u8, target, "all")) {
-            self.mute_all = !self.mute_all;
-            return self.mute_all;
-        }
-        if (std.mem.eql(u8, target, "ui")) {
-            self.mute_ui = !self.mute_ui;
-            return self.mute_ui;
-        }
-        if (std.mem.eql(u8, target, "api")) {
-            self.mute_api = !self.mute_api;
-            return self.mute_api;
-        }
-        if (std.mem.eql(u8, target, "workforce")) {
-            self.mute_workforce = !self.mute_workforce;
-            return self.mute_workforce;
-        }
-
+    fn toggleMuteName(self: *LogFilterState, target: []const u8) !bool {
         if (self.muted_names.contains(target)) {
             if (self.muted_names.fetchRemove(target)) |entry| {
                 self.muted_names.allocator.free(entry.key);
@@ -338,6 +318,32 @@ const LogFilterState = struct {
         errdefer self.muted_names.allocator.free(owned_target);
         try self.muted_names.put(owned_target, {});
         return true;
+    }
+
+    fn toggleMute(self: *LogFilterState, target: []const u8, target_is_member_name: bool) !bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        if (std.mem.eql(u8, target, "all")) {
+            self.mute_all = !self.mute_all;
+            return self.mute_all;
+        }
+        if (std.mem.eql(u8, target, "workforce")) {
+            self.mute_workforce = !self.mute_workforce;
+            return self.mute_workforce;
+        }
+        if (target_is_member_name) {
+            return self.toggleMuteName(target);
+        }
+        if (std.mem.eql(u8, target, "ui")) {
+            self.mute_ui = !self.mute_ui;
+            return self.mute_ui;
+        }
+        if (std.mem.eql(u8, target, "api")) {
+            self.mute_api = !self.mute_api;
+            return self.mute_api;
+        }
+        return self.toggleMuteName(target);
     }
 };
 
@@ -769,14 +775,19 @@ fn printCommandHelp(mutex: *std.Thread.Mutex) void {
     stdout.print("  {s}q{s}  stop services and quit\n", .{ Color.bold_cyan, Color.reset }) catch {};
 }
 
-fn isKnownLogTarget(target: []const u8, members: []const WorkforceMember, has_ui: bool, has_api: bool) bool {
-    if (std.mem.eql(u8, target, "all")) return true;
-    if (std.mem.eql(u8, target, "ui")) return has_ui;
-    if (std.mem.eql(u8, target, "api")) return has_api;
-    if (std.mem.eql(u8, target, "workforce")) return members.len > 0;
+fn isWorkforceMemberName(target: []const u8, members: []const WorkforceMember) bool {
     for (members) |member| {
         if (std.mem.eql(u8, target, member.name)) return true;
     }
+    return false;
+}
+
+fn isKnownLogTarget(target: []const u8, members: []const WorkforceMember, has_ui: bool, has_api: bool) bool {
+    if (std.mem.eql(u8, target, "all")) return true;
+    if (std.mem.eql(u8, target, "workforce")) return members.len > 0;
+    if (isWorkforceMemberName(target, members)) return true;
+    if (std.mem.eql(u8, target, "ui")) return has_ui;
+    if (std.mem.eql(u8, target, "api")) return has_api;
     return false;
 }
 
@@ -835,7 +846,7 @@ fn handleMuteCommand(
         return;
     }
 
-    const muted = log_filter.toggleMute(target) catch {
+    const muted = log_filter.toggleMute(target, isWorkforceMemberName(target, members)) catch {
         mutex.lock();
         stdout.print("\n{s}Could not update log mute state for `{s}`.{s}\n", .{ Color.dim, target, Color.reset }) catch {};
         mutex.unlock();
@@ -1340,4 +1351,37 @@ pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
         allocator.free(member.name);
         member.config.deinit(allocator);
     }
+}
+
+test "log targets include workforce members named like reserved services" {
+    const members = [_]WorkforceMember{
+        .{ .name = "ui", .config = undefined, .port = 8001 },
+        .{ .name = "api", .config = undefined, .port = 8002 },
+    };
+
+    try std.testing.expect(isKnownLogTarget("ui", &members, false, false));
+    try std.testing.expect(isKnownLogTarget("api", &members, false, false));
+    try std.testing.expect(isKnownLogTarget("ui", &members, true, false));
+    try std.testing.expect(isKnownLogTarget("api", &members, false, true));
+}
+
+test "mute can target workforce member named ui" {
+    var log_filter = LogFilterState.init(std.testing.allocator);
+    defer log_filter.deinit();
+
+    try std.testing.expect(try log_filter.toggleMute("ui", true));
+    try std.testing.expect(!log_filter.shouldPrint("ui", .workforce));
+    try std.testing.expect(log_filter.shouldPrint("other", .ui));
+
+    try std.testing.expect(!try log_filter.toggleMute("ui", true));
+    try std.testing.expect(log_filter.shouldPrint("ui", .workforce));
+}
+
+test "mute still targets ui service when no member has that name" {
+    var log_filter = LogFilterState.init(std.testing.allocator);
+    defer log_filter.deinit();
+
+    try std.testing.expect(try log_filter.toggleMute("ui", false));
+    try std.testing.expect(!log_filter.shouldPrint("ui", .ui));
+    try std.testing.expect(log_filter.shouldPrint("ui", .workforce));
 }

--- a/cli/commands/start.zig
+++ b/cli/commands/start.zig
@@ -51,17 +51,16 @@ fn restoreTermios() void {
     }
 }
 
-var g_interrupted: bool = false;
+var g_interrupted = std.atomic.Value(bool).init(false);
 
 fn sigintHandler(_: c_int) callconv(.C) void {
-    if (g_interrupted) {
+    if (g_interrupted.swap(true, .seq_cst)) {
         // Second Ctrl+C: force exit after restoring terminal.
         restoreTermios();
         std.process.exit(130);
     }
-    g_interrupted = true;
-    // First Ctrl+C: let children die from their own SIGINT naturally.
-    // The normal exit path in run() restores termios after they've exited.
+    // First Ctrl+C: let the supervisor loop stop child process groups and
+    // restore the terminal through the normal cleanup path.
 }
 
 fn getHomePath(allocator: std.mem.Allocator) ![]u8 {
@@ -149,7 +148,9 @@ fn printUsage() !void {
         "    \x1b[1;36mo\x1b[0m, \x1b[1;36mopen     \x1b[0mOpen the app in your browser\n" ++
         "    \x1b[1;36mu\x1b[0m, \x1b[1;36mui       \x1b[0mPrint the UI URL\n" ++
         "    \x1b[1;36ma\x1b[0m, \x1b[1;36mapi      \x1b[0mPrint the API URL\n" ++
-        "    \x1b[1;36mw\x1b[0m, \x1b[1;36mworkforce\x1b[0mPrint workforce service URLs\n" ++
+        "    \x1b[1;36mw\x1b[0m, \x1b[1;36mworkforce\x1b[0m Print workforce service URLs\n" ++
+        "    \x1b[1;36mf <target>\x1b[0m        Focus logs: all, ui, api, workforce, or member name\n" ++
+        "    \x1b[1;36mm <target>\x1b[0m        Toggle mute for logs: all, ui, api, workforce, or member name\n" ++
         "    \x1b[1;36mh\x1b[0m, \x1b[1;36mhelp     \x1b[0mShow commands while services are running\n" ++
         "    \x1b[1;36mq\x1b[0m, \x1b[1;36mquit     \x1b[0mStop services and quit\n" ++
         "\n" ++
@@ -226,10 +227,118 @@ const prefix_colors = [_][]const u8{
 /// Context passed to each pipe reader thread.
 const PipeReaderCtx = struct {
     pipe: std.fs.File,
+    service_name: []const u8,
+    service_kind: ServiceKind,
     prefix: []const u8,
     color: []const u8,
     mutex: *std.Thread.Mutex,
     allocator: std.mem.Allocator,
+    log_filter: *LogFilterState,
+};
+
+const ServiceKind = enum {
+    ui,
+    api,
+    workforce,
+};
+
+const LogFocus = enum {
+    all,
+    name,
+    workforce,
+};
+
+const LogFilterState = struct {
+    mutex: std.Thread.Mutex = .{},
+    focus: LogFocus = .all,
+    focus_name: [128]u8 = undefined,
+    focus_name_len: usize = 0,
+    mute_all: bool = false,
+    mute_ui: bool = false,
+    mute_api: bool = false,
+    mute_workforce: bool = false,
+    muted_names: std.StringHashMap(void),
+
+    fn init(allocator: std.mem.Allocator) LogFilterState {
+        return .{
+            .muted_names = std.StringHashMap(void).init(allocator),
+        };
+    }
+
+    fn deinit(self: *LogFilterState) void {
+        var iter = self.muted_names.keyIterator();
+        while (iter.next()) |key| {
+            self.muted_names.allocator.free(key.*);
+        }
+        self.muted_names.deinit();
+    }
+
+    fn shouldPrint(self: *LogFilterState, service_name: []const u8, service_kind: ServiceKind) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        if (self.focus == .workforce and service_kind != .workforce) return false;
+        if (self.focus == .name and !std.mem.eql(u8, service_name, self.focus_name[0..self.focus_name_len])) return false;
+
+        if (self.mute_all) return false;
+        if (service_kind == .ui and self.mute_ui) return false;
+        if (service_kind == .api and self.mute_api) return false;
+        if (service_kind == .workforce and self.mute_workforce) return false;
+        if (self.muted_names.contains(service_name)) return false;
+
+        return true;
+    }
+
+    fn setFocus(self: *LogFilterState, target: []const u8) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        if (std.mem.eql(u8, target, "all")) {
+            self.focus = .all;
+            self.focus_name_len = 0;
+        } else if (std.mem.eql(u8, target, "workforce")) {
+            self.focus = .workforce;
+            self.focus_name_len = 0;
+        } else {
+            self.focus = .name;
+            self.focus_name_len = @min(target.len, self.focus_name.len);
+            @memcpy(self.focus_name[0..self.focus_name_len], target[0..self.focus_name_len]);
+        }
+    }
+
+    fn toggleMute(self: *LogFilterState, target: []const u8) !bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        if (std.mem.eql(u8, target, "all")) {
+            self.mute_all = !self.mute_all;
+            return self.mute_all;
+        }
+        if (std.mem.eql(u8, target, "ui")) {
+            self.mute_ui = !self.mute_ui;
+            return self.mute_ui;
+        }
+        if (std.mem.eql(u8, target, "api")) {
+            self.mute_api = !self.mute_api;
+            return self.mute_api;
+        }
+        if (std.mem.eql(u8, target, "workforce")) {
+            self.mute_workforce = !self.mute_workforce;
+            return self.mute_workforce;
+        }
+
+        if (self.muted_names.contains(target)) {
+            if (self.muted_names.fetchRemove(target)) |entry| {
+                self.muted_names.allocator.free(entry.key);
+            }
+            return false;
+        }
+
+        const owned_target = try self.muted_names.allocator.dupe(u8, target);
+        errdefer self.muted_names.allocator.free(owned_target);
+        try self.muted_names.put(owned_target, {});
+        return true;
+    }
 };
 
 /// Thread function that reads from a pipe line by line, printing each with a colored prefix.
@@ -260,6 +369,7 @@ fn pipeReaderFn(ctx: PipeReaderCtx) void {
         };
         defer ctx.allocator.free(line);
         if (line.len == 0) continue;
+        if (!ctx.log_filter.shouldPrint(ctx.service_name, ctx.service_kind)) continue;
 
         ctx.mutex.lock();
         stdout.print("{s}{s}{s} {s}\n", .{ ctx.color, ctx.prefix, Color.reset, line }) catch {};
@@ -276,13 +386,58 @@ const CommandAction = enum(u8) {
     ui_url,
     api_url,
     workforce_urls,
+    focus_logs,
+    toggle_mute,
     restart,
     quit,
 };
 
-const CommandInputCtx = struct {
-    action: *std.atomic.Value(CommandAction),
+const Command = struct {
+    action: CommandAction = .none,
+    target: [128]u8 = undefined,
+    target_len: usize = 0,
 };
+
+const CommandState = struct {
+    mutex: std.Thread.Mutex = .{},
+    command: Command = .{},
+
+    fn set(self: *CommandState, action: CommandAction, target: []const u8) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        self.command.action = action;
+        self.command.target_len = @min(target.len, self.command.target.len);
+        if (self.command.target_len > 0) {
+            @memcpy(self.command.target[0..self.command.target_len], target[0..self.command.target_len]);
+        }
+    }
+
+    fn take(self: *CommandState) Command {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        const command = self.command;
+        self.command = .{};
+        return command;
+    }
+};
+
+const CommandInputCtx = struct {
+    state: *CommandState,
+};
+
+fn targetAfterCommand(command: []const u8, verb: []const u8) ?[]const u8 {
+    if (!std.mem.startsWith(u8, command, verb)) return null;
+    if (command.len == verb.len) return "";
+    if (command[verb.len] != ' ') return null;
+    return std.mem.trim(u8, command[verb.len + 1 ..], " \t\r\n");
+}
+
+fn targetAfterEitherCommand(command: []const u8, short_verb: []const u8, long_verb: []const u8) ?[]const u8 {
+    if (targetAfterCommand(command, short_verb)) |target| return target;
+    return targetAfterCommand(command, long_verb);
+}
 
 fn commandInputFn(ctx: CommandInputCtx) void {
     const stdin = std.io.getStdIn().reader();
@@ -300,23 +455,27 @@ fn commandInputFn(ctx: CommandInputCtx) void {
 
         const command = std.mem.trim(u8, line, " \t\r\n");
         if (std.mem.eql(u8, command, "r") or std.mem.eql(u8, command, "restart")) {
-            ctx.action.store(.restart, .release);
+            ctx.state.set(.restart, "");
         } else if (std.mem.eql(u8, command, "h") or std.mem.eql(u8, command, "help") or std.mem.eql(u8, command, "?")) {
-            ctx.action.store(.help, .release);
+            ctx.state.set(.help, "");
         } else if (std.mem.eql(u8, command, "s") or std.mem.eql(u8, command, "status")) {
-            ctx.action.store(.status, .release);
+            ctx.state.set(.status, "");
         } else if (std.mem.eql(u8, command, "o") or std.mem.eql(u8, command, "open")) {
-            ctx.action.store(.open, .release);
+            ctx.state.set(.open, "");
         } else if (std.mem.eql(u8, command, "url") or std.mem.eql(u8, command, "urls")) {
-            ctx.action.store(.urls, .release);
+            ctx.state.set(.urls, "");
         } else if (std.mem.eql(u8, command, "u") or std.mem.eql(u8, command, "ui")) {
-            ctx.action.store(.ui_url, .release);
+            ctx.state.set(.ui_url, "");
         } else if (std.mem.eql(u8, command, "a") or std.mem.eql(u8, command, "api")) {
-            ctx.action.store(.api_url, .release);
+            ctx.state.set(.api_url, "");
         } else if (std.mem.eql(u8, command, "w") or std.mem.eql(u8, command, "workforce")) {
-            ctx.action.store(.workforce_urls, .release);
+            ctx.state.set(.workforce_urls, "");
+        } else if (targetAfterEitherCommand(command, "f", "focus")) |target| {
+            ctx.state.set(.focus_logs, target);
+        } else if (targetAfterEitherCommand(command, "m", "mute")) |target| {
+            ctx.state.set(.toggle_mute, target);
         } else if (std.mem.eql(u8, command, "q") or std.mem.eql(u8, command, "quit")) {
-            ctx.action.store(.quit, .release);
+            ctx.state.set(.quit, "");
             break;
         }
     }
@@ -329,10 +488,12 @@ fn spawnService(
     argv: []const []const u8,
     cwd: []const u8,
     prefix: []const u8,
+    service_kind: ServiceKind,
     color: []const u8,
     mutex: *std.Thread.Mutex,
     threads: *std.ArrayList(std.Thread),
     env_map: *const std.process.EnvMap,
+    log_filter: *LogFilterState,
 ) !std.process.Child {
     var child = std.process.Child.init(argv, allocator);
     child.cwd = cwd;
@@ -352,20 +513,26 @@ fn spawnService(
     if (child.stdout) |pipe| {
         const thread = try std.Thread.spawn(.{}, pipeReaderFn, .{PipeReaderCtx{
             .pipe = pipe,
+            .service_name = prefix,
+            .service_kind = service_kind,
             .prefix = prefix,
             .color = color,
             .mutex = mutex,
             .allocator = allocator,
+            .log_filter = log_filter,
         }});
         try threads.append(thread);
     }
     if (child.stderr) |pipe| {
         const thread = try std.Thread.spawn(.{}, pipeReaderFn, .{PipeReaderCtx{
             .pipe = pipe,
+            .service_name = prefix,
+            .service_kind = service_kind,
             .prefix = prefix,
             .color = color,
             .mutex = mutex,
             .allocator = allocator,
+            .log_filter = log_filter,
         }});
         try threads.append(thread);
     }
@@ -444,6 +611,7 @@ fn startServices(
     api_port: ?u16,
     service_env: *std.process.EnvMap,
     output_mutex: *std.Thread.Mutex,
+    log_filter: *LogFilterState,
 ) !RunningServices {
     const stdout = std.io.getStdOut().writer();
     try stdout.print("\n{s}Starting services...{s}\n\n", .{ Color.bold, Color.reset });
@@ -466,7 +634,7 @@ fn startServices(
         const color = prefix_colors[color_idx % prefix_colors.len];
         color_idx += 1;
 
-        var child = spawnService(allocator, &.{ "uv", "run", "-m", "timbal.server.http", "--port", port_str, "--import_spec", member.config.fqn }, member_dir, member.name, color, output_mutex, &services.reader_threads, service_env) catch {
+        var child = spawnService(allocator, &.{ "uv", "run", "-m", "timbal.server.http", "--port", port_str, "--import_spec", member.config.fqn }, member_dir, member.name, .workforce, color, output_mutex, &services.reader_threads, service_env, log_filter) catch {
             std.debug.print("Error: failed to start {s}\n", .{member.name});
             continue;
         };
@@ -487,7 +655,7 @@ fn startServices(
         defer allocator.free(ui_port_str);
 
         service_env.put("PORT", ui_port_str) catch return error.OutOfMemory;
-        var child = spawnService(allocator, &.{ "bun", "run", "dev", "--port", ui_port_str }, ui_dir, "ui", "\x1b[1;36m", output_mutex, &services.reader_threads, service_env) catch {
+        var child = spawnService(allocator, &.{ "bun", "run", "dev", "--port", ui_port_str }, ui_dir, "ui", .ui, "\x1b[1;36m", output_mutex, &services.reader_threads, service_env, log_filter) catch {
             std.debug.print("Error: failed to start UI\n", .{});
             return error.ServiceStartFailed;
         };
@@ -508,7 +676,7 @@ fn startServices(
         defer allocator.free(api_port_str);
 
         service_env.put("PORT", api_port_str) catch return error.OutOfMemory;
-        var child = spawnService(allocator, &.{ "bun", "run", "dev" }, api_dir, "api", "\x1b[1;32m", output_mutex, &services.reader_threads, service_env) catch {
+        var child = spawnService(allocator, &.{ "bun", "run", "dev" }, api_dir, "api", .api, "\x1b[1;32m", output_mutex, &services.reader_threads, service_env, log_filter) catch {
             std.debug.print("Error: failed to start API\n", .{});
             return error.ServiceStartFailed;
         };
@@ -596,7 +764,91 @@ fn printCommandHelp(mutex: *std.Thread.Mutex) void {
     stdout.print("  {s}u{s}  print the UI URL\n", .{ Color.bold_cyan, Color.reset }) catch {};
     stdout.print("  {s}a{s}  print the API URL\n", .{ Color.bold_cyan, Color.reset }) catch {};
     stdout.print("  {s}w{s}  print workforce service URLs\n", .{ Color.bold_cyan, Color.reset }) catch {};
+    stdout.print("  {s}f <target>{s}  focus logs: all, ui, api, workforce, or member name\n", .{ Color.bold_cyan, Color.reset }) catch {};
+    stdout.print("  {s}m <target>{s}  toggle mute for logs: all, ui, api, workforce, or member name\n", .{ Color.bold_cyan, Color.reset }) catch {};
     stdout.print("  {s}q{s}  stop services and quit\n", .{ Color.bold_cyan, Color.reset }) catch {};
+}
+
+fn isKnownLogTarget(target: []const u8, members: []const WorkforceMember, has_ui: bool, has_api: bool) bool {
+    if (std.mem.eql(u8, target, "all")) return true;
+    if (std.mem.eql(u8, target, "ui")) return has_ui;
+    if (std.mem.eql(u8, target, "api")) return has_api;
+    if (std.mem.eql(u8, target, "workforce")) return members.len > 0;
+    for (members) |member| {
+        if (std.mem.eql(u8, target, member.name)) return true;
+    }
+    return false;
+}
+
+fn printUnknownLogTarget(target: []const u8, mutex: *std.Thread.Mutex) void {
+    const stdout = std.io.getStdOut().writer();
+    mutex.lock();
+    defer mutex.unlock();
+
+    stdout.print("\n{s}Unknown log target `{s}`. Use all, ui, api, workforce, or a workforce member name.{s}\n", .{ Color.dim, target, Color.reset }) catch {};
+}
+
+fn handleFocusCommand(
+    target: []const u8,
+    members: []const WorkforceMember,
+    has_ui: bool,
+    has_api: bool,
+    log_filter: *LogFilterState,
+    mutex: *std.Thread.Mutex,
+) void {
+    const stdout = std.io.getStdOut().writer();
+    if (target.len == 0) {
+        printUnknownLogTarget(target, mutex);
+        return;
+    }
+    if (!isKnownLogTarget(target, members, has_ui, has_api)) {
+        printUnknownLogTarget(target, mutex);
+        return;
+    }
+
+    log_filter.setFocus(target);
+
+    mutex.lock();
+    defer mutex.unlock();
+    if (std.mem.eql(u8, target, "all")) {
+        stdout.print("\n{s}Showing all non-muted logs.{s}\n", .{ Color.dim, Color.reset }) catch {};
+    } else {
+        stdout.print("\n{s}Showing only {s} logs. Type `f all` to restore all logs.{s}\n", .{ Color.dim, target, Color.reset }) catch {};
+    }
+}
+
+fn handleMuteCommand(
+    target: []const u8,
+    members: []const WorkforceMember,
+    has_ui: bool,
+    has_api: bool,
+    log_filter: *LogFilterState,
+    mutex: *std.Thread.Mutex,
+) void {
+    const stdout = std.io.getStdOut().writer();
+    if (target.len == 0) {
+        printUnknownLogTarget(target, mutex);
+        return;
+    }
+    if (!isKnownLogTarget(target, members, has_ui, has_api)) {
+        printUnknownLogTarget(target, mutex);
+        return;
+    }
+
+    const muted = log_filter.toggleMute(target) catch {
+        mutex.lock();
+        stdout.print("\n{s}Could not update log mute state for `{s}`.{s}\n", .{ Color.dim, target, Color.reset }) catch {};
+        mutex.unlock();
+        return;
+    };
+
+    mutex.lock();
+    defer mutex.unlock();
+    if (muted) {
+        stdout.print("\n{s}Muted {s} logs. Type `m {s}` again to unmute.{s}\n", .{ Color.dim, target, target, Color.reset }) catch {};
+    } else {
+        stdout.print("\n{s}Unmuted {s} logs.{s}\n", .{ Color.dim, target, Color.reset }) catch {};
+    }
 }
 
 fn printServiceStatus(services: ?*RunningServices, mutex: *std.Thread.Mutex) void {
@@ -674,6 +926,7 @@ pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
     defer restoreWindowsConsole(orig_cp);
 
     const stdout = std.io.getStdOut().writer();
+    g_interrupted.store(false, .seq_cst);
 
     const base_port: u16 = 4455;
     var project_path: ?[]const u8 = null;
@@ -923,8 +1176,12 @@ pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
         };
         std.posix.sigaction(std.posix.SIG.INT, &sa, null);
     }
+    defer restoreTermios();
 
     var output_mutex = std.Thread.Mutex{};
+    var command_state = CommandState{};
+    var log_filter = LogFilterState.init(allocator);
+    defer log_filter.deinit();
 
     // Shared env map with FORCE_COLOR for all services.
     var service_env = std.process.getEnvMap(allocator) catch return;
@@ -966,11 +1223,10 @@ pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
         service_env.put("TIMBAL_START_UI_PORT", ui_port_env) catch {};
     }
 
-    var requested_action = std.atomic.Value(CommandAction).init(.none);
     const command_input_enabled = std.io.getStdIn().isTty();
     if (command_input_enabled) {
         const command_thread = std.Thread.spawn(.{}, commandInputFn, .{CommandInputCtx{
-            .action = &requested_action,
+            .state = &command_state,
         }}) catch null;
         if (command_thread) |thread| thread.detach();
     }
@@ -985,6 +1241,7 @@ pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
         api_port,
         &service_env,
         &output_mutex,
+        &log_filter,
     );
     defer if (services) |*running| stopServices(running);
 
@@ -1010,8 +1267,10 @@ pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
         }
     }
 
-    while (!g_interrupted) {
-        switch (requested_action.swap(.none, .acq_rel)) {
+    while (!g_interrupted.load(.seq_cst)) {
+        const command = command_state.take();
+        const target = command.target[0..command.target_len];
+        switch (command.action) {
             .none => {},
             .help => printCommandHelp(&output_mutex),
             .status => {
@@ -1037,6 +1296,12 @@ pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
             .urls, .ui_url, .api_url, .workforce_urls => |action| {
                 printProjectUrls(members.items, has_ui, ui_port, has_api, api_port, action, &output_mutex);
             },
+            .focus_logs => {
+                handleFocusCommand(target, members.items, has_ui, has_api, &log_filter, &output_mutex);
+            },
+            .toggle_mute => {
+                handleMuteCommand(target, members.items, has_ui, has_api, &log_filter, &output_mutex);
+            },
             .restart => {
                 output_mutex.lock();
                 stdout.print("\n{s}Restarting services...{s}\n", .{ Color.bold, Color.reset }) catch {};
@@ -1056,6 +1321,7 @@ pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
                     api_port,
                     &service_env,
                     &output_mutex,
+                    &log_filter,
                 );
             },
             .quit => break,
@@ -1068,8 +1334,6 @@ pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
         stopServices(running);
         services = null;
     }
-
-    restoreTermios();
 
     // Free member data.
     for (members.items) |*member| {

--- a/cli/commands/start.zig
+++ b/cli/commands/start.zig
@@ -431,6 +431,7 @@ const CommandState = struct {
 
 const CommandInputCtx = struct {
     state: *CommandState,
+    stop: *std.atomic.Value(bool),
 };
 
 fn targetAfterCommand(command: []const u8, verb: []const u8) ?[]const u8 {
@@ -446,9 +447,22 @@ fn targetAfterEitherCommand(command: []const u8, short_verb: []const u8, long_ve
 }
 
 fn commandInputFn(ctx: CommandInputCtx) void {
-    const stdin = std.io.getStdIn().reader();
+    const stdin_file = std.io.getStdIn();
+    const stdin = stdin_file.reader();
 
-    while (true) {
+    while (!ctx.stop.load(.seq_cst)) {
+        if (comptime !is_windows) {
+            var poll_fds = [_]std.posix.pollfd{.{
+                .fd = stdin_file.handle,
+                .events = std.posix.POLL.IN,
+                .revents = 0,
+            }};
+            const ready = std.posix.poll(&poll_fds, 150) catch continue;
+            if (ready == 0) continue;
+            if ((poll_fds[0].revents & (std.posix.POLL.HUP | std.posix.POLL.ERR)) != 0) break;
+            if ((poll_fds[0].revents & std.posix.POLL.IN) == 0) continue;
+        }
+
         const line = stdin.readUntilDelimiterAlloc(std.heap.page_allocator, '\n', 1024) catch |err| switch (err) {
             error.EndOfStream => break,
             error.StreamTooLong => {
@@ -458,6 +472,7 @@ fn commandInputFn(ctx: CommandInputCtx) void {
             else => continue,
         };
         defer std.heap.page_allocator.free(line);
+        if (ctx.stop.load(.seq_cst)) break;
 
         const command = std.mem.trim(u8, line, " \t\r\n");
         if (std.mem.eql(u8, command, "r") or std.mem.eql(u8, command, "restart")) {
@@ -487,6 +502,19 @@ fn commandInputFn(ctx: CommandInputCtx) void {
     }
 }
 
+fn forceStopSpawnedChild(child: *std.process.Child) void {
+    if (comptime !is_windows) {
+        std.posix.kill(-child.id, std.posix.SIG.KILL) catch |err| switch (err) {
+            error.ProcessNotFound => {},
+            error.PermissionDenied => {},
+            else => {},
+        };
+    } else {
+        _ = child.kill() catch {};
+    }
+    _ = child.wait() catch {};
+}
+
 /// Spawn a long-running process and start threads to stream its stdout/stderr with a prefix.
 /// Returns the child process. Caller is responsible for waiting/killing it.
 fn spawnService(
@@ -514,6 +542,7 @@ fn spawnService(
     }
 
     try child.spawn();
+    errdefer forceStopSpawnedChild(&child);
 
     // Spawn threads to read stdout and stderr.
     if (child.stdout) |pipe| {
@@ -527,7 +556,7 @@ fn spawnService(
             .allocator = allocator,
             .log_filter = log_filter,
         }});
-        try threads.append(thread);
+        threads.appendAssumeCapacity(thread);
     }
     if (child.stderr) |pipe| {
         const thread = try std.Thread.spawn(.{}, pipeReaderFn, .{PipeReaderCtx{
@@ -540,7 +569,7 @@ fn spawnService(
             .allocator = allocator,
             .log_filter = log_filter,
         }});
-        try threads.append(thread);
+        threads.appendAssumeCapacity(thread);
     }
 
     return child;
@@ -577,27 +606,24 @@ fn signalServiceGroup(child: *std.process.Child, sig: u8) void {
 }
 
 fn stopServices(services: *RunningServices) void {
-    if (services.children.items.len == 0) {
-        services.deinit();
-        return;
-    }
+    if (services.children.items.len > 0) {
+        if (comptime !is_windows) {
+            for (services.children.items) |*child| signalServiceGroup(child, std.posix.SIG.INT);
+            std.time.sleep(1200 * std.time.ns_per_ms);
 
-    if (comptime !is_windows) {
-        for (services.children.items) |*child| signalServiceGroup(child, std.posix.SIG.INT);
-        std.time.sleep(1200 * std.time.ns_per_ms);
+            for (services.children.items) |*child| signalServiceGroup(child, std.posix.SIG.TERM);
+            std.time.sleep(800 * std.time.ns_per_ms);
 
-        for (services.children.items) |*child| signalServiceGroup(child, std.posix.SIG.TERM);
-        std.time.sleep(800 * std.time.ns_per_ms);
-
-        for (services.children.items) |*child| signalServiceGroup(child, std.posix.SIG.KILL);
-    } else {
-        for (services.children.items) |*child| {
-            _ = child.kill() catch {};
+            for (services.children.items) |*child| signalServiceGroup(child, std.posix.SIG.KILL);
+        } else {
+            for (services.children.items) |*child| {
+                _ = child.kill() catch {};
+            }
         }
-    }
 
-    for (services.children.items) |*child| {
-        _ = child.wait() catch {};
+        for (services.children.items) |*child| {
+            _ = child.wait() catch {};
+        }
     }
 
     for (services.reader_threads.items) |thread| {
@@ -629,6 +655,11 @@ fn startServices(
     };
     errdefer stopServices(&services);
 
+    const service_count = members.len + @as(usize, @intFromBool(has_ui)) + @as(usize, @intFromBool(has_api));
+    try services.children.ensureTotalCapacity(service_count);
+    try services.statuses.ensureTotalCapacity(service_count);
+    try services.reader_threads.ensureTotalCapacity(service_count * 2);
+
     var color_idx: usize = 0;
 
     // Start workforce members first.
@@ -640,18 +671,18 @@ fn startServices(
         const color = prefix_colors[color_idx % prefix_colors.len];
         color_idx += 1;
 
-        var child = spawnService(allocator, &.{ "uv", "run", "-m", "timbal.server.http", "--port", port_str, "--import_spec", member.config.fqn }, member_dir, member.name, .workforce, color, output_mutex, &services.reader_threads, service_env, log_filter) catch {
+        const child = spawnService(allocator, &.{ "uv", "run", "-m", "timbal.server.http", "--port", port_str, "--import_spec", member.config.fqn }, member_dir, member.name, .workforce, color, output_mutex, &services.reader_threads, service_env, log_filter) catch {
             std.debug.print("Error: failed to start {s}\n", .{member.name});
             continue;
         };
-        try services.statuses.append(.{
+        const status = ServiceStatus{
             .name = member.name,
             .port = member.port,
             .pid = if (is_windows) {} else child.id,
             .started_at_ms = std.time.milliTimestamp(),
-        });
-        try services.children.append(child);
-        _ = &child;
+        };
+        services.children.appendAssumeCapacity(child);
+        services.statuses.appendAssumeCapacity(status);
     }
 
     if (has_ui) {
@@ -661,18 +692,18 @@ fn startServices(
         defer allocator.free(ui_port_str);
 
         service_env.put("PORT", ui_port_str) catch return error.OutOfMemory;
-        var child = spawnService(allocator, &.{ "bun", "run", "dev", "--port", ui_port_str }, ui_dir, "ui", .ui, "\x1b[1;36m", output_mutex, &services.reader_threads, service_env, log_filter) catch {
+        const child = spawnService(allocator, &.{ "bun", "run", "dev", "--port", ui_port_str }, ui_dir, "ui", .ui, "\x1b[1;36m", output_mutex, &services.reader_threads, service_env, log_filter) catch {
             std.debug.print("Error: failed to start UI\n", .{});
             return error.ServiceStartFailed;
         };
-        try services.statuses.append(.{
+        const status = ServiceStatus{
             .name = "ui",
             .port = ui_port.?,
             .pid = if (is_windows) {} else child.id,
             .started_at_ms = std.time.milliTimestamp(),
-        });
-        try services.children.append(child);
-        _ = &child;
+        };
+        services.children.appendAssumeCapacity(child);
+        services.statuses.appendAssumeCapacity(status);
     }
 
     if (has_api) {
@@ -682,18 +713,18 @@ fn startServices(
         defer allocator.free(api_port_str);
 
         service_env.put("PORT", api_port_str) catch return error.OutOfMemory;
-        var child = spawnService(allocator, &.{ "bun", "run", "dev" }, api_dir, "api", .api, "\x1b[1;32m", output_mutex, &services.reader_threads, service_env, log_filter) catch {
+        const child = spawnService(allocator, &.{ "bun", "run", "dev" }, api_dir, "api", .api, "\x1b[1;32m", output_mutex, &services.reader_threads, service_env, log_filter) catch {
             std.debug.print("Error: failed to start API\n", .{});
             return error.ServiceStartFailed;
         };
-        try services.statuses.append(.{
+        const status = ServiceStatus{
             .name = "api",
             .port = api_port.?,
             .pid = if (is_windows) {} else child.id,
             .started_at_ms = std.time.milliTimestamp(),
-        });
-        try services.children.append(child);
-        _ = &child;
+        };
+        services.children.appendAssumeCapacity(child);
+        services.statuses.appendAssumeCapacity(status);
     }
 
     return services;
@@ -1190,7 +1221,25 @@ pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
     defer restoreTermios();
 
     var output_mutex = std.Thread.Mutex{};
-    var command_state = CommandState{};
+    const command_state = try std.heap.page_allocator.create(CommandState);
+    command_state.* = .{};
+    var command_input_stop = std.atomic.Value(bool).init(false);
+    var command_thread: ?std.Thread = null;
+    var command_state_owned = true;
+    defer {
+        command_input_stop.store(true, .seq_cst);
+        if (command_thread) |thread| {
+            if (comptime !is_windows) {
+                thread.join();
+            } else {
+                // Windows console reads cannot be interrupted here. Keep the
+                // state process-lived if the detached reader wakes after run().
+                thread.detach();
+                command_state_owned = false;
+            }
+        }
+        if (command_state_owned) std.heap.page_allocator.destroy(command_state);
+    }
     var log_filter = LogFilterState.init(allocator);
     defer log_filter.deinit();
 
@@ -1236,10 +1285,10 @@ pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     const command_input_enabled = std.io.getStdIn().isTty();
     if (command_input_enabled) {
-        const command_thread = std.Thread.spawn(.{}, commandInputFn, .{CommandInputCtx{
-            .state = &command_state,
+        command_thread = std.Thread.spawn(.{}, commandInputFn, .{CommandInputCtx{
+            .state = command_state,
+            .stop = &command_input_stop,
         }}) catch null;
-        if (command_thread) |thread| thread.detach();
     }
 
     var services: ?RunningServices = try startServices(

--- a/cli/commands/start.zig
+++ b/cli/commands/start.zig
@@ -143,6 +143,16 @@ fn printUsage() !void {
         "\x1b[1;32mArguments:\n" ++
         "    \x1b[1;36m[PATH] \x1b[0mPath to the project directory (default: current directory)\n" ++
         "\n" ++
+        "\x1b[1;32mInteractive commands:\n" ++
+        "    \x1b[1;36mr\x1b[0m, \x1b[1;36mrestart  \x1b[0mRestart all services\n" ++
+        "    \x1b[1;36ms\x1b[0m, \x1b[1;36mstatus   \x1b[0mShow service status, ports, PIDs, and uptime\n" ++
+        "    \x1b[1;36mo\x1b[0m, \x1b[1;36mopen     \x1b[0mOpen the app in your browser\n" ++
+        "    \x1b[1;36mu\x1b[0m, \x1b[1;36mui       \x1b[0mPrint the UI URL\n" ++
+        "    \x1b[1;36ma\x1b[0m, \x1b[1;36mapi      \x1b[0mPrint the API URL\n" ++
+        "    \x1b[1;36mw\x1b[0m, \x1b[1;36mworkforce\x1b[0mPrint workforce service URLs\n" ++
+        "    \x1b[1;36mh\x1b[0m, \x1b[1;36mhelp     \x1b[0mShow commands while services are running\n" ++
+        "    \x1b[1;36mq\x1b[0m, \x1b[1;36mquit     \x1b[0mStop services and quit\n" ++
+        "\n" ++
         utils.global_options_help ++
         "\n");
 }
@@ -257,6 +267,61 @@ fn pipeReaderFn(ctx: PipeReaderCtx) void {
     }
 }
 
+const CommandAction = enum(u8) {
+    none,
+    help,
+    status,
+    open,
+    urls,
+    ui_url,
+    api_url,
+    workforce_urls,
+    restart,
+    quit,
+};
+
+const CommandInputCtx = struct {
+    action: *std.atomic.Value(CommandAction),
+};
+
+fn commandInputFn(ctx: CommandInputCtx) void {
+    const stdin = std.io.getStdIn().reader();
+
+    while (true) {
+        const line = stdin.readUntilDelimiterAlloc(std.heap.page_allocator, '\n', 1024) catch |err| switch (err) {
+            error.EndOfStream => break,
+            error.StreamTooLong => {
+                stdin.skipUntilDelimiterOrEof('\n') catch break;
+                continue;
+            },
+            else => continue,
+        };
+        defer std.heap.page_allocator.free(line);
+
+        const command = std.mem.trim(u8, line, " \t\r\n");
+        if (std.mem.eql(u8, command, "r") or std.mem.eql(u8, command, "restart")) {
+            ctx.action.store(.restart, .release);
+        } else if (std.mem.eql(u8, command, "h") or std.mem.eql(u8, command, "help") or std.mem.eql(u8, command, "?")) {
+            ctx.action.store(.help, .release);
+        } else if (std.mem.eql(u8, command, "s") or std.mem.eql(u8, command, "status")) {
+            ctx.action.store(.status, .release);
+        } else if (std.mem.eql(u8, command, "o") or std.mem.eql(u8, command, "open")) {
+            ctx.action.store(.open, .release);
+        } else if (std.mem.eql(u8, command, "url") or std.mem.eql(u8, command, "urls")) {
+            ctx.action.store(.urls, .release);
+        } else if (std.mem.eql(u8, command, "u") or std.mem.eql(u8, command, "ui")) {
+            ctx.action.store(.ui_url, .release);
+        } else if (std.mem.eql(u8, command, "a") or std.mem.eql(u8, command, "api")) {
+            ctx.action.store(.api_url, .release);
+        } else if (std.mem.eql(u8, command, "w") or std.mem.eql(u8, command, "workforce")) {
+            ctx.action.store(.workforce_urls, .release);
+        } else if (std.mem.eql(u8, command, "q") or std.mem.eql(u8, command, "quit")) {
+            ctx.action.store(.quit, .release);
+            break;
+        }
+    }
+}
+
 /// Spawn a long-running process and start threads to stream its stdout/stderr with a prefix.
 /// Returns the child process. Caller is responsible for waiting/killing it.
 fn spawnService(
@@ -271,9 +336,15 @@ fn spawnService(
 ) !std.process.Child {
     var child = std.process.Child.init(argv, allocator);
     child.cwd = cwd;
+    child.stdin_behavior = .Ignore;
     child.stderr_behavior = .Pipe;
     child.stdout_behavior = .Pipe;
     child.env_map = env_map;
+    if (comptime !is_windows) {
+        // Put every service in its own process group so restarts also stop grandchildren
+        // spawned by wrappers like `bun run` or `uv run`.
+        child.pgid = 0;
+    }
 
     try child.spawn();
 
@@ -300,6 +371,158 @@ fn spawnService(
     }
 
     return child;
+}
+
+const ServiceStatus = struct {
+    name: []const u8,
+    port: ?u16,
+    pid: if (is_windows) void else std.posix.pid_t,
+    started_at_ms: i64,
+};
+
+const RunningServices = struct {
+    children: std.ArrayList(std.process.Child),
+    reader_threads: std.ArrayList(std.Thread),
+    statuses: std.ArrayList(ServiceStatus),
+
+    fn deinit(self: *RunningServices) void {
+        self.children.deinit();
+        self.reader_threads.deinit();
+        self.statuses.deinit();
+    }
+};
+
+fn signalServiceGroup(child: *std.process.Child, sig: u8) void {
+    if (comptime !is_windows) {
+        if (child.term != null) return;
+        std.posix.kill(-child.id, sig) catch |err| switch (err) {
+            error.ProcessNotFound => {},
+            error.PermissionDenied => {},
+            else => {},
+        };
+    }
+}
+
+fn stopServices(services: *RunningServices) void {
+    if (services.children.items.len == 0) {
+        services.deinit();
+        return;
+    }
+
+    if (comptime !is_windows) {
+        for (services.children.items) |*child| signalServiceGroup(child, std.posix.SIG.INT);
+        std.time.sleep(1200 * std.time.ns_per_ms);
+
+        for (services.children.items) |*child| signalServiceGroup(child, std.posix.SIG.TERM);
+        std.time.sleep(800 * std.time.ns_per_ms);
+
+        for (services.children.items) |*child| signalServiceGroup(child, std.posix.SIG.KILL);
+    } else {
+        for (services.children.items) |*child| {
+            _ = child.kill() catch {};
+        }
+    }
+
+    for (services.children.items) |*child| {
+        _ = child.wait() catch {};
+    }
+
+    for (services.reader_threads.items) |thread| {
+        thread.join();
+    }
+
+    services.deinit();
+}
+
+fn startServices(
+    allocator: std.mem.Allocator,
+    abs_project_path: []const u8,
+    members: []const WorkforceMember,
+    has_ui: bool,
+    ui_port: ?u16,
+    has_api: bool,
+    api_port: ?u16,
+    service_env: *std.process.EnvMap,
+    output_mutex: *std.Thread.Mutex,
+) !RunningServices {
+    const stdout = std.io.getStdOut().writer();
+    try stdout.print("\n{s}Starting services...{s}\n\n", .{ Color.bold, Color.reset });
+
+    var services = RunningServices{
+        .children = std.ArrayList(std.process.Child).init(allocator),
+        .reader_threads = std.ArrayList(std.Thread).init(allocator),
+        .statuses = std.ArrayList(ServiceStatus).init(allocator),
+    };
+    errdefer stopServices(&services);
+
+    var color_idx: usize = 0;
+
+    // Start workforce members first.
+    for (members) |member| {
+        const member_dir = try std.fmt.allocPrint(allocator, "{s}/workforce/{s}", .{ abs_project_path, member.name });
+        defer allocator.free(member_dir);
+        const port_str = try std.fmt.allocPrint(allocator, "{d}", .{member.port});
+        defer allocator.free(port_str);
+        const color = prefix_colors[color_idx % prefix_colors.len];
+        color_idx += 1;
+
+        var child = spawnService(allocator, &.{ "uv", "run", "-m", "timbal.server.http", "--port", port_str, "--import_spec", member.config.fqn }, member_dir, member.name, color, output_mutex, &services.reader_threads, service_env) catch {
+            std.debug.print("Error: failed to start {s}\n", .{member.name});
+            continue;
+        };
+        try services.statuses.append(.{
+            .name = member.name,
+            .port = member.port,
+            .pid = if (is_windows) {} else child.id,
+            .started_at_ms = std.time.milliTimestamp(),
+        });
+        try services.children.append(child);
+        _ = &child;
+    }
+
+    if (has_ui) {
+        const ui_dir = try std.fmt.allocPrint(allocator, "{s}/ui", .{abs_project_path});
+        defer allocator.free(ui_dir);
+        const ui_port_str = try std.fmt.allocPrint(allocator, "{d}", .{ui_port.?});
+        defer allocator.free(ui_port_str);
+
+        service_env.put("PORT", ui_port_str) catch return error.OutOfMemory;
+        var child = spawnService(allocator, &.{ "bun", "run", "dev", "--port", ui_port_str }, ui_dir, "ui", "\x1b[1;36m", output_mutex, &services.reader_threads, service_env) catch {
+            std.debug.print("Error: failed to start UI\n", .{});
+            return error.ServiceStartFailed;
+        };
+        try services.statuses.append(.{
+            .name = "ui",
+            .port = ui_port.?,
+            .pid = if (is_windows) {} else child.id,
+            .started_at_ms = std.time.milliTimestamp(),
+        });
+        try services.children.append(child);
+        _ = &child;
+    }
+
+    if (has_api) {
+        const api_dir = try std.fmt.allocPrint(allocator, "{s}/api", .{abs_project_path});
+        defer allocator.free(api_dir);
+        const api_port_str = try std.fmt.allocPrint(allocator, "{d}", .{api_port.?});
+        defer allocator.free(api_port_str);
+
+        service_env.put("PORT", api_port_str) catch return error.OutOfMemory;
+        var child = spawnService(allocator, &.{ "bun", "run", "dev" }, api_dir, "api", "\x1b[1;32m", output_mutex, &services.reader_threads, service_env) catch {
+            std.debug.print("Error: failed to start API\n", .{});
+            return error.ServiceStartFailed;
+        };
+        try services.statuses.append(.{
+            .name = "api",
+            .port = api_port.?,
+            .pid = if (is_windows) {} else child.id,
+            .started_at_ms = std.time.milliTimestamp(),
+        });
+        try services.children.append(child);
+        _ = &child;
+    }
+
+    return services;
 }
 
 /// Find the next available port starting from the given one.
@@ -349,6 +572,101 @@ fn openBrowserThread(ctx: BrowserContext) void {
     defer ctx.allocator.free(ctx.url);
     std.time.sleep(2 * std.time.ns_per_s);
     openBrowserUrl(ctx.allocator, ctx.url);
+}
+
+fn preferredBrowserUrl(allocator: std.mem.Allocator, has_ui: bool, ui_port: ?u16, has_api: bool, api_port: ?u16) ?[]u8 {
+    return if (has_ui)
+        std.fmt.allocPrint(allocator, "http://localhost:{d}", .{ui_port.?}) catch null
+    else if (has_api)
+        std.fmt.allocPrint(allocator, "http://localhost:{d}", .{api_port.?}) catch null
+    else
+        null;
+}
+
+fn printCommandHelp(mutex: *std.Thread.Mutex) void {
+    const stdout = std.io.getStdOut().writer();
+    mutex.lock();
+    defer mutex.unlock();
+
+    stdout.writeAll("\n") catch {};
+    stdout.print("{s}Available commands:{s}\n", .{ Color.bold, Color.reset }) catch {};
+    stdout.print("  {s}r{s}  restart all services\n", .{ Color.bold_cyan, Color.reset }) catch {};
+    stdout.print("  {s}s{s}  show service status\n", .{ Color.bold_cyan, Color.reset }) catch {};
+    stdout.print("  {s}o{s}  open the app in your browser\n", .{ Color.bold_cyan, Color.reset }) catch {};
+    stdout.print("  {s}u{s}  print the UI URL\n", .{ Color.bold_cyan, Color.reset }) catch {};
+    stdout.print("  {s}a{s}  print the API URL\n", .{ Color.bold_cyan, Color.reset }) catch {};
+    stdout.print("  {s}w{s}  print workforce service URLs\n", .{ Color.bold_cyan, Color.reset }) catch {};
+    stdout.print("  {s}q{s}  stop services and quit\n", .{ Color.bold_cyan, Color.reset }) catch {};
+}
+
+fn printServiceStatus(services: ?*RunningServices, mutex: *std.Thread.Mutex) void {
+    const stdout = std.io.getStdOut().writer();
+    mutex.lock();
+    defer mutex.unlock();
+
+    stdout.writeAll("\n") catch {};
+    stdout.print("{s}Service status:{s}\n", .{ Color.bold, Color.reset }) catch {};
+
+    const running = services orelse {
+        stdout.print("  {s}No services running{s}\n", .{ Color.dim, Color.reset }) catch {};
+        return;
+    };
+
+    const now_ms = std.time.milliTimestamp();
+    for (running.statuses.items) |status| {
+        const uptime_s: i64 = @divTrunc(now_ms - status.started_at_ms, 1000);
+        if (comptime is_windows) {
+            if (status.port) |p| {
+                stdout.print("  {s}✓{s} {s}  port={d} uptime={d}s\n", .{ Color.bold_green, Color.reset, status.name, p, uptime_s }) catch {};
+            } else {
+                stdout.print("  {s}✓{s} {s}  uptime={d}s\n", .{ Color.bold_green, Color.reset, status.name, uptime_s }) catch {};
+            }
+        } else {
+            if (status.port) |p| {
+                stdout.print("  {s}✓{s} {s}  pid={d} port={d} uptime={d}s\n", .{ Color.bold_green, Color.reset, status.name, status.pid, p, uptime_s }) catch {};
+            } else {
+                stdout.print("  {s}✓{s} {s}  pid={d} uptime={d}s\n", .{ Color.bold_green, Color.reset, status.name, status.pid, uptime_s }) catch {};
+            }
+        }
+    }
+}
+
+fn printProjectUrls(
+    members: []const WorkforceMember,
+    has_ui: bool,
+    ui_port: ?u16,
+    has_api: bool,
+    api_port: ?u16,
+    action: CommandAction,
+    mutex: *std.Thread.Mutex,
+) void {
+    const stdout = std.io.getStdOut().writer();
+    mutex.lock();
+    defer mutex.unlock();
+
+    stdout.writeAll("\n") catch {};
+
+    if ((action == .urls or action == .ui_url) and has_ui) {
+        stdout.print("  UI   {s}http://localhost:{d}{s}\n", .{ Color.bold_cyan, ui_port.?, Color.reset }) catch {};
+    } else if (action == .ui_url) {
+        stdout.print("  {s}UI not found{s}\n", .{ Color.dim, Color.reset }) catch {};
+    }
+
+    if ((action == .urls or action == .api_url) and has_api) {
+        stdout.print("  API  {s}http://localhost:{d}{s}\n", .{ Color.bold_cyan, api_port.?, Color.reset }) catch {};
+    } else if (action == .api_url) {
+        stdout.print("  {s}API not found{s}\n", .{ Color.dim, Color.reset }) catch {};
+    }
+
+    if (action == .urls or action == .workforce_urls) {
+        if (members.len == 0) {
+            stdout.print("  {s}No workforce found{s}\n", .{ Color.dim, Color.reset }) catch {};
+        } else {
+            for (members) |member| {
+                stdout.print("  {s}  {s}http://localhost:{d}{s}\n", .{ member.name, Color.bold_cyan, member.port, Color.reset }) catch {};
+            }
+        }
+    }
 }
 
 pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
@@ -606,15 +924,7 @@ pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
         std.posix.sigaction(std.posix.SIG.INT, &sa, null);
     }
 
-    // Start services.
-    try stdout.print("\n{s}Starting services...{s}\n\n", .{ Color.bold, Color.reset });
-
     var output_mutex = std.Thread.Mutex{};
-    var reader_threads = std.ArrayList(std.Thread).init(allocator);
-    defer reader_threads.deinit();
-
-    var children = std.ArrayList(std.process.Child).init(allocator);
-    defer children.deinit();
 
     // Shared env map with FORCE_COLOR for all services.
     var service_env = std.process.getEnvMap(allocator) catch return;
@@ -626,25 +936,6 @@ pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
     service_env.put("TIMBAL_API_KEY", api_key) catch return;
     service_env.put("TIMBAL_ORG_ID", org_id) catch return;
     service_env.put("TIMBAL_API_HOST", api_host) catch return;
-
-    var color_idx: usize = 0;
-
-    // Start workforce members first.
-    for (members.items) |member| {
-        const member_dir = try std.fmt.allocPrint(allocator, "{s}/workforce/{s}", .{ abs_project_path, member.name });
-        defer allocator.free(member_dir);
-        const port_str = try std.fmt.allocPrint(allocator, "{d}", .{member.port});
-        defer allocator.free(port_str);
-        const color = prefix_colors[color_idx % prefix_colors.len];
-        color_idx += 1;
-
-        var child = spawnService(allocator, &.{ "uv", "run", "-m", "timbal.server.http", "--port", port_str, "--import_spec", member.config.fqn }, member_dir, member.name, color, &output_mutex, &reader_threads, &service_env) catch {
-            std.debug.print("Error: failed to start {s}\n", .{member.name});
-            continue;
-        };
-        try children.append(child);
-        _ = &child;
-    }
 
     // Build workforce env vars: id:port,id:port,...
     {
@@ -675,44 +966,42 @@ pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
         service_env.put("TIMBAL_START_UI_PORT", ui_port_env) catch {};
     }
 
-    if (has_ui) {
-        const ui_dir = try std.fmt.allocPrint(allocator, "{s}/ui", .{abs_project_path});
-        defer allocator.free(ui_dir);
-        const ui_port_str = try std.fmt.allocPrint(allocator, "{d}", .{ui_port.?});
-        defer allocator.free(ui_port_str);
-
-        service_env.put("PORT", ui_port_str) catch return;
-        var child = spawnService(allocator, &.{ "bun", "run", "dev", "--port", ui_port_str }, ui_dir, "ui", "\x1b[1;36m", &output_mutex, &reader_threads, &service_env) catch {
-            std.debug.print("Error: failed to start UI\n", .{});
-            return;
-        };
-        try children.append(child);
-        _ = &child;
+    var requested_action = std.atomic.Value(CommandAction).init(.none);
+    const command_input_enabled = std.io.getStdIn().isTty();
+    if (command_input_enabled) {
+        const command_thread = std.Thread.spawn(.{}, commandInputFn, .{CommandInputCtx{
+            .action = &requested_action,
+        }}) catch null;
+        if (command_thread) |thread| thread.detach();
     }
 
-    if (has_api) {
-        const api_dir = try std.fmt.allocPrint(allocator, "{s}/api", .{abs_project_path});
-        defer allocator.free(api_dir);
-        const api_port_str = try std.fmt.allocPrint(allocator, "{d}", .{api_port.?});
-        defer allocator.free(api_port_str);
+    var services: ?RunningServices = try startServices(
+        allocator,
+        abs_project_path,
+        members.items,
+        has_ui,
+        ui_port,
+        has_api,
+        api_port,
+        &service_env,
+        &output_mutex,
+    );
+    defer if (services) |*running| stopServices(running);
 
-        service_env.put("PORT", api_port_str) catch return;
-        var child = spawnService(allocator, &.{ "bun", "run", "dev" }, api_dir, "api", "\x1b[1;32m", &output_mutex, &reader_threads, &service_env) catch {
-            std.debug.print("Error: failed to start API\n", .{});
-            return;
-        };
-        try children.append(child);
-        _ = &child;
+    if (command_input_enabled) {
+        try stdout.print("\n{s}Press {s}h + enter{s} for commands, {s}r + enter{s} to restart, or Ctrl+C to stop.{s}\n", .{
+            Color.dim,
+            Color.bold_cyan,
+            Color.dim,
+            Color.bold_cyan,
+            Color.dim,
+            Color.reset,
+        });
     }
 
     // Open browser after a short delay (UI takes priority over API).
     {
-        const browser_url: ?[]u8 = if (has_ui)
-            std.fmt.allocPrint(allocator, "http://localhost:{d}", .{ui_port.?}) catch null
-        else if (has_api)
-            std.fmt.allocPrint(allocator, "http://localhost:{d}", .{api_port.?}) catch null
-        else
-            null;
+        const browser_url = preferredBrowserUrl(allocator, has_ui, ui_port, has_api, api_port);
 
         if (browser_url) |url| {
             const ctx = BrowserContext{ .allocator = allocator, .url = url };
@@ -721,14 +1010,63 @@ pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
         }
     }
 
-    // Wait for all reader threads (blocks until all services exit).
-    for (reader_threads.items) |thread| {
-        thread.join();
+    while (!g_interrupted) {
+        switch (requested_action.swap(.none, .acq_rel)) {
+            .none => {},
+            .help => printCommandHelp(&output_mutex),
+            .status => {
+                if (services) |*running| {
+                    printServiceStatus(running, &output_mutex);
+                } else {
+                    printServiceStatus(null, &output_mutex);
+                }
+            },
+            .open => {
+                if (preferredBrowserUrl(allocator, has_ui, ui_port, has_api, api_port)) |url| {
+                    defer allocator.free(url);
+                    output_mutex.lock();
+                    stdout.print("\n{s}Opening {s}{s}\n", .{ Color.dim, url, Color.reset }) catch {};
+                    output_mutex.unlock();
+                    openBrowserUrl(allocator, url);
+                } else {
+                    output_mutex.lock();
+                    stdout.print("\n{s}No UI or API URL to open{s}\n", .{ Color.dim, Color.reset }) catch {};
+                    output_mutex.unlock();
+                }
+            },
+            .urls, .ui_url, .api_url, .workforce_urls => |action| {
+                printProjectUrls(members.items, has_ui, ui_port, has_api, api_port, action, &output_mutex);
+            },
+            .restart => {
+                output_mutex.lock();
+                stdout.print("\n{s}Restarting services...{s}\n", .{ Color.bold, Color.reset }) catch {};
+                output_mutex.unlock();
+
+                if (services) |*running| {
+                    stopServices(running);
+                    services = null;
+                }
+                services = try startServices(
+                    allocator,
+                    abs_project_path,
+                    members.items,
+                    has_ui,
+                    ui_port,
+                    has_api,
+                    api_port,
+                    &service_env,
+                    &output_mutex,
+                );
+            },
+            .quit => break,
+        }
+
+        std.time.sleep(150 * std.time.ns_per_ms);
     }
 
-    // Wait for all child processes to finish.
-    for (children.items) |*child| {
-        _ = child.wait() catch {};
+    if (services) |*running| {
+        stopServices(running);
+        services = null;
     }
 
     restoreTermios();


### PR DESCRIPTION
## Summary
- Add line-based interactive commands to `timbal start` for restart, status, URL printing, browser open, help, and quit.
- Restart services through a supervisor loop that stops the active service generation before starting a new one.
- Put POSIX services in their own process groups so restarts stop wrapper-spawned descendants more cleanly.

## Test plan
- `cd cli && zig fmt --check commands/start.zig`
- `cd cli && zig build-exe main.zig -fno-emit-bin --cache-dir .zig-cache --global-cache-dir .zig-cache/global`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it refactors `timbal start` into a multi-threaded supervisor with process-group signaling and log filtering, which can affect process lifecycle/cleanup across platforms.
> 
> **Overview**
> Adds an interactive supervisor loop to `timbal start` (TTY-only) with line-based commands to restart/quit, show status, print URLs/open browser, and control log focus/muting.
> 
> Refactors service management into start/stop helpers that track per-service status (pid/port/uptime) and, on POSIX, run each service in its own process group and stop entire groups on restart/exit; SIGINT handling is made atomic so the first Ctrl+C triggers graceful shutdown and the second forces exit.
> 
> Log streaming now includes service metadata and applies a shared `LogFilterState` so focused/muted services (including workforce members) are suppressed; adds targeted unit tests around log-target edge cases (e.g., workforce members named `ui`/`api`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54c666021e4cf830ccdc0c2c433ecbcacc5d1c60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->