### PR TITLE
Fix codegen streamed event JSON

### DIFF
--- a/python/tests/codegen/test_direct_api.py
+++ b/python/tests/codegen/test_direct_api.py
@@ -5,6 +5,7 @@ so that pytest-cov can measure coverage of the transformer code.
 """
 
 import io
+import json
 import textwrap
 from pathlib import Path
 from types import SimpleNamespace
@@ -94,8 +95,36 @@ class TestRunTest:
         spec = ImportSpec(path=fixture, target="tool_fixture")
         await run_test(spec, params={"x": "world"}, stream=True)
         captured = capsys.readouterr()
-        # With stream=True, each event is printed
-        assert captured.out != ""
+        events = [json.loads(line) for line in captured.out.splitlines() if line.strip()]
+        assert events
+        assert any(event["type"] == "OUTPUT" for event in events)
+
+    async def test_run_test_stream_keeps_user_prints_off_stdout(self, tmp_path, capsys):
+        from timbal.codegen.test import run_test
+        from timbal.utils import ImportSpec
+
+        fixture = tmp_path / "printing_tool.py"
+        fixture.write_text(
+            textwrap.dedent(
+                """
+                from timbal import Tool
+
+                def handler(x: str) -> str:
+                    print(f"user print: {x}")
+                    return f"result: {x}"
+
+                flow = Tool(name="printing_tool", handler=handler)
+                """
+            )
+        )
+        spec = ImportSpec(path=fixture, target="flow")
+
+        await run_test(spec, params={"x": "world"}, stream=True)
+        captured = capsys.readouterr()
+
+        events = [json.loads(line) for line in captured.out.splitlines() if line.strip()]
+        assert events
+        assert "user print: world" in captured.err
 
     async def test_run_test_with_run_context(self, capsys):
         from timbal.codegen.test import run_test

--- a/python/timbal/codegen/test.py
+++ b/python/timbal/codegen/test.py
@@ -1,4 +1,6 @@
+import contextlib
 import json
+import sys
 
 from ..state import RunContext, set_run_context
 from ..utils import ImportSpec
@@ -22,12 +24,15 @@ async def run_test(
         set_run_context(run_context)
 
     output_event = None
-    runnable = import_spec.load()
-    async for event in runnable(**params):
-        if stream:
-            print(event.model_dump(), flush=True)
-        elif event.type == "OUTPUT":
-            output_event = event
+    protocol_stdout = sys.stdout
+
+    with contextlib.redirect_stdout(sys.stderr):
+        runnable = import_spec.load()
+        async for event in runnable(**params):
+            if stream:
+                print(json.dumps(event.model_dump()), file=protocol_stdout, flush=True)
+            elif event.type == "OUTPUT":
+                output_event = event
 
     if not stream and output_event is not None:
-        print(json.dumps(output_event.model_dump()))
+        print(json.dumps(output_event.model_dump()), file=protocol_stdout)


### PR DESCRIPTION
## Summary
- Emit `timbal.codegen test --stream` events as real JSON instead of Python dict reprs.
- Redirect user `print()` output to stderr so stdout remains a clean event protocol for serverless SSE.
- Add regression coverage that streamed codegen stdout is JSON-parseable.
## Test plan
- `~/timbal/.venv/bin/python -m pytest python/tests/codegen/test_direct_api.py -q`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the stdout/stderr contract for streamed `codegen test` runs, which may affect any downstream consumers parsing output. Logic is small and covered by new regression tests.
> 
> **Overview**
> **Streaming `run_test(..., stream=True)` now prints real JSON lines** by `json.dumps`-ing each event (instead of Python dict repr) and flushing to the original stdout.
> 
> **User `print()` output is redirected to stderr** during runnable execution so stdout remains a clean event protocol. Tests are tightened to `json.loads` streamed lines and add coverage ensuring user prints don’t appear on stdout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5cc4003f70cda665cc5d844cc7d9f1d67f2a83b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->