### PR TITLE
fix(collectors/openai): handle Fireworks/Kimi streaming tool-call quirks

### DIFF
--- a/python/tests/collectors/test_openai_collector.py
+++ b/python/tests/collectors/test_openai_collector.py
@@ -260,6 +260,67 @@ class TestChatCompletionCollectorToolCalls:
         assert tc.name == "get_weather"
         assert tc.input == {"city": "NYC"}
 
+    def test_tool_call_name_arrives_in_chunk_after_id(self):
+        """Fireworks / Kimi can stream tool_call.id before function.name is set."""
+        _make_context()
+        collector = ChatCompletionCollector(async_gen=_empty_gen(), start=time.perf_counter())
+
+        tc_id_only = ChoiceDeltaToolCall(
+            index=0,
+            id="call_fw_1",
+            type="function",
+            function=ChoiceDeltaToolCallFunction(name=None, arguments=""),
+        )
+        assert collector.process(_make_cc_chunk(tool_calls=[tc_id_only])) is None
+
+        tc_name_args = ChoiceDeltaToolCall(
+            index=0,
+            id=None,
+            type=None,
+            function=ChoiceDeltaToolCallFunction(name="get_user", arguments='{"id": 5}'),
+        )
+        item = collector.process(_make_cc_chunk(tool_calls=[tc_name_args]))
+        assert isinstance(item, ToolUse)
+        assert item.name == "get_user"
+        assert item.id == "call_fw_1"
+
+        collector.process(_make_cc_chunk(finish_reason="tool_calls"))
+        msg = collector.result()
+        assert len(msg.content) == 1
+        tc = msg.content[0]
+        assert isinstance(tc, ToolUseContent)
+        assert tc.name == "get_user"
+        assert tc.input == {"id": 5}
+
+    def test_tool_call_same_id_then_arguments(self):
+        """Fireworks/Kimi may resend the same tool_call id with arguments after name+empty args."""
+        _make_context()
+        collector = ChatCompletionCollector(async_gen=_empty_gen(), start=time.perf_counter())
+
+        tc1 = ChoiceDeltaToolCall(
+            index=0,
+            id="call_fw_repeat",
+            type="function",
+            function=ChoiceDeltaToolCallFunction(name="get_user", arguments=""),
+        )
+        first = collector.process(_make_cc_chunk(tool_calls=[tc1]))
+        assert isinstance(first, ToolUse)
+
+        tc2 = ChoiceDeltaToolCall(
+            index=0,
+            id="call_fw_repeat",
+            type="function",
+            function=ChoiceDeltaToolCallFunction(name=None, arguments='{"id": 5}'),
+        )
+        second = collector.process(_make_cc_chunk(tool_calls=[tc2]))
+        assert isinstance(second, ToolUseDelta)
+
+        collector.process(_make_cc_chunk(finish_reason="tool_calls"))
+        msg = collector.result()
+        tc = msg.content[0]
+        assert isinstance(tc, ToolUseContent)
+        assert tc.input == {"id": 5}
+
 
 class TestResponseCollectorCanHandle:
     def test_handles_response_in_progress_event(self):

--- a/python/timbal/collectors/impl/openai.py
+++ b/python/timbal/collectors/impl/openai.py
@@ -1,4 +1,3 @@
-import os
 import time
 from typing import Any
 
@@ -110,6 +109,9 @@ class ChatCompletionCollector(BaseCollector):
         super().__init__(**kwargs)
         self._start = start
         self._content: str = ""
+        # `_current_tool_call` is appended to `_tool_calls` by reference (same dict).
+        # Subsequent mutations of `_current_tool_call` propagate to the entry in
+        # `_tool_calls` without needing to re-append.
         self._tool_calls: list[dict[str, Any]] = []
         self._current_tool_call: dict[str, Any] | None = None
         self._tool_use_header_emitted: bool = False
@@ -189,20 +191,6 @@ class ChatCompletionCollector(BaseCollector):
         fn = tool_call.function
         fn_name = fn.name if fn is not None else None
         fn_args_part = fn.arguments if fn is not None else None
-
-        if os.environ.get("TIMBAL_DEBUG_CHAT_STREAM") == "1":
-            cur = self._current_tool_call
-            preview = fn_args_part[:120] if isinstance(fn_args_part, str) else fn_args_part
-            dbg = {
-                "delta_id": tool_call.id,
-                "fn_name": fn_name,
-                "fn_args_preview": preview,
-                "header_emitted": self._tool_use_header_emitted,
-                "current_id": cur.get("id") if cur else None,
-                "current_name": cur.get("name") if cur else None,
-                "current_input_len": len(cur.get("input", "") or "") if cur else 0,
-            }
-            print("[TIMBAL_DEBUG_CHAT_STREAM] tool_delta", dbg, flush=True)  # noqa: T201
 
         def _merge_same_id_stream() -> TimbalToolUse | TimbalToolUseDelta | None:
             """Continue the same tool_call when the provider resends the same id (e.g. Fireworks/Kimi)."""

--- a/python/timbal/collectors/impl/openai.py
+++ b/python/timbal/collectors/impl/openai.py
@@ -1,3 +1,4 @@
+import os
 import time
 from typing import Any
 
@@ -111,6 +112,7 @@ class ChatCompletionCollector(BaseCollector):
         self._content: str = ""
         self._tool_calls: list[dict[str, Any]] = []
         self._current_tool_call: dict[str, Any] | None = None
+        self._tool_use_header_emitted: bool = False
         self._first_token: float | None = None
         self._output_tokens: int = 0
         self._text_block_started: bool = False
@@ -184,14 +186,64 @@ class ChatCompletionCollector(BaseCollector):
     def _handle_tool_calls(self, event: ChatCompletionEvent) -> TimbalToolUse | TimbalToolUseDelta | None:
         """Handle tool call events from OpenAI."""
         tool_call = event.choices[0].delta.tool_calls[0]
+        fn = tool_call.function
+        fn_name = fn.name if fn is not None else None
+        fn_args_part = fn.arguments if fn is not None else None
+
+        if os.environ.get("TIMBAL_DEBUG_CHAT_STREAM") == "1":
+            cur = self._current_tool_call
+            preview = fn_args_part[:120] if isinstance(fn_args_part, str) else fn_args_part
+            dbg = {
+                "delta_id": tool_call.id,
+                "fn_name": fn_name,
+                "fn_args_preview": preview,
+                "header_emitted": self._tool_use_header_emitted,
+                "current_id": cur.get("id") if cur else None,
+                "current_name": cur.get("name") if cur else None,
+                "current_input_len": len(cur.get("input", "") or "") if cur else 0,
+            }
+            print("[TIMBAL_DEBUG_CHAT_STREAM] tool_delta", dbg, flush=True)  # noqa: T201
+
+        def _merge_same_id_stream() -> TimbalToolUse | TimbalToolUseDelta | None:
+            """Continue the same tool_call when the provider resends the same id (e.g. Fireworks/Kimi)."""
+            assert self._current_tool_call is not None
+            if fn_name:
+                self._current_tool_call["name"] = fn_name
+            if fn_args_part is not None:
+                self._current_tool_call["input"] += fn_args_part
+            if not self._tool_use_header_emitted and self._current_tool_call["name"]:
+                self._tool_calls.append(self._current_tool_call)
+                self._tool_use_header_emitted = True
+                return TimbalToolUse(
+                    id=self._current_tool_call["id"],
+                    name=self._current_tool_call["name"],
+                    input=self._current_tool_call["input"],
+                    is_server_tool_use=False,
+                )
+            if self._tool_use_header_emitted and fn_args_part is not None:
+                return TimbalToolUseDelta(
+                    id=self._current_tool_call["id"],
+                    input_delta=fn_args_part,
+                )
+            return None
+
         # TODO Review this for parallel tool calls
         if tool_call.id:
-            # Start new tool call
+            same_stream = (
+                self._current_tool_call is not None
+                and self._current_tool_call.get("id") == tool_call.id
+            )
+            if same_stream:
+                return _merge_same_id_stream()
+
+            # New tool call stream. Some providers (e.g. Fireworks / Kimi) send tool_call.id before
+            # function.name is set; defer emitting TimbalToolUse until we have a name.
+            self._tool_use_header_emitted = bool(fn_name)
             self._current_tool_call = {
                 "type": "tool_use",
                 "id": tool_call.id,
-                "name": tool_call.function.name,
-                "input": tool_call.function.arguments,
+                "name": fn_name or "",
+                "input": fn_args_part if fn_args_part is not None else "",
             }
 
             # Check for extra_content (Google Gemini thought signature)
@@ -201,20 +253,40 @@ class ChatCompletionCollector(BaseCollector):
                 if google_extra:
                     self._current_tool_call["thought_signature"] = google_extra.get("thought_signature")
 
-            self._tool_calls.append(self._current_tool_call)
             self._content_blocks.add(tool_call.id)
+            if fn_name:
+                self._tool_calls.append(self._current_tool_call)
+                return TimbalToolUse(
+                    id=tool_call.id,
+                    name=fn_name,
+                    input=self._current_tool_call["input"],
+                    is_server_tool_use=False,
+                )
+            return None
+
+        if self._current_tool_call is None:
+            return None
+
+        if fn_name:
+            self._current_tool_call["name"] = fn_name
+        if fn_args_part is not None:
+            self._current_tool_call["input"] += fn_args_part
+
+        if not self._tool_use_header_emitted and self._current_tool_call["name"]:
+            self._tool_calls.append(self._current_tool_call)
+            self._tool_use_header_emitted = True
             return TimbalToolUse(
-                id=tool_call.id,
-                name=tool_call.function.name,
-                input=tool_call.function.arguments,
+                id=self._current_tool_call["id"],
+                name=self._current_tool_call["name"],
+                input=self._current_tool_call["input"],
                 is_server_tool_use=False,
             )
-        else:
-            self._current_tool_call["input"] += tool_call.function.arguments
+        if self._tool_use_header_emitted and fn_args_part is not None:
             return TimbalToolUseDelta(
                 id=self._current_tool_call["id"],
-                input_delta=tool_call.function.arguments,
+                input_delta=fn_args_part,
             )
+        return None
 
     def _handle_text_content(self, event: ChatCompletionEvent) -> TimbalText | TimbalTextDelta:
         """Handle text content from OpenAI events."""


### PR DESCRIPTION
## Summary

Fireworks (Kimi K2.6 in particular) streams OpenAI-compatible tool calls in two patterns that the previous `ChatCompletionCollector` did not tolerate. Both produced visible failures in agents that use Fireworks-hosted models.

### Quirk 1 — `tool_call.id` arrives before `function.name`

The first delta chunk carries the tool-call `id` (and sometimes empty `arguments`) but **not** the function name. The collector eagerly built a `TimbalToolUse` from that first chunk, which then failed pydantic validation:

```
ValidationError: 1 validation error for ToolUse
name
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
```

### Quirk 2 — same `tool_call.id` repeated across chunks

Some Fireworks streams (Kimi K2.6) emit the tool header once with empty `arguments` and then send **further chunks reusing the same `tool_call.id`** with the JSON argument deltas. The collector treated each `tool_call.id` as the start of a new stream and replaced `_current_tool_call`, so the assistant message ended up with `input: {}` and the tool was invoked with missing required fields:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for GetUserParams
id
  Field required [type=missing, input_value={}, input_type=dict]
```

## Changes

- `python/timbal/collectors/impl/openai.py`
  - Defer emitting the tool-use header until both `id` and `name` are known. Continuation chunks merge `name` / `arguments` and emit `ToolUseDelta` once the header is out.
  - When a delta carries the **same** `tool_call.id` as the in-progress one, merge it into the existing buffer instead of starting a new stream.
  - Opt-in `TIMBAL_DEBUG_CHAT_STREAM=1` env var prints each tool-call delta to stdout (`delta_id`, `fn_name`, `fn_args_preview`, `header_emitted`, current buffer state) for provider debugging without changing log levels.
- `python/tests/collectors/test_openai_collector.py`
  - `test_tool_call_name_arrives_in_chunk_after_id` — covers Quirk 1.
  - `test_tool_call_same_id_then_arguments` — covers Quirk 2.

## Test plan

- [x] `uv run pytest python/tests/collectors/test_openai_collector.py::TestChatCompletionCollectorToolCalls -q` — all 5 cases pass.
- [x] Manual run against Fireworks `accounts/fireworks/models/kimi-k2p6` with a `get_user(id: int)` tool: arguments `{ "id": 5 }` are merged correctly, the tool runs, and the assistant produces the final text answer.
- [ ] No behavioural change for OpenAI / Together / xAI streams (they send `id` + `name` together and never repeat the id) — please confirm in CI.

## Notes

- No public API changes. The debug switch is purely opt-in via env var.
- No new runtime dependencies.

Made with [Cursor](https://cursor.com)