### PR TITLE
feat(skill): namespace inner tools as `{skill}__{tool}` and detect co…

### DIFF
--- a/python/tests/codegen/test_workflow_single_agent.py
+++ b/python/tests/codegen/test_workflow_single_agent.py
@@ -410,6 +410,10 @@ class TestTracing:
         output = await agent(prompt=prompt).collect()
         skip_if_agent_error(output, "skill_standalone")
 
+        # Skill inner tools are namespaced as `{skill_name}__{tool_name}` by
+        # default, so trace paths reflect the prefix. `read_skill` is a
+        # synthetic top-level tool registered by the agent and is NOT
+        # namespaced.
         records = get_run_context()._trace.as_records()
         read_skill_paths = [r.path for r in records if "read_skill" in r.path]
         if read_skill_paths:
@@ -417,11 +421,17 @@ class TestTracing:
 
         refund_paths = [r.path for r in records if "process_refund" in r.path]
         if refund_paths:
-            assert any(p == "support_agent.process_refund" for p in refund_paths)
+            assert any(
+                p == "support_agent.payment_processing__process_refund"
+                for p in refund_paths
+            )
 
         status_paths = [r.path for r in records if "check_status" in r.path]
         if status_paths:
-            assert any(p == "support_agent.check_status" for p in status_paths)
+            assert any(
+                p == "support_agent.payment_processing__check_status"
+                for p in status_paths
+            )
 
         # Workflow-wrapped: paths should be prefixed with workflow name.
         wf = Workflow(name="support_wf").step(agent)
@@ -435,11 +445,17 @@ class TestTracing:
 
         refund_paths = [r.path for r in records if "process_refund" in r.path]
         if refund_paths:
-            assert any(p == "support_wf.support_agent.process_refund" for p in refund_paths)
+            assert any(
+                p == "support_wf.support_agent.payment_processing__process_refund"
+                for p in refund_paths
+            )
 
         status_paths = [r.path for r in records if "check_status" in r.path]
         if status_paths:
-            assert any(p == "support_wf.support_agent.check_status" for p in status_paths)
+            assert any(
+                p == "support_wf.support_agent.payment_processing__check_status"
+                for p in status_paths
+            )
 
 
 class TestEdgeCases:

--- a/python/tests/core/test_skill.py
+++ b/python/tests/core/test_skill.py
@@ -84,14 +84,19 @@ class TestSkillCreation:
     """Test Skill instantiation and validation."""
 
     def test_skill_from_valid_directory(self, skills_dir):
-        """Test creating a skill from a valid directory."""
+        """Test creating a skill from a valid directory.
+
+        Inner tools are namespaced as ``{skill_name}__{tool_name}`` by default
+        so they cannot collide with top-level tools and so the LLM sees their
+        skill provenance directly in the tool name.
+        """
         skill = Skill(path=skills_dir / "cars")
 
         assert skill.name == "cars"
         assert skill.description == "Information about cars and automotive topics"
         assert "Cars Skill" in skill.content
         assert len(skill.tools) == 1
-        assert skill.tools[0].name == "search_cars"
+        assert skill.tools[0].name == "cars__search_cars"
 
     def test_skill_path_expansion(self, skills_dir, monkeypatch):
         """Test that skill path expands ~ and resolves relative paths."""
@@ -180,7 +185,7 @@ Content
         skill = Skill(path=skills_dir / "cars")
 
         assert len(skill.tools) == 1
-        assert skill.tools[0].name == "search_cars"
+        assert skill.tools[0].name == "cars__search_cars"
         assert "Search for cars" in skill.tools[0].description
 
     def test_skill_without_tools_directory(self, skills_dir):
@@ -411,9 +416,10 @@ class TestSkillResolve:
         """Test that skill tools are loaded during initialization."""
         skill = Skill(path=skills_dir / "cars")
 
-        # Tools should be loaded in the tools list
+        # Tools should be loaded in the tools list, with names namespaced
+        # by the skill so they can't collide with top-level tools.
         assert len(skill.tools) == 1
-        assert skill.tools[0].name == "search_cars"
+        assert skill.tools[0].name == "cars__search_cars"
 
     @pytest.mark.asyncio
     async def test_skill_resolve_behavior(self, skills_dir):
@@ -472,10 +478,11 @@ class TestSkillIntegration:
             # Before reading: search_cars should not be available
             assert "search_cars" not in tool_calls[0]
 
-            # After reading (if read_skill was called): search_cars should be available
+            # After reading (if read_skill was called): namespaced cars tool should be available
             if read_skill_events:
-                # Check if search_cars appeared in any subsequent call
-                has_search_cars_later = any("search_cars" in tools for tools in tool_calls[1:])
+                has_search_cars_later = any(
+                    "cars__search_cars" in tools for tools in tool_calls[1:]
+                )
                 # This might not always be true depending on LLM behavior
                 # So we just verify the structure works
 
@@ -538,8 +545,8 @@ class TestSkillIntegration:
 
         # Initially neither should resolve tools (not in context)
 
-        # We can test the structure is correct
-        assert cars_skill.tools[0].name == "search_cars"
+        # We can test the structure is correct (skills namespace inner tools by default).
+        assert cars_skill.tools[0].name == "cars__search_cars"
 
     @pytest.mark.asyncio
     async def test_end_to_end_skill_tool_availability(self, skills_dir):
@@ -559,7 +566,7 @@ class TestSkillIntegration:
             tool_names = [t.name for t in parent_span.runnable.tools if isinstance(t, Tool)]
             call_log.append({"iteration": len(call_log), "tools": tool_names})
 
-            has_search_cars = "search_cars" in tool_names
+            has_search_cars = "cars__search_cars" in tool_names
             return f"search_cars available: {has_search_cars}"
 
         agent = Agent(
@@ -647,7 +654,7 @@ tool2 = Tool(name="tool2", handler=lambda x: x * 2)
 
         skill = Skill(path=skill_dir)
         assert len(skill.tools) == 2
-        assert {t.name for t in skill.tools} == {"tool1", "tool2"}
+        assert {t.name for t in skill.tools} == {"multi_tool__tool1", "multi_tool__tool2"}
 
     def test_skill_skips_non_python_files(self, tmp_path):
         """Test that non-Python files in tools directory are skipped."""
@@ -674,7 +681,7 @@ tool = Tool(name="valid_tool", handler=lambda: "ok")
 
         skill = Skill(path=skill_dir)
         assert len(skill.tools) == 1
-        assert skill.tools[0].name == "valid_tool"
+        assert skill.tools[0].name == "test__valid_tool"
 
     def test_skill_prevents_module_reentry(self, tmp_path):
         """Test that modules are not loaded multiple times."""
@@ -702,3 +709,364 @@ tool = Tool(name="test_tool", handler=lambda: "ok")
 
         assert len(skill1.tools) == 1
         assert len(skill2.tools) == 1
+
+
+class TestSkillNamespacing:
+    """Tool names exposed by a skill are prefixed with the skill name to prevent
+    collisions with top-level tools and to make skill provenance explicit to the
+    LLM. The prefix is applied at construction time; the agent then sees these
+    namespaced names in its tool list once `read_skill` has loaded the skill."""
+
+    def test_default_namespacing_applies_prefix(self, skills_dir):
+        """By default, inner tool names are prefixed with the slugified skill name."""
+        skill = Skill(path=skills_dir / "cars")
+
+        assert skill.namespace_tools is True
+        assert skill.tools[0].name == "cars__search_cars"
+        # _path follows name so traces stay consistent before nest()
+        assert skill.tools[0]._path == "cars__search_cars"
+
+    def test_namespace_tools_false_keeps_flat_names(self, skills_dir):
+        """`namespace_tools=False` opts out of namespacing for legacy callers."""
+        skill = Skill(path=skills_dir / "cars", namespace_tools=False)
+
+        assert skill.tools[0].name == "search_cars"
+
+    def test_namespacing_is_idempotent_across_constructions(self, skills_dir):
+        """Two `Skill()` calls for the same path must NOT compound the prefix.
+
+        Python's import system caches the underlying tool module via sys.modules,
+        so the second construction sees the same Tool object that the first one
+        already mutated. Without dedicated tracking we'd produce
+        ``cars__cars__search_cars`` on the second pass.
+        """
+        skill1 = Skill(path=skills_dir / "cars")
+        skill2 = Skill(path=skills_dir / "cars")
+
+        assert skill1.tools[0].name == "cars__search_cars"
+        assert skill2.tools[0].name == "cars__search_cars"
+
+    def test_params_model_uses_namespaced_name(self, skills_dir):
+        """Tool's params_model is a cached_property keyed on `self.name`; the
+        cache must be invalidated so the schema regenerates with the prefix.
+        Otherwise providers see one name in the tool list and a different one
+        in the JSON-Schema title."""
+        skill = Skill(path=skills_dir / "cars")
+        params_model_name = skill.tools[0].params_model.__name__
+        # Pydantic model class names use Title-case with underscores stripped:
+        # "cars__search_cars" -> "CarsSearchCars" (no leading "Search").
+        assert params_model_name.startswith("Cars"), (
+            f"params_model name {params_model_name!r} does not reflect the "
+            "namespaced tool name; cached property was not invalidated."
+        )
+
+    def test_provider_schemas_use_namespaced_name(self, skills_dir):
+        """The actual surface the LLM sees is the per-provider schema, not
+        ``tool.name``. Pin every provider serializer (Anthropic, OpenAI Chat,
+        OpenAI Responses) so a future change can't accidentally leak the bare
+        name through one path while namespacing the others."""
+        skill = Skill(path=skills_dir / "cars")
+        tool = skill.tools[0]
+
+        assert tool.anthropic_schema["name"] == "cars__search_cars"
+        assert tool.openai_chat_completions_schema["function"]["name"] == "cars__search_cars"
+        assert tool.openai_responses_schema["name"] == "cars__search_cars"
+
+    def test_provider_schemas_when_namespace_disabled(self, skills_dir):
+        """Symmetric coverage for the opt-out path: with ``namespace_tools=False``
+        every provider schema must report the bare tool name."""
+        skill = Skill(path=skills_dir / "cars", namespace_tools=False)
+        tool = skill.tools[0]
+
+        assert tool.name == "search_cars"
+        assert tool.anthropic_schema["name"] == "search_cars"
+        assert tool.openai_chat_completions_schema["function"]["name"] == "search_cars"
+        assert tool.openai_responses_schema["name"] == "search_cars"
+
+    def test_schema_caches_invalidated_across_namespace_toggle(self, skills_dir):
+        """``sys.modules`` shares the underlying Tool instance across Skill
+        constructions, and the per-provider schemas are ``cached_property``.
+        Constructing a second Skill for the same path with a different
+        ``namespace_tools`` must pop the full cache chain
+        (params_model -> params_model_schema -> _formatted_params_schema ->
+        {anthropic,openai_chat_completions,openai_responses}_schema) so
+        provider serializers don't keep returning the previous run's name."""
+        s1 = Skill(path=skills_dir / "cars")
+        # Force every cached_property in the chain to populate.
+        _ = s1.tools[0].params_model
+        _ = s1.tools[0].params_model_schema
+        _ = s1.tools[0]._formatted_params_schema
+        _ = s1.tools[0].anthropic_schema
+        _ = s1.tools[0].openai_chat_completions_schema
+        _ = s1.tools[0].openai_responses_schema
+
+        s2 = Skill(path=skills_dir / "cars", namespace_tools=False)
+        tool = s2.tools[0]
+
+        assert tool.name == "search_cars"
+        assert tool.anthropic_schema["name"] == "search_cars"
+        assert tool.openai_chat_completions_schema["function"]["name"] == "search_cars"
+        assert tool.openai_responses_schema["name"] == "search_cars"
+        # Schema title comes from the regenerated Pydantic model.
+        assert tool.anthropic_schema["input_schema"].get("title", "").startswith("SearchCars")
+
+    def test_slugifies_skill_name_with_invalid_chars(self, tmp_path):
+        """Skill names with characters disallowed in OpenAI/Anthropic tool names
+        (e.g. spaces, dots, colons) must be slugified before being used as a
+        prefix. Without this the namespaced name fails provider validation."""
+        skill_dir = tmp_path / "skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("""---
+name: My Cool Skill v1.0
+description: skill with messy name
+---
+content
+""")
+        tools_dir = skill_dir / "tools"
+        tools_dir.mkdir()
+        (tools_dir / "t.py").write_text("""
+from timbal import Tool
+t = Tool(name="ping", handler=lambda: "ok")
+""")
+
+        skill = Skill(path=skill_dir)
+        assert skill.tools[0].name == "My_Cool_Skill_v1_0__ping"
+        # All chars satisfy the OpenAI/Anthropic regex [a-zA-Z0-9_-]
+        import re
+        assert re.fullmatch(r"[a-zA-Z0-9_-]{1,64}", skill.tools[0].name)
+
+    def test_skill_name_with_only_invalid_chars_raises(self, tmp_path):
+        """A skill name that slugifies to the empty string can't form a valid
+        prefix. Fail fast with a helpful error rather than producing a tool
+        name like ``__ping`` that some providers reject."""
+        skill_dir = tmp_path / "skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("""---
+name: "...///"
+description: invalid
+---
+content
+""")
+        tools_dir = skill_dir / "tools"
+        tools_dir.mkdir()
+        (tools_dir / "t.py").write_text("""
+from timbal import Tool
+t = Tool(name="ping", handler=lambda: "ok")
+""")
+
+        with pytest.raises(ValueError, match="no characters valid for a tool-name prefix"):
+            Skill(path=skill_dir)
+
+    def test_namespaced_name_too_long_raises(self, tmp_path):
+        """OpenAI and Anthropic both cap tool names at 64 chars. Validate up
+        front so the error surfaces at agent construction, not on the first
+        request to the provider."""
+        skill_dir = tmp_path / "skill"
+        skill_dir.mkdir()
+        long_skill_name = "s" * 40
+        (skill_dir / "SKILL.md").write_text(f"""---
+name: {long_skill_name}
+description: long
+---
+content
+""")
+        tools_dir = skill_dir / "tools"
+        tools_dir.mkdir()
+        long_tool_name = "t" * 30
+        (tools_dir / "t.py").write_text(f"""
+from timbal import Tool
+t = Tool(name="{long_tool_name}", handler=lambda: "ok")
+""")
+
+        with pytest.raises(ValueError, match=r"exceeds 64 chars"):
+            Skill(path=skill_dir)
+
+    def test_top_level_tool_does_not_collide_with_skill_inner(self, skills_dir):
+        """The whole point: a top-level tool can share a base name with a
+        skill's inner tool without colliding, because the skill tool is
+        renamed at construction time."""
+        from timbal import Agent, Tool
+        from timbal.core.test_model import TestModel
+
+        # Top-level tool with same base name as the skill's inner tool.
+        def search_cars(query: str) -> str:
+            return f"top-level search for {query}"
+
+        agent = Agent(
+            name="dual_search_agent",
+            model=TestModel(),
+            skills_path=skills_dir,
+            tools=[Tool(handler=search_cars)],
+        )
+
+        # Top-level tool keeps its bare name; skill tool gets prefixed —
+        # so the names are distinct and Agent construction succeeds.
+        names = {t.name for t in agent.tools if isinstance(t, Tool)}
+        assert "search_cars" in names  # the top-level one
+        # The skill's inner tool isn't directly in agent.tools; it lives on
+        # the Skill ToolSet and only surfaces via _resolve_tools() at runtime.
+        from timbal.core.skill import Skill
+        cars_skill = next(t for t in agent.tools if isinstance(t, Skill) and t.name == "cars")
+        assert cars_skill.tools[0].name == "cars__search_cars"
+
+
+class TestAgentEagerCollisionDetection:
+    """The agent's `model_post_init` runs a final pass that enumerates every
+    tool name the LLM will ever see (top-level + skill-internal, namespaced or
+    not) and raises ValueError on any duplicate. This catches the cases the
+    earlier per-tool dedup loop misses — most importantly skill-internal tools
+    shadowing top-level tools when `namespace_tools=False`."""
+
+    def test_flat_skill_tool_collides_with_top_level_tool(self, skills_dir):
+        """`namespace_tools=False` exposes inner tools with their bare names. A
+        top-level tool sharing that name must fail at construction, not silently
+        get shadowed at runtime by `_register`'s drop-on-duplicate logic."""
+        from timbal import Agent, Tool
+        from timbal.core.skill import Skill
+        from timbal.core.test_model import TestModel
+
+        def search_cars(query: str) -> str:
+            return query
+
+        flat_skill = Skill(path=skills_dir / "cars", namespace_tools=False)
+
+        with pytest.raises(ValueError, match=r"collision.*search_cars"):
+            Agent(
+                name="conflicted_agent",
+                model=TestModel(),
+                tools=[Tool(handler=search_cars), flat_skill],
+            )
+
+    def test_two_flat_skills_with_same_inner_tool_name_collide(self, tmp_path):
+        """Two different skills with `namespace_tools=False` and an inner tool
+        of the same name must fail. With namespacing on (default) this is
+        impossible — covered separately."""
+        from timbal import Agent
+        from timbal.core.skill import Skill
+        from timbal.core.test_model import TestModel
+
+        def make_skill(dir_name: str, skill_name: str, tool_name: str = "ping") -> Skill:
+            d = tmp_path / dir_name
+            d.mkdir()
+            (d / "SKILL.md").write_text(f"""---
+name: {skill_name}
+description: x
+---
+content
+""")
+            tools = d / "tools"
+            tools.mkdir()
+            (tools / "t.py").write_text(f"""
+from timbal import Tool
+t = Tool(name="{tool_name}", handler=lambda: "ok")
+""")
+            return Skill(path=d, namespace_tools=False)
+
+        skill_a = make_skill("a", "skill_a")
+        skill_b = make_skill("b", "skill_b")
+
+        with pytest.raises(ValueError, match=r"collision.*ping"):
+            Agent(
+                name="dup_agent",
+                model=TestModel(),
+                tools=[skill_a, skill_b],
+            )
+
+    def test_namespaced_skills_dont_collide_even_with_same_inner_name(self, tmp_path):
+        """Same scenario as above but with default namespacing — must succeed
+        because tools become `skill_a__ping` and `skill_b__ping`. This is the
+        whole point of namespacing."""
+        from timbal import Agent
+        from timbal.core.skill import Skill
+        from timbal.core.test_model import TestModel
+
+        def make_skill(dir_name: str, skill_name: str) -> Skill:
+            d = tmp_path / dir_name
+            d.mkdir()
+            (d / "SKILL.md").write_text(f"""---
+name: {skill_name}
+description: x
+---
+content
+""")
+            tools = d / "tools"
+            tools.mkdir()
+            (tools / "t.py").write_text("""
+from timbal import Tool
+t = Tool(name="ping", handler=lambda: "ok")
+""")
+            return Skill(path=d)
+
+        skill_a = make_skill("a", "skill_a")
+        skill_b = make_skill("b", "skill_b")
+
+        # Should construct cleanly.
+        Agent(
+            name="ns_agent",
+            model=TestModel(),
+            tools=[skill_a, skill_b],
+        )
+
+    def test_two_skills_slugifying_to_same_prefix_collide(self, tmp_path):
+        """Edge case the eager check covers but cheaper detection misses:
+        skills whose names slugify to the same prefix produce identical
+        namespaced tool names. e.g. ``my.skill`` (dot stripped) and
+        ``my_skill`` both yield ``my_skill__ping``. The names themselves are
+        distinct so the existing skill-name dedup doesn't catch it."""
+        from timbal import Agent
+        from timbal.core.skill import Skill
+        from timbal.core.test_model import TestModel
+
+        def make_skill(dir_name: str, skill_name: str) -> Skill:
+            d = tmp_path / dir_name
+            d.mkdir()
+            (d / "SKILL.md").write_text(f"""---
+name: "{skill_name}"
+description: x
+---
+content
+""")
+            tools = d / "tools"
+            tools.mkdir()
+            (tools / "t.py").write_text("""
+from timbal import Tool
+t = Tool(name="ping", handler=lambda: "ok")
+""")
+            return Skill(path=d)
+
+        # Both slugify to "my_skill" — dot becomes underscore.
+        a = make_skill("a", "my.skill")
+        b = make_skill("b", "my_skill")
+        assert a.tools[0].name == "my_skill__ping"
+        assert b.tools[0].name == "my_skill__ping"
+
+        with pytest.raises(ValueError, match=r"collision.*my_skill__ping"):
+            Agent(
+                name="slug_collide_agent",
+                model=TestModel(),
+                tools=[a, b],
+            )
+
+    def test_collision_error_names_both_origins(self, skills_dir):
+        """Error message should identify both colliding sources so the user
+        knows which tool to rename."""
+        from timbal import Agent, Tool
+        from timbal.core.skill import Skill
+        from timbal.core.test_model import TestModel
+
+        def search_cars(query: str) -> str:
+            return query
+
+        flat_skill = Skill(path=skills_dir / "cars", namespace_tools=False)
+
+        with pytest.raises(ValueError) as exc_info:
+            Agent(
+                name="agent",
+                model=TestModel(),
+                tools=[Tool(handler=search_cars), flat_skill],
+            )
+
+        msg = str(exc_info.value)
+        # Must mention both origins so the user can find the right tool.
+        assert "skill 'cars'" in msg
+        assert "top-level tools" in msg

--- a/python/timbal/core/agent.py
+++ b/python/timbal/core/agent.py
@@ -306,15 +306,65 @@ class Agent(Runnable):
             self.tools[i] = tool
 
         if skills:
+            namespaced_skills = [s for s in skills if s.namespace_tools and s.tools]
+            if namespaced_skills:
+                example = namespaced_skills[0]
+                example_inner = example.tools[0].name  # already prefixed
+                namespace_note = (
+                    "After loading, that skill's tools become available as separate "
+                    f"tools whose names are prefixed with the skill, e.g. `{example_inner}`. "
+                    "Call them by their full prefixed name; do NOT call the skill name "
+                    "directly as if it were a tool."
+                )
+            else:
+                namespace_note = (
+                    "Do NOT call a skill name directly as if it were a tool — use "
+                    "`read_skill` first; any skill-internal tools will then appear in "
+                    "your tool list."
+                )
             self._system_prompt_skills = f"""<skills>
 Skills provide additional knowledge of a specific topic. The following skills are available:
 {chr(10).join([f"- **{skill.name}**: {skill.description}" for skill in skills])}
 In skills documentation, you will encounter references to additional files.
 If the file is relevant for the user query, USE the `read_skill` tool to get its content.
+{namespace_note}
 </skills>"""
             read_skill_tool = ReadSkill(agent_path=self._path, skills=skills)
             read_skill_tool.nest(self._path)
             self.tools.append(read_skill_tool)
+
+        # Eager collision detection across every tool name the LLM will ever
+        # see: top-level tools (already de-duped above), skill-internal tools
+        # (namespaced by Skill validation, but `namespace_tools=False` opt-out
+        # can still produce flat names), and the synthetic `read_skill` tool.
+        # Non-Skill ToolSets resolve dynamically at runtime, so their names
+        # are unknown here — for those, the defensive logger.error in
+        # `_resolve_tools._register` is the safety net. This eager pass turns
+        # silent shadowing into a fail-fast at agent construction; the runtime
+        # check should be unreachable in practice and exists only to surface
+        # bugs in custom ToolSet.resolve() implementations.
+        llm_visible_names: dict[str, str] = {}
+
+        def _claim_name(name: str, origin: str) -> None:
+            if name in llm_visible_names:
+                raise ValueError(
+                    f"Tool name collision on agent {self.name!r}: {name!r} is "
+                    f"exposed both by {llm_visible_names[name]} and by {origin}. "
+                    f"Rename one of them, or set `namespace_tools=False` on a "
+                    f"Skill that should keep flat names. Two different skills "
+                    f"can collide if their slugified names match (e.g. 'my-skill' "
+                    f"and 'my_skill' both slugify to 'my_skill')."
+                )
+            llm_visible_names[name] = origin
+
+        for tool in self.tools:
+            if isinstance(tool, Skill):
+                for inner in tool.tools:
+                    _claim_name(inner.name, f"skill {tool.name!r}")
+            elif isinstance(tool, ToolSet):
+                continue
+            else:
+                _claim_name(tool.name, "top-level tools")
 
         self._is_orchestrator = True
         self._is_coroutine = False
@@ -646,7 +696,21 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
 
         def _register(tool: Tool) -> None:
             if tool.name in tools_names:
-                logger.warning(f"Tool with name '{tool.name}' already exists. You can only add a tool once.")
+                # Should be unreachable: agent construction runs an eager
+                # collision check across all statically-known tool names, so
+                # hitting this branch implies a custom ToolSet.resolve() is
+                # producing names that overlap with another tool. Log loudly
+                # at error level (not warning) so users notice in production
+                # logs; we still drop the duplicate to keep the agent running.
+                logger.error(
+                    "Runtime tool name collision; dropping duplicate registration. "
+                    "This indicates a bug in a ToolSet.resolve() — the eager "
+                    "collision check at agent construction should have caught "
+                    "static duplicates.",
+                    agent_path=self._path,
+                    tool_name=tool.name,
+                    tool_path=getattr(tool, "_path", None),
+                )
                 return
             tools.append(tool)
             tools_names.add(tool.name)

--- a/python/timbal/core/skill.py
+++ b/python/timbal/core/skill.py
@@ -1,7 +1,8 @@
 import importlib.util
+import re
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 # `override` was introduced in Python 3.12; use `typing_extensions` for compatibility with older versions
 try:
@@ -21,14 +22,57 @@ from .tool_set import ToolSet
 logger = structlog.get_logger("timbal.core.skill")
 
 
+# Provider tool-name validators (OpenAI/Anthropic) accept ``[a-zA-Z0-9_-]{1,64}``.
+# We slugify the skill name with this in mind and cap the prefixed length to 64.
+TOOL_NAME_SEPARATOR = "__"
+TOOL_NAME_MAX_LEN = 64
+_TOOL_NAME_INVALID_RE = re.compile(r"[^a-zA-Z0-9_-]")
+
+
+def _slugify_tool_name(s: str) -> str:
+    """Replace any character not allowed in OpenAI/Anthropic tool names with ``_``.
+
+    Collapses runs of underscores to keep the prefix readable.
+    """
+    slug = _TOOL_NAME_INVALID_RE.sub("_", s)
+    return re.sub(r"_+", "_", slug).strip("_")
+
+
 class Skill(ToolSet):
-    """Skill is a tool set that can be used to provide context to the agent."""
+    """A bundle of related tools and documentation gated by ``read_skill``.
+
+    Inner tools are exposed to the LLM only after the agent loads the skill via
+    the ``read_skill`` tool. By default, exposed tool names are namespaced as
+    ``{skill_name}__{tool_name}`` so they cannot collide with top-level tools and
+    so the LLM can't confuse a skill-internal tool with a top-level one (a common
+    failure mode on weaker models). Set ``namespace_tools=False`` for legacy
+    behaviour where inner tools keep their flat names.
+    """
 
     path: Path
     tools: list[Runnable] = []
     references: dict[str, str] = {}
+    namespace_tools: bool = True
+    """When True (default), expose inner tools to the LLM as
+    ``{skill_name}__{tool_name}`` rather than their bare name. Eliminates name
+    collisions with top-level tools and makes skill provenance explicit, which
+    reduces skill-vs-tool confusion for weaker LLMs. Set to False to keep flat
+    names (legacy behaviour)."""
 
     _agent_path: str = PrivateAttr()
+    _name_prefix: str = PrivateAttr(default="")
+    """Slugified skill name applied as a prefix to inner tools when
+    ``namespace_tools`` is True; empty string otherwise."""
+
+    # Cross-instance map id(tool) -> original (un-namespaced) name. We need a
+    # class-level cache because `sys.modules` caches the imported tool module:
+    # the second ``Skill(path=...)`` for the same skill sees the already-renamed
+    # Tool object and would otherwise compound the prefix into ``cars__cars__x``.
+    # Keyed by id() rather than the Tool itself because Pydantic models have a
+    # custom __hash__ and we don't want to keep tools alive longer than needed —
+    # tools live for the process lifetime anyway via sys.modules, so id collision
+    # after GC is not a concern in practice.
+    _SHARED_TOOL_BASE_NAMES: ClassVar[dict[int, str]] = {}
 
     @model_validator(mode="after")
     def validate_skill_structure(self) -> "Skill":
@@ -92,6 +136,67 @@ class Skill(ToolSet):
                 if isinstance(attr, Runnable):
                     self.tools.append(attr)
                     logger.info(f"Loaded tool {attr_name} from {tool_path}")
+
+        # Namespace inner tools so they cannot collide with top-level tools and
+        # so the LLM sees their skill provenance in the name. Tool instances are
+        # shared across Skill constructions via Python's module cache, so we
+        # always (a) recover each tool's original name from a cross-instance
+        # tracker before deriving anything, and (b) reset the name on every
+        # construction — opting out of namespacing must restore the flat name
+        # even if a previous Skill() with the same path applied a prefix.
+        # Length validation happens up front because OpenAI and Anthropic both
+        # reject tool names longer than 64 chars at the API edge.
+        if self.namespace_tools:
+            self._name_prefix = _slugify_tool_name(self.name)
+            if not self._name_prefix:
+                raise ValueError(
+                    f"Skill name {self.name!r} has no characters valid for a tool-name "
+                    f"prefix (must contain at least one of [a-zA-Z0-9_-]). Either rename "
+                    f"the skill or set namespace_tools=False."
+                )
+
+        for tool in self.tools:
+            tool_key = id(tool)
+            base_name = self.__class__._SHARED_TOOL_BASE_NAMES.get(tool_key)
+            if base_name is None:
+                base_name = tool.name
+                self.__class__._SHARED_TOOL_BASE_NAMES[tool_key] = base_name
+
+            if self.namespace_tools:
+                target_name = f"{self._name_prefix}{TOOL_NAME_SEPARATOR}{base_name}"
+                if len(target_name) > TOOL_NAME_MAX_LEN:
+                    raise ValueError(
+                        f"Namespaced tool name {target_name!r} exceeds {TOOL_NAME_MAX_LEN} "
+                        f"chars (skill prefix {self._name_prefix!r} + tool name {base_name!r}). "
+                        f"Shorten the skill name or the inner tool name, or set "
+                        f"namespace_tools=False on this skill."
+                    )
+            else:
+                target_name = base_name
+
+            if tool.name != target_name:
+                tool.name = target_name
+                # nest() is called later by the agent and will reset _path;
+                # keep the local _path consistent so any pre-nest log lines
+                # or introspection see the right name.
+                tool._path = target_name
+                # Drop every cached_property derived from `self.name`. In
+                # production these caches are typically empty at this point
+                # (the agent hasn't built schemas yet), but the shared
+                # Tool object via sys.modules means a second Skill() for the
+                # same path with a different `namespace_tools` would otherwise
+                # serve stale schemas. Invalidate the full chain:
+                #   params_model -> params_model_schema -> _formatted_params_schema
+                #   -> {anthropic,openai_chat_completions,openai_responses}_schema
+                for cached in (
+                    "params_model",
+                    "params_model_schema",
+                    "_formatted_params_schema",
+                    "anthropic_schema",
+                    "openai_chat_completions_schema",
+                    "openai_responses_schema",
+                ):
+                    tool.__dict__.pop(cached, None)
 
         return self
 


### PR DESCRIPTION
…llisions eagerly

Default-on auto-namespacing for skill-internal tools, plus an eager construction-time check that catches every static tool-name collision the LLM could ever see. Two motivations:

1. Weaker LLMs frequently confuse a skill name with a tool name and try to call the skill directly. Prefixing inner tools makes provenance explicit in the function list and steers the model toward the right call. The system prompt is updated to teach the convention when any namespaced skill is present.
2. Inner tools could silently shadow top-level tools — `_register` only warned and dropped the duplicate. Namespacing eliminates the most common collision class structurally, and the eager check fails fast on anything that slips through (including two skills slugifying to the same prefix, e.g. `my.skill` vs `my_skill`).

Implementation notes:

- Skill names are slugified to `[a-zA-Z0-9_-]`, runs of `_` collapsed. Combined `{prefix}__{tool}` is capped at 64 chars (OpenAI/Anthropic limit) and validated up front.
- `namespace_tools=False` keeps the legacy flat names for callers who rely on the old behaviour or have already designed around it.
- Renaming is idempotent across `Skill()` constructions via a class-level `id(tool) -> base_name` map. Required because `sys.modules` shares the imported Tool object across constructions; without it a second `Skill(path=...)` would compound the prefix to `cars__cars__search_cars`.
- The full cached_property chain on Tool is invalidated whenever a tool is renamed (params_model, params_model_schema, _formatted_params_schema, anthropic_schema, openai_chat_completions_schema, openai_responses_schema). Normal agent construction never populates these before the rename, but toggling `namespace_tools` between two Skills for the same path was serving stale per-provider schemas — fixed and pinned by a regression test.
- `Agent.model_post_init` enumerates every static-known LLM-visible name (top-level tools, skill-internal tools, `read_skill`) and raises `ValueError` on duplicates, naming both origins. Dynamic ToolSets whose `resolve()` runs at runtime are deferred to a defensive `logger.error` in `_resolve_tools._register` (demoted from warning; should be unreachable for static configs).

Tests cover both with- and without-namespace flows end-to-end:
- All three provider schema serializers asserted under both modes.
- Cache-invalidation regression: warm every cached schema on Skill #1, reconstruct as flat, assert every schema reports the bare name.
- Idempotency across re-construction (no `cars__cars__` compounding).
- Slugification, empty-prefix and >64-char name validation.
- 5 collision scenarios in `TestAgentEagerCollisionDetection` (flat-skill vs top-level, two flat skills, two namespaced skills not colliding, two skills slugifying to same prefix, error message names both origins).
- Codegen + integration trace tests updated to expect the prefixed paths (`support_agent.payment_processing__process_refund`, etc.).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public tool names exposed to the LLM (and thus user prompts, traces, and provider schemas) and adds new construction-time validation that can raise `ValueError` for previously-accepted configurations. The behavior is well-covered by tests but could be a breaking change for callers relying on flat skill tool names.
> 
> **Overview**
> **Skill-internal tools are now namespaced by default** as ``{skill}__{tool}``, including slugification/length validation to meet provider tool-name constraints and cache invalidation so provider schemas reflect the renamed tool.
> 
> **Agent initialization now fails fast on any statically-detectable tool-name collision** across top-level tools, skill-internal tools (including when `namespace_tools=False`), and `read_skill`; runtime duplicate registration is treated as an error log and dropped as a last-resort fallback.
> 
> Tests are updated/expanded to assert the new names in tool lists, provider schemas, and trace paths (standalone and workflow-wrapped), and to cover opt-out behavior and multiple collision/edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a722debcc846aaa507d37eaafaa6e3cfb578c857. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->