### PR TITLE
Codegen add tool config

### DIFF
--- a/python/tests/codegen/test_add_tool.py
+++ b/python/tests/codegen/test_add_tool.py
@@ -482,3 +482,82 @@ class TestConfigFlag:
         ns = _exec_agent(output)
         my_search = next(t for t in ns["agent"].tools if t.name == "my_search")
         assert my_search.description == "uppercase search"
+
+    def test_rejects_name_in_config_when_name_flag_set(self, workspace):
+        """--name + --config '{"name": ...}' is ambiguous — must error, not generate duplicate kwargs."""
+        import json
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[])
+        """)
+        result = subprocess.run(
+            [
+                "python", "-m", "timbal.codegen", "--path", str(ws), "--dry-run",
+                "add-tool", "--type", "WebSearch", "--name", "explicit",
+                "--config", json.dumps({"name": "from_config"}),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "--name" in result.stderr and "name" in result.stderr
+        # No leaking of the underlying ruff/SyntaxError.
+        assert "Duplicate keyword argument" not in result.stderr
+
+    def test_rejects_handler_in_config_for_custom(self, workspace):
+        """Custom tools derive handler from --definition; reject 'handler' in --config."""
+        import json
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[])
+        """)
+        result = subprocess.run(
+            [
+                "python", "-m", "timbal.codegen", "--path", str(ws), "--dry-run",
+                "add-tool", "--type", "Custom",
+                "--definition", "def foo() -> int:\n    return 1",
+                "--config", json.dumps({"handler": "anything"}),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "handler" in result.stderr and "--definition" in result.stderr
+        assert "Duplicate keyword argument" not in result.stderr
+
+    def test_name_in_config_alone_works(self, workspace):
+        """Setting 'name' via --config alone (without --name) is fine."""
+        import json
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[])
+        """)
+        output = _run_dry(ws, "--type", "WebSearch", "--config", json.dumps({"name": "from_config"}))
+        assert 'name="from_config"' in output
+        # Sanity: only one name= kwarg.
+        assert output.count('name="from_config"') == 1
+
+    def test_idempotent_name_in_config_no_duplicate(self, workspace):
+        """Re-adding with --name and config that does NOT include 'name' must not duplicate name=."""
+        import json
+        ws = workspace("""\
+        from timbal.core import Agent
+        from timbal.tools import WebSearch
+
+        web_search = WebSearch(name="explicit")
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[web_search])
+        """)
+        output = _run_dry(
+            ws, "--type", "WebSearch", "--name", "explicit",
+            "--config", json.dumps({"allowed_domains": ["example.com"]}),
+        )
+        # Single name= kwarg, single allowed_domains= kwarg.
+        assert output.count("name=") == 2  # one on Agent, one on WebSearch
+        assert output.count("allowed_domains=") == 1
+        ns = _exec_agent(output)
+        ws_tool = next(t for t in ns["agent"].tools if t.name == "explicit")
+        assert ws_tool.allowed_domains == ["example.com"]

--- a/python/tests/codegen/test_add_tool.py
+++ b/python/tests/codegen/test_add_tool.py
@@ -341,3 +341,144 @@ class TestStepFlag:
         )
         assert result.returncode != 0
         assert "--step requires a Workflow" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# --config flag (one-shot add + configure)
+# ---------------------------------------------------------------------------
+
+
+class TestConfigFlag:
+    def test_framework_tool_with_config(self, workspace):
+        """add-tool --config wires constructor kwargs in a single call."""
+        import json
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[])
+        """)
+        config = json.dumps({"allowed_domains": ["example.com"]})
+        output = _run_dry(ws, "--type", "WebSearch", "--config", config)
+        assert 'allowed_domains=["example.com"]' in output
+        ns = _exec_agent(output)
+        ws_tool = next(t for t in ns["agent"].tools if t.name == "web_search")
+        assert ws_tool.allowed_domains == ["example.com"]
+
+    def test_framework_tool_with_name_and_config(self, workspace):
+        """--name and --config compose."""
+        import json
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[])
+        """)
+        config = json.dumps({"allowed_domains": ["example.com"]})
+        output = _run_dry(ws, "--type", "WebSearch", "--name", "my_search", "--config", config)
+        ns = _exec_agent(output)
+        ws_tool = next(t for t in ns["agent"].tools if t.name == "my_search")
+        assert ws_tool.allowed_domains == ["example.com"]
+
+    def test_rejects_unknown_config_field(self, workspace):
+        """Unknown config keys are rejected against the tool's schema."""
+        import json
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[])
+        """)
+        config = json.dumps({"not_a_real_field": 1})
+        result = subprocess.run(
+            [
+                "python", "-m", "timbal.codegen", "--path", str(ws), "--dry-run",
+                "add-tool", "--type", "WebSearch", "--config", config,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "Unknown config field(s)" in result.stderr
+
+    def test_rejects_invalid_json(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[])
+        """)
+        result = subprocess.run(
+            [
+                "python", "-m", "timbal.codegen", "--path", str(ws), "--dry-run",
+                "add-tool", "--type", "WebSearch", "--config", "{not json",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+
+    def test_idempotent_merges_config(self, workspace):
+        """Re-adding with --config merges into existing assignment, preserving unrelated kwargs."""
+        import json
+        ws = workspace("""\
+        from timbal.core import Agent
+        from timbal.tools import WebSearch
+
+        web_search = WebSearch(blocked_domains=["spam.com"])
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[web_search])
+        """)
+        config = json.dumps({"allowed_domains": ["example.com"]})
+        output = _run_dry(ws, "--type", "WebSearch", "--config", config)
+        ns = _exec_agent(output)
+        ws_tool = next(t for t in ns["agent"].tools if t.name == "web_search")
+        assert ws_tool.allowed_domains == ["example.com"]
+        assert ws_tool.blocked_domains == ["spam.com"]
+
+    def test_config_overrides_existing_value(self, workspace):
+        """When the same key exists, --config replaces it."""
+        import json
+        ws = workspace("""\
+        from timbal.core import Agent
+        from timbal.tools import WebSearch
+
+        web_search = WebSearch(allowed_domains=["old.com"])
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[web_search])
+        """)
+        config = json.dumps({"allowed_domains": ["new.com"]})
+        output = _run_dry(ws, "--type", "WebSearch", "--config", config)
+        ns = _exec_agent(output)
+        ws_tool = next(t for t in ns["agent"].tools if t.name == "web_search")
+        assert ws_tool.allowed_domains == ["new.com"]
+
+    def test_config_null_removes_kwarg(self, workspace):
+        """Passing null in --config removes the kwarg from an existing assignment."""
+        import json
+        ws = workspace("""\
+        from timbal.core import Agent
+        from timbal.tools import WebSearch
+
+        web_search = WebSearch(allowed_domains=["old.com"], blocked_domains=["spam.com"])
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[web_search])
+        """)
+        config = json.dumps({"allowed_domains": None})
+        output = _run_dry(ws, "--type", "WebSearch", "--config", config)
+        assert "allowed_domains" not in output
+        ns = _exec_agent(output)
+        ws_tool = next(t for t in ns["agent"].tools if t.name == "web_search")
+        assert ws_tool.blocked_domains == ["spam.com"]
+
+    def test_custom_tool_with_config(self, workspace):
+        """Custom tools accept --config and validate against the Tool schema."""
+        import json
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[])
+        """)
+        definition = "def my_search(query: str) -> str:\n    return query.upper()"
+        config = json.dumps({"description": "uppercase search"})
+        output = _run_dry(ws, "--type", "Custom", "--definition", definition, "--config", config)
+        assert 'description="uppercase search"' in output
+        ns = _exec_agent(output)
+        my_search = next(t for t in ns["agent"].tools if t.name == "my_search")
+        assert my_search.description == "uppercase search"

--- a/python/tests/codegen/test_add_tool.py
+++ b/python/tests/codegen/test_add_tool.py
@@ -540,6 +540,50 @@ class TestConfigFlag:
         # Sanity: only one name= kwarg.
         assert output.count('name="from_config"') == 1
 
+    def test_rejects_empty_name_on_fresh_add(self, workspace):
+        """`--name ""` is rejected before any code is generated."""
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[])
+        """)
+        result = subprocess.run(
+            [
+                "python", "-m", "timbal.codegen", "--path", str(ws), "--dry-run",
+                "add-tool", "--type", "WebSearch", "--name", "",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "--name cannot be empty" in result.stderr
+
+    def test_rejects_empty_name_on_re_add(self, workspace):
+        """The re-add (merge) path rejects --name '' identically to a fresh add.
+
+        Regression: previously the merge path used `is not None` while the
+        build path used truthiness, so `--name ""` produced `WebSearch()`
+        on a fresh add but `WebSearch(name="")` on a re-add.
+        """
+        ws = workspace("""\
+        from timbal.core import Agent
+        from timbal.tools import WebSearch
+
+        web_search = WebSearch(allowed_domains=["example.com"])
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[web_search])
+        """)
+        result = subprocess.run(
+            [
+                "python", "-m", "timbal.codegen", "--path", str(ws), "--dry-run",
+                "add-tool", "--type", "WebSearch", "--name", "",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "--name cannot be empty" in result.stderr
+
     def test_idempotent_name_in_config_no_duplicate(self, workspace):
         """Re-adding with --name and config that does NOT include 'name' must not duplicate name=."""
         import json

--- a/python/tests/codegen/test_arg_input.py
+++ b/python/tests/codegen/test_arg_input.py
@@ -1,0 +1,152 @@
+"""Tests for the @path/- arg_input convention used by codegen CLI args."""
+
+import json
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+TIMBAL_YAML = 'fqn: "agent.py::agent"\n'
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    def _write(source: str) -> Path:
+        (tmp_path / "agent.py").write_text(textwrap.dedent(source))
+        (tmp_path / "timbal.yaml").write_text(TIMBAL_YAML)
+        return tmp_path
+
+    return _write
+
+
+def _run(workspace_path: Path, *cli_args: str, stdin: str | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["python", "-m", "timbal.codegen", "--path", str(workspace_path), "--dry-run", *cli_args],
+        input=stdin,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _exec_agent(code: str) -> dict:
+    ns: dict = {}
+    exec(code, ns)
+    return ns
+
+
+# ---------------------------------------------------------------------------
+# @path file redirection
+# ---------------------------------------------------------------------------
+
+
+class TestAtPath:
+    def test_set_config_reads_config_from_file(self, workspace, tmp_path):
+        """`--config @file.json` slurps JSON from disk, sidestepping shell quoting."""
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini")
+        """)
+        # Use a payload with parens, embedded \n, and quotes — the kind of
+        # blob that breaks under bash single-quoting.
+        config = {"system_prompt": "You are helpful.\n\nAlways answer (succinctly)."}
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps(config))
+
+        result = _run(ws, "set-config", "--config", f"@{config_file}")
+        assert result.returncode == 0, result.stderr
+        ns = _exec_agent(result.stdout)
+        assert ns["agent"].system_prompt == "You are helpful.\n\nAlways answer (succinctly)."
+
+    def test_add_tool_reads_config_from_file(self, workspace, tmp_path):
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[])
+        """)
+        config_file = tmp_path / "tool.json"
+        config_file.write_text(json.dumps({"allowed_domains": ["example.com"]}))
+
+        result = _run(ws, "add-tool", "--type", "WebSearch", "--config", f"@{config_file}")
+        assert result.returncode == 0, result.stderr
+        ns = _exec_agent(result.stdout)
+        ws_tool = next(t for t in ns["agent"].tools if t.name == "web_search")
+        assert ws_tool.allowed_domains == ["example.com"]
+
+    def test_add_tool_reads_definition_from_file(self, workspace, tmp_path):
+        """`--definition @file.py` for Custom tools — the worst quoting case."""
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[])
+        """)
+        def_file = tmp_path / "fn.py"
+        def_file.write_text("def my_search(query: str) -> str:\n    return query.upper()\n")
+
+        result = _run(ws, "add-tool", "--type", "Custom", "--definition", f"@{def_file}")
+        assert result.returncode == 0, result.stderr
+        ns = _exec_agent(result.stdout)
+        assert "my_search" in [t.name for t in ns["agent"].tools]
+
+    def test_missing_file_reports_clear_error(self, workspace, tmp_path):
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini")
+        """)
+        missing = tmp_path / "does-not-exist.json"
+        result = _run(ws, "set-config", "--config", f"@{missing}")
+        assert result.returncode != 0
+        assert "cannot read" in result.stderr or "No such file" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# - stdin redirection
+# ---------------------------------------------------------------------------
+
+
+class TestStdin:
+    def test_set_config_reads_from_stdin(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini")
+        """)
+        config = json.dumps({"model": "openai/gpt-4o"})
+        result = _run(ws, "set-config", "--config", "-", stdin=config)
+        assert result.returncode == 0, result.stderr
+        ns = _exec_agent(result.stdout)
+        assert ns["agent"].model == "openai/gpt-4o"
+
+    def test_add_tool_reads_definition_from_stdin(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[])
+        """)
+        definition = "def my_search(query: str) -> str:\n    return query.upper()\n"
+        result = _run(
+            ws, "add-tool", "--type", "Custom", "--definition", "-", stdin=definition
+        )
+        assert result.returncode == 0, result.stderr
+        ns = _exec_agent(result.stdout)
+        assert "my_search" in [t.name for t in ns["agent"].tools]
+
+
+# ---------------------------------------------------------------------------
+# Plain literal still works
+# ---------------------------------------------------------------------------
+
+
+class TestLiteralPassthrough:
+    def test_inline_json_unchanged(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini")
+        """)
+        result = _run(ws, "set-config", "--config", '{"model": "openai/gpt-4o"}')
+        assert result.returncode == 0, result.stderr
+        ns = _exec_agent(result.stdout)
+        assert ns["agent"].model == "openai/gpt-4o"

--- a/python/timbal/codegen/README.md
+++ b/python/timbal/codegen/README.md
@@ -15,6 +15,28 @@ python -m timbal.codegen [--path <workspace>] [--dry-run] <operation> [options]
 | `--path` | `.` | Workspace directory containing `timbal.yaml` |
 | `--dry-run` | off | Print transformed code to stdout without writing to disk |
 
+### File and stdin redirection for string args
+
+Any argument that carries JSON, a Python expression, or a function definition
+(e.g. `--config`, `--definition`, `--input`, `--context`, `--value`, `--when`)
+also accepts:
+
+- `@path/to/file` — the leading `@` is stripped and the file is read as text.
+- `-` — read from stdin.
+
+Use this whenever the payload contains characters the shell cares about
+(newlines, parentheses, quotes, backslashes). It removes the need for
+heredoc gymnastics:
+
+```bash
+# Idiomatic
+python -m timbal.codegen set-config --config @./config.json
+echo '{"model": "openai/gpt-4o"}' | python -m timbal.codegen set-config --config -
+
+# Still works
+python -m timbal.codegen set-config --config '{"model": "openai/gpt-4o"}'
+```
+
 ### Workspace
 
 Every workspace must have a `timbal.yaml` with a fully-qualified entry point:

--- a/python/timbal/codegen/README.md
+++ b/python/timbal/codegen/README.md
@@ -38,6 +38,10 @@ python -m timbal.codegen add-tool --type WebSearch
 # Framework tool with custom name
 python -m timbal.codegen add-tool --type WebSearch --name my_search
 
+# Framework tool with constructor config (one-shot add + configure)
+python -m timbal.codegen add-tool --type WebSearch \
+  --config '{"allowed_domains": ["example.com"]}'
+
 # Custom tool from a function definition
 python -m timbal.codegen add-tool --type Custom \
   --definition "def search(query: str) -> str:\n    return results"
@@ -51,14 +55,16 @@ python -m timbal.codegen add-tool --type WebSearch --step agent_a
 | `--type` | yes | `Bash`, `CalaSearch`, `Edit`, `Read`, `WebSearch`, `Write`, or `Custom` |
 | `--definition` | Custom only | Full function definition as a string |
 | `--name` | no | Override the default tool name |
+| `--config` | no | Constructor kwargs as JSON. Validated against the tool's schema. Use `null` to remove a key. |
 | `--step` | no | Target step name within a Workflow (adds tool to that step's tools list) |
 
 **Requires**: Agent entry point, or Workflow entry point when using `--step`.
 
 **What it does**:
 - Adds the import (`from timbal.tools import WebSearch` or `from timbal.core import Tool`)
-- Creates a variable assignment (`web_search = WebSearch()`)
+- Creates a variable assignment (`web_search = WebSearch(...)`)
 - Adds the variable to the Agent's `tools=[...]` list
+- With `--config`: merges the kwargs into the assignment (overriding same-named existing kwargs, preserving the rest, dropping kwargs whose new value is `null`)
 - Idempotent — re-running updates rather than duplicates
 
 ---

--- a/python/timbal/codegen/__main__.py
+++ b/python/timbal/codegen/__main__.py
@@ -59,10 +59,25 @@ def main() -> None:
     get_models_parser.add_argument("--offset", type=int, default=0, help="Number of models to skip (default 0).")
 
     # Test run operation
+    from timbal.codegen.cli_utils import arg_input
+
     test_parser = subparsers.add_parser("test", help="Execute a single test run of the workspace entry point.")
-    test_parser.add_argument("--input", "-i", default=None, help="JSON string of input params.")
     test_parser.add_argument(
-        "--context", "-c", default=None, help='JSON string of RunContext fields (e.g. \'{"id": "my-run-id"}\').'
+        "--input",
+        "-i",
+        default=None,
+        type=arg_input,
+        help="JSON string of input params. Use '@path' to read from file or '-' to read from stdin.",
+    )
+    test_parser.add_argument(
+        "--context",
+        "-c",
+        default=None,
+        type=arg_input,
+        help=(
+            "JSON string of RunContext fields (e.g. '{\"id\": \"my-run-id\"}'). "
+            "Use '@path' to read from file or '-' to read from stdin."
+        ),
     )
     test_parser.add_argument(
         "--stream", "-s", action="store_true", help="Print every event instead of only the final output event."

--- a/python/timbal/codegen/cli_utils.py
+++ b/python/timbal/codegen/cli_utils.py
@@ -1,0 +1,33 @@
+"""Shared argparse helpers for the codegen CLI."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def arg_input(value: str) -> str:
+    """argparse ``type`` callable supporting file and stdin redirection.
+
+    Convention:
+
+    - ``"-"`` reads from stdin (useful for piping).
+    - ``"@path/to/file"`` reads the file contents as text. The leading ``@``
+      is stripped before opening, so the path may be absolute or relative.
+    - Any other value is returned unchanged.
+
+    This sidesteps shell quoting problems for arguments that contain
+    embedded newlines, parentheses, or backslashes (e.g. JSON config blobs
+    or Python function definitions). Pass the payload via a file with
+    ``--config @./payload.json`` and let the shell stay out of the way.
+    """
+    if value == "-":
+        return sys.stdin.read()
+    if value.startswith("@"):
+        path = Path(value[1:])
+        try:
+            return path.read_text()
+        except OSError as e:
+            raise argparse.ArgumentTypeError(f"cannot read {path}: {e}") from e
+    return value

--- a/python/timbal/codegen/transformers/add_edge.py
+++ b/python/timbal/codegen/transformers/add_edge.py
@@ -2,6 +2,7 @@ import argparse
 
 import libcst as cst
 
+from ..cli_utils import arg_input
 from ..cst_utils import (
     collect_assignments,
     collect_step_names,
@@ -28,9 +29,11 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     sp.add_argument(
         "--when",
         default=None,
+        type=arg_input,
         help=(
             "Python expression for a conditional edge. "
-            'E.g. \'lambda: get_run_context().step_span("agent_a").output.content != ""\''
+            'E.g. \'lambda: get_run_context().step_span("agent_a").output.content != ""\'. '
+            "Use '@path' to read from file or '-' to read from stdin."
         ),
     )
 

--- a/python/timbal/codegen/transformers/add_step.py
+++ b/python/timbal/codegen/transformers/add_step.py
@@ -3,6 +3,7 @@ import json
 
 import libcst as cst
 
+from ..cli_utils import arg_input
 from ..cst_utils import (
     build_cst_value,
     collect_assignments,
@@ -140,7 +141,12 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     sp.add_argument(
         "--definition",
         default=None,
-        help="Full function definition for custom steps. E.g. 'def process(x: str) -> str:\\n    return x.upper()'",
+        type=arg_input,
+        help=(
+            "Full function definition for custom steps. "
+            "E.g. 'def process(x: str) -> str:\\n    return x.upper()'. "
+            "Use '@path' to read from file or '-' to read from stdin."
+        ),
     )
     sp.add_argument(
         "--name",
@@ -151,7 +157,11 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     sp.add_argument(
         "--config",
         default=None,
-        help='Agent constructor params as JSON. E.g. \'{"name": "agent_a", "model": "openai/gpt-4o-mini"}\'.',
+        type=arg_input,
+        help=(
+            'Agent constructor params as JSON. E.g. \'{"name": "agent_a", "model": "openai/gpt-4o-mini"}\'. '
+            "Use '@path' to read from file or '-' to read from stdin."
+        ),
     )
     sp.add_argument("--x", default=None, type=float, help="X canvas position. Auto-computed if omitted.")
     sp.add_argument("--y", default=None, type=float, help="Y canvas position. Auto-computed if omitted.")

--- a/python/timbal/codegen/transformers/add_tool.py
+++ b/python/timbal/codegen/transformers/add_tool.py
@@ -1,9 +1,16 @@
 import argparse
+import json
 
 import libcst as cst
 
-from ..cst_utils import collect_assignments, has_import, resolve_entry_point_type, resolve_runnable_name
-from ..tool_discovery import get_framework_tool_names, get_framework_tools
+from ..cst_utils import (
+    build_cst_value,
+    collect_assignments,
+    has_import,
+    resolve_entry_point_type,
+    resolve_runnable_name,
+)
+from ..tool_discovery import get_framework_tool_names, get_framework_tools, validate_tool_config
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:
@@ -22,6 +29,11 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         default=None,
         dest="tool_name",
         help="Explicit name for the tool. When omitted, the tool uses its default name.",
+    )
+    sp.add_argument(
+        "--config",
+        default=None,
+        help='Tool constructor params as JSON. E.g. \'{"limit": 5}\'. Validated against the tool\'s schema.',
     )
     sp.add_argument(
         "--step",
@@ -49,6 +61,12 @@ def run(entry_point: str, args: argparse.Namespace, *, tree: cst.Module | None =
     if tool_type not in valid_types:
         raise ValueError(f"--type must be one of {valid_types}, got '{tool_type}'.")
 
+    config = json.loads(args.config) if getattr(args, "config", None) else {}
+    if config:
+        # Validate against the tool's schema. Custom tools are wrapped in `Tool`
+        # so they share its schema; framework tools validate against their own.
+        validate_tool_config("Tool" if tool_type == "Custom" else tool_type, config)
+
     if tool_type == "Custom":
         if not args.definition:
             raise ValueError("--definition is required for Custom tools.")
@@ -73,6 +91,7 @@ def run(entry_point: str, args: argparse.Namespace, *, tree: cst.Module | None =
             runtime_name=runtime_name,
             definition=args.definition,
             tool_name=args.tool_name,
+            config=config,
         )
 
     # Framework tool.
@@ -88,6 +107,7 @@ def run(entry_point: str, args: argparse.Namespace, *, tree: cst.Module | None =
         var_name=var_name,
         runtime_name=runtime_name,
         tool_name=args.tool_name,
+        config=config,
     )
 
 
@@ -105,6 +125,7 @@ class ToolAdder(cst.CSTTransformer):
         runtime_name: str,
         definition: str | None = None,
         tool_name: str | None = None,
+        config: dict | None = None,
     ):
         self.entry_point = entry_point
         self.target = target  # variable to add tools to (entry_point or step var)
@@ -116,6 +137,7 @@ class ToolAdder(cst.CSTTransformer):
         self.runtime_name = runtime_name  # name used by remove-tool
         self.definition = definition
         self.tool_name = tool_name  # explicit --name override (None = use default)
+        self.config = config or {}  # extra constructor kwargs to merge into the tool call
         # Track whether an existing variable assignment was found and updated.
         self._assignment_updated = False
 
@@ -152,7 +174,7 @@ class ToolAdder(cst.CSTTransformer):
                 if resolved == self.runtime_name:
                     self._assignment_updated = True
                     return updated_node.with_changes(
-                        value=self._build_assignment_call(),
+                        value=self._merge_config_into_call(updated_node.value),
                     )
         return updated_node
 
@@ -228,19 +250,45 @@ class ToolAdder(cst.CSTTransformer):
         args: list[cst.Arg] = []
         if self.tool_name:
             args.append(cst.Arg(keyword=cst.Name("name"), value=cst.SimpleString(f'"{self.tool_name}"')))
+        if self.tool_type == "Custom":
+            args.append(cst.Arg(keyword=cst.Name("handler"), value=cst.Name(self.func_name)))
+        for key, value in self.config.items():
+            if value is None:
+                continue
+            args.append(cst.Arg(keyword=cst.Name(key), value=build_cst_value(value)))
         if self.tool_type != "Custom":
             return cst.Call(func=cst.Name(self.class_name), args=args)
-        else:
-            args.append(cst.Arg(keyword=cst.Name("handler"), value=cst.Name(self.func_name)))
-            return cst.Call(func=cst.Name("Tool"), args=args)
+        return cst.Call(func=cst.Name("Tool"), args=args)
 
     def _build_assignment_code(self) -> str:
         """Build the source code string for the variable assignment RHS."""
-        name_part = f'name="{self.tool_name}", ' if self.tool_name else ""
-        if self.tool_type != "Custom":
-            return f"{self.class_name}({name_part.rstrip(', ')})"
-        else:
-            return f"Tool({name_part}handler={self.func_name})"
+        # Generate code via CST so kwarg ordering and quoting stay consistent.
+        return cst.parse_module("").code_for_node(self._build_assignment_call())
+
+    def _merge_config_into_call(self, existing: cst.Call) -> cst.Call:
+        """Merge new config kwargs into an existing tool Call, preserving the rest.
+
+        - Drops kwargs whose name is in self.config (they are being overridden or removed).
+        - Re-emits the `name=` kwarg from --name when provided (overriding any prior value).
+        - Appends new config kwargs (skipping those whose new value is None — that means remove).
+        """
+        override_keys = set(self.config.keys())
+        if self.tool_name is not None:
+            override_keys.add("name")
+
+        args: list[cst.Arg] = [
+            a for a in existing.args
+            if not (isinstance(a.keyword, cst.Name) and a.keyword.value in override_keys)
+        ]
+        # Re-add name= when --name was provided.
+        if self.tool_name is not None:
+            args.append(cst.Arg(keyword=cst.Name("name"), value=cst.SimpleString(f'"{self.tool_name}"')))
+        # Append new config kwargs.
+        for key, value in self.config.items():
+            if value is None:
+                continue
+            args.append(cst.Arg(keyword=cst.Name(key), value=build_cst_value(value)))
+        return existing.with_changes(args=args)
 
     def _add_to_tools(self, call: cst.Call) -> cst.Call:
         """Add or update the tool reference in the tools=[...] list."""

--- a/python/timbal/codegen/transformers/add_tool.py
+++ b/python/timbal/codegen/transformers/add_tool.py
@@ -74,6 +74,18 @@ def run(entry_point: str, args: argparse.Namespace, *, tree: cst.Module | None =
 
     config = json.loads(args.config) if getattr(args, "config", None) else {}
     if config:
+        # Reject keys that would collide with explicit flags / derived values.
+        # Without this, the generated source has duplicate kwargs and ruff
+        # rejects it with a SyntaxError ("Duplicate keyword argument").
+        if "name" in config and args.tool_name is not None:
+            raise ValueError(
+                "--name and --config both set 'name'; pass it via --name only "
+                "(or omit --name and set 'name' inside --config)."
+            )
+        if tool_type == "Custom" and "handler" in config:
+            raise ValueError(
+                "Custom tools derive 'handler' from --definition; remove 'handler' from --config."
+            )
         # Validate against the tool's schema. Custom tools are wrapped in `Tool`
         # so they share its schema; framework tools validate against their own.
         validate_tool_config("Tool" if tool_type == "Custom" else tool_type, config)
@@ -263,8 +275,16 @@ class ToolAdder(cst.CSTTransformer):
             args.append(cst.Arg(keyword=cst.Name("name"), value=cst.SimpleString(f'"{self.tool_name}"')))
         if self.tool_type == "Custom":
             args.append(cst.Arg(keyword=cst.Name("handler"), value=cst.Name(self.func_name)))
+        # Skip keys that are already emitted above; otherwise the output would
+        # contain duplicate keyword arguments. `run()` rejects these cases with
+        # a clear error, so this is just defense in depth.
+        skip_keys: set[str] = set()
+        if self.tool_name:
+            skip_keys.add("name")
+        if self.tool_type == "Custom":
+            skip_keys.add("handler")
         for key, value in self.config.items():
-            if value is None:
+            if value is None or key in skip_keys:
                 continue
             args.append(cst.Arg(keyword=cst.Name(key), value=build_cst_value(value)))
         if self.tool_type != "Custom":
@@ -291,12 +311,17 @@ class ToolAdder(cst.CSTTransformer):
             a for a in existing.args
             if not (isinstance(a.keyword, cst.Name) and a.keyword.value in override_keys)
         ]
-        # Re-add name= when --name was provided.
+        # Re-add name= when --name was provided. We then skip "name" in the
+        # config loop below to avoid emitting two `name=` kwargs (which would
+        # be a SyntaxError). `run()` already rejects --name + config['name']
+        # together, so this is defense in depth.
         if self.tool_name is not None:
             args.append(cst.Arg(keyword=cst.Name("name"), value=cst.SimpleString(f'"{self.tool_name}"')))
         # Append new config kwargs.
         for key, value in self.config.items():
             if value is None:
+                continue
+            if key == "name" and self.tool_name is not None:
                 continue
             args.append(cst.Arg(keyword=cst.Name(key), value=build_cst_value(value)))
         return existing.with_changes(args=args)

--- a/python/timbal/codegen/transformers/add_tool.py
+++ b/python/timbal/codegen/transformers/add_tool.py
@@ -72,6 +72,12 @@ def run(entry_point: str, args: argparse.Namespace, *, tree: cst.Module | None =
     if tool_type not in valid_types:
         raise ValueError(f"--type must be one of {valid_types}, got '{tool_type}'.")
 
+    # Reject `--name ""` early so downstream code can treat tool_name as a
+    # tri-state (None / non-empty string) and the build/merge helpers don't
+    # disagree about whether empty means "absent" or "explicit empty value".
+    if args.tool_name is not None and args.tool_name == "":
+        raise ValueError("--name cannot be empty. Omit --name to use the default tool name.")
+
     config = json.loads(args.config) if getattr(args, "config", None) else {}
     if config:
         # Reject keys that would collide with explicit flags / derived values.
@@ -102,8 +108,8 @@ def run(entry_point: str, args: argparse.Namespace, *, tree: cst.Module | None =
         if func_def is None:
             raise ValueError("--definition must contain a function definition.")
         func_name = func_def.name.value
-        var_name = args.tool_name if args.tool_name else f"{func_name}_tool"
-        runtime_name = args.tool_name if args.tool_name else func_name
+        var_name = args.tool_name if args.tool_name is not None else f"{func_name}_tool"
+        runtime_name = args.tool_name if args.tool_name is not None else func_name
         return ToolAdder(
             entry_point, assignments,
             target=target,
@@ -119,8 +125,8 @@ def run(entry_point: str, args: argparse.Namespace, *, tree: cst.Module | None =
 
     # Framework tool.
     framework_names = get_framework_tool_names()
-    var_name = args.tool_name if args.tool_name else framework_names[tool_type]
-    runtime_name = args.tool_name if args.tool_name else framework_names[tool_type]
+    var_name = args.tool_name if args.tool_name is not None else framework_names[tool_type]
+    runtime_name = args.tool_name if args.tool_name is not None else framework_names[tool_type]
     return ToolAdder(
         entry_point, assignments,
         target=target,
@@ -271,7 +277,7 @@ class ToolAdder(cst.CSTTransformer):
     def _build_assignment_call(self) -> cst.Call:
         """Build the CST Call node for the variable assignment RHS."""
         args: list[cst.Arg] = []
-        if self.tool_name:
+        if self.tool_name is not None:
             args.append(cst.Arg(keyword=cst.Name("name"), value=cst.SimpleString(f'"{self.tool_name}"')))
         if self.tool_type == "Custom":
             args.append(cst.Arg(keyword=cst.Name("handler"), value=cst.Name(self.func_name)))
@@ -279,7 +285,7 @@ class ToolAdder(cst.CSTTransformer):
         # contain duplicate keyword arguments. `run()` rejects these cases with
         # a clear error, so this is just defense in depth.
         skip_keys: set[str] = set()
-        if self.tool_name:
+        if self.tool_name is not None:
             skip_keys.add("name")
         if self.tool_type == "Custom":
             skip_keys.add("handler")

--- a/python/timbal/codegen/transformers/add_tool.py
+++ b/python/timbal/codegen/transformers/add_tool.py
@@ -3,6 +3,7 @@ import json
 
 import libcst as cst
 
+from ..cli_utils import arg_input
 from ..cst_utils import (
     build_cst_value,
     collect_assignments,
@@ -22,7 +23,12 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     sp.add_argument(
         "--definition",
         default=None,
-        help="Full function definition for custom tools. E.g. 'def my_tool(query: str) -> str:\\n    return query'",
+        type=arg_input,
+        help=(
+            "Full function definition for custom tools. "
+            "E.g. 'def my_tool(query: str) -> str:\\n    return query'. "
+            "Use '@path' to read from file or '-' to read from stdin."
+        ),
     )
     sp.add_argument(
         "--name",
@@ -33,7 +39,12 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     sp.add_argument(
         "--config",
         default=None,
-        help='Tool constructor params as JSON. E.g. \'{"limit": 5}\'. Validated against the tool\'s schema.',
+        type=arg_input,
+        help=(
+            'Tool constructor params as JSON. E.g. \'{"limit": 5}\'. '
+            "Validated against the tool's schema. "
+            "Use '@path' to read from file or '-' to read from stdin."
+        ),
     )
     sp.add_argument(
         "--step",

--- a/python/timbal/codegen/transformers/set_config.py
+++ b/python/timbal/codegen/transformers/set_config.py
@@ -3,6 +3,7 @@ import json
 
 import libcst as cst
 
+from ..cli_utils import arg_input
 from ..cst_utils import (
     build_cst_value,
     collect_assignments,
@@ -41,7 +42,11 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     sp.add_argument(
         "--config",
         default=None,
-        help='Configuration as a JSON object. E.g. \'{"model": "openai/gpt-4o-mini"}\'.',
+        type=arg_input,
+        help=(
+            'Configuration as a JSON object. E.g. \'{"model": "openai/gpt-4o-mini"}\'. '
+            "Use '@path' to read from file or '-' to read from stdin."
+        ),
     )
 
 

--- a/python/timbal/codegen/transformers/set_param.py
+++ b/python/timbal/codegen/transformers/set_param.py
@@ -4,6 +4,7 @@ import re
 
 import libcst as cst
 
+from ..cli_utils import arg_input
 from ..cst_utils import (
     collect_assignments,
     has_import,
@@ -85,7 +86,11 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     sp.add_argument(
         "--value",
         default=None,
-        help="Static value as a JSON literal (required for type=value). Use 'null' to remove the param.",
+        type=arg_input,
+        help=(
+            "Static value as a JSON literal (required for type=value). Use 'null' to remove the param. "
+            "Use '@path' to read from file or '-' to read from stdin."
+        ),
     )
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes code generation for `add-tool` (merging/removing constructor kwargs) and expands CLI argument parsing across multiple commands, which could affect existing workflows if edge cases are missed.
> 
> **Overview**
> Adds a new `add-tool --config` flag to generate tool constructor kwargs in one step, including **schema validation**, **idempotent merging** into existing tool assignments, and support for `null` to remove existing kwargs; it also adds clearer error handling for ambiguous/invalid inputs (e.g. `--name ""`, `--name` + config `name`, or custom-tool `handler` in config).
> 
> Introduces a shared `arg_input` argparse type so JSON/function-definition/expression string args can be provided via `@path/to/file` or `-` (stdin), and wires this into multiple CLI operations (`test`, `set-config`, `add-step`, `add-edge`, `set-param`, `add-tool`) with updated docs and new tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 422406cd1b68e59259f24c3c21480f23921c45fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->