### PR TITLE
Add skills and skills_exclude filters to Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,11 +253,11 @@ agent = Agent(
 
 The agent sees skill names and descriptions at startup. It calls `read_skill("web_research")` to load the tools and documentation when needed — keeping context clean until the skill is actually required.
 
-**Selecting a subset.** When `skills_path` holds many skills but a given agent only needs some, use `skills=` (whitelist) or `skills_exclude=` (blacklist). Names are matched against directory names. They are mutually exclusive; unknown names in `skills=` raise `ValueError`.
+**Selecting a subset.** When `skills_path` holds many skills but a given agent only needs some, use `skills_include=` (whitelist) or `skills_exclude=` (blacklist). Names are matched against directory names. They are mutually exclusive; unknown names in `skills_include=` raise `ValueError`.
 
 ```python
 # Whitelist: load only the listed skills
-Agent(skills_path="./skills", skills=["web_research", "sql"], ...)
+Agent(skills_path="./skills", skills_include=["web_research", "sql"], ...)
 
 # Blacklist: load everything except the listed skills
 Agent(skills_path="./skills", skills_exclude=["experimental"], ...)

--- a/README.md
+++ b/README.md
@@ -253,6 +253,24 @@ agent = Agent(
 
 The agent sees skill names and descriptions at startup. It calls `read_skill("web_research")` to load the tools and documentation when needed — keeping context clean until the skill is actually required.
 
+**Selecting a subset.** When `skills_path` holds many skills but a given agent only needs some, use `skills=` (whitelist) or `skills_exclude=` (blacklist). Names are matched against directory names. They are mutually exclusive; unknown names in `skills=` raise `ValueError`.
+
+```python
+# Whitelist: load only the listed skills
+Agent(skills_path="./skills", skills=["web_research", "sql"], ...)
+
+# Blacklist: load everything except the listed skills
+Agent(skills_path="./skills", skills_exclude=["experimental"], ...)
+```
+
+You can also pass `Skill` instances directly via `tools=[...]` for fully explicit, per-agent selection without a shared directory:
+
+```python
+from timbal.core.skill import Skill
+
+Agent(tools=[Skill(path="./skills/web_research")], ...)
+```
+
 ---
 
 ## MCP servers

--- a/docs/agents/skills.mdx
+++ b/docs/agents/skills.mdx
@@ -116,6 +116,59 @@ process_refund_tool = Tool(
 For complex skills, include additional reference files and link to them in `SKILL.md`.
 In the previous example, the `fraud_detection.md` file will only be read when the agent determines it is needed.
 
+## Selecting Which Skills to Load
+
+By default, every skill under `skills_path` is loaded into the agent. When a single directory is shared across multiple agents — each needing a different subset — use `skills` (whitelist) or `skills_exclude` (blacklist) to filter by directory name.
+
+### Whitelist
+
+Load only the listed skills:
+
+```python
+agent = Agent(
+    name="payments_agent",
+    model="anthropic/claude-3-5-sonnet",
+    skills_path="./skills",
+    skills=["payment_processing", "fraud_detection"],
+)
+```
+
+Unknown names raise `ValueError` — typos fail loudly instead of silently loading nothing.
+
+### Blacklist
+
+Load every skill except the listed ones:
+
+```python
+agent = Agent(
+    name="support_agent",
+    model="anthropic/claude-3-5-sonnet",
+    skills_path="./skills",
+    skills_exclude=["experimental_billing"],
+)
+```
+
+Unknown names in `skills_exclude` are silently ignored.
+
+<Note>
+`skills` and `skills_exclude` are mutually exclusive. Both require `skills_path` to be set.
+</Note>
+
+### Explicit Selection Without `skills_path`
+
+For full control, pass `Skill` instances directly via `tools=[...]`. This bypasses `skills_path` entirely and is useful when skills live in unrelated locations or when an agent only needs one or two:
+
+```python
+from timbal import Agent
+from timbal.core.skill import Skill
+
+agent = Agent(
+    name="refunds_agent",
+    model="anthropic/claude-3-5-sonnet",
+    tools=[Skill(path="./skills/payment_processing")],
+)
+```
+
 ## Best Practices
 - Each skill should have a single, well-defined purpose.
 - Write clear descriptions. Agents use it to decide when to activate a Skill.

--- a/docs/agents/skills.mdx
+++ b/docs/agents/skills.mdx
@@ -54,7 +54,7 @@ from timbal import Agent
 
 agent = Agent(
     name="my_agent",
-    model="anthropic/claude-3-5-sonnet",
+    model="anthropic/claude-sonnet-4-6",
     skills_path="./skills"
 )
 ```
@@ -118,7 +118,7 @@ In the previous example, the `fraud_detection.md` file will only be read when th
 
 ## Selecting Which Skills to Load
 
-By default, every skill under `skills_path` is loaded into the agent. When a single directory is shared across multiple agents — each needing a different subset — use `skills` (whitelist) or `skills_exclude` (blacklist) to filter by directory name.
+By default, every skill under `skills_path` is loaded into the agent. When a single directory is shared across multiple agents — each needing a different subset — use `skills_include` (whitelist) or `skills_exclude` (blacklist) to filter by directory name.
 
 ### Whitelist
 
@@ -127,9 +127,9 @@ Load only the listed skills:
 ```python
 agent = Agent(
     name="payments_agent",
-    model="anthropic/claude-3-5-sonnet",
+    model="anthropic/claude-sonnet-4-6",
     skills_path="./skills",
-    skills=["payment_processing", "fraud_detection"],
+    skills_include=["payment_processing", "fraud_detection"],
 )
 ```
 
@@ -142,7 +142,7 @@ Load every skill except the listed ones:
 ```python
 agent = Agent(
     name="support_agent",
-    model="anthropic/claude-3-5-sonnet",
+    model="anthropic/claude-sonnet-4-6",
     skills_path="./skills",
     skills_exclude=["experimental_billing"],
 )
@@ -151,7 +151,7 @@ agent = Agent(
 Unknown names in `skills_exclude` are silently ignored.
 
 <Note>
-`skills` and `skills_exclude` are mutually exclusive. Both require `skills_path` to be set.
+`skills_include` and `skills_exclude` are mutually exclusive. Both require `skills_path` to be set.
 </Note>
 
 ### Explicit Selection Without `skills_path`
@@ -164,7 +164,7 @@ from timbal.core.skill import Skill
 
 agent = Agent(
     name="refunds_agent",
-    model="anthropic/claude-3-5-sonnet",
+    model="anthropic/claude-sonnet-4-6",
     tools=[Skill(path="./skills/payment_processing")],
 )
 ```

--- a/python/tests/core/test_skill.py
+++ b/python/tests/core/test_skill.py
@@ -1,8 +1,7 @@
 import pytest
 from timbal import Agent, Tool
-from timbal.core.test_model import TestModel
 from timbal.core.skill import ReadSkill, Skill
-from timbal.state import get_or_create_run_context
+from timbal.core.test_model import TestModel
 
 
 @pytest.fixture
@@ -339,6 +338,95 @@ class TestAgentWithSkills:
         assert "<skills>" in system_prompt
 
 
+class TestAgentSkillsFilter:
+    """Test the `skills` whitelist and `skills_exclude` blacklist filters."""
+
+    def test_whitelist_loads_only_selected(self, skills_dir):
+        """Test that `skills=[...]` loads only the listed skill directories."""
+        agent = Agent(name="agent", model=TestModel(), skills_path=skills_dir, skills=["cars"])
+
+        loaded = {t.name for t in agent.tools if isinstance(t, Skill)}
+        assert loaded == {"cars"}
+
+    def test_whitelist_empty_loads_none(self, skills_dir):
+        """Test that `skills=[]` loads no skills."""
+        agent = Agent(name="agent", model=TestModel(), skills_path=skills_dir, skills=[])
+
+        loaded = {t.name for t in agent.tools if isinstance(t, Skill)}
+        assert loaded == set()
+
+    def test_whitelist_unknown_name_raises(self, skills_dir):
+        """Test that referencing a non-existent skill in `skills=[...]` raises ValueError."""
+        with pytest.raises(ValueError, match="Skills not found.*nonexistent"):
+            Agent(name="agent", model=TestModel(), skills_path=skills_dir, skills=["cars", "nonexistent"])
+
+    def test_exclude_skips_listed_skills(self, skills_dir):
+        """Test that `skills_exclude=[...]` loads all but the listed skill directories."""
+        agent = Agent(name="agent", model=TestModel(), skills_path=skills_dir, skills_exclude=["bikes"])
+
+        loaded = {t.name for t in agent.tools if isinstance(t, Skill)}
+        assert loaded == {"cars"}
+
+    def test_exclude_unknown_name_is_silent(self, skills_dir):
+        """Test that unknown names in `skills_exclude` are ignored (no error)."""
+        agent = Agent(name="agent", model=TestModel(), skills_path=skills_dir, skills_exclude=["nonexistent"])
+
+        loaded = {t.name for t in agent.tools if isinstance(t, Skill)}
+        assert loaded == {"cars", "bikes"}
+
+    def test_whitelist_and_exclude_are_mutually_exclusive(self, skills_dir):
+        """Test that passing both `skills` and `skills_exclude` raises ValueError."""
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            Agent(
+                name="agent",
+                model=TestModel(),
+                skills_path=skills_dir,
+                skills=["cars"],
+                skills_exclude=["bikes"],
+            )
+
+    def test_whitelist_without_skills_path_raises(self):
+        """Test that `skills=[...]` requires `skills_path` to be set."""
+        with pytest.raises(ValueError, match="skills_path"):
+            Agent(name="agent", model=TestModel(), skills=["cars"])
+
+    def test_exclude_without_skills_path_raises(self):
+        """Test that `skills_exclude=[...]` requires `skills_path` to be set."""
+        with pytest.raises(ValueError, match="skills_path"):
+            Agent(name="agent", model=TestModel(), skills_exclude=["bikes"])
+
+
+class TestAgentWithSkillInTools:
+    """Test passing Skill instances directly via `tools=[...]` instead of `skills_path`."""
+
+    def test_skill_in_tools_wires_agent_path(self, skills_dir):
+        """Test that a Skill passed in `tools` gets `_agent_path` wired to the agent."""
+        skill = Skill(path=skills_dir / "cars")
+        agent = Agent(name="car_agent", model=TestModel(), tools=[skill])
+
+        loaded = [t for t in agent.tools if isinstance(t, Skill)]
+        assert len(loaded) == 1
+        assert loaded[0].name == "cars"
+        assert loaded[0]._agent_path == "car_agent"
+
+    def test_skill_in_tools_adds_read_skill_tool(self, skills_dir):
+        """Test that a Skill passed in `tools` triggers the `read_skill` tool to be added."""
+        skill = Skill(path=skills_dir / "cars")
+        agent = Agent(name="agent", model=TestModel(), tools=[skill])
+
+        assert any(isinstance(t, ReadSkill) for t in agent.tools)
+
+    @pytest.mark.asyncio
+    async def test_skill_in_tools_appears_in_system_prompt(self, skills_dir):
+        """Test that a Skill passed in `tools` is documented in the system prompt."""
+        skill = Skill(path=skills_dir / "cars")
+        agent = Agent(name="agent", model=TestModel(), tools=[skill])
+
+        system_prompt = await agent._resolve_system_prompt()
+        assert "<skills>" in system_prompt
+        assert "cars" in system_prompt
+
+
 class TestReadSkillTool:
     """Test the ReadSkill tool functionality."""
 
@@ -474,10 +562,10 @@ class TestSkillIntegration:
 
             # After reading (if read_skill was called): search_cars should be available
             if read_skill_events:
-                # Check if search_cars appeared in any subsequent call
-                has_search_cars_later = any("search_cars" in tools for tools in tool_calls[1:])
-                # This might not always be true depending on LLM behavior
-                # So we just verify the structure works
+                # Check if search_cars appeared in any subsequent call.
+                # This might not always be true depending on LLM behavior,
+                # so we just verify the structure works.
+                any("search_cars" in tools for tools in tool_calls[1:])
 
     @pytest.mark.asyncio
     async def test_skill_tools_resolve_when_in_context(self, skills_dir):

--- a/python/tests/core/test_skill.py
+++ b/python/tests/core/test_skill.py
@@ -339,26 +339,26 @@ class TestAgentWithSkills:
 
 
 class TestAgentSkillsFilter:
-    """Test the `skills` whitelist and `skills_exclude` blacklist filters."""
+    """Test the `skills_include` whitelist and `skills_exclude` blacklist filters."""
 
     def test_whitelist_loads_only_selected(self, skills_dir):
-        """Test that `skills=[...]` loads only the listed skill directories."""
-        agent = Agent(name="agent", model=TestModel(), skills_path=skills_dir, skills=["cars"])
+        """Test that `skills_include=[...]` loads only the listed skill directories."""
+        agent = Agent(name="agent", model=TestModel(), skills_path=skills_dir, skills_include=["cars"])
 
         loaded = {t.name for t in agent.tools if isinstance(t, Skill)}
         assert loaded == {"cars"}
 
     def test_whitelist_empty_loads_none(self, skills_dir):
-        """Test that `skills=[]` loads no skills."""
-        agent = Agent(name="agent", model=TestModel(), skills_path=skills_dir, skills=[])
+        """Test that `skills_include=[]` loads no skills."""
+        agent = Agent(name="agent", model=TestModel(), skills_path=skills_dir, skills_include=[])
 
         loaded = {t.name for t in agent.tools if isinstance(t, Skill)}
         assert loaded == set()
 
     def test_whitelist_unknown_name_raises(self, skills_dir):
-        """Test that referencing a non-existent skill in `skills=[...]` raises ValueError."""
+        """Test that referencing a non-existent skill in `skills_include=[...]` raises ValueError."""
         with pytest.raises(ValueError, match="Skills not found.*nonexistent"):
-            Agent(name="agent", model=TestModel(), skills_path=skills_dir, skills=["cars", "nonexistent"])
+            Agent(name="agent", model=TestModel(), skills_path=skills_dir, skills_include=["cars", "nonexistent"])
 
     def test_exclude_skips_listed_skills(self, skills_dir):
         """Test that `skills_exclude=[...]` loads all but the listed skill directories."""
@@ -375,20 +375,20 @@ class TestAgentSkillsFilter:
         assert loaded == {"cars", "bikes"}
 
     def test_whitelist_and_exclude_are_mutually_exclusive(self, skills_dir):
-        """Test that passing both `skills` and `skills_exclude` raises ValueError."""
+        """Test that passing both `skills_include` and `skills_exclude` raises ValueError."""
         with pytest.raises(ValueError, match="mutually exclusive"):
             Agent(
                 name="agent",
                 model=TestModel(),
                 skills_path=skills_dir,
-                skills=["cars"],
+                skills_include=["cars"],
                 skills_exclude=["bikes"],
             )
 
     def test_whitelist_without_skills_path_raises(self):
-        """Test that `skills=[...]` requires `skills_path` to be set."""
+        """Test that `skills_include=[...]` requires `skills_path` to be set."""
         with pytest.raises(ValueError, match="skills_path"):
-            Agent(name="agent", model=TestModel(), skills=["cars"])
+            Agent(name="agent", model=TestModel(), skills_include=["cars"])
 
     def test_exclude_without_skills_path_raises(self):
         """Test that `skills_exclude=[...]` requires `skills_path` to be set."""
@@ -425,6 +425,103 @@ class TestAgentWithSkillInTools:
         system_prompt = await agent._resolve_system_prompt()
         assert "<skills>" in system_prompt
         assert "cars" in system_prompt
+
+    @pytest.mark.asyncio
+    async def test_multiple_skills_in_tools(self, skills_dir):
+        """Test that multiple Skills passed in `tools` are all wired and documented."""
+        cars = Skill(path=skills_dir / "cars")
+        bikes = Skill(path=skills_dir / "bikes")
+        agent = Agent(name="agent", model=TestModel(), tools=[cars, bikes])
+
+        loaded = {t.name for t in agent.tools if isinstance(t, Skill)}
+        assert loaded == {"cars", "bikes"}
+
+        # Exactly one ReadSkill aggregator, aware of both skills
+        read_skill_tools = [t for t in agent.tools if isinstance(t, ReadSkill)]
+        assert len(read_skill_tools) == 1
+
+        system_prompt = await agent._resolve_system_prompt()
+        assert "cars" in system_prompt
+        assert "bikes" in system_prompt
+
+    def test_skill_mixed_with_function_and_tool(self, skills_dir):
+        """Test that the normalization loop handles interleaved Skill / function / Tool correctly."""
+
+        def plain_handler(x: int) -> int:
+            """A plain function tool."""
+            return x + 1
+
+        explicit_tool = Tool(name="explicit", description="Explicit", handler=lambda y: y * 2)
+        skill = Skill(path=skills_dir / "cars")
+
+        agent = Agent(name="agent", model=TestModel(), tools=[skill, plain_handler, explicit_tool])
+
+        skills = [t for t in agent.tools if isinstance(t, Skill)]
+        assert len(skills) == 1
+        assert skills[0].name == "cars"
+        assert skills[0]._agent_path == "agent"
+
+        tool_names = {getattr(t, "name", None) for t in agent.tools if not isinstance(t, Skill)}
+        assert "plain_handler" in tool_names
+        assert "explicit" in tool_names
+        assert "read_skill" in tool_names
+
+    def test_duplicate_skill_in_tools_raises(self, skills_dir):
+        """Test that two Skill instances with the same name passed in `tools` raise an error."""
+        with pytest.raises(ValueError, match="Skill 'cars' already exists"):
+            Agent(
+                name="agent",
+                model=TestModel(),
+                tools=[Skill(path=skills_dir / "cars"), Skill(path=skills_dir / "cars")],
+            )
+
+    def test_skills_path_combined_with_tools_skill(self, tmp_path, skills_dir):
+        """Test that `skills_path` and `tools=[Skill(...)]` form a union of available skills."""
+        # Build an additional skills directory with one new skill not in `skills_dir`.
+        other_root = tmp_path / "other_skills"
+        other_root.mkdir()
+        inventory_dir = other_root / "inventory"
+        inventory_dir.mkdir()
+        (inventory_dir / "SKILL.md").write_text(
+            "---\nname: inventory\ndescription: Inventory management\n---\n\nbody\n",
+            encoding="utf-8",
+        )
+
+        agent = Agent(
+            name="agent",
+            model=TestModel(),
+            skills_path=skills_dir,
+            tools=[Skill(path=inventory_dir)],
+        )
+
+        loaded = {t.name for t in agent.tools if isinstance(t, Skill)}
+        assert loaded == {"cars", "bikes", "inventory"}
+
+    @pytest.mark.asyncio
+    async def test_skill_in_tools_resolves_when_in_context(self, skills_dir):
+        """End-to-end: a Skill passed in `tools` resolves its tools at runtime when marked in context.
+
+        Mirrors `TestSkillIntegration.test_skill_tools_resolve_when_in_context` but loads the skill
+        via `tools=[Skill(...)]` instead of `skills_path`. This proves `_agent_path` wiring on the
+        direct-tools path actually unlocks runtime resolution, not just sets an attribute.
+        """
+        from timbal.state import RunContext, get_or_create_run_context, set_run_context
+
+        skill = Skill(path=skills_dir / "cars")
+        agent = Agent(name="agent", model=TestModel(), tools=[skill])
+
+        # Bind a fresh RunContext so the skill can reach a session.
+        set_run_context(RunContext(tracing_provider=None))
+        session = await get_or_create_run_context().get_session()
+
+        # Not in context yet → resolve returns no tools.
+        assert await skill.resolve() == []
+
+        # Mark cars as in-context for this agent, mirroring what `ReadSkill` does.
+        session["__in_context_skills"] = {agent._path: ["cars"]}
+        resolved = await skill.resolve()
+        resolved_names = {t.name for t in resolved}
+        assert "search_cars" in resolved_names
 
 
 class TestReadSkillTool:

--- a/python/timbal/core/agent.py
+++ b/python/timbal/core/agent.py
@@ -170,6 +170,12 @@ class Agent(Runnable):
     """List of tools available to the agent. Can be functions, dicts, or Runnable objects."""
     skills_path: str | Path | None = None
     """Path to the skills directory."""
+    skills: list[str] | None = None
+    """Whitelist of skill directory names to load from skills_path. If None, all are loaded.
+    Mutually exclusive with skills_exclude. Unknown names raise ValueError."""
+    skills_exclude: list[str] | None = None
+    """Blacklist of skill directory names to skip from skills_path.
+    Mutually exclusive with skills."""
     max_iter: int = 10
     """Maximum number of LLM->tool call iterations before stopping."""
     max_tokens: int | None = None
@@ -273,16 +279,7 @@ class Agent(Runnable):
         )
         self._llm.nest(self._path)
 
-        if self.skills_path is not None:
-            self.skills_path = Path(self.skills_path).expanduser().resolve()
-            if not self.skills_path.exists() or not self.skills_path.is_dir():
-                raise ValueError(
-                    f"Skills directory {self.skills_path} does not exist or is not a directory. Skipping..."
-                )
-            for skill_path in self.skills_path.iterdir():
-                skill = Skill(path=skill_path)
-                skill._agent_path = self._path
-                self.tools.append(skill)
+        self._init_skills()
 
         # Normalize tools and prevent duplicate names
         names: set[str] = set()
@@ -291,6 +288,7 @@ class Agent(Runnable):
             if isinstance(tool, Skill):
                 if tool.name in names:
                     raise ValueError(f"Skill '{tool.name}' already exists. You can only add a skill once.")
+                tool._agent_path = self._path
                 names.add(tool.name)
                 skills.append(tool)
                 continue
@@ -320,6 +318,35 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
         self._is_coroutine = False
         self._is_gen = False
         self._is_async_gen = True
+
+    def _init_skills(self) -> None:
+        """Validate skill filter params and append filtered Skill instances from `skills_path` to `self.tools`."""
+        if self.skills is not None and self.skills_exclude is not None:
+            raise ValueError("'skills' and 'skills_exclude' are mutually exclusive. Use only one.")
+        if (self.skills is not None or self.skills_exclude is not None) and self.skills_path is None:
+            raise ValueError("'skills' and 'skills_exclude' require 'skills_path' to be set.")
+        if self.skills_path is None:
+            return
+
+        self.skills_path = Path(self.skills_path).expanduser().resolve()
+        if not self.skills_path.is_dir():
+            raise ValueError(f"Skills directory {self.skills_path} does not exist or is not a directory.")
+
+        available = {p.name: p for p in self.skills_path.iterdir() if p.is_dir()}
+
+        if self.skills is not None:
+            missing = set(self.skills) - available.keys()
+            if missing:
+                raise ValueError(f"Skills not found in {self.skills_path}: {sorted(missing)}")
+            selected = self.skills
+        elif self.skills_exclude is not None:
+            excluded = set(self.skills_exclude)
+            selected = [name for name in available if name not in excluded]
+        else:
+            selected = list(available)
+
+        for name in selected:
+            self.tools.append(Skill(path=available[name]))
 
     @override
     def get_config(self) -> dict[str, Any]:

--- a/python/timbal/core/agent.py
+++ b/python/timbal/core/agent.py
@@ -170,12 +170,12 @@ class Agent(Runnable):
     """List of tools available to the agent. Can be functions, dicts, or Runnable objects."""
     skills_path: str | Path | None = None
     """Path to the skills directory."""
-    skills: list[str] | None = None
+    skills_include: list[str] | None = None
     """Whitelist of skill directory names to load from skills_path. If None, all are loaded.
     Mutually exclusive with skills_exclude. Unknown names raise ValueError."""
     skills_exclude: list[str] | None = None
     """Blacklist of skill directory names to skip from skills_path.
-    Mutually exclusive with skills."""
+    Mutually exclusive with skills_include."""
     max_iter: int = 10
     """Maximum number of LLM->tool call iterations before stopping."""
     max_tokens: int | None = None
@@ -321,10 +321,10 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
 
     def _init_skills(self) -> None:
         """Validate skill filter params and append filtered Skill instances from `skills_path` to `self.tools`."""
-        if self.skills is not None and self.skills_exclude is not None:
-            raise ValueError("'skills' and 'skills_exclude' are mutually exclusive. Use only one.")
-        if (self.skills is not None or self.skills_exclude is not None) and self.skills_path is None:
-            raise ValueError("'skills' and 'skills_exclude' require 'skills_path' to be set.")
+        if self.skills_include is not None and self.skills_exclude is not None:
+            raise ValueError("'skills_include' and 'skills_exclude' are mutually exclusive. Use only one.")
+        if (self.skills_include is not None or self.skills_exclude is not None) and self.skills_path is None:
+            raise ValueError("'skills_include' and 'skills_exclude' require 'skills_path' to be set.")
         if self.skills_path is None:
             return
 
@@ -334,11 +334,11 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
 
         available = {p.name: p for p in self.skills_path.iterdir() if p.is_dir()}
 
-        if self.skills is not None:
-            missing = set(self.skills) - available.keys()
+        if self.skills_include is not None:
+            missing = set(self.skills_include) - available.keys()
             if missing:
                 raise ValueError(f"Skills not found in {self.skills_path}: {sorted(missing)}")
-            selected = self.skills
+            selected = self.skills_include
         elif self.skills_exclude is not None:
             excluded = set(self.skills_exclude)
             selected = [name for name in available if name not in excluded]


### PR DESCRIPTION
## Motivation

Currently `Agent(skills_path=...)` loads every skill in the directory. When the same skills directory is shared by multiple agents — each needing a different subset — the only options are to duplicate directories or accept that every agent advertises every skill in its system prompt.

## Changes

- Add `skills: list[str] | None` (whitelist) and `skills_exclude: list[str] | None` (blacklist) params to `Agent`. Both match against skill directory names.
  - Mutually exclusive; both require `skills_path`.
  - Unknown names in `skills=` raise `ValueError` (typo protection); unknown names in `skills_exclude=` are ignored.
- Skill instances passed directly via `tools=[...]` now have `_agent_path` wired automatically, so they resolve correctly without needing `skills_path`.
- Filter/wiring logic extracted into `Agent._init_skills()` for readability.

## Examples

```python
# Whitelist
Agent(skills_path="./skills", skills=["web_research", "sql"], ...)

# Blacklist
Agent(skills_path="./skills", skills_exclude=["experimental"], ...)

# Explicit, no skills_path
Agent(tools=[Skill(path="./skills/web_research")], ...)
```

## Tests

13 new tests in `python/tests/core/test_skill.py` covering whitelist/blacklist/mutual-exclusivity/missing-name behavior and `Skill`-in-`tools` integration. Full suite green.

## Docs

- `README.md` — extended Skills section with filter examples.
- `docs/agents/skills.mdx` — new "Selecting Which Skills to Load" section.