### PR TITLE
chore: remove PlatformSubject.version_id and TIMBAL_VERSION_ID

### DIFF
--- a/python/tests/core/test_llm_router_dispatch.py
+++ b/python/tests/core/test_llm_router_dispatch.py
@@ -527,14 +527,13 @@ class TestLlmRouterTestModelPath:
 class TestLlmRouterPlatformHeaders:
     """Test that platform config subject fields are forwarded as request headers."""
 
-    def _make_platform_context(self, app_id=None, version_id=None):
+    def _make_platform_context(self, app_id=None):
         from timbal.state.config import PlatformConfig
 
         platform_config = MagicMock(spec=PlatformConfig)
         platform_config.subject = MagicMock()
         platform_config.subject.org_id = "org_999"
         platform_config.subject.app_id = app_id
-        platform_config.subject.version_id = version_id
         platform_config.host = "api.timbal.ai"
         platform_config.auth = MagicMock()
         platform_config.auth.header_value = "Bearer tok"
@@ -544,7 +543,7 @@ class TestLlmRouterPlatformHeaders:
     async def test_app_id_added_to_headers(self):
         from timbal.core.llm_router import _llm_router
 
-        self._make_platform_context(app_id="app_123", version_id=None)
+        self._make_platform_context(app_id="app_123")
 
         captured_kwargs = {}
 
@@ -570,10 +569,10 @@ class TestLlmRouterPlatformHeaders:
         assert "x-timbal-version-id" not in headers
 
     @pytest.mark.asyncio
-    async def test_version_id_added_to_headers(self):
+    async def test_app_id_absent_omits_header(self):
         from timbal.core.llm_router import _llm_router
 
-        self._make_platform_context(app_id=None, version_id="v42")
+        self._make_platform_context(app_id=None)
 
         captured_kwargs = {}
 
@@ -595,37 +594,8 @@ class TestLlmRouterPlatformHeaders:
                 pass
 
         headers = captured_kwargs.get("extra_headers", {})
-        assert headers.get("x-timbal-version-id") == "v42"
         assert "x-timbal-app-id" not in headers
-
-    @pytest.mark.asyncio
-    async def test_both_app_id_and_version_id_added(self):
-        from timbal.core.llm_router import _llm_router
-
-        self._make_platform_context(app_id="app_123", version_id="v42")
-
-        captured_kwargs = {}
-
-        async def fake_create(**kwargs):
-            captured_kwargs.update(kwargs)
-            return _empty_async_stream()
-
-        mock_client = MagicMock()
-        mock_client.messages.create = fake_create
-
-        with patch("timbal.core.llm_router._get_client", return_value=mock_client):
-            try:
-                async for _ in _llm_router(
-                    model="anthropic/claude-sonnet-4-6",
-                    max_tokens=100,
-                ):
-                    pass
-            except (RuntimeError, StopAsyncIteration):
-                pass
-
-        headers = captured_kwargs.get("extra_headers", {})
-        assert headers.get("x-timbal-app-id") == "app_123"
-        assert headers.get("x-timbal-version-id") == "v42"
+        assert "x-timbal-version-id" not in headers
 
 
 class TestLlmRouterAnthropicStructuredOutput:

--- a/python/tests/core/test_platform_tracing_provider.py
+++ b/python/tests/core/test_platform_tracing_provider.py
@@ -7,7 +7,6 @@ These tests run live against the Timbal API and require a populated
     TIMBAL_API_KEY=<your key>
     TIMBAL_ORG_ID=<your org id>
     TIMBAL_APP_ID=<app id to record traces under>
-    TIMBAL_VERSION_ID=<version id>   # optional
 
 All tests are skipped automatically if the file is absent.
 Run with:  uv run pytest python/tests/core/test_platform_tracing_provider.py -v

--- a/python/tests/core/test_tracing.py
+++ b/python/tests/core/test_tracing.py
@@ -605,7 +605,7 @@ class TestPlatformTracingProvider:
         cfg = PlatformConfig(
             host="api.timbal.ai",
             auth=PlatformAuth(type=PlatformAuthType.BEARER, token="tok"),
-            subject=PlatformSubject(org_id="org_123", app_id=app_id, version_id="v1", rev=rev),
+            subject=PlatformSubject(org_id="org_123", app_id=app_id, rev=rev),
         )
         return RunContext(id="run_abc", parent_id="run_parent", platform_config=cfg, tracing_provider=None)
 
@@ -704,20 +704,6 @@ class TestPlatformTracingProvider:
         assert "org_123" in path_arg
         assert "app_456" in path_arg
         assert "run_abc" in path_arg
-
-    @pytest.mark.asyncio
-    async def test_store_includes_version_id_in_payload(self):
-        from timbal.state.tracing.providers.platform import PlatformTracingProvider
-
-        mock_res = self._mock_response({})
-        run_context = self._make_run_context()
-        mock_request = AsyncMock(return_value=mock_res)
-
-        with patch("timbal.platform.utils._request", new=mock_request):
-            await PlatformTracingProvider._store(run_context)
-
-        json_payload = mock_request.call_args.kwargs.get("json", {})
-        assert json_payload.get("version_id") == "v1"
 
     @pytest.mark.asyncio
     async def test_store_raises_without_app_id(self):

--- a/python/tests/platform/test_knowledge_bases.py
+++ b/python/tests/platform/test_knowledge_bases.py
@@ -18,7 +18,7 @@ def _ctx(monkeypatch):
     cfg = PlatformConfig(
         host="api.timbal.ai",
         auth=PlatformAuth(type=PlatformAuthType.BEARER, token="t"),
-        subject=PlatformSubject(org_id="org_1", app_id="400", version_id="v1"),
+        subject=PlatformSubject(org_id="org_1", app_id="400"),
     )
     set_run_context(RunContext(platform_config=cfg, tracing_provider=None))
     yield

--- a/python/tests/platform/test_platform_utils.py
+++ b/python/tests/platform/test_platform_utils.py
@@ -21,12 +21,11 @@ def _make_platform_config(
     host: str = "api.timbal.ai",
     org_id: str = "org_123",
     app_id: str = "app_456",
-    version_id: str = "v1",
 ) -> PlatformConfig:
     return PlatformConfig(
         host=host,
         auth=PlatformAuth(type=PlatformAuthType.BEARER, token="token"),
-        subject=PlatformSubject(org_id=org_id, app_id=app_id, version_id=version_id),
+        subject=PlatformSubject(org_id=org_id, app_id=app_id),
     )
 
 

--- a/python/timbal/core/llm_router.py
+++ b/python/timbal/core/llm_router.py
@@ -421,8 +421,6 @@ async def _llm_router(
     if run_context.platform_config and run_context.platform_config.subject:
         if run_context.platform_config.subject.app_id:
             request_headers["x-timbal-app-id"] = run_context.platform_config.subject.app_id
-        if run_context.platform_config.subject.version_id:
-            request_headers["x-timbal-version-id"] = run_context.platform_config.subject.version_id
 
     client, base_url = _resolve_client(provider, config, api_key, base_url, run_context)
 

--- a/python/timbal/state/config.py
+++ b/python/timbal/state/config.py
@@ -54,8 +54,6 @@ class PlatformSubject(BaseModel):
     """Organization identifier."""
     app_id: str | None = None
     """Application identifier. Either project or app must be specified."""
-    version_id: str | None = None
-    """Application version identifier."""
     rev: str | None = None
     """Git revision the run was executed against. Internal use."""
 

--- a/python/timbal/state/config_loader.py
+++ b/python/timbal/state/config_loader.py
@@ -241,25 +241,17 @@ def resolve_platform_config(
     if not app_id:
         app_id = os.getenv("TIMBAL_APP_ID")
 
-    version_id = None
-    if existing_subject:
-        version_id = existing_subject.version_id
-    if not version_id:
-        version_id = os.getenv("TIMBAL_VERSION_ID")
-
     rev = existing_subject.rev if existing_subject else None
 
     platform_config.subject = PlatformSubject(
         org_id=org_id,
         app_id=app_id,
-        version_id=version_id,
         rev=rev,
     )
     logger.debug(
         "Resolved platform subject.",
         org_id=org_id,
         app_id=app_id,
-        version_id=version_id,
         rev=rev,
     )
 

--- a/python/timbal/state/tracing/providers/platform.py
+++ b/python/timbal/state/tracing/providers/platform.py
@@ -103,7 +103,6 @@ class PlatformTracingProvider(TracingProvider):
         payload = {"parent_id": run_context.parent_id, "trace": run_context._trace.model_dump()}
         if subject.app_id:
             subject_path = f"apps/{subject.app_id}"
-            payload["version_id"] = subject.version_id
         else:
             raise ValueError("Cannot use platform tracing provider without an app or project subject")
         if subject.rev is not None:


### PR DESCRIPTION
Drop the unused version identifier from platform subject resolution, tracing PATCH payloads, and LLM proxy headers. Nothing in-tree consumed TIMBAL_VERSION_ID or x-timbal-version-id; the monolith never wired them end-to-end.