### PR TITLE
Add CalaQuery and align Cala knowledge tools with current API

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -12,7 +12,7 @@ os.environ["PYTHONWARNINGS"] = "ignore::DeprecationWarning"
 def pytest_configure(config):
     """Configure pytest with global settings."""
     # Load environment variables
-    load_dotenv()
+    load_dotenv(override=True)
 
 
 @pytest.fixture(autouse=True)

--- a/python/tests/tools/test_cala.py
+++ b/python/tests/tools/test_cala.py
@@ -1,0 +1,66 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from timbal.tools import CalaQuery, CalaSearch
+
+
+def _mock_httpx_context(mock_client):
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=mock_client)
+    ctx.__aexit__ = AsyncMock(return_value=None)
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_cala_search_posts_full_search_request():
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {"content": "answer", "entities": []}
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+
+    with patch("httpx.AsyncClient", return_value=_mock_httpx_context(mock_client)):
+        tool = CalaSearch(api_key=SecretStr("cala-key"))
+        out = await tool.handler(
+            input="What are the biggest AI startups in Europe?",
+            explainability=False,
+            return_entities=False,
+        )
+
+    assert out == {"content": "answer", "entities": []}
+    url = mock_client.post.await_args[0][0]
+    assert url == "https://api.cala.ai/v1/knowledge/search"
+    assert mock_client.post.await_args.kwargs["headers"]["x-api-key"] == "cala-key"
+    assert mock_client.post.await_args.kwargs["json"] == {
+        "input": "What are the biggest AI startups in Europe?",
+        "explainability": False,
+        "return_entities": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_cala_query_posts_structured_query_request():
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {"results": [], "entities": []}
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+
+    with patch("httpx.AsyncClient", return_value=_mock_httpx_context(mock_client)):
+        tool = CalaQuery(api_key=SecretStr("cala-key"), base_url="https://custom.api/v1")
+        out = await tool.handler(
+            input="startups.location=Spain.funding>10M",
+            return_entities=True,
+        )
+
+    assert out == {"results": [], "entities": []}
+    url = mock_client.post.await_args[0][0]
+    assert url == "https://custom.api/v1/knowledge/query"
+    assert mock_client.post.await_args.kwargs["json"] == {
+        "input": "startups.location=Spain.funding>10M",
+        "return_entities": True,
+    }

--- a/python/tests/tools/test_web_search_providers.py
+++ b/python/tests/tools/test_web_search_providers.py
@@ -203,7 +203,11 @@ async def test_web_search_cala_posts_natural_language_query():
     headers = mock_client.post.await_args.kwargs["headers"]
     assert headers["x-api-key"] == "cala-key"
     body = mock_client.post.await_args.kwargs["json"]
-    assert body == {"input": "what is the capital of Mali"}
+    assert body == {
+        "input": "what is the capital of Mali",
+        "explainability": True,
+        "return_entities": True,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -356,7 +360,11 @@ async def test_agent_invokes_cala_web_search_via_tool_use():
     assert result.status.code == "success"
     mock_client.post.assert_awaited_once()
     assert mock_client.post.await_args[0][0].endswith("/knowledge/search")
-    assert mock_client.post.await_args.kwargs["json"] == {"input": "capital of Mali"}
+    assert mock_client.post.await_args.kwargs["json"] == {
+        "input": "capital of Mali",
+        "explainability": True,
+        "return_entities": True,
+    }
 
 
 @pytest.mark.asyncio

--- a/python/timbal/codegen/README.md
+++ b/python/timbal/codegen/README.md
@@ -74,7 +74,7 @@ python -m timbal.codegen add-tool --type WebSearch --step agent_a
 
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `--type` | yes | `Bash`, `CalaSearch`, `Edit`, `Read`, `WebSearch`, `Write`, or `Custom` |
+| `--type` | yes | `Bash`, `CalaQuery`, `CalaSearch`, `Edit`, `Read`, `WebSearch`, `Write`, or `Custom` |
 | `--definition` | Custom only | Full function definition as a string |
 | `--name` | no | Override the default tool name |
 | `--config` | no | Constructor kwargs as JSON. Validated against the tool's schema. Use `null` to remove a key. |
@@ -136,7 +136,7 @@ python -m timbal.codegen set-config --config '{"system_prompt": null}'
 python -m timbal.codegen set-config --name web_search --config '{"timeout": 30}'
 ```
 
-Config fields are validated against the tool's schema. Supported configurable tools: `WebSearch`, `CalaSearch`, `Tool` (custom).
+Config fields are validated against the tool's schema. Supported configurable tools: `WebSearch`, `CalaSearch`, `CalaQuery`, `Tool` (custom).
 
 #### Configure a workflow step's constructor
 
@@ -170,7 +170,7 @@ python -m timbal.codegen add-step --type Custom \
 
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `--type` | yes | `Agent`, `Custom`, or a framework tool (`Bash`, `CalaSearch`, `Edit`, `Read`, `WebSearch`, `Write`) |
+| `--type` | yes | `Agent`, `Custom`, or a framework tool (`Bash`, `CalaQuery`, `CalaSearch`, `Edit`, `Read`, `WebSearch`, `Write`) |
 | `--config` | Agent only | JSON with Agent constructor params (must include `name`) |
 | `--definition` | Custom only | Full function definition |
 | `--name` | no | Override the step name |

--- a/python/timbal/tools/__init__.py
+++ b/python/timbal/tools/__init__.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
         AsanaUpdateTask,
     )
     from .bash import Bash
-    from .cala import CalaSearch
+    from .cala import CalaQuery, CalaSearch
     from .cloudflare import (
         CloudflareCrawlCancel,
         CloudflareCrawlGet,
@@ -947,6 +947,7 @@ if TYPE_CHECKING:
     )
 __all__ = [
     "Bash",
+    "CalaQuery",
     "CalaSearch",
     "Edit",
     "FirecrawlCrawl",
@@ -1831,6 +1832,7 @@ __all__ = [
 
 _LAZY_IMPORTS = {
     "Bash": ".bash",
+    "CalaQuery": ".cala",
     "CalaSearch": ".cala",
     "Edit": ".edit",
     "FirecrawlCrawl": ".firecrawl",

--- a/python/timbal/tools/cala.py
+++ b/python/timbal/tools/cala.py
@@ -5,12 +5,15 @@ from pydantic import Field, SecretStr
 from ..core.tool import Tool
 from ..platform.integrations import Integration
 
-_BASE_URL = "https://api.cala.ai/v1"
+_DEFAULT_BASE_URL = "https://api.cala.ai/v1"
+# Back-compat alias for web_search imports
+_BASE_URL = _DEFAULT_BASE_URL
 
 
 async def _resolve_api_key(*, integration: Any = None, api_key: SecretStr | None = None) -> str:
     """Resolve Cala API key from integration, explicit field, or env var."""
     from ._creds import resolve_api_key
+
     return await resolve_api_key(
         env_var="CALA_API_KEY",
         provider_name="Cala",
@@ -19,34 +22,127 @@ async def _resolve_api_key(*, integration: Any = None, api_key: SecretStr | None
     )
 
 
-class CalaSearch(Tool):
-    name: str = "cala_search"
-    description: str | None = "Search for verified knowledge using natural language queries."
+def _normalize_base_url(base_url: str | None) -> str:
+    return (base_url or _DEFAULT_BASE_URL).rstrip("/")
+
+
+async def _post_cala(
+    *,
+    path: str,
+    api_key: str,
+    base_url: str,
+    body: dict[str, Any],
+) -> dict:
+    import httpx
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{_normalize_base_url(base_url)}{path}",
+            headers={"x-api-key": api_key, "Content-Type": "application/json"},
+            json=body,
+            timeout=httpx.Timeout(10.0, read=None),
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+def _search_request_body(
+    *,
+    input: str,
+    explainability: bool = True,
+    return_entities: bool = True,
+) -> dict[str, Any]:
+    return {
+        "input": input,
+        "explainability": explainability,
+        "return_entities": return_entities,
+    }
+
+
+def _query_request_body(
+    *,
+    input: str,
+    return_entities: bool = True,
+) -> dict[str, Any]:
+    return {
+        "input": input,
+        "return_entities": return_entities,
+    }
+
+
+class _CalaKnowledgeTool(Tool):
     integration: Annotated[str, Integration("cala")] | None = None
     api_key: SecretStr | None = None
+    base_url: str = _DEFAULT_BASE_URL
 
     def get_config(self) -> dict[str, Any]:
         """See base class."""
         return {
             **super().get_config(),
-            **self._annotate_config({"integration": self.integration, "api_key": self.api_key}),
+            **self._annotate_config(
+                {
+                    "integration": self.integration,
+                    "api_key": self.api_key,
+                    "base_url": self.base_url,
+                }
+            ),
         }
+
+
+class CalaSearch(_CalaKnowledgeTool):
+    name: str = "cala_search"
+    description: str | None = (
+        "Get a succinct natural-language answer in markdown with explainability, source citations, "
+        "and matching entities. Accepts Cala QL or a natural-language question. "
+        "Use CalaQuery for structured tabular rows instead."
+    )
 
     def __init__(self, **kwargs: Any) -> None:
         async def _cala_search(
-            query: str = Field(..., description="Natural language search query"),
+            input: str = Field(
+                ...,
+                description="Cala QL expression or natural-language question (API field: input)",
+            ),
+            explainability: bool = True,
+            return_entities: bool = True,
         ) -> dict:
             api_key = await _resolve_api_key(integration=self.integration, api_key=self.api_key)
-            import httpx
-
-            async with httpx.AsyncClient() as client:
-                response = await client.post(
-                    f"{_BASE_URL}/knowledge/search",
-                    headers={"x-api-key": api_key, "Content-Type": "application/json"},
-                    json={"input": query},
-                    timeout=httpx.Timeout(10.0, read=None),
-                )
-                response.raise_for_status()
-                return response.json()
+            return await _post_cala(
+                path="/knowledge/search",
+                api_key=api_key,
+                base_url=self.base_url,
+                body=_search_request_body(
+                    input=input,
+                    explainability=explainability,
+                    return_entities=return_entities,
+                ),
+            )
 
         super().__init__(handler=_cala_search, **kwargs)
+
+
+class CalaQuery(_CalaKnowledgeTool):
+    name: str = "cala_query"
+    description: str | None = (
+        "Get structured JSON rows plus matching entities from Cala's knowledge base. "
+        "Accepts Cala QL dot-notation filters (e.g. startups.location=Spain.funding>10M) "
+        "or a natural-language question. Use CalaSearch for markdown answers with sources."
+    )
+
+    def __init__(self, **kwargs: Any) -> None:
+        async def _cala_query(
+            input: str = Field(
+                ...,
+                description="Cala QL expression or natural-language question (API field: input)",
+            ),
+            return_entities: bool = True,
+        ) -> dict:
+            api_key = await _resolve_api_key(integration=self.integration, api_key=self.api_key)
+            return await _post_cala(
+                path="/knowledge/query",
+                api_key=api_key,
+                base_url=self.base_url,
+                body=_query_request_body(input=input, return_entities=return_entities),
+            )
+
+        super().__init__(handler=_cala_query, **kwargs)

--- a/python/timbal/tools/web_search.py
+++ b/python/timbal/tools/web_search.py
@@ -36,8 +36,10 @@ from pydantic import Field, SecretStr, computed_field
 
 from ..core.tool import Tool
 from ..platform.integrations import Integration
-from ..tools.cala import _BASE_URL as _CALA_BASE_URL
+from ..tools.cala import _normalize_base_url as _normalize_cala_base_url
+from ..tools.cala import _post_cala as _cala_post
 from ..tools.cala import _resolve_api_key as _resolve_cala_key
+from ..tools.cala import _search_request_body as _cala_search_request_body
 from ..tools.firecrawl import _BASE_URL as _FIRECRAWL_BASE_URL
 from ..tools.firecrawl import _resolve_api_key as _resolve_firecrawl_key
 from ..tools.scraperapi import _STRUCTURED_URL as _SCRAPERAPI_STRUCTURED_URL
@@ -144,24 +146,25 @@ def _make_scraperapi_handler(*, integration=None, api_key=None, user_location=No
     return web_search
 
 
-def _make_cala_handler(*, integration=None, api_key=None):
-    """Return an async handler that searches via Cala."""
+def _make_cala_handler(*, integration=None, api_key=None, base_url=None):
+    """Return an async handler that searches via Cala knowledge/search."""
 
     async def web_search(
-        query: str = Field(..., description="Natural language search query"),
+        query: str = Field(..., description="Cala QL expression or natural-language question"),
+        explainability: bool = True,
+        return_entities: bool = True,
     ) -> dict:
         resolved_key = await _resolve_cala_key(integration=integration, api_key=api_key)
-        import httpx
-
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                f"{_CALA_BASE_URL}/knowledge/search",
-                headers={"x-api-key": resolved_key, "Content-Type": "application/json"},
-                json={"input": query},
-                timeout=httpx.Timeout(10.0, read=None),
-            )
-            response.raise_for_status()
-            return response.json()
+        return await _cala_post(
+            path="/knowledge/search",
+            api_key=resolved_key,
+            base_url=_normalize_cala_base_url(base_url),
+            body=_cala_search_request_body(
+                input=query,
+                explainability=explainability,
+                return_entities=return_entities,
+            ),
+        )
 
     return web_search
 
@@ -352,6 +355,7 @@ class WebSearch(Tool):
                 kwargs["handler"] = _make_cala_handler(
                     integration=kwargs.get("integration"),
                     api_key=kwargs.get("api_key"),
+                    base_url=kwargs.get("base_url"),
                 )
             elif provider == "firecrawl":
                 kwargs["handler"] = _make_firecrawl_handler(


### PR DESCRIPTION
CalaSearch now sends explainability and return_entities to /knowledge/search and supports base_url. Add CalaQuery for structured /knowledge/query results. Update WebSearch Cala provider and tests.