### PR TITLE
Propagate workflow step failures to final output and fix integration …

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -16,16 +16,28 @@ def pytest_configure(config):
 
 
 @pytest.fixture(autouse=True)
-def reset_platform_config_cache():
-    """Force platform config to resolve as None for every non-integration test.
+def reset_platform_config_cache(request):
+    """Force platform config to resolve as None for unit tests only.
 
     Setting _default_config_resolved=True with _cached_default_config=None tells
     resolve_platform_config() "already resolved — there is no platform config".
     Any RunContext() without an explicit tracing_provider then falls back to
     InMemoryTracingProvider instead of PlatformTracingProvider, preventing HTTP
     calls on every _save_trace() / get_session() across the suite.
+
+    Integration tests opt out so they can use ~/.timbal credentials and the
+    platform LLM proxy when provider API keys are not in the environment.
     """
     import timbal.state.config_loader as _cl
+
+    is_integration = request.node.get_closest_marker("integration") is not None
+    if is_integration:
+        _cl._cached_default_config = None
+        _cl._default_config_resolved = False
+        yield
+        _cl._cached_default_config = None
+        _cl._default_config_resolved = False
+        return
 
     _cl._cached_default_config = None
     _cl._default_config_resolved = True

--- a/python/tests/core/test_files_integration.py
+++ b/python/tests/core/test_files_integration.py
@@ -4,8 +4,40 @@ from pathlib import Path
 import pytest
 from timbal import Agent
 from timbal.types import File
+from timbal.types.events import OutputEvent
 
 pytestmark = pytest.mark.integration
+
+_MODEL_ENV_KEYS = {
+    "openai": "OPENAI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    "google": "GEMINI_API_KEY",
+}
+
+
+def _provider_api_key_env(model: str) -> str | None:
+    provider = model.split("/", 1)[0]
+    return _MODEL_ENV_KEYS.get(provider)
+
+
+def _llm_credentials_available(model: str) -> bool:
+    env_key = _provider_api_key_env(model)
+    if env_key and os.getenv(env_key):
+        return True
+    try:
+        from timbal.state.config_loader import resolve_platform_config
+
+        cfg = resolve_platform_config()
+    except Exception:
+        return False
+    return cfg is not None and cfg.auth is not None
+
+
+def _assert_agent_answer(res: OutputEvent, expected: str) -> None:
+    assert res.status.code == "success", res.error
+    assert res.error is None, res.error
+    assert res.output is not None, res.error
+    assert expected in res.output.content[0].text
 
 
 @pytest.fixture(
@@ -18,15 +50,19 @@ pytestmark = pytest.mark.integration
     ]
 )
 def model(request):
-    if request.param.startswith("openai"):
-        if request.param.endswith("-responses"):
+    model_name = request.param
+    if not _llm_credentials_available(model_name):
+        env_key = _provider_api_key_env(model_name) or "provider API key"
+        pytest.skip(f"{env_key} not set and no platform credentials available for {model_name}")
+    if model_name.startswith("openai"):
+        if model_name.endswith("-responses"):
             # Responses API is now the default, so remove any disable flag
             os.environ.pop("TIMBAL_DISABLE_OPENAI_RESPONSES_API", None)
-            return request.param.replace("-responses", "")
+            return model_name.replace("-responses", "")
         else:
             # Disable responses API for non-responses tests
             os.environ["TIMBAL_DISABLE_OPENAI_RESPONSES_API"] = "true"
-    return request.param
+    return model_name
 
 
 @pytest.fixture(
@@ -46,8 +82,7 @@ async def test_png(model, png) -> None:
     prompt = [File.validate(png), "What's Bob's score?"]
 
     res = await agent(prompt=prompt).collect()
-    print(res)
-    assert "87" in res.output.content[0].text
+    _assert_agent_answer(res, "87")
 
 
 @pytest.fixture(
@@ -67,8 +102,7 @@ async def test_pdf(model, pdf) -> None:
     prompt = [File.validate(pdf), "What's Bob's score?"]
 
     res = await agent(prompt=prompt).collect()
-    print(res)
-    assert "87.2" in res.output.content[0].text
+    _assert_agent_answer(res, "87.2")
 
 
 @pytest.fixture(
@@ -88,7 +122,7 @@ async def test_md(model, md) -> None:
     prompt = [File.validate(md), "What's Alice's age?"]
 
     res = await agent(prompt=prompt).collect()
-    assert "28" in res.output.content[0].text
+    _assert_agent_answer(res, "28")
 
 
 @pytest.fixture(
@@ -108,6 +142,8 @@ async def test_csv(model, csv) -> None:
     prompt = [File.validate(csv), "What's Bob's full name?"]
 
     res = await agent(prompt=prompt).collect()
+    assert res.status.code == "success", res.error
+    assert res.output is not None, res.error
     assert "bob johnson" in res.output.content[0].text.lower()
 
 
@@ -128,6 +164,8 @@ async def test_tsv(model, tsv) -> None:
     prompt = [File.validate(tsv), "What's Bob's full name?"]
 
     res = await agent(prompt=prompt).collect()
+    assert res.status.code == "success", res.error
+    assert res.output is not None, res.error
     assert "bob johnson" in res.output.content[0].text.lower()
 
 
@@ -148,7 +186,7 @@ async def test_jsonl(model, jsonl) -> None:
     prompt = [File.validate(jsonl), "What's Alice's score?"]
 
     res = await agent(prompt=prompt).collect()
-    assert "95.5" in res.output.content[0].text
+    _assert_agent_answer(res, "95.5")
 
 
 @pytest.fixture(
@@ -168,6 +206,8 @@ async def test_json(model, json) -> None:
     prompt = [File.validate(json), "Is Bob still active?"]
 
     res = await agent(prompt=prompt).collect()
+    assert res.status.code == "success", res.error
+    assert res.output is not None, res.error
     assert "no" in res.output.content[0].text.lower()
 
 
@@ -188,7 +228,7 @@ async def test_xlsx(model, xlsx) -> None:
     prompt = [File.validate(xlsx), "What's Alice's score?"]
 
     res = await agent(prompt=prompt).collect()
-    assert "95.5" in res.output.content[0].text
+    _assert_agent_answer(res, "95.5")
 
 
 @pytest.fixture(
@@ -208,4 +248,6 @@ async def test_docx(model, docx) -> None:
     prompt = [File.validate(docx), "What's Bob's full name?"]
 
     res = await agent(prompt=prompt).collect()
+    assert res.status.code == "success", res.error
+    assert res.output is not None, res.error
     assert "bob johnson" in res.output.content[0].text.lower()

--- a/python/tests/core/test_workflow.py
+++ b/python/tests/core/test_workflow.py
@@ -502,6 +502,56 @@ class TestWorkflowIntegration:
         assert anthropic_schema["name"] == "simple_workflow"
 
 
+class TestWorkflowErrorStatus:
+    """Workflow final output must reflect step failures."""
+
+    @pytest.mark.asyncio
+    async def test_single_step_error_marks_workflow_as_error(self, error_step_tool):
+        wf = Workflow(name="error_workflow").step(error_step_tool, x="boom")
+        result = await wf().collect()
+        assert result.status.code == "error"
+        assert result.status.reason == "step_failed"
+        assert result.status.message is not None
+        assert "boom" in result.status.message
+        assert result.error is not None
+        assert result.error["type"] == "ValueError"
+        assert "boom" in result.error["message"]
+
+    @pytest.mark.asyncio
+    async def test_single_step_error_via_callable(self):
+        wf = Workflow(name="error_workflow").step(error_step_handler, x="boom")
+        result = await wf().collect()
+        assert result.status.code == "error"
+        assert result.error is not None
+
+    @pytest.mark.asyncio
+    async def test_parallel_step_error_marks_workflow_as_error(self):
+        """Even if another parallel step succeeds, workflow must report error."""
+        wf = (
+            Workflow(name="parallel_error_workflow")
+            .step(error_step_handler, x="boom")
+            .step(step3_handler, x="ok")
+        )
+        result = await wf().collect()
+        assert result.status.code == "error"
+        assert result.error is not None
+
+    @pytest.mark.asyncio
+    async def test_dependent_step_error_marks_workflow_as_error(self):
+        wf = (
+            Workflow(name="dependent_error_workflow")
+            .step(error_step_handler, x="boom")
+            .step(
+                step2_handler,
+                x="after",
+                step1_result=lambda: get_run_context().step_span("error_step_handler").output,
+            )
+        )
+        result = await wf().collect()
+        assert result.status.code == "error"
+        assert result.error is not None
+
+
 class TestWorkflowSentinelStarvation:
     """Regression tests: paths through `_enqueue_step_events` that previously
     leaked an exception past `except Exception` (e.g. a BaseException raised

--- a/python/timbal/core/runnable.py
+++ b/python/timbal/core/runnable.py
@@ -27,7 +27,7 @@ from pydantic import (
 from uuid_extensions import uuid7
 
 from ..collectors import get_collector_registry
-from ..errors import ApprovalPolicyError, ApprovalRequired, EarlyExit, InterruptError
+from ..errors import ApprovalPolicyError, ApprovalRequired, EarlyExit, InterruptError, WorkflowStepError
 from ..state import (
     get_call_id,
     get_parent_call_id,
@@ -1332,8 +1332,10 @@ class Runnable(ABC, BaseModel):
             # to avoid nesting an output event inside another output event
             status_already_set = False
             if isinstance(output, OutputEvent):
-                if output.status.code == "cancelled":
+                if output.status.code in {"cancelled", "error"}:
                     span.status = output.status
+                    if output.error is not None:
+                        span.error = output.error
                     status_already_set = True
                 output = output.output
 
@@ -1421,6 +1423,23 @@ class Runnable(ABC, BaseModel):
                     output = _collector_output_on_interrupt(collector)
                     span.output = output
                     span._output_dump = await dump(output)
+
+        except WorkflowStepError as workflow_step_err:
+            step_error = workflow_step_err.step_error
+            span.status = RunStatus(
+                code="error",
+                reason="step_failed",
+                message=step_error.get("message") if step_error else str(workflow_step_err),
+            )
+            if step_error is not None:
+                span.error = step_error
+            else:
+                span.error = {
+                    "type": type(workflow_step_err).__name__,
+                    "message": str(workflow_step_err),
+                    "traceback": traceback.format_exc(),
+                    "step_name": workflow_step_err.step_name,
+                }
 
         except Exception as err:
             # Set status FIRST before any operations that could raise (str(err),

--- a/python/timbal/core/workflow.py
+++ b/python/timbal/core/workflow.py
@@ -1,4 +1,5 @@
 import asyncio
+import traceback
 from collections.abc import AsyncGenerator, Callable
 from enum import Enum
 from functools import cached_property
@@ -13,7 +14,7 @@ except ImportError:
 import structlog
 from pydantic import BaseModel, ConfigDict, PrivateAttr, computed_field, create_model
 
-from ..errors import ApprovalRequired, InterruptError, SpanNotFound
+from ..errors import ApprovalRequired, InterruptError, SpanNotFound, WorkflowStepError
 from ..state import get_call_id, get_parent_call_id, set_parent_call_id
 from ..types.events.output import OutputEvent
 from .runnable import Runnable, RunnableLike
@@ -29,11 +30,12 @@ class StepState(Enum):
 
 
 class StepStatus:
-    __slots__ = ("state", "done")
+    __slots__ = ("state", "done", "error")
 
     def __init__(self) -> None:
         self.state: StepState = StepState.PENDING
         self.done: asyncio.Event = asyncio.Event()
+        self.error: dict[str, Any] | None = None
 
 
 logger = structlog.get_logger("timbal.core.workflow")
@@ -231,6 +233,11 @@ class Workflow(Runnable):
             except Exception as e:
                 logger.info(f"Failing {step.name} due to error during evaluation: {e}")
                 status.state = StepState.FAILED
+                status.error = {
+                    "type": type(e).__name__,
+                    "message": str(e),
+                    "traceback": traceback.format_exc(),
+                }
                 status.done.set()
                 return
 
@@ -253,11 +260,17 @@ class Workflow(Runnable):
                     if isinstance(event, OutputEvent) and event.error is not None:
                         logger.info(f"Step {step.name} completed with error.")
                         status.state = StepState.FAILED
+                        status.error = event.error
                         status.done.set()
                         return
                 status.state = StepState.COMPLETED
             except Exception as e:
                 status.state = StepState.FAILED
+                status.error = {
+                    "type": type(e).__name__,
+                    "message": str(e),
+                    "traceback": traceback.format_exc(),
+                }
                 sentinel = e
                 return
             finally:
@@ -334,6 +347,14 @@ class Workflow(Runnable):
                 raise first_pending_approval
             if first_pending_exception is not None:
                 raise first_pending_exception
+            failed_steps = sorted(
+                (name, step_status)
+                for name, step_status in statuses.items()
+                if step_status.state == StepState.FAILED
+            )
+            if failed_steps:
+                step_name, step_status = failed_steps[0]
+                raise WorkflowStepError(step_name, step_status.error)
         except (asyncio.CancelledError, InterruptError):
             raise
         finally:

--- a/python/timbal/errors.py
+++ b/python/timbal/errors.py
@@ -97,6 +97,20 @@ class FallbackExhausted(TimbalError):
         super().__init__(f"All {len(errors)} fallback models failed: {models}")
 
 
+class WorkflowStepError(TimbalError):
+    """Raised when a workflow step fails and the workflow should report error status.
+
+    Carries the original step error dict (when available) so orchestrators can
+    surface it on the workflow span without losing the child traceback.
+    """
+
+    def __init__(self, step_name: str, step_error: dict[str, Any] | None = None) -> None:
+        self.step_name = step_name
+        self.step_error = step_error
+        message = step_error.get("message") if step_error else f"Step '{step_name}' failed"
+        super().__init__(message or f"Step '{step_name}' failed")
+
+
 class SpanNotFound(TimbalError):
     """Error raised when trying to access a span that doesn't exist in the trace.
 


### PR DESCRIPTION
…test auth.

Workflows now raise WorkflowStepError when any step fails, Runnable unwraps nested error OutputEvents correctly, and integration tests can use platform credentials instead of masking LLM failures as AttributeErrors