### PR TITLE
fix: drop empty assistant text blocks that break Anthropic memory

### DIFF
--- a/python/tests/core/test_debug2_empty_assistant_text.py
+++ b/python/tests/core/test_debug2_empty_assistant_text.py
@@ -1,0 +1,300 @@
+"""Regression tests for Benito DEBUG2 (empty assistant text bricking Anthropic memory).
+
+Incident: assistant turns with thinking + ``TextContent(text="")`` caused
+``messages: text content blocks must be non-empty`` on the next LLM call.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from anthropic.types import (
+    RawContentBlockDeltaEvent,
+    RawContentBlockStartEvent,
+    RawContentBlockStopEvent,
+    RawMessageStartEvent,
+    TextBlock,
+    ThinkingBlock,
+    ThinkingDelta,
+)
+from timbal import Agent
+from timbal.collectors.impl.anthropic import AnthropicCollector
+from timbal.core.llm_router import _llm_router
+from timbal.core.test_model import TestModel
+from timbal.state import set_call_id, set_run_context
+from timbal.state.context import RunContext
+from timbal.state.tracing.span import Span
+from timbal.types.content import TextContent, ThinkingContent
+from timbal.types.message import Message
+
+
+def _debug2_poison_assistant_message() -> Message:
+    return Message(
+        role="assistant",
+        content=[
+            ThinkingContent(
+                thinking="motivo_rechazo_clave '#' = Sin asignar → ofertas pendientes en Vallès Oriental",
+                signature="sig_debug2",
+            ),
+            TextContent(text=""),
+        ],
+        stop_reason="end_turn",
+    )
+
+
+def _debug2_memory_after_partial_sql_turn() -> list[Message]:
+    return [
+        Message(role="user", content=[TextContent(text="Hola")]),
+        Message(role="assistant", content=[TextContent(text="Hola, ¿en qué puedo ayudarte?")]),
+        Message(
+            role="user",
+            content=[
+                TextContent(text="Ruta comercial Vallès Oriental: municipios por actividad y presupuestos pendientes")
+            ],
+        ),
+        _debug2_poison_assistant_message(),
+        Message(
+            role="user",
+            content=[
+                TextContent(text="Dels municipis del valles oriental diguem quins sin els que tenem temes pendents")
+            ],
+        ),
+    ]
+
+
+def _anthropic_messages_have_empty_text_block(messages: list[dict]) -> bool:
+    for msg in messages:
+        for block in msg.get("content") or []:
+            if isinstance(block, dict) and block.get("type") == "text" and block.get("text") == "":
+                return True
+    return False
+
+
+def _benito_style_only_select_allowed(sql: str) -> str | None:
+    """Replicates Benito execute_sql rejection described in DEBUG2 (not in timbal core)."""
+    stripped = sql.lstrip()
+    if stripped.startswith("--"):
+        return "only_select_allowed"
+    upper = stripped.upper()
+    if not (upper.startswith("SELECT") or upper.startswith("WITH")):
+        return "only_select_allowed"
+    return None
+
+
+async def _empty_gen():
+    return
+    yield
+
+
+async def _empty_async_stream():
+    return
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _clean_context():
+    from timbal.state import _call_id, _run_context_var
+
+    token_ctx = _run_context_var.set(None)
+    token_cid = _call_id.set(None)
+    yield
+    _run_context_var.reset(token_ctx)
+    _call_id.reset(token_cid)
+
+
+def _make_collector_context() -> None:
+    ctx = RunContext(tracing_provider=None)
+    call_id = "debug2_call"
+    span = Span(path="test", call_id=call_id, parent_call_id=None, t0=int(time.time() * 1000))
+    ctx._trace[call_id] = span
+    set_run_context(ctx)
+    set_call_id(call_id)
+
+
+def _make_message_start(msg_id: str = "msg_debug2") -> RawMessageStartEvent:
+    return RawMessageStartEvent(
+        **{
+            "type": "message_start",
+            "message": {
+                "id": msg_id,
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "model": "claude-sonnet-4-6",
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {"input_tokens": 1, "output_tokens": 0},
+            },
+        }
+    )
+
+
+class TestDebug2AnthropicCollectorFix:
+    def test_empty_text_block_start_stop_omitted_from_result(self):
+        _make_collector_context()
+        collector = AnthropicCollector(async_gen=_empty_gen(), start=time.perf_counter())
+        collector.process(_make_message_start())
+        collector.process(
+            RawContentBlockStartEvent(
+                **{
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": TextBlock(type="text", text=""),
+                }
+            )
+        )
+        collector.process(RawContentBlockStopEvent(**{"type": "content_block_stop", "index": 0}))
+        assert not any(isinstance(c, TextContent) for c in collector.result().content)
+
+    def test_thinking_without_visible_text_keeps_thinking_only(self):
+        _make_collector_context()
+        collector = AnthropicCollector(async_gen=_empty_gen(), start=time.perf_counter())
+        collector.process(_make_message_start())
+        collector.process(
+            RawContentBlockStartEvent(
+                **{
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": ThinkingBlock(type="thinking", thinking="", signature=""),
+                }
+            )
+        )
+        collector.process(
+            RawContentBlockDeltaEvent(
+                **{
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": ThinkingDelta(type="thinking_delta", thinking="Analyzing # Sin asignar offers..."),
+                }
+            )
+        )
+        collector.process(RawContentBlockStopEvent(**{"type": "content_block_stop", "index": 0}))
+        collector.process(
+            RawContentBlockStartEvent(
+                **{
+                    "type": "content_block_start",
+                    "index": 1,
+                    "content_block": TextBlock(type="text", text=""),
+                }
+            )
+        )
+        collector.process(RawContentBlockStopEvent(**{"type": "content_block_stop", "index": 1}))
+        msg = collector.result()
+        assert any(isinstance(c, ThinkingContent) for c in msg.content)
+        assert not any(isinstance(c, TextContent) for c in msg.content)
+
+    def test_text_on_block_start_seeded_without_deltas(self):
+        _make_collector_context()
+        collector = AnthropicCollector(async_gen=_empty_gen(), start=time.perf_counter())
+        collector.process(_make_message_start())
+        collector.process(
+            RawContentBlockStartEvent(
+                **{
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": TextBlock(type="text", text="Visible on start only"),
+                }
+            )
+        )
+        collector.process(RawContentBlockStopEvent(**{"type": "content_block_stop", "index": 0}))
+        text_blocks = [c for c in collector.result().content if isinstance(c, TextContent)]
+        assert len(text_blocks) == 1
+        assert text_blocks[0].text == "Visible on start only"
+
+
+class TestDebug2MemorySerializationFix:
+    def test_to_anthropic_input_omits_empty_text_block(self):
+        payload = _debug2_poison_assistant_message().to_anthropic_input()
+        assert {"type": "text", "text": ""} not in payload["content"]
+        assert any(b.get("type") == "thinking" for b in payload["content"])
+
+    def test_full_debug2_memory_payload_has_no_empty_text(self):
+        anthropic_messages = [m.to_anthropic_input() for m in _debug2_memory_after_partial_sql_turn()]
+        assert not _anthropic_messages_have_empty_text_block(anthropic_messages)
+
+    def test_without_empty_text_blocks_strips_poison(self):
+        cleaned = _debug2_poison_assistant_message().without_empty_text_blocks()
+        assert cleaned is not None
+        assert not any(isinstance(c, TextContent) for c in cleaned.content)
+
+
+class TestDebug2LlmRouterFix:
+    @pytest.mark.asyncio
+    async def test_anthropic_create_never_receives_empty_text(self):
+        captured: dict = {}
+
+        async def fake_create(**kwargs):
+            captured.update(kwargs)
+            return _empty_async_stream()
+
+        mock_client = MagicMock()
+        mock_client.messages.create = fake_create
+        set_run_context(RunContext(tracing_provider=None))
+        with patch("timbal.core.llm_router._get_client", return_value=mock_client):
+            with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "key"}):
+                try:
+                    async for _ in _llm_router(
+                        model="anthropic/claude-sonnet-4-6",
+                        max_tokens=256,
+                        messages=_debug2_memory_after_partial_sql_turn(),
+                    ):
+                        pass
+                except (RuntimeError, StopAsyncIteration):
+                    pass
+        assert not _anthropic_messages_have_empty_text_block(captured["messages"])
+
+
+class TestDebug2AgentSessionFix:
+    @pytest.mark.asyncio
+    async def test_chained_turn_succeeds_after_poison_stripped_from_memory(self):
+        agent1 = Agent(
+            name="Benito_AI",
+            model=TestModel(responses=[_debug2_poison_assistant_message()]),
+            tools=[],
+        )
+        turn1 = await agent1(prompt="Ruta Vallès Oriental presupuestos pendientes").collect()
+        assert turn1.status.code == "success"
+
+        captured: dict = {}
+
+        async def rejecting_create(**kwargs):
+            captured.update(kwargs)
+            if _anthropic_messages_have_empty_text_block(kwargs.get("messages", [])):
+                raise RuntimeError("messages: text content blocks must be non-empty")
+            return _empty_async_stream()
+
+        mock_client = MagicMock()
+        mock_client.messages.create = rejecting_create
+        agent2 = Agent(
+            name="Benito_AI",
+            model="anthropic/claude-sonnet-4-6",
+            max_tokens=1024,
+            tools=[],
+        )
+        with patch("timbal.core.llm_router._get_client", return_value=mock_client):
+            with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "key"}):
+                turn2 = await agent2(
+                    prompt="Dels municipis del valles oriental diguem quins sin els que tenem temes pendents",
+                    parent_id=turn1.run_id,
+                ).collect()
+
+        assert "text content blocks must be non-empty" not in (turn2.error or {}).get("message", "")
+        assert not _anthropic_messages_have_empty_text_block(captured.get("messages", []))
+
+
+class TestDebug2SqlCommentReplication:
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "-- Activitat per municipi\nSELECT 1",
+            "--\nSELECT cl.poblacion FROM clientes cl",
+        ],
+    )
+    def test_leading_line_comment_rejected_as_only_select_allowed(self, sql: str) -> None:
+        assert _benito_style_only_select_allowed(sql) == "only_select_allowed"
+
+    def test_same_query_without_comment_is_allowed(self) -> None:
+        sql = "SELECT cl.poblacion FROM clientes cl WHERE cl.region = 'Vallès Oriental'"
+        assert _benito_style_only_select_allowed(sql) is None

--- a/python/tests/core/test_debug2_empty_assistant_text.py
+++ b/python/tests/core/test_debug2_empty_assistant_text.py
@@ -248,6 +248,27 @@ class TestDebug2LlmRouterFix:
 
 class TestDebug2AgentSessionFix:
     @pytest.mark.asyncio
+    async def test_memory_dump_matches_sanitized_memory_not_raw_output_dump(self):
+        """event._output_dump can retain empty text; persisted trace must use re-dump."""
+        from timbal.state.tracing.providers import InMemoryTracingProvider
+        from timbal.utils import dump
+
+        provider = InMemoryTracingProvider.configured()
+        agent = Agent(
+            name="Benito_AI",
+            model=TestModel(responses=[_debug2_poison_assistant_message()]),
+            tools=[],
+            tracing_provider=provider,
+        )
+        out = await agent(prompt="Ruta Vallès Oriental").collect()
+        trace = provider._storage.get(out.run_id)
+        agent_span = next(s for s in trace.values() if s.path == "Benito_AI")
+
+        expected = await dump([Message.validate(m) for m in agent_span.memory])
+        assert agent_span._memory_dump == expected
+        assert not _anthropic_messages_have_empty_text_block(agent_span._memory_dump)
+
+    @pytest.mark.asyncio
     async def test_chained_turn_succeeds_after_poison_stripped_from_memory(self):
         agent1 = Agent(
             name="Benito_AI",

--- a/python/tests/types/test_message.py
+++ b/python/tests/types/test_message.py
@@ -31,6 +31,18 @@ def test_message_text_to_anthropic_input() -> None:
     assert message.to_anthropic_input() == {"role": "assistant", "content": [{"type": "text", "text": "Hello, World!"}]}
 
 
+def test_message_to_anthropic_input_omits_empty_text() -> None:
+    message = Message(
+        role="assistant",
+        content=[
+            TextContent(text=""),
+            TextContent(text="visible"),
+        ],
+    )
+    payload = message.to_anthropic_input()
+    assert payload["content"] == [{"type": "text", "text": "visible"}]
+
+
 def test_message_file_validation(tmp_path: pathlib.Path) -> None:
     test_file = tmp_path / "image.png"
     png_content = bytes.fromhex(

--- a/python/timbal/collectors/impl/anthropic.py
+++ b/python/timbal/collectors/impl/anthropic.py
@@ -191,7 +191,7 @@ class AnthropicCollector(BaseCollector):
                 {
                     "type": "text",
                     "citations": [],
-                    "text": "",
+                    "text": event.content_block.text or "",
                     "block_id": content_block_id,
                 }
             )
@@ -313,6 +313,8 @@ class AnthropicCollector(BaseCollector):
                     domain = urlparse(citation.url).netloc
                     domain = domain.removeprefix("www.")
                     text += f" [[{domain}]({citation.url})]"
+                if not text:
+                    continue
                 if len(content) > 0 and isinstance(content[-1], TextContent):
                     content[-1].text += text
                 else:

--- a/python/timbal/core/agent.py
+++ b/python/timbal/core/agent.py
@@ -538,7 +538,12 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
         # User can override the message list
         input_messages = current_span.input.get("messages", [])
         if input_messages:
-            current_span.memory = [Message.validate(m) for m in input_messages]
+            loaded: list[Message] = []
+            for raw in input_messages:
+                msg = Message.validate(raw).without_empty_text_blocks()
+                if msg is not None:
+                    loaded.append(msg)
+            current_span.memory = loaded
             return
 
         if not run_context.parent_id:
@@ -586,18 +591,15 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
         is_approval_resume = prev_code == "cancelled" and prev_reason == "approval_required"
         if not is_approval_resume:
             self._synthesize_missing_tool_results(memory)
-        current_span.memory = memory + current_span.memory
+        merged: list[Message] = []
+        for msg in memory + current_span.memory:
+            cleaned = msg.without_empty_text_blocks()
+            if cleaned is not None:
+                merged.append(cleaned)
+        current_span.memory = merged
 
-        # Cache the already-serialized previous memory so handler() can skip re-dumping.
-        # Two cases:
-        #   InMemory provider  — previous_span is the live Span object; _memory_dump
-        #                        is set and contains dicts (serialized in prior handler()).
-        #   JSONL/disk reload  — previous_span was reconstructed from JSON; _memory_dump
-        #                        is not set, but span.memory holds the dicts from the file.
-        if hasattr(previous_span, "_memory_dump"):
-            current_span._prev_memory_dump = list(previous_span._memory_dump)
-        else:
-            current_span._prev_memory_dump = list(previous_span.memory)
+        # Re-dump prior turns so stored memory matches sanitized messages (no empty text blocks).
+        current_span._prev_memory_dump = await dump(merged[:-1])
 
         # Apply memory compaction if configured and context window utilization warrants it
         if self.memory_compaction is not None:
@@ -839,7 +841,9 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
         llm_path = f"{self._path}.llm"
         for span in reversed(run_context._trace.as_records()):
             if span.path == llm_path and isinstance(span.output, Message):
-                current_span.memory.append(span.output)
+                cleaned = span.output.without_empty_text_blocks()
+                if cleaned is not None:
+                    current_span.memory.append(cleaned)
                 break
 
     async def handler(self, **kwargs: Any) -> AsyncGenerator[Any, None]:
@@ -872,6 +876,9 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
 
         async def _append_memory(message: Message, dump_value: Any = None) -> None:
             """Append a message to both memory and its serialized dump in lockstep."""
+            message = message.without_empty_text_blocks()
+            if message is None:
+                return
             current_span.memory.append(message)
             current_span._memory_dump.append(dump_value if dump_value is not None else await dump(message))
 

--- a/python/timbal/core/agent.py
+++ b/python/timbal/core/agent.py
@@ -874,13 +874,13 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
         kwargs.pop("prompt", None)
         kwargs.pop("messages", None)
 
-        async def _append_memory(message: Message, dump_value: Any = None) -> None:
+        async def _append_memory(message: Message) -> None:
             """Append a message to both memory and its serialized dump in lockstep."""
             message = message.without_empty_text_blocks()
             if message is None:
                 return
             current_span.memory.append(message)
-            current_span._memory_dump.append(dump_value if dump_value is not None else await dump(message))
+            current_span._memory_dump.append(await dump(message))
 
         async def _process_tool_event(event: BaseEvent, tool_call_id: str, append_to_messages: bool = True):
             """Helper to process tool output events and create tool results."""
@@ -1035,7 +1035,7 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
                         )
 
                         # Add LLM response to conversation for next iteration
-                        await _append_memory(event.output, dump_value=event._output_dump)
+                        await _append_memory(event.output)
                         _llm_memory_saved = True
 
                         if self.output_model is not None:

--- a/python/timbal/types/content/tool_result.py
+++ b/python/timbal/types/content/tool_result.py
@@ -41,8 +41,14 @@ class ToolResultContent(BaseContent):
     @override
     def to_anthropic_input(self, **kwargs: Any) -> dict[str, Any]:
         """See base class."""
+        nested: list[dict[str, Any]] = []
+        for item in self.content:
+            block = item.to_anthropic_input()
+            if block.get("type") == "text" and not block.get("text"):
+                continue
+            nested.append(block)
         return {
             "type": "tool_result",
             "tool_use_id": self.id,
-            "content": [item.to_anthropic_input() for item in self.content],
+            "content": nested,
         }

--- a/python/timbal/types/message.py
+++ b/python/timbal/types/message.py
@@ -13,6 +13,17 @@ from pydantic_core import CoreSchema, core_schema
 from .content import TextContent, ToolResultContent, ToolUseContent, content_factory
 
 
+def _append_anthropic_content_blocks(target: list[dict[str, Any]], anthropic_input: dict[str, Any] | list[dict[str, Any]]) -> None:
+    """Append Anthropic content blocks, dropping empty text (API rejects text: '')."""
+    if isinstance(anthropic_input, list):
+        for block in anthropic_input:
+            _append_anthropic_content_blocks(target, block)
+        return
+    if anthropic_input.get("type") == "text" and not anthropic_input.get("text"):
+        return
+    target.append(anthropic_input)
+
+
 class Message:
     """A class representing a message in a conversation with an LLM.
 
@@ -95,14 +106,9 @@ class Message:
 
     def to_anthropic_input(self) -> dict[str, Any]:
         """Convert the message to Anthropic's expected input format."""
-        content = []
+        content: list[dict[str, Any]] = []
         for content_item in self.content:
-            anthropic_input = content_item.to_anthropic_input()
-            # Enabling splitting files into multiple pages or chunks.
-            if isinstance(anthropic_input, list):
-                content.extend(anthropic_input)
-            else:
-                content.append(anthropic_input)
+            _append_anthropic_content_blocks(content, content_item.to_anthropic_input())
         # Anthropic doesn't accept the tool role. We must send this under the user role.
         role = self.role
         if role == "tool":
@@ -142,6 +148,15 @@ class Message:
             if isinstance(content, TextContent):
                 message_text += content.text + "\n\n"
         return message_text.strip()
+
+    def without_empty_text_blocks(self) -> "Message | None":
+        """Drop ``TextContent`` with empty text (invalid for Anthropic; see DEBUG2)."""
+        kept = [c for c in self.content if not (isinstance(c, TextContent) and c.text == "")]
+        if not kept:
+            return None
+        if len(kept) == len(self.content):
+            return self
+        return Message(role=self.role, content=kept, stop_reason=self.stop_reason)
 
     @classmethod
     def validate(cls, value: ValidatorFunctionWrapHandler, _info: dict | ValidationInfo | None = None) -> "Message":


### PR DESCRIPTION
Anthropic rejects messages with text: "", which bricked multi-turn sessions when the collector or stored memory retained thinking-only turns with an empty TextContent. Omit empty text at collection and serialization time, sanitize agent memory on append and resolve, and add DEBUG2 regression tests.