### PR TITLE
feat(agent): pin tool results so skill guidance survives compaction

### DIFF
--- a/docs/agents/memory-compaction.mdx
+++ b/docs/agents/memory-compaction.mdx
@@ -127,6 +127,30 @@ agent = Agent(
 Use a smaller, cheaper model for summarization to reduce cost. For example, `model="openai/gpt-5.4-nano"` works well for summarization tasks.
 </Tip>
 
+## Pinned results
+
+Some tool results are durable context the model must keep referencing — for example loaded
+[skill](/agents/skills) documentation. Those results are **pinned**: every compaction strategy
+preserves them verbatim (and never orphans their paired tool call), regardless of `keep_last_n`,
+turn windows, or drop/replacement mode. For `keep_last_n_messages` / `keep_last_n_turns` the
+effective behavior is "last N **plus** pinned"; for `summarize`, pinned results are kept verbatim
+and never fed to the summarizer (like system messages).
+
+You opt a tool in declaratively with `pin_result=True`:
+
+```python
+from timbal.core.tool import Tool
+
+tool = Tool(
+    name="load_policy",
+    handler=load_policy,
+    pin_result=True,  # results survive compaction for the life of the conversation
+)
+```
+
+The built-in `read_skill` tool sets this automatically, so skill guidance never gets compacted
+away. Pinning is durable across pause/resume — the flag is persisted with the trace.
+
 ## Composing Strategies
 
 Pass a list of compactors to apply them in order. Each compactor receives the output of the previous one.

--- a/docs/agents/skills.mdx
+++ b/docs/agents/skills.mdx
@@ -42,6 +42,10 @@ skills/
 
 This lazy-loading approach keeps the agent's context efficient while ensuring specialized knowledge is available when needed.
 
+<Note>
+**Skills and memory compaction.** A skill's documentation reaches the model as the result of the `read_skill` tool call. Those results are **pinned**, so [memory compaction](/agents/memory-compaction) never drops or truncates them — the guidance stays available for as long as the skill is active, even on long runs where the rest of the history is compacted. This keeps an agent's tools and the instructions for using them from drifting apart.
+</Note>
+
 
 ## Using Skills
 

--- a/python/tests/core/test_memory_compaction.py
+++ b/python/tests/core/test_memory_compaction.py
@@ -51,6 +51,13 @@ def _msg_tool(uid: str, result_text: str = "ok") -> Message:
     )
 
 
+def _msg_tool_pinned(uid: str, result_text: str = "pinned-doc") -> Message:
+    return Message(
+        role="tool",
+        content=[ToolResultContent(id=uid, content=[TextContent(text=result_text)], pinned=True)],
+    )
+
+
 # ---------------------------------------------------------------------------
 # compact_tool_results — drop mode (replacement=None)
 # ---------------------------------------------------------------------------
@@ -1135,6 +1142,204 @@ class TestCompactionMetadata:
         assert meta["utilization"] is None
 
         InMemoryTracingProvider._storage.clear()
+
+
+# ---------------------------------------------------------------------------
+# Pinned results survive every compactor
+# ---------------------------------------------------------------------------
+
+
+def _has_id(memory: list[Message], uid: str, role: str, content_type: type) -> bool:
+    return any(
+        m.role == role and any(isinstance(c, content_type) and c.id == uid for c in m.content)
+        for m in memory
+    )
+
+
+class TestPinnedResults:
+    """A pinned tool_result (and its paired tool_use) must survive every compaction strategy,
+    while unpinned tool results around it are compacted as usual. This is what keeps loaded
+    skill documentation alive against compaction."""
+
+    def _memory(self) -> list[Message]:
+        # user / assistant(pin tool_use P) / tool(P, pinned) / assistant(tool_use A) / tool(A)
+        # / user / assistant(tool_use B) / tool(B) / assistant(final text)
+        return [
+            _msg_user("load the docs"),
+            _msg_assistant_tool("P", name="read_skill"),
+            _msg_tool_pinned("P", result_text="SKILL DOC BODY"),
+            _msg_assistant_tool("A", name="other"),
+            _msg_tool("A", result_text="unpinned-A"),
+            _msg_user("now do work"),
+            _msg_assistant_tool("B", name="other"),
+            _msg_tool("B", result_text="unpinned-B"),
+            _msg_assistant_text("done"),
+        ]
+
+    def _assert_pinned_pair_intact(self, result: list[Message]) -> None:
+        assert _has_id(result, "P", "tool", ToolResultContent), "pinned result dropped"
+        assert _has_id(result, "P", "assistant", ToolUseContent), "pinned tool_use orphaned/dropped"
+        # The pinned body must be verbatim, never replaced/truncated.
+        pinned = next(
+            c for m in result if m.role == "tool" for c in m.content
+            if isinstance(c, ToolResultContent) and c.id == "P"
+        )
+        assert pinned.content[0].text == "SKILL DOC BODY"
+        assert pinned.pinned is True
+
+    def test_compact_tool_results_drop_preserves_pinned(self) -> None:
+        result = compact_tool_results()(self._memory())
+        self._assert_pinned_pair_intact(result)
+        # Unpinned results are dropped.
+        assert not _has_id(result, "A", "tool", ToolResultContent)
+        assert not _has_id(result, "B", "tool", ToolResultContent)
+
+    def test_compact_tool_results_replacement_preserves_pinned(self) -> None:
+        result = compact_tool_results(replacement="[{tool_name}: {result_length} chars]")(self._memory())
+        self._assert_pinned_pair_intact(result)
+        # Unpinned results are replaced (not verbatim).
+        a = next(
+            c for m in result if m.role == "tool" for c in m.content
+            if isinstance(c, ToolResultContent) and c.id == "A"
+        )
+        assert "chars]" in a.content[0].text
+
+    def test_compact_tool_results_keep_last_n_plus_pinned(self) -> None:
+        # keep_last_n=1 keeps only batch B intact; P is older but pinned, so it survives too.
+        result = compact_tool_results(keep_last_n=1)(self._memory())
+        self._assert_pinned_pair_intact(result)
+        assert _has_id(result, "B", "tool", ToolResultContent)  # last batch kept
+        assert not _has_id(result, "A", "tool", ToolResultContent)  # middle dropped
+
+    def test_keep_last_n_messages_preserves_pinned(self) -> None:
+        # Keep only the last 2 messages; the pinned pair is far earlier but must be hoisted in.
+        result = keep_last_n_messages(2)(self._memory())
+        self._assert_pinned_pair_intact(result)
+        # Order preserved: pinned tool_use precedes its result.
+        idx_use = next(i for i, m in enumerate(result) if m.role == "assistant"
+                       and any(isinstance(c, ToolUseContent) and c.id == "P" for c in m.content))
+        idx_res = next(i for i, m in enumerate(result) if m.role == "tool"
+                       and any(isinstance(c, ToolResultContent) and c.id == "P" for c in m.content))
+        assert idx_use < idx_res
+        # No consecutive same-role messages.
+        for prev, cur in zip(result, result[1:], strict=False):
+            assert prev.role != cur.role, f"consecutive {prev.role!r}"
+
+    def test_keep_last_n_turns_preserves_pinned(self) -> None:
+        # Keep only the last turn (after the 2nd user message); pinned pair is in the 1st turn.
+        result = keep_last_n_turns(1)(self._memory())
+        self._assert_pinned_pair_intact(result)
+        assert _has_id(result, "B", "tool", ToolResultContent)  # last turn kept
+        assert not _has_id(result, "A", "tool", ToolResultContent)  # earlier turn dropped
+
+    @pytest.mark.asyncio
+    async def test_summarize_keeps_pinned_verbatim(self) -> None:
+        captured = []
+
+        def handler(messages):
+            captured.append(messages)
+            return "SUMMARY TEXT"
+
+        compactor = summarize(threshold=3, model=TestModel(handler=handler), keep_last_n=1)
+        result = await compactor(self._memory())
+
+        self._assert_pinned_pair_intact(result)
+        # The summary was produced and the pinned body was NOT fed to the summarizer.
+        assert any(m.collect_text().startswith(_SUMMARY_MARKER) for m in result)
+        summarizer_input = captured[0][0].collect_text()
+        assert "SKILL DOC BODY" not in summarizer_input
+        # No consecutive same-role messages (alternation preserved).
+        for prev, cur in zip(result, result[1:], strict=False):
+            assert prev.role != cur.role, f"consecutive {prev.role!r}"
+
+    @pytest.mark.asyncio
+    async def test_pinned_flag_survives_dump_and_reload(self) -> None:
+        """The pinned flag must persist through serialization so it still protects the result
+        after a paused run is reloaded in another process."""
+        from timbal.utils import dump
+
+        reloaded = Message.validate(await dump(_msg_tool_pinned("P", "BODY")))
+        c = reloaded.content[0]
+        assert isinstance(c, ToolResultContent)
+        assert c.pinned is True
+        assert c.content[0].text == "BODY"
+
+    # --- Parallel/mixed batch: pinned tool_use shares one assistant message with siblings ---
+
+    def _parallel_batch_memory(self) -> list[Message]:
+        # One assistant message issues two tool calls in parallel: P (pinned) and Q (not).
+        return [
+            _msg_user("do both"),
+            Message(
+                role="assistant",
+                content=[
+                    ToolUseContent(id="P", name="read_skill", input={}),
+                    ToolUseContent(id="Q", name="other", input={}),
+                ],
+            ),
+            _msg_tool_pinned("P", result_text="SKILL DOC BODY"),
+            _msg_tool("Q", result_text="unpinned-Q"),
+            _msg_user("next"),
+            _msg_assistant_tool("R", name="other"),
+            _msg_tool("R", result_text="unpinned-R"),
+            _msg_assistant_text("done"),
+        ]
+
+    def test_parallel_batch_drop_keeps_pinned_strips_sibling(self) -> None:
+        result = compact_tool_results()(self._parallel_batch_memory())
+        # Pinned half survives; sibling tool_use + result are gone, but the assistant message
+        # that carried the batch must remain (it still holds the pinned tool_use).
+        assert _has_id(result, "P", "assistant", ToolUseContent)
+        assert _has_id(result, "P", "tool", ToolResultContent)
+        assert not _has_id(result, "Q", "assistant", ToolUseContent), "sibling tool_use not stripped"
+        assert not _has_id(result, "Q", "tool", ToolResultContent)
+
+    def test_parallel_batch_keep_last_n_messages_hoists_pinned_only(self) -> None:
+        # Keep only the last message; the pinned half of the old parallel batch is hoisted back,
+        # the unpinned sibling is dropped as an orphan, and alternation holds.
+        result = keep_last_n_messages(1)(self._parallel_batch_memory())
+        assert _has_id(result, "P", "assistant", ToolUseContent)
+        assert _has_id(result, "P", "tool", ToolResultContent)
+        assert not _has_id(result, "Q", "assistant", ToolUseContent)
+        assert not _has_id(result, "Q", "tool", ToolResultContent)
+        for prev, cur in zip(result, result[1:], strict=False):
+            assert prev.role != cur.role, f"consecutive {prev.role!r}"
+
+    # --- Composed pipeline (the common real-world config) ---
+
+    def test_composed_pipeline_preserves_pinned(self) -> None:
+        memory = self._memory()
+        for compactor in (compact_tool_results(keep_last_n=1), keep_last_n_turns(1)):
+            memory = compactor(memory)
+        self._assert_pinned_pair_intact(memory)
+        assert not _has_id(memory, "A", "tool", ToolResultContent)
+
+    # --- summarize incremental path (a previous summary already exists) ---
+
+    @pytest.mark.asyncio
+    async def test_summarize_incremental_keeps_pinned_verbatim(self) -> None:
+        captured = []
+
+        def handler(messages):
+            captured.append(messages)
+            return "UPDATED SUMMARY"
+
+        compactor = summarize(threshold=3, model=TestModel(handler=handler), keep_last_n=1)
+        memory = [
+            Message(role="user", content=[TextContent(text=f"{_SUMMARY_MARKER}\nprior summary")]),
+            _msg_assistant_tool("P", name="read_skill"),
+            _msg_tool_pinned("P", result_text="SKILL DOC BODY"),
+            _msg_user("more"),
+            _msg_assistant_text("ok"),
+            _msg_user("even more"),
+            _msg_assistant_text("done"),
+        ]
+        result = await compactor(memory)
+        # Pinned pair preserved despite living in the already-summarized region.
+        assert _has_id(result, "P", "tool", ToolResultContent)
+        assert _has_id(result, "P", "assistant", ToolUseContent)
+        # The pinned body was not fed to the (incremental) summarizer.
+        assert "SKILL DOC BODY" not in captured[0][0].collect_text()
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/core/test_skill.py
+++ b/python/tests/core/test_skill.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from timbal import Agent, Tool
 from timbal.core.skill import ReadSkill, Skill
@@ -522,6 +524,211 @@ class TestAgentWithSkillInTools:
         resolved = await skill.resolve()
         resolved_names = {t.name for t in resolved}
         assert "search_cars" in resolved_names
+
+
+class TestSkillResultsPinnedAgainstCompaction:
+    """A skill's instructions reach the model only as the read_skill tool_result, but its
+    activation lives in the session. Memory compaction must not evict that result, or the
+    model keeps the skill's tools while losing the guidance for using them. read_skill pins
+    its results so every compaction strategy preserves them."""
+
+    @pytest.mark.asyncio
+    async def test_read_skill_result_is_pinned(self, skills_dir):
+        """Running read_skill through the agent produces a pinned tool_result carrying the
+        skill body."""
+        from timbal.state import RunContext, set_run_context
+        from timbal.state.tracing.providers import InMemoryTracingProvider
+        from timbal.types.content import ToolResultContent, ToolUseContent
+        from timbal.types.message import Message
+
+        model = TestModel(responses=[
+            Message(
+                role="assistant",
+                content=[ToolUseContent(id="r1", name="read_skill", input={"name": "cars"})],
+                stop_reason="tool_use",
+            ),
+            "loaded",
+        ])
+        agent = Agent(name="agent", model=model, skills_path=skills_dir)
+
+        ctx = RunContext(tracing_provider=InMemoryTracingProvider)
+        set_run_context(ctx)
+        await agent(prompt="read the cars skill").collect()
+
+        memory = ctx._trace.get_path(agent._path)[0].memory
+        pinned = [
+            c for m in memory if m.role == "tool" for c in m.content
+            if isinstance(c, ToolResultContent) and c.pinned
+        ]
+        assert pinned, "read_skill result should be pinned"
+        assert any("Cars Skill" in c.content[0].text for c in pinned)
+
+        InMemoryTracingProvider._storage.clear()
+
+    @pytest.mark.asyncio
+    async def test_regular_tool_result_is_not_pinned(self, skills_dir):
+        """Only tools that opt in (pin_result=True) get pinned results — a plain tool's result
+        must stay compactable. Proves the agent stamps pinning selectively."""
+        from timbal.state import RunContext, set_run_context
+        from timbal.state.tracing.providers import InMemoryTracingProvider
+        from timbal.types.content import ToolResultContent, ToolUseContent
+        from timbal.types.message import Message
+
+        def plain(x: int) -> str:
+            """A plain tool."""
+            return f"value-{x}"
+
+        model = TestModel(responses=[
+            Message(
+                role="assistant",
+                content=[ToolUseContent(id="p1", name="plain", input={"x": 1})],
+                stop_reason="tool_use",
+            ),
+            "ok",
+        ])
+        agent = Agent(name="agent", model=model, skills_path=skills_dir, tools=[Tool(handler=plain)])
+
+        ctx = RunContext(tracing_provider=InMemoryTracingProvider)
+        set_run_context(ctx)
+        await agent(prompt="call plain").collect()
+
+        memory = ctx._trace.get_path(agent._path)[0].memory
+        results = [
+            c for m in memory if m.role == "tool" for c in m.content
+            if isinstance(c, ToolResultContent)
+        ]
+        assert results, "expected a tool result"
+        assert all(c.pinned is False for c in results), "regular tool result must not be pinned"
+
+        InMemoryTracingProvider._storage.clear()
+
+    @pytest.mark.asyncio
+    async def test_pinned_skill_body_survives_jsonl_resume_with_compaction(self, skills_dir, tmp_path):
+        """Full durability path: an agent reads a skill (pinned result), suspends via ask_user,
+        and persists to JSONL. A *fresh* agent + RunContext resumes from disk with drop-mode
+        compaction forced — so the pinned skill body must survive both serialization and
+        `_compact_on_resume` (which compacts the head while protecting the suspended tool_use)."""
+        from timbal.state import suspend
+        from timbal.state.tracing.providers.jsonl import JsonlTracingProvider
+        from timbal.types.content import ToolResultContent, ToolUseContent
+        from timbal.types.events import InteractionEvent
+        from timbal.core.memory_compaction import compact_tool_results
+        from timbal.types.message import Message
+
+        def ask_user(question: str) -> str:
+            """Ask the user a question."""
+            return suspend({"question": question}, kind="ask_user")
+
+        path = tmp_path / "traces.jsonl"
+        provider = JsonlTracingProvider.configured(_path=path)
+
+        def make_agent(model):
+            return Agent(
+                name="agent",
+                model=model,
+                skills_path=skills_dir,
+                tools=[ask_user],
+                tracing_provider=provider,
+                memory_compaction=compact_tool_results(),  # drop mode
+                memory_compaction_ratio=0.0,  # force compaction on every pass, incl. resume
+                max_iter=6,
+            )
+
+        # --- process A: read skill -> pinned result, then suspend ---
+        suspend_model = TestModel(responses=[
+            Message(
+                role="assistant",
+                content=[ToolUseContent(id="r1", name="read_skill", input={"name": "cars"})],
+                stop_reason="tool_use",
+            ),
+            Message(
+                role="assistant",
+                content=[ToolUseContent(id="a1", name="ask_user", input={"question": "which model?"})],
+                stop_reason="tool_use",
+            ),
+        ])
+        events1 = [e async for e in make_agent(suspend_model)(prompt="read the cars skill then ask me")]
+        out1 = next(e for e in reversed(events1) if hasattr(e, "status"))
+        interaction = next(e for e in events1 if isinstance(e, InteractionEvent))
+        assert out1.status.reason == "input_required"
+        assert path.exists()
+
+        # --- process B: brand-new agent + context, resume purely from the JSONL trace ---
+        resume_model = TestModel(responses=["Porsche 911 it is."])
+        out2 = await make_agent(resume_model)(
+            prompt="read the cars skill then ask me",
+            parent_id=out1.run_id,
+            resume={interaction.interaction_id: "the 911"},
+        ).collect()
+        assert out2.status.code == "success", out2.error
+
+        # The pinned skill body survived serialization + compaction-on-resume. Read the resumed
+        # run's persisted memory back off disk and re-validate it into Messages.
+        record = next(
+            json.loads(line)
+            for line in path.read_text().splitlines()[::-1]
+            if line.strip() and json.loads(line).get("run_id") == out2.run_id
+        )
+        agent_span = next(s for s in record["spans"] if s["path"] == "agent")
+        memory = [Message.validate(m) for m in agent_span["memory"]]
+        bodies = [
+            c.content[0].text for m in memory if m.role == "tool" for c in m.content
+            if isinstance(c, ToolResultContent) and c.pinned
+        ]
+        assert any("Cars Skill" in b for b in bodies), "pinned skill body lost across JSONL resume + compaction"
+
+    @pytest.mark.asyncio
+    async def test_skill_body_survives_aggressive_compaction(self, skills_dir):
+        """End-to-end: with drop-mode compaction forced every iteration, the pinned skill body
+        stays in memory and its tools stay resolvable — tools and guidance don't drift apart."""
+        from timbal.core.memory_compaction import compact_tool_results
+        from timbal.state import RunContext, get_or_create_run_context, set_run_context
+        from timbal.state.tracing.providers import InMemoryTracingProvider
+        from timbal.types.content import ToolResultContent, ToolUseContent
+        from timbal.types.message import Message
+
+        # read the skill, then make an unrelated tool call (so the skill result is no longer the
+        # latest batch and a naive compactor would drop it), then finish.
+        model = TestModel(responses=[
+            Message(
+                role="assistant",
+                content=[ToolUseContent(id="r1", name="read_skill", input={"name": "cars"})],
+                stop_reason="tool_use",
+            ),
+            Message(
+                role="assistant",
+                content=[ToolUseContent(id="s1", name="search_cars", input={"query": "911"})],
+                stop_reason="tool_use",
+            ),
+            "done",
+        ])
+        agent = Agent(
+            name="agent",
+            model=model,
+            skills_path=skills_dir,
+            memory_compaction=compact_tool_results(),  # drop mode
+            memory_compaction_ratio=0.0,  # force compaction every iteration
+            max_iter=6,
+        )
+
+        ctx = RunContext(tracing_provider=InMemoryTracingProvider)
+        set_run_context(ctx)
+        result = await agent(prompt="read the cars skill then search").collect()
+        assert result.status.code == "success", result.error
+
+        memory = ctx._trace.get_path(agent._path)[0].memory
+        # The pinned skill body survived aggressive compaction.
+        bodies = [
+            c.content[0].text for m in memory if m.role == "tool" for c in m.content
+            if isinstance(c, ToolResultContent) and c.pinned
+        ]
+        assert any("Cars Skill" in b for b in bodies), "pinned skill body was compacted away"
+
+        # And the skill's tools are still resolvable (activation intact).
+        session = await get_or_create_run_context().get_session()
+        assert "cars" in session["__in_context_skills"][agent._path]
+
+        InMemoryTracingProvider._storage.clear()
 
 
 class TestReadSkillTool:

--- a/python/timbal/core/agent.py
+++ b/python/timbal/core/agent.py
@@ -987,6 +987,10 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
             current_span.memory.append(message)
             current_span._memory_dump.append(await dump(message))
 
+        # Names of tools (resolved for the current iteration) whose results must be pinned
+        # against memory compaction. Updated each iteration from the resolved tool list.
+        pinned_tool_names: set[str] = set()
+
         async def _process_tool_event(event: BaseEvent, tool_call_id: str, append_to_messages: bool = True):
             """Helper to process tool output events and create tool results."""
             if not isinstance(event, OutputEvent) or event.path.count(".") != self._path.count(".") + 1:
@@ -1016,6 +1020,10 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
                 content = [c for c in event.output.content if isinstance(c, TextContent | FileContent)]
             else:
                 content = event.output
+            # Pin the result when the originating tool opted in (e.g. read_skill), so memory
+            # compaction never strips this durable context. The tool name is the final path
+            # segment of its OutputEvent.
+            pinned = event.path.rsplit(".", 1)[-1] in pinned_tool_names
             tool_result = Message.validate(
                 {
                     "role": "tool",
@@ -1024,6 +1032,7 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
                             "type": "tool_result",
                             "id": tool_call_id,
                             "content": content,
+                            "pinned": pinned,
                         }
                     ],
                 }
@@ -1045,6 +1054,7 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
                 _llm_memory_saved = False
                 # ? We could resolve the system prompt at each iteration
                 tools, commands = await self._resolve_tools(i)
+                pinned_tool_names = {t.name for t in tools if getattr(t, "pin_result", False)}
                 if commands:
                     # Commands will only be user messages with a single text content
                     if len(current_span.memory[-1].content) == 1:

--- a/python/timbal/core/memory_compaction.py
+++ b/python/timbal/core/memory_compaction.py
@@ -41,6 +41,38 @@ def _collect_ids(messages: list[Message], role: str, content_type: type) -> set[
     return {c.id for msg in messages if msg.role == role for c in msg.content if isinstance(c, content_type)}
 
 
+def _collect_pinned_ids(memory: list[Message]) -> set[str]:
+    """Collect the tool_use/result ids of every pinned tool result.
+
+    A pinned result must never be dropped or truncated by compaction (see
+    ``ToolResultContent.pinned``). The id is shared by the result and its paired tool_use, so
+    this single set protects both halves."""
+    return {
+        c.id
+        for msg in memory
+        if msg.role == "tool"
+        for c in msg.content
+        if isinstance(c, ToolResultContent) and c.pinned
+    }
+
+
+def _pinned_protected_indices(memory: list[Message]) -> set[int]:
+    """Indices of messages that must be preserved verbatim by positional compactors because
+    they carry a pinned tool_result or the tool_use paired with one."""
+    pinned_ids = _collect_pinned_ids(memory)
+    if not pinned_ids:
+        return set()
+    keep: set[int] = set()
+    for i, msg in enumerate(memory):
+        if msg.role == "tool":
+            if any(isinstance(c, ToolResultContent) and c.id in pinned_ids for c in msg.content):
+                keep.add(i)
+        elif msg.role == "assistant":
+            if any(isinstance(c, ToolUseContent) and c.id in pinned_ids for c in msg.content):
+                keep.add(i)
+    return keep
+
+
 def _remove_orphaned_tool_parts(memory: list[Message]) -> list[Message]:
     """Remove tool_use without tool_result, and tool_result without tool_use."""
     tool_use_ids = _collect_ids(memory, "assistant", ToolUseContent)
@@ -264,6 +296,9 @@ def compact_tool_results(
         else:
             kept_ids = set()
 
+        # Pinned results (and their paired tool_use) are never dropped or replaced.
+        kept_ids |= _collect_pinned_ids(memory)
+
         drop_mode = replacement is None
 
         result: list[Message] = []
@@ -350,8 +385,10 @@ def keep_last_n_messages(n: int) -> Callable[[list[Message]], list[Message]]:
     def _compact(memory: list[Message]) -> list[Message]:
         if len(memory) <= n:
             return _remove_orphaned_tool_parts(memory)
-        truncated = memory[-n:]
-        return _remove_orphaned_tool_parts(truncated)
+        # Keep the last n messages, plus any pinned messages (and their paired tool_use) that
+        # fell outside the window — "last n PLUS pinned". Order is preserved.
+        keep = set(range(len(memory) - n, len(memory))) | _pinned_protected_indices(memory)
+        return _remove_orphaned_tool_parts([memory[i] for i in sorted(keep)])
 
     return _compact
 
@@ -376,7 +413,10 @@ def keep_last_n_turns(n: int) -> Callable[[list[Message]], list[Message]]:
         if len(user_indices) <= n:
             return _remove_orphaned_tool_parts(memory)
         start = user_indices[-n]
-        return _remove_orphaned_tool_parts(memory[start:])
+        # Keep the last n turns, plus any pinned messages (and their paired tool_use) from
+        # earlier turns. Order is preserved.
+        keep = set(range(start, len(memory))) | _pinned_protected_indices(memory)
+        return _remove_orphaned_tool_parts([memory[i] for i in sorted(keep)])
 
     return _compact
 
@@ -439,11 +479,17 @@ def summarize(
             start_idx = 1  # Skip the summary message itself
 
         # Determine what to keep vs. what to summarize.
-        # Apply orphan cleanup to to_keep: if the cut falls mid-tool-call-sequence,
-        # the orphaned tool result at the boundary is removed. After cleanup,
-        # to_keep[0] can only be "user" or "assistant", never "tool".
-        to_keep = _remove_orphaned_tool_parts(non_system[-keep_last_n:]) if keep_last_n > 0 else []
-        to_summarize = non_system[start_idx : len(non_system) - keep_last_n if keep_last_n > 0 else len(non_system)]
+        # Keep the last keep_last_n messages, PLUS any pinned messages (and their paired
+        # tool_use) from the older region — pinned context is preserved verbatim, like system
+        # messages, never fed to the summarizer. Apply orphan cleanup to to_keep: if the cut
+        # falls mid-tool-call-sequence, the orphaned tool result at the boundary is removed.
+        # After cleanup, to_keep[0] can only be "user" or "assistant", never "tool".
+        protected_idx = {i for i in _pinned_protected_indices(non_system) if i >= start_idx}
+        keep_idx = set(range(len(non_system) - keep_last_n, len(non_system))) if keep_last_n > 0 else set()
+        keep_idx |= protected_idx
+        keep_idx = {i for i in keep_idx if i >= start_idx}
+        to_keep = _remove_orphaned_tool_parts([non_system[i] for i in sorted(keep_idx)])
+        to_summarize = [non_system[i] for i in range(start_idx, len(non_system)) if i not in keep_idx]
 
         if not to_summarize:
             return memory  # Nothing new to summarize

--- a/python/timbal/core/skill.py
+++ b/python/timbal/core/skill.py
@@ -155,5 +155,10 @@ class ReadSkill(Tool):
                 "Provide the skill name to read its documentation file or provide reference to read a specific file from the skill."
             ),
             handler=_read_skill,
+            # Skill documentation is durable context: once loaded, the model must keep following
+            # it even after the conversation grows. Pin the results so memory compaction never
+            # strips the guidance while the skill's tools remain available (activation lives in
+            # the session, not memory, so the two must not drift apart).
+            pin_result=True,
             **kwargs,
         )

--- a/python/timbal/core/tool.py
+++ b/python/timbal/core/tool.py
@@ -39,6 +39,15 @@ class Tool(Runnable):
         ),
     )
 
+    pin_result: bool = Field(
+        default=False,
+        description=(
+            "If True, the agent marks this tool's results as pinned, so memory compaction never "
+            "drops or truncates them. Use for tools whose output is durable context the model must "
+            "keep referencing (e.g. loaded skill documentation)."
+        ),
+    )
+
     @model_validator(mode="before")
     @classmethod
     def validate_handler_and_name(cls, values: dict[str, Any]) -> dict[str, Any]:

--- a/python/timbal/types/content/__init__.py
+++ b/python/timbal/types/content/__init__.py
@@ -47,6 +47,7 @@ def content_factory(value: Any) -> BaseContent:
                 id=value.get("id"), 
                 # TODO Change this
                 content=[content_factory(item) for item in tool_result_content],
+                pinned=value.get("pinned", False),
             )
     # By default try to convert whatever python object we have into a string.
     return TextContent(text=str(value))

--- a/python/timbal/types/content/tool_result.py
+++ b/python/timbal/types/content/tool_result.py
@@ -16,6 +16,10 @@ class ToolResultContent(BaseContent):
     type: Literal["tool_result"] = "tool_result"
     id: str
     content: list[TextContent | FileContent]
+    pinned: bool = False
+    """When True, memory compaction must never drop or truncate this result (nor orphan its
+    paired tool_use). Used to keep durable context — e.g. loaded skill documentation — alive
+    for as long as the conversation lives. Internal hint only: never serialized to providers."""
 
     @override
     def to_openai_responses_input(self, **kwargs: Any) -> dict[str, Any]:


### PR DESCRIPTION
Skill activation is session-durable but its instructions only reach the model as the read_skill tool_result. Memory compaction could evict that result, leaving the model with the skill's tools but no guidance for using them.

Add a generic pinning mechanism:
- ToolResultContent.pinned: compaction must never drop or truncate it.
- Tool.pin_result: declarative opt-in; ReadSkill sets it so skill docs persist.
- agent stamps pinned on results selectively, based on the tool's pin_result.
- all four compactors (compact_tool_results, keep_last_n_messages, keep_last_n_turns, summarize) preserve pinned results verbatim, incl. in parallel batches and the summarize incremental path.
- fix content_factory to carry pinned through serialize/deserialize.

Tests: per-compactor preservation, parallel/mixed batches, composed pipelines, summarize incremental, negative (unpinned) case, dump round-trip, and an end-to-end JSONL suspend→resume provinthe pinned skill body survives serialization + _compact_on_resume.

Docs: pinned-results section in memory-compaction, skills note on read_skill.