### PR TITLE
fix(codegen): reorder steps after add-step

### DIFF
--- a/python/tests/codegen/test_reorder_steps.py
+++ b/python/tests/codegen/test_reorder_steps.py
@@ -150,6 +150,75 @@ class TestReorderViaAddEdge:
         assert _step_order(output) == ["agent_a", "agent_b"]
 
 
+class TestReorderViaAddStep:
+    """Test that add-step triggers reordering end-to-end.
+
+    Re-adding a step (after remove-step) appends its .step() call last. If
+    existing steps depend on it (via step_span / depends_on), the source ends
+    up with a dependent before its dependency, which fails at runtime with
+    "Source step <x> not found in workflow". add-step must topologically
+    re-sort so the re-added dependency lands before its dependents.
+    """
+
+    def test_readd_dependency_lands_before_dependents(self, wf_workspace):
+        # Post-remove state: agent_b references agent_a, but agent_a is gone.
+        ws = wf_workspace("""\
+        from timbal import Agent, Workflow
+        from timbal.state import get_run_context
+
+        agent_b = Agent(name="agent_b", model="openai/gpt-4o-mini")
+
+        workflow = Workflow(name="wf")
+        workflow.step(agent_b, prompt=lambda: get_run_context().step_span("agent_a").output)
+        """)
+        output = apply_operation(
+            ws, "add_step",
+            step_type="Agent",
+            config='{"name": "agent_a", "model": "openai/gpt-4o-mini"}',
+            definition=None, step_name=None, x=None, y=None,
+        )
+        assert _step_order(output) == ["agent_a", "agent_b"]
+
+    def test_add_step_fixes_existing_violation(self, wf_workspace):
+        ws = wf_workspace("""\
+        from timbal import Agent, Workflow
+        from timbal.state import get_run_context
+
+        agent_a = Agent(name="agent_a", model="openai/gpt-4o-mini")
+        agent_b = Agent(name="agent_b", model="openai/gpt-4o-mini")
+
+        workflow = Workflow(name="wf")
+        workflow.step(agent_b, prompt=lambda: get_run_context().step_span("agent_a").output)
+        workflow.step(agent_a)
+        """)
+        output = apply_operation(
+            ws, "add_step",
+            step_type="Agent",
+            config='{"name": "agent_c", "model": "openai/gpt-4o-mini"}',
+            definition=None, step_name=None, x=None, y=None,
+        )
+        order = _step_order(output)
+        assert order.index("agent_a") < order.index("agent_b")
+
+    def test_independent_step_preserves_order(self, wf_workspace):
+        ws = wf_workspace("""\
+        from timbal import Agent, Workflow
+
+        agent_a = Agent(name="agent_a", model="openai/gpt-4o-mini")
+
+        workflow = Workflow(name="wf")
+        workflow.step(agent_a)
+        """)
+        output = apply_operation(
+            ws, "add_step",
+            step_type="Agent",
+            config='{"name": "agent_b", "model": "openai/gpt-4o-mini"}',
+            definition=None, step_name=None, x=None, y=None,
+        )
+        # No dependency between them — original order preserved.
+        assert _step_order(output) == ["agent_a", "agent_b"]
+
+
 class TestReorderViaSetParam:
     """Test that set-param type=map triggers reordering end-to-end."""
 

--- a/python/timbal/codegen/transformers/add_step.py
+++ b/python/timbal/codegen/transformers/add_step.py
@@ -274,6 +274,10 @@ def run(entry_point: str, args: argparse.Namespace, *, tree: cst.Module | None =
 
 
 class StepAdder(cst.CSTTransformer):
+    # A re-added step's .step() call is appended last; if existing steps depend
+    # on it, topologically re-sort so dependencies precede their dependents.
+    needs_reorder = True
+
     def __init__(
         self,
         entry_point: str,


### PR DESCRIPTION
add-step appended a re-added step's .step() call last, so existing steps depending on it (via step_span / depends_on) ended up before their dependency and failed at runtime with "Source step <x> not found in workflow". add-edge and set-param map already triggered a topological re-sort; add-step did not.

Set needs_reorder on StepAdder so apply_operation runs reorder_step_calls (a no-op when ordering is already valid, so independent steps keep their source order).