### PR TITLE
Add Krea.ai image and video generation tools

### DIFF
--- a/python/tests/tools/test_krea.py
+++ b/python/tests/tools/test_krea.py
@@ -1,0 +1,252 @@
+"""Tests for Krea.ai tools.
+
+Unit tests use mocked httpx. Live integration tests require ``KREA_API_KEY``.
+
+Run integration tests explicitly::
+
+    uv run python -m pytest python/tests/tools/test_krea.py -m integration -v
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+from timbal.tools.krea import (
+    KreaGenerateImage,
+    KreaGenerateVideo,
+    KreaGetJob,
+    KreaListJobs,
+    _build_generate_path,
+    _extract_job_urls,
+)
+
+
+def _mock_httpx_context(mock_client: MagicMock) -> MagicMock:
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=mock_client)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+def _completed_job(job_id: str = "job-abc", url: str = "https://cdn.example.com/out.mp4") -> dict[str, Any]:
+    return {
+        "job_id": job_id,
+        "status": "completed",
+        "created_at": "2026-01-01T00:00:00Z",
+        "completed_at": "2026-01-01T00:01:00Z",
+        "result": {"urls": [url]},
+    }
+
+
+def test_build_generate_path_video():
+    assert _build_generate_path("video", "google/veo-3.1-fast") == "/generate/video/google/veo-3.1-fast"
+    assert _build_generate_path("video", "video/kling/kling-2.5") == "/generate/video/kling/kling-2.5"
+
+
+def test_build_generate_path_image():
+    assert _build_generate_path("image", "bfl/flux-1-dev") == "/generate/image/bfl/flux-1-dev"
+
+
+def test_extract_job_urls():
+    assert _extract_job_urls({"result": {"urls": ["https://a", "https://b"]}}) == ["https://a", "https://b"]
+    assert _extract_job_urls({"result": None}) == []
+
+
+@pytest.mark.asyncio
+async def test_krea_list_jobs():
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {"items": [], "next_cursor": None}
+
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    with patch("httpx.AsyncClient", return_value=_mock_httpx_context(mock_client)):
+        tool = KreaListJobs(api_key=SecretStr("krea-test"))
+        out = await tool.handler(limit=10, cursor=None, types=None, status=None)
+
+    assert out == {"items": [], "next_cursor": None}
+    url = mock_client.get.await_args[0][0]
+    assert url == "https://api.krea.ai/jobs"
+    headers = mock_client.get.await_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer krea-test"
+
+
+@pytest.mark.asyncio
+async def test_krea_get_job():
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = _completed_job()
+
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    with patch("httpx.AsyncClient", return_value=_mock_httpx_context(mock_client)):
+        tool = KreaGetJob(api_key=SecretStr("krea-test"))
+        out = await tool.handler(job_id="job-abc")
+
+    assert out["status"] == "completed"
+    assert mock_client.get.await_args[0][0] == "https://api.krea.ai/jobs/job-abc"
+
+
+@pytest.mark.asyncio
+async def test_krea_generate_video_submit_and_poll():
+    submit_response = MagicMock()
+    submit_response.raise_for_status = MagicMock()
+    submit_response.json.return_value = {
+        "job_id": "job-video-1",
+        "status": "queued",
+        "created_at": "2026-01-01T00:00:00Z",
+        "completed_at": None,
+        "result": None,
+    }
+
+    poll_pending = MagicMock()
+    poll_pending.raise_for_status = MagicMock()
+    poll_pending.json.return_value = {"job_id": "job-video-1", "status": "processing", "created_at": "2026-01-01T00:00:00Z"}
+
+    poll_done = MagicMock()
+    poll_done.raise_for_status = MagicMock()
+    poll_done.json.return_value = _completed_job("job-video-1", "https://cdn.example.com/video.mp4")
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=submit_response)
+    mock_client.get = AsyncMock(side_effect=[poll_pending, poll_done])
+
+    with patch("httpx.AsyncClient", return_value=_mock_httpx_context(mock_client)):
+        tool = KreaGenerateVideo(api_key=SecretStr("krea-test"))
+        out = await tool.handler(
+            prompt="A boat on water",
+            model="google/veo-3.1-fast",
+            aspect_ratio="16:9",
+            duration=4,
+            resolution="720p",
+            generate_audio=False,
+            start_image=None,
+            end_image=None,
+            reference_images=None,
+            provider_params=None,
+            webhook_url=None,
+            poll_interval=0,
+            timeout=30,
+        )
+
+    assert out["success"] is True
+    assert out["video_url"] == "https://cdn.example.com/video.mp4"
+    assert out["job_id"] == "job-video-1"
+
+    post_url = mock_client.post.await_args[0][0]
+    assert post_url == "https://api.krea.ai/generate/video/google/veo-3.1-fast"
+    body = mock_client.post.await_args.kwargs["json"]
+    assert body["prompt"] == "A boat on water"
+    assert body["duration"] == 4
+    assert body["aspect_ratio"] == "16:9"
+
+
+@pytest.mark.asyncio
+async def test_krea_generate_video_empty_prompt():
+    tool = KreaGenerateVideo(api_key=SecretStr("krea-test"))
+    out = await tool.handler(
+        prompt="   ",
+        model="google/veo-3.1-fast",
+        aspect_ratio="16:9",
+        duration=4,
+        resolution="720p",
+        generate_audio=False,
+        start_image=None,
+        end_image=None,
+        reference_images=None,
+        provider_params=None,
+        webhook_url=None,
+        poll_interval=0,
+        timeout=30,
+    )
+    assert out["success"] is False
+    assert "prompt" in out["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_krea_generate_image_submit_and_poll():
+    submit_response = MagicMock()
+    submit_response.raise_for_status = MagicMock()
+    submit_response.json.return_value = {
+        "job_id": "job-img-1",
+        "status": "queued",
+        "created_at": "2026-01-01T00:00:00Z",
+        "completed_at": None,
+        "result": None,
+    }
+
+    poll_done = MagicMock()
+    poll_done.raise_for_status = MagicMock()
+    poll_done.json.return_value = _completed_job("job-img-1", "https://cdn.example.com/image.png")
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=submit_response)
+    mock_client.get = AsyncMock(return_value=poll_done)
+
+    with patch("httpx.AsyncClient", return_value=_mock_httpx_context(mock_client)):
+        tool = KreaGenerateImage(api_key=SecretStr("krea-test"))
+        out = await tool.handler(
+            prompt="A red balloon",
+            model="bfl/flux-1-dev",
+            width=1024,
+            height=1024,
+            seed=42,
+            image_url=None,
+            provider_params={"steps": 20},
+            webhook_url=None,
+            poll_interval=0,
+            timeout=30,
+        )
+
+    assert out["success"] is True
+    assert out["image_url"] == "https://cdn.example.com/image.png"
+    post_url = mock_client.post.await_args[0][0]
+    assert post_url == "https://api.krea.ai/generate/image/bfl/flux-1-dev"
+    body = mock_client.post.await_args.kwargs["json"]
+    assert body["steps"] == 20
+    assert body["seed"] == 42
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_krea_list_jobs_live():
+    if not os.getenv("KREA_API_KEY"):
+        pytest.skip("Set KREA_API_KEY for Krea integration test")
+    tool = KreaListJobs()
+    out = await tool.handler(limit=5, cursor=None, types=None, status=None)
+    assert "items" in out
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_krea_generate_video_live_or_balance_error():
+    if not os.getenv("KREA_API_KEY"):
+        pytest.skip("Set KREA_API_KEY for Krea integration test")
+    tool = KreaGenerateVideo()
+    out = await tool.handler(
+        prompt="A paper boat on calm water, macro cinematic.",
+        model="google/veo-3.1-fast",
+        aspect_ratio="16:9",
+        duration=4,
+        resolution="720p",
+        generate_audio=False,
+        start_image=None,
+        end_image=None,
+        reference_images=None,
+        provider_params=None,
+        webhook_url=None,
+        poll_interval=5,
+        timeout=600,
+    )
+    if out["success"]:
+        assert out["video_url"]
+        assert out["job_id"]
+    else:
+        assert out["error_type"] in ("RuntimeError", "TimeoutError")
+        assert out["error"]

--- a/python/timbal/tools/__init__.py
+++ b/python/timbal/tools/__init__.py
@@ -489,6 +489,13 @@ if TYPE_CHECKING:
         QuiverAIListModels,
         QuiverAIVectorizeSVG,
     )
+    from .krea import (
+        KreaCancelJob,
+        KreaGenerateImage,
+        KreaGenerateVideo,
+        KreaGetJob,
+        KreaListJobs,
+    )
     from .read import Read
     from .replicate import (
         ReplicateCancelPrediction,
@@ -2019,6 +2026,11 @@ __all__ = [
     "PowerBIQueryDataset",
     "PowerBIListReports",
     "PowerBIGetReport",
+    "KreaCancelJob",
+    "KreaGenerateImage",
+    "KreaGenerateVideo",
+    "KreaGetJob",
+    "KreaListJobs",
     "ReplicateCreatePrediction",
     "ReplicateGetPrediction",
     "ReplicateCancelPrediction",
@@ -3059,6 +3071,11 @@ _LAZY_IMPORTS = {
     "PowerBIQueryDataset": ".powerbi",
     "PowerBIListReports": ".powerbi",
     "PowerBIGetReport": ".powerbi",
+    "KreaCancelJob": ".krea",
+    "KreaGenerateImage": ".krea",
+    "KreaGenerateVideo": ".krea",
+    "KreaGetJob": ".krea",
+    "KreaListJobs": ".krea",
     "ReplicateCreatePrediction": ".replicate",
     "ReplicateGetPrediction": ".replicate",
     "ReplicateCancelPrediction": ".replicate",

--- a/python/timbal/tools/krea.py
+++ b/python/timbal/tools/krea.py
@@ -1,0 +1,505 @@
+"""
+Krea.ai REST API tools.
+
+Async job flow: POST /generate/{media}/{provider}/{model} → job_id → poll GET /jobs/{id}.
+Docs: https://docs.krea.ai/
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from typing import Annotated, Any, Literal
+
+import structlog
+from pydantic import Field, SecretStr
+
+from ..core.tool import Tool
+from ..platform.integrations import Integration
+
+logger = structlog.get_logger("timbal.tools.krea")
+
+_KREA_BASE = "https://api.krea.ai"
+_TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled"})
+_FAILED_STATUSES = frozenset({"failed", "cancelled"})
+
+MediaKind = Literal["video", "image"]
+
+
+async def _resolve_krea_api_key(tool: Any) -> str:
+    """Resolve Krea API key from integration, explicit field, or env var."""
+    if getattr(tool, "integration", None) is not None and isinstance(tool.integration, Integration):
+        credentials = await tool.integration.resolve()
+        key = credentials.get("api_key")
+        if key:
+            return str(key)
+    if tool.api_key is not None:
+        return tool.api_key.get_secret_value()
+    env_key = os.getenv("KREA_API_KEY")
+    if env_key:
+        return env_key
+    raise ValueError(
+        "Krea API key not found. Set KREA_API_KEY, pass api_key, or configure a krea integration."
+    )
+
+
+def _krea_headers(api_key: str, *, webhook_url: str | None = None) -> dict[str, str]:
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    if webhook_url:
+        headers["X-Webhook-URL"] = webhook_url
+    return headers
+
+
+def _format_krea_error(response: Any) -> str:
+    try:
+        body = response.json()
+    except Exception:
+        text = getattr(response, "text", "") or ""
+        return text[:500] or f"HTTP {getattr(response, 'status_code', '?')}"
+
+    if isinstance(body, dict):
+        for key in ("message", "error", "detail"):
+            value = body.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return str(body)[:500]
+
+
+async def _raise_for_krea_response(response: Any) -> None:
+    import httpx
+
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        detail = _format_krea_error(response)
+        raise RuntimeError(f"Krea API error ({response.status_code}): {detail}") from exc
+
+
+def _build_generate_path(media: MediaKind, model: str) -> str:
+    normalized = (model or "").strip().strip("/")
+    if not normalized:
+        raise ValueError("model is required (e.g. google/veo-3.1-fast or bfl/flux-1-dev)")
+    prefix = f"generate/{media}/"
+    if normalized.startswith(prefix):
+        return f"/{normalized}"
+    if normalized.startswith(f"{media}/"):
+        return f"/generate/{normalized}"
+    return f"/generate/{media}/{normalized}"
+
+
+def _extract_job_urls(job: dict[str, Any]) -> list[str]:
+    result = job.get("result")
+    if not isinstance(result, dict):
+        return []
+    urls = result.get("urls")
+    if isinstance(urls, list):
+        return [str(u) for u in urls if isinstance(u, str) and u]
+    return []
+
+
+async def _poll_krea_job(
+    client: Any,
+    *,
+    api_key: str,
+    job_id: str,
+    poll_interval: float,
+    timeout: float,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout
+    last: dict[str, Any] = {}
+    headers = _krea_headers(api_key)
+
+    while time.monotonic() < deadline:
+        response = await client.get(f"{_KREA_BASE}/jobs/{job_id}", headers=headers)
+        await _raise_for_krea_response(response)
+        last = response.json()
+        status = (last.get("status") or "").lower()
+        if status in _TERMINAL_STATUSES:
+            if status in _FAILED_STATUSES:
+                err = last.get("error") or {}
+                message = err.get("message") if isinstance(err, dict) else str(err)
+                raise RuntimeError(f"Krea job {job_id} {status}: {message or last}")
+            return last
+        if poll_interval > 0:
+            await asyncio.sleep(poll_interval)
+
+    raise TimeoutError(f"Krea job {job_id} timed out after {timeout}s (last status={last.get('status')})")
+
+
+class KreaListJobs(Tool):
+    name: str = "krea_list_jobs"
+    description: str | None = (
+        "List Krea generation jobs for the authenticated API key with optional pagination and filters."
+    )
+    integration: Annotated[str, Integration("krea")] | None = None
+    api_key: SecretStr | None = None
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            **super().get_config(),
+            **self._annotate_config({"integration": self.integration, "api_key": self.api_key}),
+        }
+
+    def __init__(self, **kwargs: Any) -> None:
+        async def _krea_list_jobs(
+            limit: int = Field(100, description="Number of jobs to return (1-1000)."),
+            cursor: str | None = Field(
+                None,
+                description="ISO 8601 timestamp cursor (jobs created before this time).",
+            ),
+            types: str | None = Field(
+                None,
+                description='Comma-separated job types filter (e.g. "flux,k1,externalImage").',
+            ),
+            status: str | None = Field(None, description="Filter by job status."),
+        ) -> dict[str, Any]:
+            api_key = await _resolve_krea_api_key(self)
+            import httpx
+
+            params: dict[str, Any] = {"limit": max(1, min(limit, 1000))}
+            if cursor:
+                params["cursor"] = cursor
+            if types:
+                params["types"] = types
+            if status:
+                params["status"] = status
+
+            async with httpx.AsyncClient(timeout=httpx.Timeout(60.0, read=None)) as client:
+                response = await client.get(
+                    f"{_KREA_BASE}/jobs",
+                    headers=_krea_headers(api_key),
+                    params=params,
+                )
+                await _raise_for_krea_response(response)
+                return response.json()
+
+        super().__init__(handler=_krea_list_jobs, **kwargs)
+
+
+class KreaGetJob(Tool):
+    name: str = "krea_get_job"
+    description: str | None = (
+        "Get the current state of a Krea job by id. When status is completed, result.urls contains output URLs."
+    )
+    integration: Annotated[str, Integration("krea")] | None = None
+    api_key: SecretStr | None = None
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            **super().get_config(),
+            **self._annotate_config({"integration": self.integration, "api_key": self.api_key}),
+        }
+
+    def __init__(self, **kwargs: Any) -> None:
+        async def _krea_get_job(
+            job_id: str = Field(..., description="Job UUID returned by a Krea generate call."),
+        ) -> dict[str, Any]:
+            api_key = await _resolve_krea_api_key(self)
+            import httpx
+
+            async with httpx.AsyncClient(timeout=httpx.Timeout(60.0, read=None)) as client:
+                response = await client.get(
+                    f"{_KREA_BASE}/jobs/{job_id}",
+                    headers=_krea_headers(api_key),
+                )
+                await _raise_for_krea_response(response)
+                return response.json()
+
+        super().__init__(handler=_krea_get_job, **kwargs)
+
+
+class KreaCancelJob(Tool):
+    name: str = "krea_cancel_job"
+    description: str | None = "Delete/cancel a Krea job by id."
+    integration: Annotated[str, Integration("krea")] | None = None
+    api_key: SecretStr | None = None
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            **super().get_config(),
+            **self._annotate_config({"integration": self.integration, "api_key": self.api_key}),
+        }
+
+    def __init__(self, **kwargs: Any) -> None:
+        async def _krea_cancel_job(
+            job_id: str = Field(..., description="Job UUID to delete/cancel."),
+        ) -> dict[str, Any]:
+            api_key = await _resolve_krea_api_key(self)
+            import httpx
+
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, read=None)) as client:
+                response = await client.delete(
+                    f"{_KREA_BASE}/jobs/{job_id}",
+                    headers=_krea_headers(api_key),
+                )
+                await _raise_for_krea_response(response)
+                if response.content:
+                    body = response.json()
+                    if isinstance(body, dict):
+                        return body
+                return {"deleted": True, "job_id": job_id}
+
+        super().__init__(handler=_krea_cancel_job, **kwargs)
+
+
+class KreaGenerateVideo(Tool):
+    name: str = "krea_generate_video"
+    description: str | None = (
+        "Generate a video via Krea.ai. Submits to POST /generate/video/{provider}/{model}, "
+        "polls /jobs/{id} until complete, and returns output URLs. "
+        "Examples: google/veo-3.1-fast, kling/kling-2.5, alibaba/wan-2.5, bytedance/seedance-2-fast."
+    )
+    integration: Annotated[str, Integration("krea")] | None = None
+    api_key: SecretStr | None = None
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            **super().get_config(),
+            **self._annotate_config({"integration": self.integration, "api_key": self.api_key}),
+        }
+
+    def __init__(self, **kwargs: Any) -> None:
+        async def _krea_generate_video(
+            prompt: str = Field(..., description="Text description of the video to generate."),
+            model: str = Field(
+                "google/veo-3.1-fast",
+                description="Krea video model path: provider/model (e.g. google/veo-3.1-fast).",
+            ),
+            aspect_ratio: str = Field("16:9", description="Aspect ratio when supported by the model."),
+            duration: int | None = Field(None, description="Duration in seconds when supported by the model."),
+            resolution: str | None = Field(None, description="Output resolution when supported (e.g. 720p, 1080p)."),
+            generate_audio: bool | None = Field(None, description="Whether to generate audio when supported."),
+            start_image: str | None = Field(
+                None,
+                description="Optional first-frame image URL, base64 data URI, or Krea asset URL.",
+            ),
+            end_image: str | None = Field(None, description="Optional last-frame image URL when supported."),
+            reference_images: list[str] | None = Field(
+                None,
+                description="Optional reference image URLs when supported by the model.",
+            ),
+            provider_params: dict[str, Any] | None = Field(
+                None,
+                description="Additional model-native fields merged into the request body.",
+            ),
+            webhook_url: str | None = Field(
+                None,
+                description="Optional X-Webhook-URL header; Krea POSTs completion payload here.",
+            ),
+            poll_interval: float = Field(5.0, description="Seconds between job status polls."),
+            timeout: float = Field(600.0, description="Max seconds to wait for job completion."),
+        ) -> dict[str, Any]:
+            start = time.monotonic()
+            resolved_model = model.strip()
+
+            try:
+                if not prompt or not prompt.strip():
+                    raise ValueError("prompt is required and must be non-empty")
+
+                payload: dict[str, Any] = {"prompt": prompt.strip()}
+                if aspect_ratio:
+                    payload["aspect_ratio"] = aspect_ratio
+                if duration is not None:
+                    payload["duration"] = duration
+                if resolution is not None:
+                    payload["resolution"] = resolution
+                if generate_audio is not None:
+                    payload["generate_audio"] = generate_audio
+                if start_image:
+                    payload["start_image"] = start_image
+                if end_image:
+                    payload["end_image"] = end_image
+                if reference_images:
+                    payload["reference_images"] = reference_images
+                if provider_params:
+                    for key, value in provider_params.items():
+                        if value is not None:
+                            payload[key] = value
+
+                path = _build_generate_path("video", resolved_model)
+                api_key = await _resolve_krea_api_key(self)
+                import httpx
+
+                async with httpx.AsyncClient(timeout=httpx.Timeout(60.0, read=None)) as client:
+                    submit = await client.post(
+                        f"{_KREA_BASE}{path}",
+                        headers=_krea_headers(api_key, webhook_url=webhook_url),
+                        json=payload,
+                    )
+                    await _raise_for_krea_response(submit)
+                    submit_data = submit.json()
+
+                    job_id = submit_data.get("job_id")
+                    if not isinstance(job_id, str) or not job_id:
+                        raise ValueError(f"Krea video API returned no job_id: {submit_data}")
+
+                    job = await _poll_krea_job(
+                        client,
+                        api_key=api_key,
+                        job_id=job_id,
+                        poll_interval=poll_interval,
+                        timeout=timeout,
+                    )
+
+                urls = _extract_job_urls(job)
+                if not urls:
+                    raise ValueError(f"No output URLs in completed Krea job: {job}")
+
+                elapsed = time.monotonic() - start
+                logger.info(
+                    "Krea video generated",
+                    model=resolved_model,
+                    job_id=job_id,
+                    elapsed_s=round(elapsed, 2),
+                )
+                return {
+                    "success": True,
+                    "model": resolved_model,
+                    "job_id": job_id,
+                    "video_url": urls[0],
+                    "urls": urls,
+                    "job": job,
+                    "elapsed_seconds": round(elapsed, 2),
+                }
+
+            except Exception as exc:
+                elapsed = time.monotonic() - start
+                logger.error("Krea video generation failed", model=resolved_model, error=str(exc))
+                return {
+                    "success": False,
+                    "model": resolved_model,
+                    "job_id": None,
+                    "video_url": None,
+                    "urls": [],
+                    "error": str(exc),
+                    "error_type": type(exc).__name__,
+                    "elapsed_seconds": round(elapsed, 2),
+                }
+
+        super().__init__(handler=_krea_generate_video, **kwargs)
+
+
+class KreaGenerateImage(Tool):
+    name: str = "krea_generate_image"
+    description: str | None = (
+        "Generate an image via Krea.ai. Submits to POST /generate/image/{provider}/{model}, "
+        "polls /jobs/{id} until complete, and returns output URLs. "
+        "Examples: bfl/flux-1-dev, krea/krea-2/medium, google/imagen-4."
+    )
+    integration: Annotated[str, Integration("krea")] | None = None
+    api_key: SecretStr | None = None
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            **super().get_config(),
+            **self._annotate_config({"integration": self.integration, "api_key": self.api_key}),
+        }
+
+    def __init__(self, **kwargs: Any) -> None:
+        async def _krea_generate_image(
+            prompt: str = Field(..., description="Text description of the image to generate."),
+            model: str = Field(
+                "bfl/flux-1-dev",
+                description="Krea image model path: provider/model (e.g. bfl/flux-1-dev).",
+            ),
+            width: int | None = Field(None, description="Output width in pixels when supported."),
+            height: int | None = Field(None, description="Output height in pixels when supported."),
+            seed: int | None = Field(None, description="Optional random seed."),
+            image_url: str | None = Field(
+                None,
+                description="Optional init/reference image URL for img2img when supported.",
+            ),
+            provider_params: dict[str, Any] | None = Field(
+                None,
+                description="Additional model-native fields merged into the request body.",
+            ),
+            webhook_url: str | None = Field(None, description="Optional X-Webhook-URL header."),
+            poll_interval: float = Field(3.0, description="Seconds between job status polls."),
+            timeout: float = Field(300.0, description="Max seconds to wait for job completion."),
+        ) -> dict[str, Any]:
+            start = time.monotonic()
+            resolved_model = model.strip()
+
+            try:
+                if not prompt or not prompt.strip():
+                    raise ValueError("prompt is required and must be non-empty")
+
+                payload: dict[str, Any] = {"prompt": prompt.strip()}
+                if width is not None:
+                    payload["width"] = width
+                if height is not None:
+                    payload["height"] = height
+                if seed is not None:
+                    payload["seed"] = seed
+                if image_url:
+                    payload["image_url"] = image_url
+                if provider_params:
+                    for key, value in provider_params.items():
+                        if value is not None:
+                            payload[key] = value
+
+                path = _build_generate_path("image", resolved_model)
+                api_key = await _resolve_krea_api_key(self)
+                import httpx
+
+                async with httpx.AsyncClient(timeout=httpx.Timeout(60.0, read=None)) as client:
+                    submit = await client.post(
+                        f"{_KREA_BASE}{path}",
+                        headers=_krea_headers(api_key, webhook_url=webhook_url),
+                        json=payload,
+                    )
+                    await _raise_for_krea_response(submit)
+                    submit_data = submit.json()
+
+                    job_id = submit_data.get("job_id")
+                    if not isinstance(job_id, str) or not job_id:
+                        raise ValueError(f"Krea image API returned no job_id: {submit_data}")
+
+                    job = await _poll_krea_job(
+                        client,
+                        api_key=api_key,
+                        job_id=job_id,
+                        poll_interval=poll_interval,
+                        timeout=timeout,
+                    )
+
+                urls = _extract_job_urls(job)
+                if not urls:
+                    raise ValueError(f"No output URLs in completed Krea job: {job}")
+
+                elapsed = time.monotonic() - start
+                logger.info(
+                    "Krea image generated",
+                    model=resolved_model,
+                    job_id=job_id,
+                    elapsed_s=round(elapsed, 2),
+                )
+                return {
+                    "success": True,
+                    "model": resolved_model,
+                    "job_id": job_id,
+                    "image_url": urls[0],
+                    "urls": urls,
+                    "job": job,
+                    "elapsed_seconds": round(elapsed, 2),
+                }
+
+            except Exception as exc:
+                elapsed = time.monotonic() - start
+                logger.error("Krea image generation failed", model=resolved_model, error=str(exc))
+                return {
+                    "success": False,
+                    "model": resolved_model,
+                    "job_id": None,
+                    "image_url": None,
+                    "urls": [],
+                    "error": str(exc),
+                    "error_type": type(exc).__name__,
+                    "elapsed_seconds": round(elapsed, 2),
+                }
+
+        super().__init__(handler=_krea_generate_image, **kwargs)


### PR DESCRIPTION
## Summary
- Add `python/timbal/tools/krea.py` with five tools: `KreaGenerateVideo`, `KreaGenerateImage`, `KreaGetJob`, `KreaListJobs`, `KreaCancelJob`
- Bearer auth via `KREA_API_KEY`, optional `Integration("krea")`, async submit + poll on `/jobs/{id}`
- Unit tests with mocked httpx; integration tests gated on `KREA_API_KEY`

## Validation
- Live auth OK: `GET /jobs` returns 200
- Generate returns clear 402 when API balance is empty (separate from workspace compute)
- 8 unit tests + 2 integration tests passing

## Test plan
- [x] `uv run python -m pytest python/tests/tools/test_krea.py -m "not integration" -v`
- [x] `KREA_API_KEY=... uv run python -m pytest python/tests/tools/test_krea.py -m integration -v`
- [ ] Top up Krea API balance and confirm end-to-end video generation


Made with [Cursor](https://cursor.com)