### PR TITLE
fix(tools): set explicit httpx timeouts to prevent premature read tim…

### DIFF
--- a/python/timbal/tools/asana.py
+++ b/python/timbal/tools/asana.py
@@ -69,7 +69,7 @@ class AsanaCreateProject(Tool):
             if due_on:
                 data["due_on"] = due_on
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_ASANA_API_BASE}/projects",
                     headers=_auth_headers(token),
@@ -98,7 +98,7 @@ class AsanaListWorkspaces(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_ASANA_API_BASE}/workspaces",
                     headers=_auth_headers(token),
@@ -145,7 +145,7 @@ class AsanaUpdateTask(Tool):
             if assignee_gid is not None:
                 data["assignee"] = assignee_gid
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{_ASANA_API_BASE}/tasks/{task_gid}",
                     headers=_auth_headers(token),
@@ -187,7 +187,7 @@ class AsanaListUserProjects(Tool):
             if owner_gid:
                 params["owner"] = owner_gid
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_ASANA_API_BASE}/projects",
                     headers=_auth_headers(token),
@@ -227,7 +227,7 @@ class AsanaListTeams(Tool):
                 "limit": limit,
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_ASANA_API_BASE}/teams",
                     headers=_auth_headers(token),
@@ -268,7 +268,7 @@ class AsanaSearchTasks(Tool):
                 "limit": limit,
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_ASANA_API_BASE}/tasks/search",
                     headers=_auth_headers(token),
@@ -300,7 +300,7 @@ class AsanaSearchSections(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_ASANA_API_BASE}/projects/{project_gid}/sections",
                     headers=_auth_headers(token),
@@ -339,7 +339,7 @@ class AsanaSearchProjects(Tool):
                 "archived": str(archived).lower(),
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_ASANA_API_BASE}/projects",
                     headers=_auth_headers(token),
@@ -372,7 +372,7 @@ class AsanaListTaskStories(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_ASANA_API_BASE}/tasks/{task_gid}/stories",
                     headers=_auth_headers(token),
@@ -415,7 +415,7 @@ class AsanaGetTasksFromTaskList(Tool):
 
             resolved_user_task_list_gid = user_task_list_gid
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 # If only user_gid is provided, resolve the corresponding user_task_list first.
                 if resolved_user_task_list_gid is None and user_gid is not None:
                     resolve_resp = await client.get(
@@ -459,7 +459,7 @@ class AsanaFindTaskById(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_ASANA_API_BASE}/tasks/{task_gid}",
                     headers=_auth_headers(token),
@@ -489,7 +489,7 @@ class AsanaDeleteTask(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{_ASANA_API_BASE}/tasks/{task_gid}",
                     headers=_auth_headers(token),
@@ -540,7 +540,7 @@ class AsanaCreateTask(Tool):
             if due_on is not None:
                 data["due_on"] = due_on
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_ASANA_API_BASE}/tasks",
                     headers=_auth_headers(token),
@@ -586,7 +586,7 @@ class AsanaCreateTaskFromTemplate(Tool):
             if workspace_gid is not None:
                 data["workspace"] = workspace_gid
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_ASANA_API_BASE}/tasks",
                     headers=_auth_headers(token),
@@ -622,7 +622,7 @@ class AsanaCreateTaskComment(Tool):
                 "text": text,
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_ASANA_API_BASE}/tasks/{task_gid}/stories",
                     headers=_auth_headers(token),
@@ -667,7 +667,7 @@ class AsanaCreateSubtask(Tool):
             if due_on is not None:
                 data["due_on"] = due_on
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_ASANA_API_BASE}/tasks/{parent_task_gid}/subtasks",
                     headers=_auth_headers(token),
@@ -703,7 +703,7 @@ class AsanaAddTaskToSection(Tool):
                 "task": task_gid,
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_ASANA_API_BASE}/sections/{section_gid}/addTask",
                     headers=_auth_headers(token),

--- a/python/timbal/tools/cala.py
+++ b/python/timbal/tools/cala.py
@@ -35,7 +35,7 @@ async def _post_cala(
 ) -> dict:
     import httpx
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
         response = await client.post(
             f"{_normalize_base_url(base_url)}{path}",
             headers={"x-api-key": api_key, "Content-Type": "application/json"},

--- a/python/timbal/tools/cloudflare.py
+++ b/python/timbal/tools/cloudflare.py
@@ -140,7 +140,7 @@ class CloudflareCrawlStart(Tool):
             if options:
                 body["options"] = options
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_CF_API_BASE}/{account_id}/browser-rendering/crawl",
                     headers=_auth_headers(api_token),
@@ -196,7 +196,7 @@ class CloudflareCrawlGet(Tool):
             if status_filter is not None:
                 params["status"] = status_filter
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_CF_API_BASE}/{account_id}/browser-rendering/crawl/{job_id}",
                     headers=_auth_headers(api_token),
@@ -228,7 +228,7 @@ class CloudflareCrawlCancel(Tool):
             api_token, account_id = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{_CF_API_BASE}/{account_id}/browser-rendering/crawl/{job_id}",
                     headers=_auth_headers(api_token),

--- a/python/timbal/tools/dynamics_business_central.py
+++ b/python/timbal/tools/dynamics_business_central.py
@@ -23,7 +23,7 @@ async def _get_token_from_client_credentials(
     import httpx
 
     token_url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
         response = await client.post(
             token_url,
             data={
@@ -148,7 +148,7 @@ class DynamicsBCCreateCustomer(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     _bc_url(tenant_id, environment_name, company_id, "customers"),
                     headers={
@@ -230,7 +230,7 @@ class DynamicsBCUpdateCustomer(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     _bc_url(tenant_id, environment_name, company_id, f"customers({customer_id})"),
                     headers={
@@ -286,7 +286,7 @@ class DynamicsBCGetSalesOrder(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={"Authorization": f"Bearer {token}"},
@@ -373,7 +373,7 @@ class DynamicsBCGetItemPrices(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={

--- a/python/timbal/tools/dynamics_sales.py
+++ b/python/timbal/tools/dynamics_sales.py
@@ -25,7 +25,7 @@ async def _get_token_from_client_credentials(
 
     scope = f"{resource.rstrip('/')}/.default"
     token_url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
         response = await client.post(
             token_url,
             data={
@@ -149,7 +149,7 @@ class DynamicsSalesFindContact(Tool):
                 if select:
                     params["$select"] = select
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={
@@ -221,7 +221,7 @@ class DynamicsSalesCreateCustomEntity(Tool):
             if return_representation:
                 headers["Prefer"] = "return=representation"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(url, headers=headers, json=data)
                 response.raise_for_status()
                 if return_representation and response.content:
@@ -321,7 +321,7 @@ class DynamicsSalesCreateOpportunity(Tool):
             if return_representation:
                 headers["Prefer"] = "return=representation"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(url, headers=headers, json=data)
                 response.raise_for_status()
                 if return_representation and response.content:

--- a/python/timbal/tools/elasticsearch.py
+++ b/python/timbal/tools/elasticsearch.py
@@ -64,7 +64,7 @@ class ElasticsearchIngestAttachment(Tool):
             if fields:
                 body.update(fields)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base}/{index}/_doc/{document_id}",
                     headers={"Authorization": f"ApiKey {api_key}"},
@@ -110,7 +110,7 @@ class ElasticsearchBulkOperations(Tool):
 
             url = f"{base}/_bulk" if not index else f"{base}/{index}/_bulk"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     url,
                     headers={
@@ -151,7 +151,7 @@ class ElasticsearchDeleteDocument(Tool):
                 raise ValueError("host required. Set ELASTICSEARCH_HOST or pass host.")
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base}/{index}/_doc/{document_id}",
                     headers={"Authorization": f"ApiKey {api_key}"},
@@ -195,7 +195,7 @@ class ElasticsearchGetDocument(Tool):
             if source_excludes:
                 params["_source_excludes"] = ",".join(source_excludes)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base}/{index}/_doc/{document_id}",
                     headers={"Authorization": f"ApiKey {api_key}"},
@@ -233,7 +233,7 @@ class ElasticsearchIndexDocument(Tool):
                 raise ValueError("host required. Set ELASTICSEARCH_HOST or pass host.")
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 if document_id:
                     response = await client.put(
                         f"{base}/{index}/_doc/{document_id}",
@@ -290,7 +290,7 @@ class ElasticsearchUpdateDocument(Tool):
             if upsert is not None:
                 body["upsert"] = upsert
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base}/{index}/_update/{document_id}",
                     headers={"Authorization": f"ApiKey {api_key}"},
@@ -337,7 +337,7 @@ class ElasticsearchCreateIndex(Tool):
             if aliases:
                 body["aliases"] = aliases
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base}/{index}",
                     headers={"Authorization": f"ApiKey {api_key}"},
@@ -373,7 +373,7 @@ class ElasticsearchUpdateIndexSettings(Tool):
                 raise ValueError("host required. Set ELASTICSEARCH_HOST or pass host.")
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base}/{index}/_settings",
                     headers={"Authorization": f"ApiKey {api_key}"},
@@ -409,7 +409,7 @@ class ElasticsearchListIndices(Tool):
             import httpx
 
             path = f"/_cat/indices/{index_pattern}" if index_pattern else "/_cat/indices"
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base.rstrip('/')}{path}",
                     headers={"Authorization": f"ApiKey {api_key}"},
@@ -451,7 +451,7 @@ class ElasticsearchListDocuments(Tool):
             if source is not None:
                 body["_source"] = source
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base}/{index}/_search",
                     headers={"Authorization": f"ApiKey {api_key}"},
@@ -520,7 +520,7 @@ class ElasticsearchSearchDocuments(Tool):
             if knn:
                 body["knn"] = knn
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base}/{index}/_search",
                     headers={"Authorization": f"ApiKey {api_key}"},

--- a/python/timbal/tools/elevenlabs.py
+++ b/python/timbal/tools/elevenlabs.py
@@ -54,7 +54,7 @@ class ElevenLabsTextToSpeech(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_ELEVENLABS_BASE}/text-to-speech/{voice_id}",
                     headers={"xi-api-key": api_key},
@@ -102,7 +102,7 @@ class ElevenLabsListPhoneNumbers(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_ELEVENLABS_BASE}/convai/phone-numbers",
                     headers={"xi-api-key": api_key},
@@ -149,7 +149,7 @@ class ElevenLabsMakeOutboundCall(Tool):
                 "to_number": to_number,
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_ELEVENLABS_BASE}/convai/twilio/outbound-call",
                     headers={"xi-api-key": api_key},
@@ -180,7 +180,7 @@ class ElevenLabsListAgents(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_ELEVENLABS_BASE}/convai/agents",
                     headers={"xi-api-key": api_key},
@@ -208,7 +208,7 @@ class ElevenLabsGetModels(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_ELEVENLABS_BASE}/models",
                     headers={"xi-api-key": api_key},
@@ -241,7 +241,7 @@ class ElevenLabsGetVoicesWithDescriptions(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_ELEVENLABS_BASE}/voices",
                     headers={"xi-api-key": api_key},
@@ -299,7 +299,7 @@ class ElevenLabsListHistory(Tool):
             if source:
                 params["source"] = source
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_ELEVENLABS_BASE}/history",
                     headers={"xi-api-key": api_key},
@@ -334,7 +334,7 @@ class ElevenLabsGetAudioFromHistoryItem(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_ELEVENLABS_BASE}/history/{history_item_id}/audio",
                     headers={"xi-api-key": api_key},
@@ -376,7 +376,7 @@ class ElevenLabsDownloadHistoryItems(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_ELEVENLABS_BASE}/history/download",
                     headers={"xi-api-key": api_key},
@@ -460,7 +460,7 @@ class ElevenLabsCreateAgent(Tool):
             if first_message:
                 payload["conversation_config"]["agent"]["first_message"] = first_message
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_ELEVENLABS_BASE}/convai/agents/create",
                     headers={"xi-api-key": api_key},
@@ -534,7 +534,7 @@ class ElevenLabsAddVoice(Tool):
                 import json
                 data["labels"] = json.dumps(labels)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_ELEVENLABS_BASE}/voices/add",
                     headers={"xi-api-key": api_key},

--- a/python/timbal/tools/excel.py
+++ b/python/timbal/tools/excel.py
@@ -60,7 +60,7 @@ class MicrosoftExcelWriteToSheet(Tool):
             cols = max(len(r) for r in values) if values else 1
             range_addr = _expand_address(address, rows, cols)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{_sheet(drive_id, workbook_id, sheet_name)}/range(address='{range_addr}')",
                     headers={"Authorization": f"Bearer {token}"},
@@ -98,7 +98,7 @@ class MicrosoftExcelClearSheet(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_sheet(drive_id, workbook_id, sheet_name)}/range/clear",
                     headers={"Authorization": f"Bearer {token}"},
@@ -131,7 +131,7 @@ class MicrosoftExcelCreateSheet(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_wb(drive_id, workbook_id)}/worksheets/add",
                     headers={"Authorization": f"Bearer {token}"},
@@ -164,7 +164,7 @@ class MicrosoftExcelDeleteSheet(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{_sheet(drive_id, workbook_id, sheet_name)}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -195,7 +195,7 @@ class MicrosoftExcelListSheets(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_wb(drive_id, workbook_id)}/worksheets",
                     headers={"Authorization": f"Bearer {token}"},
@@ -235,7 +235,7 @@ class MicrosoftExcelReadFromSheet(Tool):
             else:
                 url = f"{_sheet(drive_id, workbook_id, sheet_name)}/usedRange"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={"Authorization": f"Bearer {token}"},
@@ -269,7 +269,7 @@ class MicrosoftExcelUpdateCell(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{_sheet(drive_id, workbook_id, sheet_name)}/range(address='{address}')",
                     headers={"Authorization": f"Bearer {token}"},
@@ -312,7 +312,7 @@ class MicrosoftExcelFindRow(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_sheet(drive_id, workbook_id, sheet_name)}/usedRange",
                     headers={"Authorization": f"Bearer {token}"},
@@ -358,7 +358,7 @@ class MicrosoftExcelGetCellsInRange(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_sheet(drive_id, workbook_id, sheet_name)}/range(address='{address}')",
                     headers={"Authorization": f"Bearer {token}"},
@@ -392,7 +392,7 @@ class MicrosoftExcelGetRowByIndex(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_sheet(drive_id, workbook_id, sheet_name)}/usedRange",
                     headers={"Authorization": f"Bearer {token}"},
@@ -446,7 +446,7 @@ class MicrosoftExcelUpdateRow(Tool):
             end_col = _col_index_to_letter(cols - 1)
             address = f"A{excel_row}:{end_col}{excel_row}"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{_sheet(drive_id, workbook_id, sheet_name)}/range(address='{address}')",
                     headers={"Authorization": f"Bearer {token}"},
@@ -486,7 +486,7 @@ class MicrosoftExcelAddDataToTable(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_sheet(drive_id, workbook_id, sheet_name)}/tables/{table_name}/rows/add",
                     headers={"Authorization": f"Bearer {token}"},
@@ -523,7 +523,7 @@ class MicrosoftExcelCreateTable(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_sheet(drive_id, workbook_id, sheet_name)}/tables/add",
                     headers={"Authorization": f"Bearer {token}"},
@@ -579,7 +579,7 @@ class MicrosoftExcelCreateWorkbook(Tool):
                 else:
                     url = f"{_GRAPH_BASE}/me/drive/root:/{name}:/content"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     url,
                     headers={
@@ -628,7 +628,7 @@ class MicrosoftExcelListWorkbooks(Tool):
                 else:
                     url = f"{_GRAPH_BASE}/me/drive/root/children"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={"Authorization": f"Bearer {token}"},
@@ -666,7 +666,7 @@ class MicrosoftExcelGetSheetById(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_wb(drive_id, workbook_id)}/worksheets/{sheet_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -699,7 +699,7 @@ class MicrosoftExcelRenameSheet(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{_sheet(drive_id, workbook_id, sheet_name)}",
                     headers={"Authorization": f"Bearer {token}"},

--- a/python/timbal/tools/fal.py
+++ b/python/timbal/tools/fal.py
@@ -102,7 +102,7 @@ class FalQueueSubmit(Tool):
                 sep = "&" if "?" in url else "?"
                 url = f"{url}{sep}fal_webhook={quote(webhook_url, safe='')}"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.post(
                     url,
                     headers=_fal_auth_headers(api_key),
@@ -157,7 +157,7 @@ class FalQueueStatus(Tool):
             if include_logs:
                 url = f"{url}?logs=1"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={"Authorization": f"Key {api_key}"},
@@ -203,7 +203,7 @@ class FalQueueResult(Tool):
             path = _encode_model_path(model_id)
             url = f"{_QUEUE_BASE}/{path}/requests/{request_id}"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={"Authorization": f"Key {api_key}"},
@@ -248,7 +248,7 @@ class FalQueueCancel(Tool):
             path = _encode_model_path(model_id)
             url = f"{_QUEUE_BASE}/{path}/requests/{request_id}/cancel"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.put(
                     url,
                     headers={"Authorization": f"Key {api_key}"},

--- a/python/timbal/tools/fathom.py
+++ b/python/timbal/tools/fathom.py
@@ -145,7 +145,7 @@ class FathomListMeetings(Tool):
             if include_crm_matches:
                 params.append(("include_crm_matches", "true"))
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_FATHOM_BASE}/meetings",
                     headers=_fathom_headers(kind=auth_kind, credential=credential),
@@ -188,7 +188,7 @@ class FathomGetRecordingSummary(Tool):
             if destination_url is not None:
                 params["destination_url"] = destination_url
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_FATHOM_BASE}/recordings/{recording_id}/summary",
                     headers=_fathom_headers(kind=auth_kind, credential=credential),
@@ -233,7 +233,7 @@ class FathomGetRecordingTranscript(Tool):
             if destination_url is not None:
                 params["destination_url"] = destination_url
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_FATHOM_BASE}/recordings/{recording_id}/transcript",
                     headers=_fathom_headers(kind=auth_kind, credential=credential),
@@ -272,7 +272,7 @@ class FathomListTeams(Tool):
             if cursor is not None:
                 params["cursor"] = cursor
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_FATHOM_BASE}/teams",
                     headers=_fathom_headers(kind=auth_kind, credential=credential),
@@ -314,7 +314,7 @@ class FathomListTeamMembers(Tool):
             if team is not None:
                 params["team"] = team
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_FATHOM_BASE}/team_members",
                     headers=_fathom_headers(kind=auth_kind, credential=credential),

--- a/python/timbal/tools/firecrawl.py
+++ b/python/timbal/tools/firecrawl.py
@@ -113,7 +113,7 @@ class FirecrawlScrape(Tool):
             if actions:
                 payload["actions"] = actions
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/scrape",
                     headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
@@ -204,7 +204,7 @@ class FirecrawlSearch(Tool):
                     scrape_opts["excludeTags"] = scrape_exclude_tags
                 payload["scrapeOptions"] = scrape_opts
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/search",
                     headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
@@ -283,7 +283,7 @@ class FirecrawlCrawl(Tool):
 
             headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 # Start the crawl job.
                 response = await client.post(
                     f"{_BASE_URL}/crawl",
@@ -347,7 +347,7 @@ class FirecrawlMap(Tool):
             if search:
                 payload["search"] = search
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/map",
                     headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
@@ -407,7 +407,7 @@ class FirecrawlExtract(Tool):
             if schema:
                 payload["schema"] = schema
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/extract",
                     headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},

--- a/python/timbal/tools/gmail.py
+++ b/python/timbal/tools/gmail.py
@@ -269,7 +269,7 @@ class GmailSend(Tool):
             message = "\r\n".join(message_parts)
             raw = base64.urlsafe_b64encode(message.encode()).decode()
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/messages/send",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -404,7 +404,7 @@ class GmailCreateDraft(Tool):
             if thread_id:
                 draft_message["threadId"] = thread_id
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/drafts",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -450,7 +450,7 @@ class GmailReply(Tool):
             api_key = credentials["token"]
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/messages/{email_conversation}",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -601,7 +601,7 @@ class GmailReply(Tool):
             message = "\r\n".join(message_parts)
             raw = base64.urlsafe_b64encode(message.encode()).decode()
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 send_data = {"raw": raw}
                 if not reply_to_specific_message:
                     send_data["threadId"] = thread_id
@@ -646,7 +646,7 @@ class GmailSearch(Tool):
             api_key = credentials["token"]
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/messages",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -659,7 +659,7 @@ class GmailSearch(Tool):
             messages = search_results.get("messages", [])
             full_messages = []
 
-            async with httpx.AsyncClient() as detail_client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as detail_client:
                 for msg in messages:
                     msg_id = msg["id"]
                     msg_response = await detail_client.get(
@@ -751,7 +751,7 @@ class GmailAddLabel(Tool):
             api_key = credentials["token"]
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/labels",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -772,7 +772,7 @@ class GmailAddLabel(Tool):
                 else:
                     return {"status": "error", "message": f"Label '{label_name_item}' not found."}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/messages/{email_to_label}/modify",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -819,7 +819,7 @@ class GmailListLabels(Tool):
             api_key = credentials["token"]
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/labels",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -891,7 +891,7 @@ class GmailRemoveLabel(Tool):
             api_key = credentials["token"]
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/labels",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -912,7 +912,7 @@ class GmailRemoveLabel(Tool):
                 else:
                     return {"status": "error", "message": f"Label '{label_name_item}' not found."}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/messages/{email_to_update}/modify",
                     headers={"Authorization": f"Bearer {api_key}"},

--- a/python/timbal/tools/google_analytics.py
+++ b/python/timbal/tools/google_analytics.py
@@ -60,7 +60,7 @@ class GoogleAnalyticsListAccountSummaries(Tool):
             if page_token:
                 params["pageToken"] = page_token
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_ADMIN_BASE}/accountSummaries",
                     headers=_auth_headers(token),
@@ -117,7 +117,7 @@ class GoogleAnalyticsRunReport(Tool):
             if order_bys:
                 body["orderBys"] = order_bys
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_DATA_BASE}/{prop}:runReport",
                     headers=_auth_headers(token),
@@ -166,7 +166,7 @@ class GoogleAnalyticsRunRealtimeReport(Tool):
             if metric_filter:
                 body["metricFilter"] = metric_filter
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_DATA_BASE}/{prop}:runRealtimeReport",
                     headers=_auth_headers(token),
@@ -212,7 +212,7 @@ class GoogleAnalyticsRunPivotReport(Tool):
             if dimensions:
                 body["dimensions"] = [{"name": d} for d in dimensions]
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_DATA_BASE}/{prop}:runPivotReport",
                     headers=_auth_headers(token),
@@ -246,7 +246,7 @@ class GoogleAnalyticsBatchRunReports(Tool):
             prop = _resolve_property_id(self, property_id)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_DATA_BASE}/{prop}:batchRunReports",
                     headers=_auth_headers(token),
@@ -279,7 +279,7 @@ class GoogleAnalyticsGetMetadata(Tool):
             prop = _resolve_property_id(self, property_id)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_DATA_BASE}/{prop}/metadata",
                     headers=_auth_headers(token),
@@ -318,7 +318,7 @@ class GoogleAnalyticsListProperties(Tool):
             if page_token:
                 params["pageToken"] = page_token
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_ADMIN_BASE}/properties",
                     headers=_auth_headers(token),
@@ -351,7 +351,7 @@ class GoogleAnalyticsGetProperty(Tool):
             prop = _resolve_property_id(self, property_id)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_ADMIN_BASE}/{prop}",
                     headers=_auth_headers(token),
@@ -389,7 +389,7 @@ class GoogleAnalyticsListDataStreams(Tool):
             if page_token:
                 params["pageToken"] = page_token
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_ADMIN_BASE}/{prop}/dataStreams",
                     headers=_auth_headers(token),
@@ -424,7 +424,7 @@ class GoogleAnalyticsGetDataStream(Tool):
             stream = data_stream_id if data_stream_id.startswith("dataStreams/") else f"dataStreams/{data_stream_id}"
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_ADMIN_BASE}/{prop}/{stream}",
                     headers=_auth_headers(token),
@@ -462,7 +462,7 @@ class GoogleAnalyticsListCustomDimensions(Tool):
             if page_token:
                 params["pageToken"] = page_token
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_ADMIN_BASE}/{prop}/customDimensions",
                     headers=_auth_headers(token),
@@ -501,7 +501,7 @@ class GoogleAnalyticsListCustomMetrics(Tool):
             if page_token:
                 params["pageToken"] = page_token
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_ADMIN_BASE}/{prop}/customMetrics",
                     headers=_auth_headers(token),

--- a/python/timbal/tools/google_business.py
+++ b/python/timbal/tools/google_business.py
@@ -78,7 +78,7 @@ class GoogleBusinessListAccounts(Tool):
             if page_token:
                 params["pageToken"] = page_token
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_ACCOUNT_BASE}/accounts",
                     headers=_auth_headers(token),
@@ -129,7 +129,7 @@ class GoogleBusinessListLocations(Tool):
             if page_token:
                 params["pageToken"] = page_token
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_INFO_BASE}/{account}/locations",
                     headers=_auth_headers(token),
@@ -176,7 +176,7 @@ class GoogleBusinessGetLocation(Tool):
             location = _resolve_location_id(self, location_id)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_INFO_BASE}/{account}/{location}",
                     headers=_auth_headers(token),
@@ -222,7 +222,7 @@ class GoogleBusinessUpdateLocation(Tool):
             if validate_only:
                 params["validateOnly"] = "true"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{_INFO_BASE}/{location['name']}",
                     headers=_auth_headers(token),
@@ -272,7 +272,7 @@ class GoogleBusinessListReviews(Tool):
             if page_token:
                 params["pageToken"] = page_token
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_LEGACY_BASE}/{account}/{location}/reviews",
                     headers=_auth_headers(token),
@@ -316,7 +316,7 @@ class GoogleBusinessGetReview(Tool):
             location = _resolve_location_id(self, location_id)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_LEGACY_BASE}/{account}/{location}/reviews/{review_id}",
                     headers=_auth_headers(token),
@@ -360,7 +360,7 @@ class GoogleBusinessReplyToReview(Tool):
             location = _resolve_location_id(self, location_id)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{_LEGACY_BASE}/{account}/{location}/reviews/{review_id}/reply",
                     headers=_auth_headers(token),
@@ -404,7 +404,7 @@ class GoogleBusinessDeleteReviewReply(Tool):
             location = _resolve_location_id(self, location_id)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{_LEGACY_BASE}/{account}/{location}/reviews/{review_id}/reply",
                     headers=_auth_headers(token),
@@ -464,7 +464,7 @@ class GoogleBusinessGetDailyMetrics(Tool):
                 },
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_PERFORMANCE_BASE}/{location}:getDailyMetricsTimeSeries",
                     headers=_auth_headers(token),
@@ -522,7 +522,7 @@ class GoogleBusinessGetMultiDailyMetrics(Tool):
                 },
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_PERFORMANCE_BASE}/{location}:fetchMultiDailyMetricsTimeSeries",
                     headers=_auth_headers(token),
@@ -566,7 +566,7 @@ class GoogleBusinessListCategories(Tool):
             if page_token:
                 params["pageToken"] = page_token
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_INFO_BASE}/categories",
                     headers=_auth_headers(token),
@@ -610,7 +610,7 @@ class GoogleBusinessCreateLocalPost(Tool):
             location = _resolve_location_id(self, location_id)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_LEGACY_BASE}/{account}/{location}/localPosts",
                     headers=_auth_headers(token),

--- a/python/timbal/tools/google_calendar.py
+++ b/python/timbal/tools/google_calendar.py
@@ -55,7 +55,7 @@ class GoogleCalendarListEvents(Tool):
             if q:
                 params["q"] = q
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_CALENDAR_BASE}/calendars/{calendar_id}/events",
                     headers={"Authorization": f"Bearer {token}"},
@@ -105,7 +105,7 @@ class GoogleCalendarCreateEvent(Tool):
             if attendees:
                 body["attendees"] = [{"email": email} for email in attendees]
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_CALENDAR_BASE}/calendars/{calendar_id}/events",
                     headers={"Authorization": f"Bearer {token}"},
@@ -157,7 +157,7 @@ class GoogleCalendarUpdateEvent(Tool):
             if end:
                 body["end"] = {"dateTime": end, "timeZone": timezone or "UTC"}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{_CALENDAR_BASE}/calendars/{calendar_id}/events/{event_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -189,7 +189,7 @@ class GoogleCalendarDeleteEvent(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{_CALENDAR_BASE}/calendars/{calendar_id}/events/{event_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -227,7 +227,7 @@ class GoogleCalendarUpdateAttendeeStatus(Tool):
 
             headers = {"Authorization": f"Bearer {token}"}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 get_response = await client.get(
                     f"{_CALENDAR_BASE}/calendars/{calendar_id}/events/{event_id}",
                     headers=headers,
@@ -285,7 +285,7 @@ class GoogleCalendarCheckFreeSlots(Tool):
                 "items": [{"id": cal_id} for cal_id in calendar_ids],
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_CALENDAR_BASE}/freeBusy",
                     headers={"Authorization": f"Bearer {token}"},

--- a/python/timbal/tools/google_docs.py
+++ b/python/timbal/tools/google_docs.py
@@ -172,7 +172,7 @@ class GoogleDocsFindDocument(Tool):
             if folder_id:
                 query_parts.append(f"'{folder_id}' in parents")
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_DRIVE_BASE}/files",
                     headers={"Authorization": f"Bearer {token}"},
@@ -233,7 +233,7 @@ class GoogleDocsCreateFromTemplate(Tool):
             if folder_id:
                 copy_body["parents"] = [folder_id]
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_DRIVE_BASE}/files/{template_id}/copy",
                     headers=_auth_headers(token),
@@ -295,7 +295,7 @@ class GoogleDocsReplaceText(Tool):
                 }
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 result = await _batch_update(client, token, document_id, [request])
 
             replies = result.get("replies", [])
@@ -337,7 +337,7 @@ class GoogleDocsReplaceImage(Tool):
                 }
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 await _batch_update(client, token, document_id, [request])
 
             return {"documentId": document_id, "imageObjectId": image_object_id}
@@ -371,7 +371,7 @@ class GoogleDocsInsertText(Tool):
                 }
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 await _batch_update(client, token, document_id, [request])
 
             return {"documentId": document_id, "insertedLength": len(text)}
@@ -399,7 +399,7 @@ class GoogleDocsInsertTable(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 if index is None:
                     doc = await _get_document(client, token, document_id, include_tabs_content=tab_id is not None)
                     index = _document_end_index(doc, tab_id=tab_id)
@@ -440,7 +440,7 @@ class GoogleDocsInsertPageBreak(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 if index is None:
                     doc = await _get_document(client, token, document_id, include_tabs_content=tab_id is not None)
                     index = _document_end_index(doc, tab_id=tab_id)
@@ -481,7 +481,7 @@ class GoogleDocsGetTabContent(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 document = await _get_document(client, token, document_id, include_tabs_content=True)
 
             tab = _find_tab(document, tab_id) if tab_id else _find_tab_by_title(document, tab_title or "")
@@ -525,7 +525,7 @@ class GoogleDocsGetDocument(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 return await _get_document(
                     client,
                     token,
@@ -556,7 +556,7 @@ class GoogleDocsCreate(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 created = await _create_document_file(client, token, title=title, folder_id=folder_id)
                 document_id = created["id"]
 
@@ -595,7 +595,7 @@ class GoogleDocsAppendText(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 document = await _get_document(client, token, document_id, include_tabs_content=tab_id is not None)
                 index = _document_end_index(document, tab_id=tab_id)
                 await _batch_update(
@@ -633,7 +633,7 @@ class GoogleDocsAppendImage(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 document = await _get_document(client, token, document_id, include_tabs_content=tab_id is not None)
                 index = _document_end_index(document, tab_id=tab_id)
                 request = {

--- a/python/timbal/tools/google_drive.py
+++ b/python/timbal/tools/google_drive.py
@@ -58,7 +58,7 @@ class GoogleDriveCreateFile(Tool):
                 "file": (name, file_content, mime_type)
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_DRIVE_UPLOAD_BASE}/files",
                     headers={
@@ -117,7 +117,7 @@ class GoogleDriveGetDownloadLink(Tool):
                 params["driveId"] = drive
                 params["includeItemsFromAllDrives"] = "true"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_DRIVE_BASE}/files/{file_id}",
                     headers={
@@ -160,7 +160,7 @@ class GoogleDriveGetFile(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_DRIVE_BASE}/files/{file_id}",
                     headers={
@@ -212,7 +212,7 @@ class GoogleDriveCreateFolder(Tool):
             if parent_folder_id:
                 folder_metadata["parents"] = [parent_folder_id]
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_DRIVE_BASE}/files",
                     headers={
@@ -262,7 +262,7 @@ class GoogleDriveSearchFolders(Tool):
             else:
                 query = f"'me' in parents and {query}"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 all_folders = []
                 page_token = None
                 
@@ -355,7 +355,7 @@ class GoogleDriveSearchFiles(Tool):
             query_string = " and ".join(query_parts)
             fields_param = fields or "files(id,name,parents,mimeType,webViewLink,modifiedTime,createdTime,size)"
             
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 all_files = []
                 page_token = None
                 
@@ -427,7 +427,7 @@ class GoogleDriveUploadFile(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(file_url)
                 response.raise_for_status()
                 file_content = response.content
@@ -495,7 +495,7 @@ class GoogleDriveCreateSharedDrive(Tool):
                 "name": name
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_DRIVE_BASE}/drives",
                     headers={

--- a/python/timbal/tools/google_maps.py
+++ b/python/timbal/tools/google_maps.py
@@ -85,7 +85,7 @@ class GoogleMapsTextSearch(Tool):
                     }
                 }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_PLACES_BASE_URL}/places:searchText",
                     headers={
@@ -127,7 +127,7 @@ class GoogleMapsPlaceDetails(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_PLACES_BASE_URL}/places/{place_id}",
                     headers={
@@ -184,7 +184,7 @@ class GoogleMapsNearbySearch(Tool):
                 "languageCode": language_code,
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_PLACES_BASE_URL}/places:searchNearby",
                     headers={
@@ -241,7 +241,7 @@ class GoogleMapsValidateAddress(Tool):
             if postal_code:
                 address["postalCode"] = postal_code
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     _ADDRESS_VALIDATION_URL,
                     headers={

--- a/python/timbal/tools/google_merchant_center.py
+++ b/python/timbal/tools/google_merchant_center.py
@@ -52,7 +52,7 @@ class GoogleMerchantListAccounts(Tool):
             if page_token:
                 params["pageToken"] = page_token
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_CONTENT_BASE}/accounts",
                     headers=_auth_headers(token),
@@ -89,7 +89,7 @@ class GoogleMerchantGetAccount(Tool):
             acct = account_id or merchant
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_CONTENT_BASE}/{merchant}/accounts/{acct}",
                     headers=_auth_headers(token),
@@ -129,7 +129,7 @@ class GoogleMerchantListProducts(Tool):
             if page_token:
                 params["pageToken"] = page_token
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_CONTENT_BASE}/{merchant}/products",
                     headers=_auth_headers(token),
@@ -167,7 +167,7 @@ class GoogleMerchantGetProduct(Tool):
             merchant = _resolve_merchant_id(self, merchant_id)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_CONTENT_BASE}/{merchant}/products/{product_id}",
                     headers=_auth_headers(token),
@@ -202,7 +202,7 @@ class GoogleMerchantInsertProduct(Tool):
             merchant = _resolve_merchant_id(self, merchant_id)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_CONTENT_BASE}/{merchant}/products",
                     headers=_auth_headers(token),
@@ -239,7 +239,7 @@ class GoogleMerchantUpdateProduct(Tool):
             merchant = _resolve_merchant_id(self, merchant_id)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{_CONTENT_BASE}/{merchant}/products/{product_id}",
                     headers=_auth_headers(token),
@@ -275,7 +275,7 @@ class GoogleMerchantDeleteProduct(Tool):
             merchant = _resolve_merchant_id(self, merchant_id)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{_CONTENT_BASE}/{merchant}/products/{product_id}",
                     headers=_auth_headers(token),
@@ -315,7 +315,7 @@ class GoogleMerchantListProductStatuses(Tool):
             if page_token:
                 params["pageToken"] = page_token
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_CONTENT_BASE}/{merchant}/productstatuses",
                     headers=_auth_headers(token),
@@ -351,7 +351,7 @@ class GoogleMerchantGetProductStatus(Tool):
             merchant = _resolve_merchant_id(self, merchant_id)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_CONTENT_BASE}/{merchant}/productstatuses/{product_id}",
                     headers=_auth_headers(token),
@@ -391,7 +391,7 @@ class GoogleMerchantListDatafeeds(Tool):
             if page_token:
                 params["pageToken"] = page_token
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_CONTENT_BASE}/{merchant}/datafeeds",
                     headers=_auth_headers(token),
@@ -427,7 +427,7 @@ class GoogleMerchantGetDatafeed(Tool):
             merchant = _resolve_merchant_id(self, merchant_id)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_CONTENT_BASE}/{merchant}/datafeeds/{datafeed_id}",
                     headers=_auth_headers(token),

--- a/python/timbal/tools/google_search_console.py
+++ b/python/timbal/tools/google_search_console.py
@@ -52,7 +52,7 @@ class GoogleSearchConsoleListSites(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_WEBMASTERS_BASE}/sites",
                     headers=_auth_headers(token),
@@ -86,7 +86,7 @@ class GoogleSearchConsoleGetSite(Tool):
             site = _resolve_site_url(self, site_url)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_WEBMASTERS_BASE}/sites/{_encoded_site_url(site)}",
                     headers=_auth_headers(token),
@@ -113,7 +113,7 @@ class GoogleSearchConsoleAddSite(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{_WEBMASTERS_BASE}/sites/{_encoded_site_url(site_url)}",
                     headers=_auth_headers(token),
@@ -145,7 +145,7 @@ class GoogleSearchConsoleDeleteSite(Tool):
             site = _resolve_site_url(self, site_url)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{_WEBMASTERS_BASE}/sites/{_encoded_site_url(site)}",
                     headers=_auth_headers(token),
@@ -201,7 +201,7 @@ class GoogleSearchConsoleSearchAnalytics(Tool):
             if data_state:
                 body["dataState"] = data_state
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_WEBMASTERS_BASE}/sites/{_encoded_site_url(site)}/searchAnalytics/query",
                     headers=_auth_headers(token),
@@ -234,7 +234,7 @@ class GoogleSearchConsoleListSitemaps(Tool):
             site = _resolve_site_url(self, site_url)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_WEBMASTERS_BASE}/sites/{_encoded_site_url(site)}/sitemaps",
                     headers=_auth_headers(token),
@@ -267,7 +267,7 @@ class GoogleSearchConsoleGetSitemap(Tool):
             site = _resolve_site_url(self, site_url)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_WEBMASTERS_BASE}/sites/{_encoded_site_url(site)}/sitemaps/{_encoded_site_url(feedpath)}",
                     headers=_auth_headers(token),
@@ -300,7 +300,7 @@ class GoogleSearchConsoleSubmitSitemap(Tool):
             site = _resolve_site_url(self, site_url)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{_WEBMASTERS_BASE}/sites/{_encoded_site_url(site)}/sitemaps/{_encoded_site_url(feedpath)}",
                     headers=_auth_headers(token),
@@ -333,7 +333,7 @@ class GoogleSearchConsoleDeleteSitemap(Tool):
             site = _resolve_site_url(self, site_url)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{_WEBMASTERS_BASE}/sites/{_encoded_site_url(site)}/sitemaps/{_encoded_site_url(feedpath)}",
                     headers=_auth_headers(token),
@@ -373,7 +373,7 @@ class GoogleSearchConsoleInspectUrl(Tool):
                 "languageCode": language_code,
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_INSPECTION_BASE}/urlInspection/index:inspect",
                     headers=_auth_headers(token),
@@ -420,7 +420,7 @@ class GoogleSearchConsoleSearchAnalyticsByPage(Tool):
                 "startRow": start_row,
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_WEBMASTERS_BASE}/sites/{_encoded_site_url(site)}/searchAnalytics/query",
                     headers=_auth_headers(token),

--- a/python/timbal/tools/google_sheets.py
+++ b/python/timbal/tools/google_sheets.py
@@ -44,7 +44,7 @@ class GoogleSheetsCreateSheet(Tool):
             if sheet_names:
                 body["sheets"] = [{"properties": {"title": name}} for name in sheet_names]
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     _SHEETS_BASE,
                     headers={"Authorization": f"Bearer {token}"},
@@ -73,7 +73,7 @@ class GoogleSheetsGetSpreadsheetInfo(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_SHEETS_BASE}/{spreadsheet_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -102,7 +102,7 @@ class GoogleSheetsGetSheetNames(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_SHEETS_BASE}/{spreadsheet_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -141,7 +141,7 @@ class GoogleSheetsBatchGet(Tool):
             query.append(("majorDimension", major_dimension))
             query.append(("valueRenderOption", value_render_option))
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_SHEETS_BASE}/{spreadsheet_id}/values:batchGet",
                     headers={"Authorization": f"Bearer {token}"},
@@ -176,7 +176,7 @@ class GoogleSheetsBatchUpdate(Tool):
 
             body = {"valueInputOption": value_input_option, "data": data}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_SHEETS_BASE}/{spreadsheet_id}/values:batchUpdate",
                     headers={"Authorization": f"Bearer {token}"},
@@ -213,7 +213,7 @@ class GoogleSheetsAppendValues(Tool):
 
             body = {"values": values}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_SHEETS_BASE}/{spreadsheet_id}/values/{range}:append",
                     headers={"Authorization": f"Bearer {token}"},
@@ -251,7 +251,7 @@ class GoogleSheetsLookupRow(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_SHEETS_BASE}/{spreadsheet_id}/values/{range}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -290,7 +290,7 @@ class GoogleSheetsClearValues(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_SHEETS_BASE}/{spreadsheet_id}/values/{range}:clear",
                     headers={"Authorization": f"Bearer {token}"},
@@ -324,7 +324,7 @@ class GoogleSheetsCopySheet(Tool):
 
             body = {"destinationSpreadsheetId": destination_spreadsheet_id}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_SHEETS_BASE}/{source_spreadsheet_id}/sheets/{sheet_id}:copyTo",
                     headers={"Authorization": f"Bearer {token}"},
@@ -368,7 +368,7 @@ class GoogleSheetsAddSheet(Tool):
 
             body = {"requests": [{"addSheet": {"properties": sheet_properties}}]}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_SHEETS_BASE}/{spreadsheet_id}:batchUpdate",
                     headers={"Authorization": f"Bearer {token}"},
@@ -415,7 +415,7 @@ class GoogleSheetsShareSpreadsheet(Tool):
             if email_message:
                 params["emailMessage"] = email_message
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_DRIVE_BASE}/files/{spreadsheet_id}/permissions",
                     headers={"Authorization": f"Bearer {token}"},

--- a/python/timbal/tools/happy_scribe.py
+++ b/python/timbal/tools/happy_scribe.py
@@ -106,7 +106,7 @@ async def _request(
     api_key = await _resolve_api_key(integration=tool.integration, api_key=tool.api_key)
     import httpx
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
         response = await client.request(
             method,
             f"{_BASE_URL}{path}",
@@ -136,7 +136,7 @@ async def _load_upload_bytes(
         return base64.b64decode(file_content_base64), None
     import httpx
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
         response = await client.get(file_url, timeout=httpx.Timeout(120.0, read=None))
         response.raise_for_status()
         filename = file_url.rsplit("/", 1)[-1].split("?", 1)[0] if file_url else None
@@ -199,7 +199,7 @@ class HappyScribeUploadFile(_HappyScribeTool):
             import httpx
 
             headers = {"Content-Type": content_type or "application/octet-stream"}
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.put(
                     signed_url,
                     content=content,

--- a/python/timbal/tools/hubspot.py
+++ b/python/timbal/tools/hubspot.py
@@ -52,7 +52,7 @@ class HubSpotListContacts(Tool):
             if properties:
                 params["properties"] = ",".join(properties)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/crm/v3/objects/contacts",
                     headers={"Authorization": f"Bearer {token}"},
@@ -91,7 +91,7 @@ class HubSpotGetContact(Tool):
             if associations:
                 params["associations"] = ",".join(associations)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/crm/v3/objects/contacts/{contact_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -148,7 +148,7 @@ class HubSpotCreateContact(Tool):
             if hs_lead_status:
                 properties["hs_lead_status"] = hs_lead_status
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/crm/v3/objects/contacts",
                     headers={"Authorization": f"Bearer {token}"},
@@ -208,7 +208,7 @@ class HubSpotUpdateContact(Tool):
             if hs_lead_status:
                 properties["hs_lead_status"] = hs_lead_status
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{_API_BASE}/crm/v3/objects/contacts/{contact_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -259,7 +259,7 @@ class HubSpotSearchContacts(Tool):
             if sorts:
                 body["sorts"] = sorts
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/crm/v3/objects/contacts/search",
                     headers={"Authorization": f"Bearer {token}"},
@@ -291,7 +291,7 @@ class HubSpotMergeContacts(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/crm/v3/objects/contacts/merge",
                     headers={"Authorization": f"Bearer {token}"},
@@ -332,7 +332,7 @@ class HubSpotGdprDeleteContact(Tool):
             if email:
                 body["email"] = email
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/crm/v3/objects/contacts/gdpr-delete",
                     headers={"Authorization": f"Bearer {token}"},
@@ -372,7 +372,7 @@ class HubSpotListCompanies(Tool):
             if properties:
                 params["properties"] = ",".join(properties)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/crm/v3/objects/companies",
                     headers={"Authorization": f"Bearer {token}"},
@@ -411,7 +411,7 @@ class HubSpotGetCompany(Tool):
             if associations:
                 params["associations"] = ",".join(associations)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/crm/v3/objects/companies/{company_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -471,7 +471,7 @@ class HubSpotCreateCompany(Tool):
             if annualrevenue:
                 properties["annualrevenue"] = annualrevenue
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/crm/v3/objects/companies",
                     headers={"Authorization": f"Bearer {token}"},
@@ -534,7 +534,7 @@ class HubSpotUpdateCompany(Tool):
             if annualrevenue:
                 properties["annualrevenue"] = annualrevenue
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{_API_BASE}/crm/v3/objects/companies/{company_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -588,7 +588,7 @@ class HubSpotSearchCompanies(Tool):
             if sorts:
                 body["sorts"] = sorts
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/crm/v3/objects/companies/search",
                     headers={"Authorization": f"Bearer {token}"},
@@ -628,7 +628,7 @@ class HubSpotListDeals(Tool):
             if properties:
                 params["properties"] = ",".join(properties)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/crm/v3/objects/deals",
                     headers={"Authorization": f"Bearer {token}"},
@@ -667,7 +667,7 @@ class HubSpotGetDeal(Tool):
             if associations:
                 params["associations"] = ",".join(associations)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/crm/v3/objects/deals/{deal_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -718,7 +718,7 @@ class HubSpotCreateDeal(Tool):
             if description:
                 properties["description"] = description
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/crm/v3/objects/deals",
                     headers={"Authorization": f"Bearer {token}"},
@@ -772,7 +772,7 @@ class HubSpotUpdateDeal(Tool):
             if description:
                 properties["description"] = description
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{_API_BASE}/crm/v3/objects/deals/{deal_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -801,7 +801,7 @@ class HubSpotGetDealPipelines(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/crm/v3/pipelines/deals",
                     headers={"Authorization": f"Bearer {token}"},
@@ -840,7 +840,7 @@ class HubSpotListTickets(Tool):
             if properties:
                 params["properties"] = ",".join(properties)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/crm/v3/objects/tickets",
                     headers={"Authorization": f"Bearer {token}"},
@@ -879,7 +879,7 @@ class HubSpotGetTicket(Tool):
             if associations:
                 params["associations"] = ",".join(associations)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/crm/v3/objects/tickets/{ticket_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -927,7 +927,7 @@ class HubSpotCreateTicket(Tool):
             if hubspot_owner_id:
                 properties["hubspot_owner_id"] = hubspot_owner_id
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/crm/v3/objects/tickets",
                     headers={"Authorization": f"Bearer {token}"},
@@ -978,7 +978,7 @@ class HubSpotUpdateTicket(Tool):
             if hubspot_owner_id:
                 properties["hubspot_owner_id"] = hubspot_owner_id
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{_API_BASE}/crm/v3/objects/tickets/{ticket_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -1007,7 +1007,7 @@ class HubSpotDeleteTicket(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{_API_BASE}/crm/v3/objects/tickets/{ticket_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -1038,7 +1038,7 @@ class HubSpotMergeTickets(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/crm/v3/objects/tickets/merge",
                     headers={"Authorization": f"Bearer {token}"},
@@ -1078,7 +1078,7 @@ class HubSpotListProducts(Tool):
             if properties:
                 params["properties"] = ",".join(properties)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/crm/v3/objects/products",
                     headers={"Authorization": f"Bearer {token}"},
@@ -1114,7 +1114,7 @@ class HubSpotGetProduct(Tool):
             if properties:
                 params["properties"] = ",".join(properties)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/crm/v3/objects/products/{product_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -1162,7 +1162,7 @@ class HubSpotCreateProduct(Tool):
             if hs_recurring_billing_period:
                 properties["hs_recurring_billing_period"] = hs_recurring_billing_period
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/crm/v3/objects/products",
                     headers={"Authorization": f"Bearer {token}"},
@@ -1213,7 +1213,7 @@ class HubSpotUpdateProduct(Tool):
             if hs_recurring_billing_period:
                 properties["hs_recurring_billing_period"] = hs_recurring_billing_period
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{_API_BASE}/crm/v3/objects/products/{product_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -1242,7 +1242,7 @@ class HubSpotDeleteProduct(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{_API_BASE}/crm/v3/objects/products/{product_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -1274,7 +1274,7 @@ class HubSpotGetEngagements(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/engagements/v1/engagements/associated/contact/{contact_id}/paged",
                     headers={"Authorization": f"Bearer {token}"},
@@ -1303,7 +1303,7 @@ class HubSpotGetEngagement(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/engagements/v1/engagements/{engagement_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -1334,7 +1334,7 @@ class HubSpotListEngagements(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/engagements/v1/engagements/paged",
                     headers={"Authorization": f"Bearer {token}"},
@@ -1371,7 +1371,7 @@ class HubSpotGetRecentEngagements(Tool):
             if since:
                 params["since"] = since
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/engagements/v1/engagements/recent/modified",
                     headers={"Authorization": f"Bearer {token}"},
@@ -1400,7 +1400,7 @@ class HubSpotGetCallDispositions(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/calling/v1/dispositions",
                     headers={"Authorization": f"Bearer {token}"},
@@ -1445,7 +1445,7 @@ class HubSpotCreateEngagement(Tool):
             if associations:
                 body["associations"] = associations
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/engagements/v1/engagements",
                     headers={"Authorization": f"Bearer {token}"},
@@ -1484,7 +1484,7 @@ class UpdateEngagement(Tool):
             if metadata:
                 body["metadata"] = metadata
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{_API_BASE}/engagements/v1/engagements/{engagement_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -1513,7 +1513,7 @@ class HubSpotDeleteEngagement(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{_API_BASE}/engagements/v1/engagements/{engagement_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -1559,7 +1559,7 @@ class HubSpotSendEmail(Tool):
                     {"name": k, "value": v} for k, v in custom_properties.items()
                 ]
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/marketing/v3/transactional/single-email/send",
                     headers={"Authorization": f"Bearer {token}"},
@@ -1598,7 +1598,7 @@ class HubSpotGetAssociations(Tool):
             if after:
                 params["after"] = after
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/crm/v3/objects/{from_object_type}/{object_id}/associations/{to_object_type}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -1636,7 +1636,7 @@ class HubSpotCreateAssociation(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{_API_BASE}/crm/v3/objects/{from_object_type}/{from_object_id}"
                     f"/associations/{to_object_type}/{to_object_id}/{association_type}",
@@ -1671,7 +1671,7 @@ class HubSpotDeleteAssociation(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{_API_BASE}/crm/v3/objects/{from_object_type}/{from_object_id}"
                     f"/associations/{to_object_type}/{to_object_id}/{association_type}",
@@ -1703,7 +1703,7 @@ class HubSpotGetAssociationTypes(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/crm/v3/associations/{from_object_type}/{to_object_type}/types",
                     headers={"Authorization": f"Bearer {token}"},
@@ -1731,7 +1731,7 @@ class HubSpotGetUsers(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/crm/v3/owners",
                     headers={"Authorization": f"Bearer {token}"},

--- a/python/timbal/tools/jira.py
+++ b/python/timbal/tools/jira.py
@@ -110,7 +110,7 @@ async def _resolve_token(tool: Any) -> str:
 async def _fetch_accessible_resources(token: str) -> list[dict[str, Any]]:
     import httpx
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
         response = await client.get(
             _ACCESSIBLE_RESOURCES,
             headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
@@ -191,7 +191,7 @@ async def _jira_request(
     url = f"{base}{path}"
     if headers:
         hdrs = {**hdrs, **headers}
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
         kwargs: dict[str, Any] = {"method": method, "url": url, "headers": hdrs, "params": params}
         if files is not None:
             kwargs["files"] = files
@@ -902,7 +902,7 @@ class JiraAddAttachment(Tool):
 
             ct = content_type or "application/octet-stream"
             files = {"file": (filename, raw, ct)}
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(url, headers=headers, files=files)
                 response.raise_for_status()
                 return response.json()
@@ -993,7 +993,7 @@ class JiraAddUserToIssue(Tool):
                 headers = {**hdrs, "Content-Type": "application/json"}
                 import httpx
 
-                async with httpx.AsyncClient() as client:
+                async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                     response = await client.post(url, headers=headers, content=json.dumps(account_id))
                     response.raise_for_status()
                     if response.status_code == 204 or not response.content:

--- a/python/timbal/tools/klaviyo.py
+++ b/python/timbal/tools/klaviyo.py
@@ -102,7 +102,7 @@ class KlaviyoListProfiles(Tool):
             if additional_fields:
                 params["additional-fields[profile]"] = additional_fields
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/profiles",
                     headers=_headers(api_key),
@@ -144,7 +144,7 @@ class KlaviyoGetProfile(Tool):
             if additional_fields:
                 params["additional-fields[profile]"] = additional_fields
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/profiles/{profile_id}",
                     headers=_headers(api_key),
@@ -208,7 +208,7 @@ class KlaviyoCreateProfile(Tool):
 
             payload = {"data": {"type": "profile", "attributes": attributes}}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/profiles",
                     headers=_headers(api_key),
@@ -273,7 +273,7 @@ class KlaviyoUpdateProfile(Tool):
 
             payload = {"data": {"type": "profile", "id": profile_id, "attributes": attributes}}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{_API_BASE}/profiles/{profile_id}",
                     headers=_headers(api_key),
@@ -307,7 +307,7 @@ class KlaviyoGetProfileLists(Tool):
 
             params = _pagination_params(page_cursor) or None
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/profiles/{profile_id}/lists",
                     headers=_headers(api_key),
@@ -346,7 +346,7 @@ class KlaviyoListLists(Tool):
             if sort:
                 params["sort"] = sort
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/lists",
                     headers=_headers(api_key),
@@ -375,7 +375,7 @@ class KlaviyoGetList(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/lists/{list_id}",
                     headers=_headers(api_key),
@@ -405,7 +405,7 @@ class KlaviyoCreateList(Tool):
 
             payload = {"data": {"type": "list", "attributes": {"name": name}}}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/lists",
                     headers=_headers(api_key),
@@ -441,7 +441,7 @@ class KlaviyoAddProfilesToList(Tool):
                 "data": [{"type": "profile", "id": profile_id} for profile_id in profile_ids],
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/lists/{list_id}/relationships/profiles",
                     headers=_headers(api_key),
@@ -477,7 +477,7 @@ class KlaviyoRemoveProfilesFromList(Tool):
                 "data": [{"type": "profile", "id": profile_id} for profile_id in profile_ids],
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.request(
                     "DELETE",
                     f"{_API_BASE}/lists/{list_id}/relationships/profiles",
@@ -521,7 +521,7 @@ class KlaviyoGetListProfiles(Tool):
             if sort:
                 params["sort"] = sort
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/lists/{list_id}/profiles",
                     headers=_headers(api_key),
@@ -560,7 +560,7 @@ class KlaviyoListSegments(Tool):
             if sort:
                 params["sort"] = sort
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/segments",
                     headers=_headers(api_key),
@@ -589,7 +589,7 @@ class KlaviyoGetSegment(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/segments/{segment_id}",
                     headers=_headers(api_key),
@@ -635,7 +635,7 @@ class KlaviyoListEvents(Tool):
             if include:
                 params["include"] = include
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/events",
                     headers=_headers(api_key),
@@ -708,7 +708,7 @@ class KlaviyoCreateEvent(Tool):
 
             payload = {"data": {"type": "event", "attributes": event_attrs}}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/events",
                     headers=_headers(api_key),
@@ -757,7 +757,7 @@ class KlaviyoListCampaigns(Tool):
             if sort:
                 params["sort"] = sort
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/campaigns",
                     headers=_headers(api_key),
@@ -786,7 +786,7 @@ class KlaviyoGetCampaign(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/campaigns/{campaign_id}",
                     headers=_headers(api_key),
@@ -824,7 +824,7 @@ class KlaviyoListMetrics(Tool):
             if sort:
                 params["sort"] = sort
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/metrics",
                     headers=_headers(api_key),
@@ -863,7 +863,7 @@ class KlaviyoListFlows(Tool):
             if sort:
                 params["sort"] = sort
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/flows",
                     headers=_headers(api_key),
@@ -892,7 +892,7 @@ class KlaviyoGetFlow(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/flows/{flow_id}",
                     headers=_headers(api_key),
@@ -964,7 +964,7 @@ class KlaviyoSubscribeProfiles(Tool):
 
             payload = {"data": job_data}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/profile-subscription-bulk-create-jobs",
                     headers=_headers(api_key),
@@ -1024,7 +1024,7 @@ class KlaviyoUnsubscribeProfiles(Tool):
 
             payload = {"data": job_data}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/profile-subscription-bulk-delete-jobs",
                     headers=_headers(api_key),
@@ -1055,7 +1055,7 @@ class KlaviyoGetProfileSubscriptions(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/profiles/{profile_id}",
                     headers=_headers(api_key),
@@ -1094,7 +1094,7 @@ class KlaviyoListCatalogItems(Tool):
             if filter:
                 params["filter"] = filter
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/catalog-items",
                     headers=_headers(api_key),
@@ -1150,7 +1150,7 @@ class KlaviyoCreateCatalogItem(Tool):
 
             payload = {"data": {"type": "catalog-item", "attributes": attributes}}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/catalog-items",
                     headers=_headers(api_key),
@@ -1186,7 +1186,7 @@ class KlaviyoGetCatalogItem(Tool):
 
             catalog_id = item_id if item_id.startswith("$custom:::") else _catalog_item_id(item_id)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/catalog-items/{catalog_id}",
                     headers=_headers(api_key),
@@ -1254,7 +1254,7 @@ class KlaviyoCreatePlacedOrderEvent(Tool):
 
             payload = {"data": {"type": "event", "attributes": event_attrs}}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/events",
                     headers=_headers(api_key),
@@ -1285,7 +1285,7 @@ class KlaviyoGetProfilePredictiveAnalytics(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/profiles/{profile_id}",
                     headers=_headers(api_key),
@@ -1355,7 +1355,7 @@ class KlaviyoCreateCampaign(Tool):
                 },
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/campaigns",
                     headers=_headers(api_key),
@@ -1408,7 +1408,7 @@ class KlaviyoUpdateCampaign(Tool):
                 },
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{_API_BASE}/campaigns/{campaign_id}",
                     headers=_headers(api_key),
@@ -1443,7 +1443,7 @@ class KlaviyoSendCampaign(Tool):
 
             payload = {"data": {"type": "campaign-send-job", "id": campaign_id}}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/campaign-send-jobs",
                     headers=_headers(api_key),
@@ -1509,7 +1509,7 @@ class KlaviyoQueryCampaignValues(Tool):
                 },
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/campaign-values-reports",
                     headers=_headers(api_key),
@@ -1553,7 +1553,7 @@ class KlaviyoUpdateFlowStatus(Tool):
                 },
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{_API_BASE}/flows/{flow_id}",
                     headers=_headers(api_key),
@@ -1587,7 +1587,7 @@ class KlaviyoListFlowActions(Tool):
 
             params = _pagination_params(page_cursor) or None
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_API_BASE}/flows/{flow_id}/flow-actions",
                     headers=_headers(api_key),
@@ -1642,7 +1642,7 @@ class KlaviyoTriggerFlowViaEvent(Tool):
 
             payload = {"data": {"type": "event", "attributes": event_attrs}}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_API_BASE}/events",
                     headers=_headers(api_key),

--- a/python/timbal/tools/linkedin.py
+++ b/python/timbal/tools/linkedin.py
@@ -91,7 +91,7 @@ class LinkedInSearchPeople(Tool):
             if network_depths:
                 params["facetNetwork"] = network_depths
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/search",
                     headers={
@@ -150,7 +150,7 @@ class LinkedInSearchCompanies(Tool):
             if company_sizes:
                 params["facetCompanySize"] = company_sizes
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/organizationsLookup",
                     headers={
@@ -223,7 +223,7 @@ class LinkedInSearchJobs(Tool):
             if posted_at_range:
                 params["f_TPR"] = posted_at_range
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/jobSearch",
                     headers={
@@ -341,7 +341,7 @@ class LinkedInSearch(Tool):
                     params["f_TPR"] = parsed["posted"][0]
                 endpoint = f"{_BASE_URL}/jobSearch"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     endpoint,
                     headers={

--- a/python/timbal/tools/mongodb.py
+++ b/python/timbal/tools/mongodb.py
@@ -66,7 +66,7 @@ class MongoCreateDocument(Tool):
             import httpx
 
             body = {**_base_body(data_source, database, collection), "document": document}
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     _atlas_url(app_id, "insertOne"),
                     headers={"api-key": api_key},
@@ -116,7 +116,7 @@ class MongoFindDocumentById(Tool):
             }
             if projection:
                 body["projection"] = projection
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     _atlas_url(app_id, "findOne"),
                     headers={"api-key": api_key},
@@ -161,7 +161,7 @@ class MongoFindDocument(Tool):
             }
             if projection:
                 body["projection"] = projection
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     _atlas_url(app_id, "findOne"),
                     headers={"api-key": api_key},
@@ -220,7 +220,7 @@ class MongoSearchDocuments(Tool):
                 body["projection"] = projection
             if sort:
                 body["sort"] = sort
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     _atlas_url(app_id, "find"),
                     headers={"api-key": api_key},
@@ -272,7 +272,7 @@ class MongoUpdateDocument(Tool):
                 "update": update,
                 "upsert": upsert,
             }
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     _atlas_url(app_id, "updateOne"),
                     headers={"api-key": api_key},
@@ -322,7 +322,7 @@ class MongoUpdateDocuments(Tool):
                 "update": update,
                 "upsert": upsert,
             }
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     _atlas_url(app_id, "updateMany"),
                     headers={"api-key": api_key},
@@ -367,7 +367,7 @@ class MongoDeleteDocument(Tool):
                 **_base_body(data_source, database, collection),
                 "filter": {"_id": {"$oid": document_id}},
             }
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     _atlas_url(app_id, "deleteOne"),
                     headers={"api-key": api_key},
@@ -418,7 +418,7 @@ class MongoExecuteAggregation(Tool):
                 **_base_body(data_source, database, collection),
                 "pipeline": pipeline,
             }
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     _atlas_url(app_id, "aggregate"),
                     headers={"api-key": api_key},

--- a/python/timbal/tools/netsuite.py
+++ b/python/timbal/tools/netsuite.py
@@ -168,7 +168,7 @@ class NetSuiteCreateAccount(Tool):
                 data["description"] = description
 
             auth = _netsuite_auth_header("POST", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     url,
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -224,7 +224,7 @@ class NetSuiteDeleteAccount(Tool):
             import httpx
 
             auth = _netsuite_auth_header("DELETE", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(url, headers={"Authorization": auth, "Content-Type": "application/json"})
                 response.raise_for_status()
                 return {"deleted": True, "record_type": "account", "record_id": record_id}
@@ -274,7 +274,7 @@ class NetSuiteGetAccount(Tool):
                 params["fields"] = fields
 
             auth = _netsuite_auth_header("GET", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -329,7 +329,7 @@ class NetSuiteListAccounts(Tool):
                 params["q"] = query
 
             auth = _netsuite_auth_header("GET", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(url, headers={"Authorization": auth, "Content-Type": "application/json"}, params=params)
                 response.raise_for_status()
                 return response.json()
@@ -391,7 +391,7 @@ class NetSuiteCreateAssemblyBuild(Tool):
                 data["memo"] = memo
 
             auth = _netsuite_auth_header("POST", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(url, headers={"Authorization": auth, "Content-Type": "application/json"}, json=data)
                 response.raise_for_status()
                 location = response.headers.get("Location", "")
@@ -443,7 +443,7 @@ class NetSuiteDeleteAssemblyBuild(Tool):
             import httpx
 
             auth = _netsuite_auth_header("DELETE", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(url, headers={"Authorization": auth, "Content-Type": "application/json"})
                 response.raise_for_status()
                 return {"deleted": True, "record_type": "assemblybuild", "record_id": record_id}
@@ -493,7 +493,7 @@ class NetSuiteGetAssemblyBuild(Tool):
                 params["fields"] = fields
 
             auth = _netsuite_auth_header("GET", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -548,7 +548,7 @@ class NetSuiteListAssemblyBuilds(Tool):
                 params["q"] = query
 
             auth = _netsuite_auth_header("GET", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(url, headers={"Authorization": auth, "Content-Type": "application/json"}, params=params)
                 response.raise_for_status()
                 return response.json()
@@ -594,7 +594,7 @@ class NetSuiteUpdateAssemblyBuild(Tool):
             import httpx
 
             auth = _netsuite_auth_header("PATCH", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(url, headers={"Authorization": auth, "Content-Type": "application/json"}, json=data)
                 response.raise_for_status()
                 return {"updated": True, "record_type": "assemblybuild", "record_id": record_id}
@@ -651,7 +651,7 @@ class NetSuiteTransformAssemblyItemToBuild(Tool):
                 data["memo"] = memo
 
             auth = _netsuite_auth_header("POST", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(url, headers={"Authorization": auth, "Content-Type": "application/json"}, json=data)
                 response.raise_for_status()
                 location = response.headers.get("Location", "")
@@ -715,7 +715,7 @@ class NetSuiteTransformAssemblyItemToWorkOrder(Tool):
                 data["memo"] = memo
 
             auth = _netsuite_auth_header("POST", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(url, headers={"Authorization": auth, "Content-Type": "application/json"}, json=data)
                 response.raise_for_status()
                 location = response.headers.get("Location", "")
@@ -776,7 +776,7 @@ class NetSuiteTransformAssemblyToUnbuild(Tool):
                 data["memo"] = memo
 
             auth = _netsuite_auth_header("POST", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(url, headers={"Authorization": auth, "Content-Type": "application/json"}, json=data)
                 response.raise_for_status()
                 location = response.headers.get("Location", "")
@@ -851,7 +851,7 @@ class NetSuiteCreateAssemblyItem(Tool):
                 data["upcCode"] = upc_code
 
             auth = _netsuite_auth_header("POST", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(url, headers={"Authorization": auth, "Content-Type": "application/json"}, json=data)
                 response.raise_for_status()
                 location = response.headers.get("Location", "")
@@ -903,7 +903,7 @@ class NetSuiteDeleteAssemblyItem(Tool):
             import httpx
 
             auth = _netsuite_auth_header("DELETE", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(url, headers={"Authorization": auth, "Content-Type": "application/json"})
                 response.raise_for_status()
                 return {"deleted": True, "record_type": "assemblyitem", "record_id": record_id}
@@ -953,7 +953,7 @@ class NetSuiteGetAssemblyItem(Tool):
                 params["fields"] = fields
 
             auth = _netsuite_auth_header("GET", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -1008,7 +1008,7 @@ class NetSuiteListAssemblyItems(Tool):
                 params["q"] = query
 
             auth = _netsuite_auth_header("GET", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(url, headers={"Authorization": auth, "Content-Type": "application/json"}, params=params)
                 response.raise_for_status()
                 return response.json()
@@ -1054,7 +1054,7 @@ class NetSuiteUpdateAssemblyItem(Tool):
             import httpx
 
             auth = _netsuite_auth_header("PATCH", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(url, headers={"Authorization": auth, "Content-Type": "application/json"}, json=data)
                 response.raise_for_status()
                 return {"updated": True, "record_type": "assemblyitem", "record_id": record_id}
@@ -1110,7 +1110,7 @@ class NetSuiteSuiteQL(Tool):
             params = {"limit": min(limit, 1000), "offset": offset}
             auth = _netsuite_auth_header("POST", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     url,
                     headers={"Authorization": auth, "Content-Type": "application/json", "Prefer": "transient"},
@@ -1179,7 +1179,7 @@ class NetSuiteCreateBillingAccount(Tool):
                 data["memo"] = memo
 
             auth = _netsuite_auth_header("POST", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     url,
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -1235,7 +1235,7 @@ class NetSuiteDeleteBillingAccount(Tool):
             import httpx
 
             auth = _netsuite_auth_header("DELETE", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(url, headers={"Authorization": auth, "Content-Type": "application/json"})
                 response.raise_for_status()
                 return {"deleted": True, "record_type": "billingaccount", "record_id": record_id}
@@ -1285,7 +1285,7 @@ class NetSuiteGetBillingAccount(Tool):
                 params["fields"] = fields
 
             auth = _netsuite_auth_header("GET", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -1340,7 +1340,7 @@ class NetSuiteListBillingAccounts(Tool):
                 params["q"] = query
 
             auth = _netsuite_auth_header("GET", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(url, headers={"Authorization": auth, "Content-Type": "application/json"}, params=params)
                 response.raise_for_status()
                 return response.json()
@@ -1386,7 +1386,7 @@ class NetSuiteUpdateBillingAccount(Tool):
             import httpx
 
             auth = _netsuite_auth_header("PATCH", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(url, headers={"Authorization": auth, "Content-Type": "application/json"}, json=data)
                 response.raise_for_status()
                 return {"updated": True, "record_type": "billingaccount", "record_id": record_id}
@@ -1447,7 +1447,7 @@ class NetSuiteCreateBillingSchedule(Tool):
                 data["memo"] = memo
 
             auth = _netsuite_auth_header("POST", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     url,
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -1503,7 +1503,7 @@ class NetSuiteDeleteBillingSchedule(Tool):
             import httpx
 
             auth = _netsuite_auth_header("DELETE", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(url, headers={"Authorization": auth, "Content-Type": "application/json"})
                 response.raise_for_status()
                 return {"deleted": True, "record_type": "billingschedule", "record_id": record_id}
@@ -1553,7 +1553,7 @@ class NetSuiteGetBillingSchedule(Tool):
                 params["fields"] = fields
 
             auth = _netsuite_auth_header("GET", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -1608,7 +1608,7 @@ class NetSuiteListBillingSchedules(Tool):
                 params["q"] = query
 
             auth = _netsuite_auth_header("GET", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(url, headers={"Authorization": auth, "Content-Type": "application/json"}, params=params)
                 response.raise_for_status()
                 return response.json()
@@ -1654,7 +1654,7 @@ class NetSuiteUpdateBillingSchedule(Tool):
             import httpx
 
             auth = _netsuite_auth_header("PATCH", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(url, headers={"Authorization": auth, "Content-Type": "application/json"}, json=data)
                 response.raise_for_status()
                 return {"updated": True, "record_type": "billingschedule", "record_id": record_id}
@@ -1700,7 +1700,7 @@ class NetSuiteUpsertBillingAccount(Tool):
             import httpx
 
             auth = _netsuite_auth_header("PUT", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(url, headers={"Authorization": auth, "Content-Type": "application/json"}, json=data)
                 response.raise_for_status()
                 return {"upserted": True, "record_type": "billingaccount", "external_id": external_id}
@@ -1746,7 +1746,7 @@ class NetSuiteUpsertBillingSchedule(Tool):
             import httpx
 
             auth = _netsuite_auth_header("PUT", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(url, headers={"Authorization": auth, "Content-Type": "application/json"}, json=data)
                 response.raise_for_status()
                 return {"upserted": True, "record_type": "billingschedule", "external_id": external_id}
@@ -1811,7 +1811,7 @@ class NetSuiteCreateCalendarEvent(Tool):
                 data["allDayEvent"] = all_day_event
 
             auth = _netsuite_auth_header("POST", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     url,
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -1867,7 +1867,7 @@ class NetSuiteDeleteCalendarEvent(Tool):
             import httpx
 
             auth = _netsuite_auth_header("DELETE", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(url, headers={"Authorization": auth, "Content-Type": "application/json"})
                 response.raise_for_status()
                 return {"deleted": True, "record_type": "calendarevent", "record_id": record_id}
@@ -1917,7 +1917,7 @@ class NetSuiteGetCalendarEvent(Tool):
                 params["fields"] = fields
 
             auth = _netsuite_auth_header("GET", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -1972,7 +1972,7 @@ class NetSuiteListCalendarEvents(Tool):
                 params["q"] = query
 
             auth = _netsuite_auth_header("GET", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(url, headers={"Authorization": auth, "Content-Type": "application/json"}, params=params)
                 response.raise_for_status()
                 return response.json()
@@ -2018,7 +2018,7 @@ class NetSuiteUpdateCalendarEvent(Tool):
             import httpx
 
             auth = _netsuite_auth_header("PATCH", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(url, headers={"Authorization": auth, "Content-Type": "application/json"}, json=data)
                 response.raise_for_status()
                 return {"updated": True, "record_type": "calendarevent", "record_id": record_id}
@@ -2064,7 +2064,7 @@ class NetSuiteUpsertCalendarEvent(Tool):
             import httpx
 
             auth = _netsuite_auth_header("PUT", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(url, headers={"Authorization": auth, "Content-Type": "application/json"}, json=data)
                 response.raise_for_status()
                 return {"upserted": True, "record_type": "calendarevent", "external_id": external_id}
@@ -2120,7 +2120,7 @@ class NetSuiteCustomSuiteQL(Tool):
             params = {"limit": min(limit, 1000), "offset": offset}
             auth = _netsuite_auth_header("POST", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     url,
                     headers={"Authorization": auth, "Content-Type": "application/json", "Prefer": "transient"},
@@ -2182,7 +2182,7 @@ class NetSuiteCreateIntercompanyJournalEntry(Tool):
                 data["line"] = {"items": lines}
 
             auth = _netsuite_auth_header("POST", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     url,
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -2238,7 +2238,7 @@ class NetSuiteDeleteIntercompanyJournalEntry(Tool):
             import httpx
 
             auth = _netsuite_auth_header("DELETE", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(url, headers={"Authorization": auth, "Content-Type": "application/json"})
                 response.raise_for_status()
                 return {"deleted": True, "record_type": "intercompanyjournalentry", "record_id": record_id}
@@ -2288,7 +2288,7 @@ class NetSuiteGetIntercompanyJournalEntry(Tool):
                 params["fields"] = fields
 
             auth = _netsuite_auth_header("GET", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -2343,7 +2343,7 @@ class NetSuiteListIntercompanyJournalEntries(Tool):
                 params["q"] = query
 
             auth = _netsuite_auth_header("GET", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(url, headers={"Authorization": auth, "Content-Type": "application/json"}, params=params)
                 response.raise_for_status()
                 return response.json()
@@ -2389,7 +2389,7 @@ class NetSuiteUpdateIntercompanyJournalEntry(Tool):
             import httpx
 
             auth = _netsuite_auth_header("PATCH", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(url, headers={"Authorization": auth, "Content-Type": "application/json"}, json=data)
                 response.raise_for_status()
                 return {"updated": True, "record_type": "intercompanyjournalentry", "record_id": record_id}
@@ -2452,7 +2452,7 @@ class NetSuiteCreateBinTransfer(Tool):
                 data["inventory"] = {"items": inventory}
 
             auth = _netsuite_auth_header("POST", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     url,
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -2508,7 +2508,7 @@ class NetSuiteDeleteBinTransfer(Tool):
             import httpx
 
             auth = _netsuite_auth_header("DELETE", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(url, headers={"Authorization": auth, "Content-Type": "application/json"})
                 response.raise_for_status()
                 return {"deleted": True, "record_type": "bintransfer", "record_id": record_id}
@@ -2558,7 +2558,7 @@ class NetSuiteGetBinTransfer(Tool):
                 params["fields"] = fields
 
             auth = _netsuite_auth_header("GET", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -2613,7 +2613,7 @@ class NetSuiteListBinTransfers(Tool):
                 params["q"] = query
 
             auth = _netsuite_auth_header("GET", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(url, headers={"Authorization": auth, "Content-Type": "application/json"}, params=params)
                 response.raise_for_status()
                 return response.json()
@@ -2659,7 +2659,7 @@ class NetSuiteUpdateBinTransfer(Tool):
             import httpx
 
             auth = _netsuite_auth_header("PATCH", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(url, headers={"Authorization": auth, "Content-Type": "application/json"}, json=data)
                 response.raise_for_status()
                 return {"updated": True, "record_type": "bintransfer", "record_id": record_id}
@@ -2705,7 +2705,7 @@ class NetSuiteUpsertBinTransfer(Tool):
             import httpx
 
             auth = _netsuite_auth_header("PUT", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(url, headers={"Authorization": auth, "Content-Type": "application/json"}, json=data)
                 response.raise_for_status()
                 return {"upserted": True, "record_type": "bintransfer", "external_id": external_id}
@@ -2772,7 +2772,7 @@ class NetSuiteCreateAccountingPeriod(Tool):
                 data["isYear"] = is_year
 
             auth = _netsuite_auth_header("POST", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     url,
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -2828,7 +2828,7 @@ class NetSuiteDeleteAccountingPeriod(Tool):
             import httpx
 
             auth = _netsuite_auth_header("DELETE", url, account_id, consumer_key, consumer_secret, token_id, token_secret)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(url, headers={"Authorization": auth, "Content-Type": "application/json"})
                 response.raise_for_status()
                 return {"deleted": True, "record_type": "accountingperiod", "record_id": record_id}

--- a/python/timbal/tools/onedrive.py
+++ b/python/timbal/tools/onedrive.py
@@ -33,7 +33,7 @@ class OneDriveSearchFiles(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/me/drive/root/search(q='{query}')",
                     headers={"Authorization": f"Bearer {token}"},
@@ -68,7 +68,7 @@ class OneDriveUploadFile(Tool):
             import httpx
 
             if url:
-                async with httpx.AsyncClient() as client:
+                async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                     response = await client.get(url, timeout=httpx.Timeout(30.0, read=None))
                     response.raise_for_status()
                     content = response.text
@@ -77,7 +77,7 @@ class OneDriveUploadFile(Tool):
             if folder_id:
                 upload_url = f"{_BASE_URL}/me/drive/items/{folder_id}:/{name}:/content"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.put(
                     upload_url,
                     headers={"Authorization": f"Bearer {token}"},
@@ -113,7 +113,7 @@ class OneDriveListFiles(Tool):
             if folder_id:
                 url = f"{_BASE_URL}/me/drive/items/{folder_id}/children"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={"Authorization": f"Bearer {token}"},
@@ -142,7 +142,7 @@ class OneDriveGetFile(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient(follow_redirects=True) as client:
+            async with httpx.AsyncClient(follow_redirects=True, timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 metadata_response = await client.get(
                     f"{_BASE_URL}/me/drive/items/{file_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -189,7 +189,7 @@ class OneDriveFindFile(Tool):
             if folder_id:
                 search_url = f"{_BASE_URL}/me/drive/items/{folder_id}/search(q='{name}')"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     search_url,
                     headers={"Authorization": f"Bearer {token}"},
@@ -225,7 +225,7 @@ class OneDriveDownloadFile(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient(follow_redirects=True) as client:
+            async with httpx.AsyncClient(follow_redirects=True, timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/me/drive/items/{file_id}/content",
                     headers={"Authorization": f"Bearer {token}"},

--- a/python/timbal/tools/outlook.py
+++ b/python/timbal/tools/outlook.py
@@ -63,7 +63,7 @@ class OutlookReadEmails(Tool):
             if select:
                 params["$select"] = ",".join(select)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/me/mailFolders/{folder}/messages",
                     headers={"Authorization": f"Bearer {token}"},
@@ -99,7 +99,7 @@ class OutlookSend(Tool):
         async def _download_and_encode(url: str) -> str:
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(url)
                 response.raise_for_status()
                 return base64.b64encode(response.content).decode("utf-8")
@@ -173,7 +173,7 @@ class OutlookSend(Tool):
 
                 message["attachments"] = attachment_data
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/me/sendMail",
                     headers={"Authorization": f"Bearer {token}"},
@@ -218,7 +218,7 @@ class OutlookUpdateEmail(Tool):
             if categories is not None:
                 body["categories"] = categories
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{_BASE_URL}/me/messages/{message_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -271,7 +271,7 @@ class OutlookCreateDraft(Tool):
             if bcc:
                 message["bccRecipients"] = _address_list(bcc)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/me/messages",
                     headers={"Authorization": f"Bearer {token}"},
@@ -313,7 +313,7 @@ class OutlookForward(Tool):
             if comment:
                 body["comment"] = comment
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/me/messages/{message_id}/forward",
                     headers={"Authorization": f"Bearer {token}"},
@@ -347,7 +347,7 @@ class OutlookArchive(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/me/messages/{message_id}/move",
                     headers={"Authorization": f"Bearer {token}"},
@@ -381,7 +381,7 @@ class OutlookTrash(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/me/messages/{message_id}/move",
                     headers={"Authorization": f"Bearer {token}"},
@@ -500,7 +500,7 @@ class OutlookListEvents(Tool):
             if timezone:
                 headers["Prefer"] = f'outlook.timezone="{timezone}"'
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(url, headers=headers, params=params)
                 response.raise_for_status()
                 return response.json()
@@ -558,7 +558,7 @@ class OutlookGetEvent(Tool):
             if timezone:
                 headers["Prefer"] = f'outlook.timezone="{timezone}"'
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(url, headers=headers, params=params)
                 response.raise_for_status()
                 return response.json()
@@ -614,7 +614,7 @@ class OutlookGetSchedule(Tool):
                 "availabilityViewInterval": availability_view_interval,
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/me/calendar/getSchedule",
                     headers={"Authorization": f"Bearer {token}"},
@@ -697,7 +697,7 @@ class OutlookFindMeetingTimes(Tool):
                     ]
                 }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/me/findMeetingTimes",
                     headers={"Authorization": f"Bearer {token}"},
@@ -802,7 +802,7 @@ class OutlookCreateEvent(Tool):
             if calendar_id:
                 base = f"{base}/calendars/{calendar_id}"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base}/events",
                     headers={"Authorization": f"Bearer {token}"},
@@ -901,7 +901,7 @@ class OutlookManageEvent(Tool):
             event_url = f"{base}/events/{event_id}"
             headers = {"Authorization": f"Bearer {token}"}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 if action == "update":
                     body_payload: dict[str, Any] = {}
                     if subject is not None:
@@ -991,7 +991,7 @@ class OutlookGetAttachments(Tool):
             if not include_content:
                 params["$select"] = "id,name,contentType,size,isInline,lastModifiedDateTime"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/me/messages/{message_id}/attachments",
                     headers={"Authorization": f"Bearer {token}"},

--- a/python/timbal/tools/pinecone.py
+++ b/python/timbal/tools/pinecone.py
@@ -45,7 +45,7 @@ class PineconeListIndexes(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/indexes",
                     headers={"Api-Key": api_key},
@@ -89,7 +89,7 @@ class PineconeCreateIndex(Tool):
                 "deletion_protection": deletion_protection,
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/indexes",
                     headers={"Api-Key": api_key, "Content-Type": "application/json"},
@@ -126,7 +126,7 @@ class PineconeIndexStats(Tool):
             if metadata_filter:
                 body["filter"] = metadata_filter
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"https://{index_host}/describe_index_stats",
                     headers={"Api-Key": api_key},
@@ -162,7 +162,7 @@ class PineconeUpsertVectors(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"https://{index_host}/vectors/upsert",
                     headers={"Api-Key": api_key},
@@ -212,7 +212,7 @@ class PineconeQuery(Tool):
             if metadata_filter:
                 body["filter"] = metadata_filter
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"https://{index_host}/query",
                     headers={"Api-Key": api_key},
@@ -250,7 +250,7 @@ class PineconeFetchVectors(Tool):
             if namespace:
                 params["namespace"] = namespace
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"https://{index_host}/vectors/fetch",
                     headers={"Api-Key": api_key},
@@ -296,7 +296,7 @@ class PineconeDeleteVectors(Tool):
             if metadata_filter:
                 body["filter"] = metadata_filter
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"https://{index_host}/vectors/delete",
                     headers={"Api-Key": api_key},

--- a/python/timbal/tools/powerbi.py
+++ b/python/timbal/tools/powerbi.py
@@ -63,7 +63,7 @@ class PowerBIListWorkspaces(Tool):
             if filter:
                 params["$filter"] = filter
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/groups",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -95,7 +95,7 @@ class PowerBIListDatasets(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     _datasets_url(workspace_id),
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -127,7 +127,7 @@ class PowerBIGetDataset(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     _datasets_url(workspace_id, f"/{dataset_id}"),
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -165,7 +165,7 @@ class PowerBIQueryDataset(Tool):
             if impersonated_user_name:
                 body["impersonatedUserName"] = impersonated_user_name
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     _datasets_url(workspace_id, f"/{dataset_id}/executeQueries"),
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -195,7 +195,7 @@ class PowerBIListReports(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     _reports_url(workspace_id),
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -227,7 +227,7 @@ class PowerBIGetReport(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     _reports_url(workspace_id, f"/{report_id}"),
                     headers={"Authorization": f"Bearer {api_key}"},

--- a/python/timbal/tools/quiver_ai.py
+++ b/python/timbal/tools/quiver_ai.py
@@ -111,7 +111,7 @@ class QuiverAIGenerateSVG(Tool):
             if normalized_refs:
                 payload["references"] = normalized_refs
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/svgs/generations",
                     headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
@@ -178,7 +178,7 @@ class QuiverAIVectorizeSVG(Tool):
             if max_output_tokens is not None:
                 payload["max_output_tokens"] = max_output_tokens
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/svgs/vectorizations",
                     headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
@@ -212,7 +212,7 @@ class QuiverAIListModels(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/models",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -244,7 +244,7 @@ class QuiverAIGetModel(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/models/{model}",
                     headers={"Authorization": f"Bearer {api_key}"},

--- a/python/timbal/tools/replicate.py
+++ b/python/timbal/tools/replicate.py
@@ -77,7 +77,7 @@ class ReplicateCreatePrediction(Tool):
                 w = max(1, min(60, prefer_wait_seconds))
                 headers["Prefer"] = f"wait={w}"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/predictions",
                     headers=headers,
@@ -110,7 +110,7 @@ class ReplicateGetPrediction(Tool):
             api_token = await _resolve_api_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/predictions/{prediction_id}",
                     headers=_replicate_headers(api_token),
@@ -142,7 +142,7 @@ class ReplicateCancelPrediction(Tool):
             api_token = await _resolve_api_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/predictions/{prediction_id}/cancel",
                     headers=_replicate_headers(api_token),
@@ -182,7 +182,7 @@ class ReplicateSearchModels(Tool):
             import httpx
 
             lim = max(1, min(50, limit))
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/search",
                     headers=_replicate_headers(api_token),

--- a/python/timbal/tools/resend.py
+++ b/python/timbal/tools/resend.py
@@ -183,7 +183,7 @@ class ResendSendEmail(Tool):
             key = await _resolve_api_key(integration=self.integration, api_key=self.api_key)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/emails",
                     headers=_headers(key, idempotency_key=idempotency_key),
@@ -243,7 +243,7 @@ class ResendSendBatch(Tool):
             key = await _resolve_api_key(integration=self.integration, api_key=self.api_key)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/emails/batch",
                     headers=_headers(key, idempotency_key=idempotency_key),
@@ -278,7 +278,7 @@ class ResendListEmails(Tool):
             if after:
                 params["after"] = after
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/emails",
                     headers=_headers(key),
@@ -309,7 +309,7 @@ class ResendGetEmail(Tool):
             key = await _resolve_api_key(integration=self.integration, api_key=self.api_key)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/emails/{email_id}",
                     headers=_headers(key),
@@ -343,7 +343,7 @@ class ResendUpdateEmail(Tool):
             key = await _resolve_api_key(integration=self.integration, api_key=self.api_key)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{_BASE_URL}/emails/{email_id}",
                     headers=_headers(key),
@@ -374,7 +374,7 @@ class ResendCancelEmail(Tool):
             key = await _resolve_api_key(integration=self.integration, api_key=self.api_key)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/emails/{email_id}/cancel",
                     headers=_headers(key),
@@ -404,7 +404,7 @@ class ResendListEmailAttachments(Tool):
             key = await _resolve_api_key(integration=self.integration, api_key=self.api_key)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/emails/{email_id}/attachments",
                     headers=_headers(key),
@@ -435,7 +435,7 @@ class ResendGetEmailAttachment(Tool):
             key = await _resolve_api_key(integration=self.integration, api_key=self.api_key)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/emails/{email_id}/attachments/{attachment_id}",
                     headers=_headers(key),
@@ -469,7 +469,7 @@ class ResendListReceivedEmails(Tool):
             if after:
                 params["after"] = after
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/emails/receiving",
                     headers=_headers(key),
@@ -500,7 +500,7 @@ class ResendGetReceivedEmail(Tool):
             key = await _resolve_api_key(integration=self.integration, api_key=self.api_key)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/emails/receiving/{email_id}",
                     headers=_headers(key),
@@ -530,7 +530,7 @@ class ResendListReceivedAttachments(Tool):
             key = await _resolve_api_key(integration=self.integration, api_key=self.api_key)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/emails/receiving/{email_id}/attachments",
                     headers=_headers(key),
@@ -561,7 +561,7 @@ class ResendGetReceivedAttachment(Tool):
             key = await _resolve_api_key(integration=self.integration, api_key=self.api_key)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/emails/receiving/{email_id}/attachments/{attachment_id}",
                     headers=_headers(key),

--- a/python/timbal/tools/salesforce.py
+++ b/python/timbal/tools/salesforce.py
@@ -73,7 +73,7 @@ class SalesforceCreateCase(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     _sf(instance_url, "sobjects/Case/"),
                     headers={"Authorization": f"Bearer {token}"},
@@ -136,7 +136,7 @@ class SalesforceUpdateCase(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     _sf(instance_url, f"sobjects/Case/{case_id}"),
                     headers={"Authorization": f"Bearer {token}"},
@@ -170,7 +170,7 @@ class SalesforceDeleteCase(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     _sf(instance_url, f"sobjects/Case/{case_id}"),
                     headers={"Authorization": f"Bearer {token}"},
@@ -205,7 +205,7 @@ class SalesforceCreateComment(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     _sf(instance_url, "sobjects/CaseComment/"),
                     headers={"Authorization": f"Bearer {token}"},
@@ -247,7 +247,7 @@ class SalesforceUpdateComment(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     _sf(instance_url, f"sobjects/CaseComment/{comment_id}"),
                     headers={"Authorization": f"Bearer {token}"},
@@ -281,7 +281,7 @@ class SalesforceDeleteComment(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     _sf(instance_url, f"sobjects/CaseComment/{comment_id}"),
                     headers={"Authorization": f"Bearer {token}"},
@@ -340,7 +340,7 @@ class SalesforceCreateContact(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     _sf(instance_url, "sobjects/Contact/"),
                     headers={"Authorization": f"Bearer {token}"},
@@ -403,7 +403,7 @@ class SalesforceUpdateContact(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     _sf(instance_url, f"sobjects/Contact/{contact_id}"),
                     headers={"Authorization": f"Bearer {token}"},
@@ -437,7 +437,7 @@ class SalesforceDeleteContact(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     _sf(instance_url, f"sobjects/Contact/{contact_id}"),
                     headers={"Authorization": f"Bearer {token}"},
@@ -505,7 +505,7 @@ class SalesforceCreateLead(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     _sf(instance_url, "sobjects/Lead/"),
                     headers={"Authorization": f"Bearer {token}"},
@@ -544,7 +544,7 @@ class SalesforceGetLead(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={"Authorization": f"Bearer {token}"},
@@ -609,7 +609,7 @@ class SalesforceUpdateLead(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     _sf(instance_url, f"sobjects/Lead/{lead_id}"),
                     headers={"Authorization": f"Bearer {token}"},
@@ -643,7 +643,7 @@ class SalesforceDeleteLead(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     _sf(instance_url, f"sobjects/Lead/{lead_id}"),
                     headers={"Authorization": f"Bearer {token}"},
@@ -681,7 +681,7 @@ class SalesforceSearchLeads(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     _sf(instance_url, "search/"),
                     headers={"Authorization": f"Bearer {token}"},
@@ -741,7 +741,7 @@ class SalesforceCreateOpportunity(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     _sf(instance_url, "sobjects/Opportunity/"),
                     headers={"Authorization": f"Bearer {token}"},
@@ -801,7 +801,7 @@ class SalesforceUpdateOpportunity(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     _sf(instance_url, f"sobjects/Opportunity/{opportunity_id}"),
                     headers={"Authorization": f"Bearer {token}"},
@@ -835,7 +835,7 @@ class SalesforceDeleteOpportunity(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     _sf(instance_url, f"sobjects/Opportunity/{opportunity_id}"),
                     headers={"Authorization": f"Bearer {token}"},
@@ -890,7 +890,7 @@ class SalesforceCreateTask(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     _sf(instance_url, "sobjects/Task/"),
                     headers={"Authorization": f"Bearer {token}"},
@@ -929,7 +929,7 @@ class SalesforceGetTask(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={"Authorization": f"Bearer {token}"},
@@ -982,7 +982,7 @@ class SalesforceUpdateTask(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     _sf(instance_url, f"sobjects/Task/{task_id}"),
                     headers={"Authorization": f"Bearer {token}"},
@@ -1016,7 +1016,7 @@ class SalesforceDeleteTask(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     _sf(instance_url, f"sobjects/Task/{task_id}"),
                     headers={"Authorization": f"Bearer {token}"},
@@ -1054,7 +1054,7 @@ class SalesforceSearchTasks(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     _sf(instance_url, "search/"),
                     headers={"Authorization": f"Bearer {token}"},
@@ -1091,7 +1091,7 @@ class SalesforceQuery(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     _sf(instance_url, endpoint),
                     headers={"Authorization": f"Bearer {token}"},
@@ -1126,7 +1126,7 @@ class SalesforceCreateRecord(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     _sf(instance_url, f"sobjects/{object_type}/"),
                     headers={"Authorization": f"Bearer {token}"},

--- a/python/timbal/tools/scraperapi.py
+++ b/python/timbal/tools/scraperapi.py
@@ -88,7 +88,7 @@ class ScraperAPIScrape(Tool):
             if retry_404:
                 params["retry_404"] = "true"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     _BASE_URL,
                     params=params,
@@ -148,7 +148,7 @@ class ScraperAPIAsyncScrape(Tool):
             if premium:
                 payload["premium"] = "true"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 # Submit the job.
                 response = await client.post(
                     f"{_ASYNC_URL}/jobs",
@@ -223,7 +223,7 @@ class ScraperAPIGoogleSearch(Tool):
             if tbs:
                 params["tbs"] = tbs
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_STRUCTURED_URL}/google/search",
                     params=params,
@@ -270,7 +270,7 @@ class ScraperAPIAmazonProduct(Tool):
             if tld:
                 params["tld"] = tld
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_STRUCTURED_URL}/amazon/product",
                     params=params,
@@ -317,7 +317,7 @@ class ScraperAPIAmazonSearch(Tool):
             if tld:
                 params["tld"] = tld
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_STRUCTURED_URL}/amazon/search",
                     params=params,

--- a/python/timbal/tools/sharepoint.py
+++ b/python/timbal/tools/sharepoint.py
@@ -35,7 +35,7 @@ class SharePointSearchSites(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/sites",
                     params={"search": query},
@@ -75,7 +75,7 @@ class SharePointGetSite(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/sites/{site_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -106,7 +106,7 @@ class SharePointListDrives(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/sites/{site_id}/drives",
                     headers={"Authorization": f"Bearer {token}"},
@@ -148,7 +148,7 @@ class SharePointListFiles(Tool):
             if folder_id:
                 url = f"{_BASE_URL}/sites/{site_id}/drive/items/{folder_id}/children"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={"Authorization": f"Bearer {token}"},
@@ -180,7 +180,7 @@ class SharePointSearchFiles(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/sites/{site_id}/drive/root/search(q='{query}')",
                     headers={"Authorization": f"Bearer {token}"},
@@ -213,7 +213,7 @@ class SharePointGetFile(Tool):
             import base64
             import httpx
 
-            async with httpx.AsyncClient(follow_redirects=True) as client:
+            async with httpx.AsyncClient(follow_redirects=True, timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 metadata_response = await client.get(
                     f"{_BASE_URL}/sites/{site_id}/drive/items/{file_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -273,7 +273,7 @@ class SharePointDownloadFile(Tool):
             import base64
             import httpx
 
-            async with httpx.AsyncClient(follow_redirects=True) as client:
+            async with httpx.AsyncClient(follow_redirects=True, timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/sites/{site_id}/drive/items/{file_id}/content",
                     headers={"Authorization": f"Bearer {token}"},
@@ -334,7 +334,7 @@ class SharePointMoveItem(Tool):
             if new_name:
                 payload["name"] = new_name
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{_BASE_URL}/sites/{site_id}/drive/items/{item_id}",
                     headers={
@@ -388,7 +388,7 @@ class SharePointCopyItem(Tool):
             if new_name:
                 payload["name"] = new_name
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/sites/{site_id}/drive/items/{item_id}/copy",
                     headers={
@@ -430,7 +430,7 @@ class SharePointListPermissions(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/sites/{site_id}/drive/items/{item_id}/permissions",
                     headers={"Authorization": f"Bearer {token}"},
@@ -481,7 +481,7 @@ class SharePointInvite(Tool):
             if message:
                 payload["message"] = message
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/sites/{site_id}/drive/items/{item_id}/invite",
                     headers={
@@ -538,7 +538,7 @@ class SharePointCreateShareLink(Tool):
             if expiration_datetime:
                 payload["expirationDateTime"] = expiration_datetime
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/sites/{site_id}/drive/items/{item_id}/createLink",
                     headers={
@@ -575,7 +575,7 @@ class SharePointDeletePermission(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{_BASE_URL}/sites/{site_id}/drive/items/{item_id}/permissions/{permission_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -620,7 +620,7 @@ class SharePointUploadFile(Tool):
             import httpx
 
             if url:
-                async with httpx.AsyncClient() as client:
+                async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                     response = await client.get(url, timeout=httpx.Timeout(30.0, read=None))
                     response.raise_for_status()
                     content = response.text
@@ -629,7 +629,7 @@ class SharePointUploadFile(Tool):
             if folder_id:
                 upload_url = f"{_BASE_URL}/sites/{site_id}/drive/items/{folder_id}:/{name}:/content"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.put(
                     upload_url,
                     headers={"Authorization": f"Bearer {token}"},
@@ -662,7 +662,7 @@ class SharePointDeleteItem(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{_BASE_URL}/sites/{site_id}/drive/items/{item_id}",
                     headers={"Authorization": f"Bearer {token}"},
@@ -709,7 +709,7 @@ class SharePointCreateFolder(Tool):
                 "@microsoft.graph.conflictBehavior": "rename",
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.post(
                     url,
                     headers={
@@ -744,7 +744,7 @@ class SharePointListLists(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/sites/{site_id}/lists",
                     headers={"Authorization": f"Bearer {token}"},
@@ -784,7 +784,7 @@ class SharePointGetListItems(Tool):
             if top is not None:
                 params["$top"] = top
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/sites/{site_id}/lists/{list_id}/items",
                     params=params,
@@ -823,7 +823,7 @@ class SharePointCreateListItem(Tool):
 
             payload = {"fields": fields}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/sites/{site_id}/lists/{list_id}/items",
                     headers={
@@ -864,7 +864,7 @@ class SharePointUpdateListItem(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{_BASE_URL}/sites/{site_id}/lists/{list_id}/items/{item_id}/fields",
                     headers={
@@ -901,7 +901,7 @@ class SharePointDeleteListItem(Tool):
             token = await _resolve_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{_BASE_URL}/sites/{site_id}/lists/{list_id}/items/{item_id}",
                     headers={"Authorization": f"Bearer {token}"},

--- a/python/timbal/tools/shopify.py
+++ b/python/timbal/tools/shopify.py
@@ -47,7 +47,7 @@ class ShopifyGetShopDetails(Tool):
             token, shop_url = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_shopify_base(shop_url)}/shop.json",
                     headers={"X-Shopify-Access-Token": token},
@@ -99,7 +99,7 @@ class ShopifyGetProducts(Tool):
             if ids:
                 params["ids"] = ",".join(ids)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_shopify_base(shop_url)}/products.json",
                     headers={"X-Shopify-Access-Token": token},
@@ -130,7 +130,7 @@ class ShopifyGetProduct(Tool):
             token, shop_url = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_shopify_base(shop_url)}/products/{product_id}.json",
                     headers={"X-Shopify-Access-Token": token},
@@ -186,7 +186,7 @@ class ShopifyCreateProduct(Tool):
             if images:
                 product["images"] = images
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_shopify_base(shop_url)}/products.json",
                     headers={"X-Shopify-Access-Token": token},
@@ -217,7 +217,7 @@ class ShopifyDeleteProduct(Tool):
             token, shop_url = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{_shopify_base(shop_url)}/products/{product_id}.json",
                     headers={"X-Shopify-Access-Token": token},
@@ -256,7 +256,7 @@ class ShopifyGetInventoryLevel(Tool):
             if location_ids:
                 params["location_ids"] = ",".join(location_ids)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_shopify_base(shop_url)}/inventory_levels.json",
                     headers={"X-Shopify-Access-Token": token},
@@ -291,7 +291,7 @@ class ShopifyAdjustInventory(Tool):
             token, shop_url = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_shopify_base(shop_url)}/inventory_levels/adjust.json",
                     headers={"X-Shopify-Access-Token": token},
@@ -329,7 +329,7 @@ class ShopifyUpdateInventoryTracking(Tool):
             token, shop_url = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{_shopify_base(shop_url)}/inventory_items/{inventory_item_id}.json",
                     headers={"X-Shopify-Access-Token": token},
@@ -360,7 +360,7 @@ class ShopifyGetVariantInventoryItem(Tool):
             token, shop_url = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_shopify_base(shop_url)}/variants/{variant_id}.json",
                     headers={"X-Shopify-Access-Token": token},

--- a/python/timbal/tools/slack.py
+++ b/python/timbal/tools/slack.py
@@ -77,7 +77,7 @@ class SlackReadMessages(Tool):
             if latest:
                 params["latest"] = latest
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/conversations.history",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -142,7 +142,7 @@ class SlackSendMessage(Tool):
             if icon_url:
                 body["icon_url"] = icon_url
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/chat.postMessage",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -188,7 +188,7 @@ class SlackSendEphemeralMessage(Tool):
             if thread_ts:
                 body["thread_ts"] = thread_ts
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/chat.postEphemeral",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -230,7 +230,7 @@ class SlackCreateCanvas(Tool):
             if channel_id:
                 body["channel_id"] = channel_id
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/canvases.create",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -266,7 +266,7 @@ class SlackDeleteMessage(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/chat.delete",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -307,7 +307,7 @@ class SlackGetMessageThread(Tool):
             if cursor:
                 params["cursor"] = cursor
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/conversations.replies",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -342,7 +342,7 @@ class SlackPinMessage(Tool):
             channel_id = await _resolve_channel_id(self, channel)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/pins.add",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -377,7 +377,7 @@ class SlackUnpinMessage(Tool):
             channel_id = await _resolve_channel_id(self, channel)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/pins.remove",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -409,7 +409,7 @@ class SlackListPinnedItems(Tool):
             channel_id = await _resolve_channel_id(self, channel)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/pins.list",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -439,7 +439,7 @@ class SlackGetUserPresence(Tool):
             api_token = await _resolve_api_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/users.getPresence",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -478,7 +478,7 @@ class SlackSearchUsers(Tool):
             api_token = await _resolve_api_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 if email:
                     response = await client.get(
                         f"{_BASE_URL}/users.lookupByEmail",
@@ -531,7 +531,7 @@ class SlackAddUserToChannel(Tool):
             channel_id = await _resolve_channel_id(self, channel)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/conversations.invite",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -566,7 +566,7 @@ class SlackRemoveFromChannel(Tool):
             channel_id = await _resolve_channel_id(self, channel)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/conversations.kick",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -610,7 +610,7 @@ class SlackListUsersInChannel(Tool):
             if cursor:
                 params["cursor"] = cursor
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/conversations.members",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -645,7 +645,7 @@ class SlackUpdateChannelTopic(Tool):
             channel_id = await _resolve_channel_id(self, channel)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/conversations.setTopic",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -680,7 +680,7 @@ class SlackUpdateChannelPurpose(Tool):
             channel_id = await _resolve_channel_id(self, channel)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/conversations.setPurpose",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -712,7 +712,7 @@ class SlackArchiveChannel(Tool):
             channel_id = await _resolve_channel_id(self, channel)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/conversations.archive",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -744,7 +744,7 @@ class SlackUnarchiveChannel(Tool):
             channel_id = await _resolve_channel_id(self, channel)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/conversations.unarchive",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -780,7 +780,7 @@ class SlackGetConversationInfo(Tool):
             channel_id = await _resolve_channel_id(self, channel)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/conversations.info",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -828,7 +828,7 @@ class SlackListChannels(Tool):
             if cursor:
                 params["cursor"] = cursor
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/conversations.list",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -869,7 +869,7 @@ class SlackAddReaction(Tool):
             channel_id = await _resolve_channel_id(self, channel)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/reactions.add",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -905,7 +905,7 @@ class SlackRemoveReaction(Tool):
             channel_id = await _resolve_channel_id(self, channel)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/reactions.remove",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -962,7 +962,7 @@ class SlackListFiles(Tool):
             if ts_to:
                 params["ts_to"] = ts_to
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/files.list",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -992,7 +992,7 @@ class SlackGetFileInfo(Tool):
             api_token = await _resolve_api_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/files.info",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -1024,7 +1024,7 @@ class SlackDownloadFile(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     url_private,
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -1058,7 +1058,7 @@ class SlackDeleteFile(Tool):
             api_token = await _resolve_api_token(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/files.delete",
                     headers={"Authorization": f"Bearer {api_token}"},
@@ -1105,7 +1105,7 @@ class SlackSendAndWaitForResponse(Tool):
 
             headers = {"Authorization": f"Bearer {api_token}"}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 send_body: dict[str, Any] = {"channel": channel_id, "text": text}
                 if blocks:
                     send_body["blocks"] = blocks

--- a/python/timbal/tools/stripe.py
+++ b/python/timbal/tools/stripe.py
@@ -62,7 +62,7 @@ class ListCharges(Tool):
             if created_lte:
                 params["created[lte]"] = created_lte
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/charges",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -111,7 +111,7 @@ class CreateCustomer(Tool):
                 for k, v in metadata.items():
                     data[f"metadata[{k}]"] = v
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/customers",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -149,7 +149,7 @@ class SearchCustomer(Tool):
             if page:
                 params["page"] = page
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/customers/search",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -205,7 +205,7 @@ class CreatePayment(Tool):
                 for k, v in metadata.items():
                     data[f"metadata[{k}]"] = v
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/payment_intents",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -254,7 +254,7 @@ class SendRefund(Tool):
                 for k, v in metadata.items():
                     data[f"metadata[{k}]"] = v
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/refunds",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -306,7 +306,7 @@ class UpdateCustomer(Tool):
                 for k, v in metadata.items():
                     data[f"metadata[{k}]"] = v
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/customers/{customer_id}",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -338,7 +338,7 @@ class RetrieveCustomer(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/customers/{customer_id}",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -394,7 +394,7 @@ class ListCustomers(Tool):
             if created_lte:
                 params["created[lte]"] = created_lte
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/customers",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -426,7 +426,7 @@ class DeleteCustomer(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{_BASE_URL}/customers/{customer_id}",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -478,7 +478,7 @@ class UpdatePaymentIntent(Tool):
                 for k, v in metadata.items():
                     data[f"metadata[{k}]"] = v
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/payment_intents/{payment_intent_id}",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -512,7 +512,7 @@ class RetrievePaymentIntent(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/payment_intents/{payment_intent_id}",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -560,7 +560,7 @@ class ListPaymentIntents(Tool):
             if created_lte:
                 params["created[lte]"] = created_lte
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/payment_intents",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -600,7 +600,7 @@ class ConfirmPaymentIntent(Tool):
             if return_url:
                 data["return_url"] = return_url
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/payment_intents/{payment_intent_id}/confirm",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -637,7 +637,7 @@ class CapturePaymentIntent(Tool):
             if amount_to_capture is not None:
                 data["amount_to_capture"] = amount_to_capture
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/payment_intents/{payment_intent_id}/capture",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -674,7 +674,7 @@ class CancelPaymentIntent(Tool):
             if cancellation_reason:
                 data["cancellation_reason"] = cancellation_reason
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/payment_intents/{payment_intent_id}/cancel",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -712,7 +712,7 @@ class UpdateRefund(Tool):
                 for k, v in metadata.items():
                     data[f"metadata[{k}]"] = v
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/refunds/{refund_id}",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -744,7 +744,7 @@ class RetrieveRefund(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/refunds/{refund_id}",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -789,7 +789,7 @@ class ListRefunds(Tool):
             if ending_before:
                 params["ending_before"] = ending_before
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/refunds",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -839,7 +839,7 @@ class CreateInvoice(Tool):
                 for k, v in metadata.items():
                     data[f"metadata[{k}]"] = v
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/invoices",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -889,7 +889,7 @@ class UpdateInvoice(Tool):
                 for k, v in metadata.items():
                     data[f"metadata[{k}]"] = v
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/invoices/{invoice_id}",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -921,7 +921,7 @@ class RetrieveInvoice(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/invoices/{invoice_id}",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -969,7 +969,7 @@ class ListInvoices(Tool):
             if ending_before:
                 params["ending_before"] = ending_before
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/invoices",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1001,7 +1001,7 @@ class SendInvoice(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/invoices/{invoice_id}/send",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1037,7 +1037,7 @@ class FinalizeInvoice(Tool):
             if auto_advance is not None:
                 data["auto_advance"] = str(auto_advance).lower()
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/invoices/{invoice_id}/finalize",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1069,7 +1069,7 @@ class VoidInvoice(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/invoices/{invoice_id}/void",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1100,7 +1100,7 @@ class WriteOffInvoice(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/invoices/{invoice_id}/mark_uncollectible",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1131,7 +1131,7 @@ class DeleteOrVoidInvoice(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 headers = {"Authorization": f"Bearer {api_key}"}
                 get_response = await client.get(
                     f"{_BASE_URL}/invoices/{invoice_id}",
@@ -1200,7 +1200,7 @@ class CreateInvoiceLineItem(Tool):
                 for k, v in metadata.items():
                     data[f"metadata[{k}]"] = v
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/invoiceitems",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1247,7 +1247,7 @@ class UpdateInvoiceLineItem(Tool):
                 for k, v in metadata.items():
                     data[f"metadata[{k}]"] = v
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/invoiceitems/{invoice_item_id}",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1279,7 +1279,7 @@ class RetrieveInvoiceLineItem(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/invoiceitems/{invoice_item_id}",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1310,7 +1310,7 @@ class DeleteInvoiceLineItem(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{_BASE_URL}/invoiceitems/{invoice_item_id}",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1357,7 +1357,7 @@ class CreateSubscription(Tool):
                 for k, v in metadata.items():
                     data[f"metadata[{k}]"] = v
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/subscriptions",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1395,7 +1395,7 @@ class SearchSubscriptions(Tool):
             if page:
                 params["page"] = page
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/subscriptions/search",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1429,7 +1429,7 @@ class CancelSubscription(Tool):
             import httpx
 
             if cancel_at_period_end:
-                async with httpx.AsyncClient() as client:
+                async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                     response = await client.post(
                         f"{_BASE_URL}/subscriptions/{subscription_id}",
                         headers={"Authorization": f"Bearer {api_key}"},
@@ -1438,7 +1438,7 @@ class CancelSubscription(Tool):
                     response.raise_for_status()
                     return response.json()
             else:
-                async with httpx.AsyncClient() as client:
+                async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                     response = await client.delete(
                         f"{_BASE_URL}/subscriptions/{subscription_id}",
                         headers={"Authorization": f"Bearer {api_key}"},
@@ -1482,7 +1482,7 @@ class CreateProduct(Tool):
                 for k, v in metadata.items():
                     data[f"metadata[{k}]"] = v
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/products",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1514,7 +1514,7 @@ class RetrieveProduct(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/products/{product_id}",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1556,7 +1556,7 @@ class ListProducts(Tool):
             if ending_before:
                 params["ending_before"] = ending_before
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/products",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1606,7 +1606,7 @@ class CreatePrice(Tool):
                 for k, v in metadata.items():
                     data[f"metadata[{k}]"] = v
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/prices",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1638,7 +1638,7 @@ class RetrievePrice(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/prices/{price_id}",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1685,7 +1685,7 @@ class CreatePayout(Tool):
                 for k, v in metadata.items():
                     data[f"metadata[{k}]"] = v
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/payouts",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1723,7 +1723,7 @@ class UpdatePayout(Tool):
                 for k, v in metadata.items():
                     data[f"metadata[{k}]"] = v
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/payouts/{payout_id}",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1755,7 +1755,7 @@ class RetrievePayout(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/payouts/{payout_id}",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1803,7 +1803,7 @@ class ListPayouts(Tool):
             if arrival_date_lte:
                 params["arrival_date[lte]"] = arrival_date_lte
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/payouts",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1842,7 +1842,7 @@ class CancelOrReversePayout(Tool):
                 for k, v in metadata.items():
                     data[f"metadata[{k}]"] = v
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/payouts/{payout_id}/{action}",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1872,7 +1872,7 @@ class RetrieveBalance(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/balance",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1920,7 +1920,7 @@ class ListBalanceHistory(Tool):
             if created_lte:
                 params["created[lte]"] = created_lte
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/balance_transactions",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1952,7 +1952,7 @@ class RetrieveCheckoutSession(Tool):
             api_key = await _resolve_api_key(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/checkout/sessions/{session_id}",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -1989,7 +1989,7 @@ class RetrieveCheckoutSessionLineItems(Tool):
             if starting_after:
                 params["starting_after"] = starting_after
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/checkout/sessions/{session_id}/line_items",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -2029,7 +2029,7 @@ class CreateBillingMeter(Tool):
                 "default_aggregation[formula]": aggregation_formula,
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/billing/meters",
                     headers={"Authorization": f"Bearer {api_key}"},
@@ -2071,7 +2071,7 @@ class CreateUsageRecord(Tool):
             if timestamp is not None:
                 data["timestamp"] = timestamp
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/subscription_items/{subscription_item_id}/usage_records",
                     headers={"Authorization": f"Bearer {api_key}"},

--- a/python/timbal/tools/tavily.py
+++ b/python/timbal/tools/tavily.py
@@ -64,7 +64,7 @@ class TavilySearch(Tool):
             if exclude_domains:
                 payload["exclude_domains"] = exclude_domains
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/search",
                     headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
@@ -107,7 +107,7 @@ class TavilyExtract(Tool):
                 "format": format,
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/extract",
                     headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
@@ -170,7 +170,7 @@ class TavilyCrawl(Tool):
             if exclude_paths:
                 payload["exclude_paths"] = exclude_paths
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/crawl",
                     headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
@@ -227,7 +227,7 @@ class TavilyMap(Tool):
             if exclude_paths:
                 payload["exclude_paths"] = exclude_paths
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{_BASE_URL}/map",
                     headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},

--- a/python/timbal/tools/web_search.py
+++ b/python/timbal/tools/web_search.py
@@ -95,7 +95,7 @@ def _make_tavily_handler(
         if blocked_domains:
             payload["exclude_domains"] = blocked_domains
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
             response = await client.post(
                 f"{_TAVILY_BASE_URL}/search",
                 headers={"Authorization": f"Bearer {resolved_key}", "Content-Type": "application/json"},
@@ -134,7 +134,7 @@ def _make_scraperapi_handler(*, integration=None, api_key=None, user_location=No
         if start is not None:
             params["start"] = start
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
             response = await client.get(
                 f"{_SCRAPERAPI_STRUCTURED_URL}/google/search",
                 params=params,
@@ -196,7 +196,7 @@ def _make_firecrawl_handler(*, integration=None, api_key=None, max_results=None)
         if country:
             payload["country"] = country
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
             response = await client.post(
                 f"{_FIRECRAWL_BASE_URL}/search",
                 headers={"Authorization": f"Bearer {resolved_key}", "Content-Type": "application/json"},
@@ -284,7 +284,7 @@ def _make_google_handler(
         if date_restrict:
             params["dateRestrict"] = date_restrict
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
             response = await client.get(
                 _GOOGLE_BASE_URL,
                 params=params,

--- a/python/timbal/tools/zendesk.py
+++ b/python/timbal/tools/zendesk.py
@@ -98,7 +98,7 @@ class ZendeskCreateTicket(Tool):
             if tags:
                 ticket["tags"] = tags
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/tickets.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -142,7 +142,7 @@ class ZendeskListTickets(Tool):
 
             params = {"per_page": per_page, "page": page, "sort_by": sort_by, "sort_order": sort_order}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/tickets.json",
                     headers={"Authorization": auth},
@@ -181,7 +181,7 @@ class ZendeskShowTicket(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/tickets/{ticket_id}.json",
                     headers={"Authorization": auth},
@@ -243,7 +243,7 @@ class ZendeskUpdateTicket(Tool):
             if not ticket:
                 return {"error": "No fields to update"}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/tickets/{ticket_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -288,7 +288,7 @@ class ZendeskSearchTickets(Tool):
 
             params = {"query": query, "sort_by": sort_by, "sort_order": sort_order, "per_page": per_page, "page": page}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/search.json",
                     headers={"Authorization": auth},
@@ -332,7 +332,7 @@ class ZendeskShowManyTickets(Tool):
             import httpx
 
             ids_param = ",".join(str(i) for i in ids)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/tickets/show_many.json",
                     headers={"Authorization": auth},
@@ -371,7 +371,7 @@ class ZendeskUpdateManyTickets(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/tickets/update_many.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -408,7 +408,7 @@ class ZendeskCountTickets(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/tickets/count.json",
                     headers={"Authorization": auth},
@@ -446,7 +446,7 @@ class ZendeskCreateManyTickets(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/tickets/create_many.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -485,7 +485,7 @@ class ZendeskDeleteTicket(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/tickets/{ticket_id}.json",
                     headers={"Authorization": auth},
@@ -524,7 +524,7 @@ class ZendeskBulkDeleteTickets(Tool):
             import httpx
 
             ids_param = ",".join(str(i) for i in ids)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/tickets/destroy_many.json",
                     headers={"Authorization": auth},
@@ -563,7 +563,7 @@ class ZendeskMarkTicketAsSpam(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/tickets/{ticket_id}/mark_as_spam.json",
                     headers={"Authorization": auth},
@@ -602,7 +602,7 @@ class ZendeskBulkMarkTicketsAsSpam(Tool):
             import httpx
 
             ids_param = ",".join(str(i) for i in ids)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/tickets/mark_many_as_spam.json",
                     headers={"Authorization": auth},
@@ -642,7 +642,7 @@ class ZendeskMergeTickets(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/tickets/{target_ticket_id}/merge.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -681,7 +681,7 @@ class ZendeskTicketRelatedInformation(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/tickets/{ticket_id}/related.json",
                     headers={"Authorization": auth},
@@ -719,7 +719,7 @@ class ZendeskListCollaborators(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/tickets/{ticket_id}/collaborators.json",
                     headers={"Authorization": auth},
@@ -757,7 +757,7 @@ class ZendeskListEmailCcs(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/tickets/{ticket_id}/email_ccs.json",
                     headers={"Authorization": auth},
@@ -795,7 +795,7 @@ class ZendeskListFollowers(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/tickets/{ticket_id}/followers.json",
                     headers={"Authorization": auth},
@@ -835,7 +835,7 @@ class ZendeskListDeletedTickets(Tool):
             import httpx
 
             params = {"per_page": per_page, "page": page}
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/deleted_tickets.json",
                     headers={"Authorization": auth},
@@ -874,7 +874,7 @@ class ZendeskRestoreDeletedTicket(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/deleted_tickets/{ticket_id}/restore.json",
                     headers={"Authorization": auth},
@@ -913,7 +913,7 @@ class ZendeskRestoreMultipleDeletedTickets(Tool):
             import httpx
 
             ids_param = ",".join(str(i) for i in ids)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/deleted_tickets/restore_many.json",
                     headers={"Authorization": auth},
@@ -952,7 +952,7 @@ class ZendeskDeleteTicketPermanently(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/deleted_tickets/{ticket_id}.json",
                     headers={"Authorization": auth},
@@ -991,7 +991,7 @@ class ZendeskDeleteMultipleTicketsPermanently(Tool):
             import httpx
 
             ids_param = ",".join(str(i) for i in ids)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/deleted_tickets/destroy_many.json",
                     headers={"Authorization": auth},
@@ -1030,7 +1030,7 @@ class ZendeskListTicketIncidents(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/tickets/{ticket_id}/incidents.json",
                     headers={"Authorization": auth},
@@ -1070,7 +1070,7 @@ class ZendeskListProblems(Tool):
             import httpx
 
             params = {"per_page": per_page, "page": page}
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/problems.json",
                     headers={"Authorization": auth},
@@ -1109,7 +1109,7 @@ class ZendeskAutocompleteProblems(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/problems/autocomplete.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -1148,7 +1148,7 @@ class ZendeskCountOrganizationTickets(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/organizations/{organization_id}/tickets/count.json",
                     headers={"Authorization": auth},
@@ -1195,7 +1195,7 @@ class ZendeskListUsers(Tool):
             if role:
                 params["role"] = role
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/users.json",
                     headers={"Authorization": auth},
@@ -1234,7 +1234,7 @@ class ZendeskShowUser(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/users/{user_id}.json",
                     headers={"Authorization": auth},
@@ -1273,7 +1273,7 @@ class ZendeskListGroups(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/groups.json",
                     headers={"Authorization": auth},
@@ -1311,7 +1311,7 @@ class ZendeskShowGroup(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/groups/{group_id}.json",
                     headers={"Authorization": auth},
@@ -1347,7 +1347,7 @@ class ZendeskCountGroups(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/groups/count.json",
                     headers={"Authorization": auth},
@@ -1385,7 +1385,7 @@ class ZendeskCreateGroup(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/groups.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -1425,7 +1425,7 @@ class ZendeskUpdateGroup(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/groups/{group_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -1464,7 +1464,7 @@ class ZendeskDeleteGroup(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/groups/{group_id}.json",
                     headers={"Authorization": auth},
@@ -1500,7 +1500,7 @@ class ZendeskListAssignableGroups(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/groups/assignable.json",
                     headers={"Authorization": auth},
@@ -1541,7 +1541,7 @@ class ZendeskListComments(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/tickets/{ticket_id}/comments.json",
                     headers={"Authorization": auth},
@@ -1579,7 +1579,7 @@ class ZendeskCountTicketComments(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/tickets/{ticket_id}/comments/count.json",
                     headers={"Authorization": auth},
@@ -1618,7 +1618,7 @@ class ZendeskMakeCommentPrivate(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/tickets/{ticket_id}/comments/{ticket_comment_id}/make_private.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -1668,7 +1668,7 @@ class ZendeskRedactTicketCommentInAgentWorkspace(Tool):
             if external_attachment_urls is not None:
                 body["external_attachment_urls"] = external_attachment_urls
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/comment_redactions/{ticket_comment_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -1717,7 +1717,7 @@ class ZendeskRedactChatComment(Tool):
             if message_id is not None:
                 body["message_id"] = message_id
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/chat_redactions/{ticket_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -1765,7 +1765,7 @@ class ZendeskRedactChatCommentAttachment(Tool):
             if message_ids is not None:
                 body["message_ids"] = message_ids
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/chat_file_redactions/{ticket_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -1806,7 +1806,7 @@ class ZendeskRedactStringInComment(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/tickets/{ticket_id}/comments/{ticket_comment_id}/redact.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -1846,7 +1846,7 @@ class ZendeskListBookmarks(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/bookmarks.json",
                     headers={"Authorization": auth},
@@ -1884,7 +1884,7 @@ class ZendeskCreateBookmark(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/bookmarks.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -1923,7 +1923,7 @@ class ZendeskDeleteBookmark(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/bookmarks/{bookmark_id}.json",
                     headers={"Authorization": auth},
@@ -1964,7 +1964,7 @@ class ZendeskListWorkspaces(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/workspaces.json",
                     headers={"Authorization": auth},
@@ -2003,7 +2003,7 @@ class ZendeskShowWorkspace(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/workspaces/{workspace_id}.json",
                     headers={"Authorization": auth},
@@ -2053,7 +2053,7 @@ class ZendeskCreateWorkspace(Tool):
             if conditions is not None:
                 workspace["conditions"] = conditions
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/workspaces.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -2112,7 +2112,7 @@ class ZendeskUpdateWorkspace(Tool):
             if not workspace:
                 return {"error": "No fields to update"}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/workspaces/{workspace_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -2151,7 +2151,7 @@ class ZendeskDeleteWorkspace(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/workspaces/{workspace_id}.json",
                     headers={"Authorization": auth},
@@ -2190,7 +2190,7 @@ class ZendeskBulkDeleteWorkspaces(Tool):
             import httpx
 
             ids_param = ",".join(str(i) for i in ids)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/workspaces/destroy_many.json",
                     headers={"Authorization": auth},
@@ -2229,7 +2229,7 @@ class ZendeskReorderWorkspaces(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/workspaces/reorder.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -2282,7 +2282,7 @@ class ZendeskListViews(Tool):
             if active is not None:
                 params["active"] = str(active).lower()
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/views.json",
                     headers={"Authorization": auth},
@@ -2319,7 +2319,7 @@ class ZendeskListViewsCompact(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/views/compact.json",
                     headers={"Authorization": auth},
@@ -2362,7 +2362,7 @@ class ZendeskListViewsById(Tool):
             if active is not None:
                 params["active"] = str(active).lower()
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/views/show_many.json",
                     headers={"Authorization": auth},
@@ -2402,7 +2402,7 @@ class ZendeskListActiveViews(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/views/active.json",
                     headers={"Authorization": auth},
@@ -2439,7 +2439,7 @@ class ZendeskCountViews(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/views/count.json",
                     headers={"Authorization": auth},
@@ -2483,7 +2483,7 @@ class ZendeskSearchViews(Tool):
             if sort_by:
                 params["sort_by"] = sort_by
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/views/search.json",
                     headers={"Authorization": auth},
@@ -2522,7 +2522,7 @@ class ZendeskShowView(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/views/{view_id}.json",
                     headers={"Authorization": auth},
@@ -2579,7 +2579,7 @@ class ZendeskCreateView(Tool):
             if output:
                 view["output"] = output
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/views.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -2638,7 +2638,7 @@ class ZendeskUpdateView(Tool):
             if not view:
                 return {"error": "No fields to update"}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/views/{view_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -2680,7 +2680,7 @@ class ZendeskUpdateManyViews(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/views/update_many.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -2719,7 +2719,7 @@ class ZendeskDeleteView(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/views/{view_id}.json",
                     headers={"Authorization": auth},
@@ -2758,7 +2758,7 @@ class ZendeskBulkDeleteViews(Tool):
             import httpx
 
             ids_param = ",".join(str(i) for i in ids)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/views/destroy_many.json",
                     headers={"Authorization": auth},
@@ -2805,7 +2805,7 @@ class ZendeskExecuteView(Tool):
             if sort_by:
                 params["sort_by"] = sort_by
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/views/{view_id}/execute.json",
                     headers={"Authorization": auth},
@@ -2850,7 +2850,7 @@ class ZendeskListTicketsFromView(Tool):
             if sort_by:
                 params["sort_by"] = sort_by
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/views/{view_id}/tickets.json",
                     headers={"Authorization": auth},
@@ -2889,7 +2889,7 @@ class ZendeskCountTicketsInView(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/views/{view_id}/count.json",
                     headers={"Authorization": auth},
@@ -2932,7 +2932,7 @@ class ZendeskPreviewViews(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/views/preview.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -2975,7 +2975,7 @@ class ZendeskPreviewTicketCount(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/views/preview/count.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -3020,7 +3020,7 @@ class ZendeskCreateUser(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/users.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -3076,7 +3076,7 @@ class ZendeskUpdateUser(Tool):
             if not user:
                 return {"error": "No fields to update"}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/users/{user_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -3115,7 +3115,7 @@ class ZendeskDeleteUser(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/users/{user_id}.json",
                     headers={"Authorization": auth},
@@ -3155,7 +3155,7 @@ class ZendeskSearchUsers(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/users/search.json",
                     headers={"Authorization": auth},
@@ -3192,7 +3192,7 @@ class ZendeskCountUsers(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/users/count.json",
                     headers={"Authorization": auth},
@@ -3231,7 +3231,7 @@ class ZendeskShowManyUsers(Tool):
             import httpx
 
             ids_param = ",".join(str(i) for i in ids)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/users/show_many.json",
                     headers={"Authorization": auth},
@@ -3268,7 +3268,7 @@ class ZendeskShowSelf(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/users/me.json",
                     headers={"Authorization": auth},
@@ -3306,7 +3306,7 @@ class ZendeskShowUserRelatedInformation(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/users/{user_id}/related.json",
                     headers={"Authorization": auth},
@@ -3345,7 +3345,7 @@ class ZendeskListDeletedUsers(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/deleted_users.json",
                     headers={"Authorization": auth},
@@ -3384,7 +3384,7 @@ class ZendeskShowDeletedUser(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/deleted_users/{deleted_user_id}.json",
                     headers={"Authorization": auth},
@@ -3420,7 +3420,7 @@ class ZendeskCountDeletedUsers(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/deleted_users/count.json",
                     headers={"Authorization": auth},
@@ -3458,7 +3458,7 @@ class ZendeskAutocompleteUsers(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/users/autocomplete.json",
                     headers={"Authorization": auth},
@@ -3498,7 +3498,7 @@ class ZendeskBulkDeleteUsers(Tool):
             import httpx
 
             ids_param = ",".join(str(i) for i in ids)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/users/destroy_many.json",
                     headers={"Authorization": auth},
@@ -3537,7 +3537,7 @@ class ZendeskPermanentlyDeleteUser(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/deleted_users/{deleted_user_id}.json",
                     headers={"Authorization": auth},
@@ -3585,7 +3585,7 @@ class ZendeskListTicketTriggerCategories(Tool):
             if sort:
                 params["sort"] = sort
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/trigger_categories.json",
                     headers={"Authorization": auth},
@@ -3627,7 +3627,7 @@ class ZendeskCreateTicketTriggerCategory(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/trigger_categories.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -3669,7 +3669,7 @@ class ZendeskCreateBatchJobForTicketTriggerCategories(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/trigger_categories/jobs.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -3708,7 +3708,7 @@ class ZendeskShowTicketTriggerCategory(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/trigger_categories/{trigger_category_id}.json",
                     headers={"Authorization": auth},
@@ -3750,7 +3750,7 @@ class ZendeskUpdateTicketTriggerCategory(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{base_url}/trigger_categories/{trigger_category_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -3789,7 +3789,7 @@ class ZendeskDeleteTicketTriggerCategory(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/trigger_categories/{trigger_category_id}.json",
                     headers={"Authorization": auth},
@@ -3836,7 +3836,7 @@ class ZendeskListTicketTriggers(Tool):
             if active is not None:
                 params["active"] = str(active).lower()
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/triggers.json",
                     headers={"Authorization": auth},
@@ -3873,7 +3873,7 @@ class ZendeskListActiveTicketTriggers(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/triggers/active.json",
                     headers={"Authorization": auth},
@@ -3911,7 +3911,7 @@ class ZendeskSearchTicketTriggers(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/triggers/search.json",
                     headers={"Authorization": auth},
@@ -3950,7 +3950,7 @@ class ZendeskShowTicketTrigger(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/triggers/{trigger_id}.json",
                     headers={"Authorization": auth},
@@ -3986,7 +3986,7 @@ class ZendeskListTicketTriggerDefinitions(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/triggers/definitions.json",
                     headers={"Authorization": auth},
@@ -4024,7 +4024,7 @@ class ZendeskListTicketTriggerRevisions(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/triggers/{trigger_id}/revisions.json",
                     headers={"Authorization": auth},
@@ -4077,7 +4077,7 @@ class ZendeskCreateTicketTrigger(Tool):
                 "active": active,
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/triggers.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -4133,7 +4133,7 @@ class ZendeskUpdateTicketTrigger(Tool):
             if not trigger:
                 return {"error": "No fields to update"}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/triggers/{trigger_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -4172,7 +4172,7 @@ class ZendeskDeleteTicketTrigger(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/triggers/{trigger_id}.json",
                     headers={"Authorization": auth},
@@ -4211,7 +4211,7 @@ class ZendeskBulkDeleteTicketTriggers(Tool):
             import httpx
 
             ids_param = ",".join(str(i) for i in ids)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/triggers/destroy_many.json",
                     headers={"Authorization": auth},
@@ -4251,7 +4251,7 @@ class ZendeskListTargets(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/targets.json",
                     headers={"Authorization": auth},
@@ -4289,7 +4289,7 @@ class ZendeskShowTarget(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/targets/{target_id}.json",
                     headers={"Authorization": auth},
@@ -4327,7 +4327,7 @@ class ZendeskCreateTarget(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/targets.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -4367,7 +4367,7 @@ class ZendeskUpdateTarget(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/targets/{target_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -4406,7 +4406,7 @@ class ZendeskDeleteTarget(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/targets/{target_id}.json",
                     headers={"Authorization": auth},
@@ -4442,7 +4442,7 @@ class ZendeskListTargetFailures(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/target_failures.json",
                     headers={"Authorization": auth},
@@ -4480,7 +4480,7 @@ class ZendeskShowTargetFailure(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/target_failures/{target_failure_id}.json",
                     headers={"Authorization": auth},
@@ -4532,7 +4532,7 @@ class ZendeskListAutomations(Tool):
             if include:
                 params["include"] = include
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/automations.json",
                     headers={"Authorization": auth},
@@ -4569,7 +4569,7 @@ class ZendeskListActiveAutomations(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/automations/active.json",
                     headers={"Authorization": auth},
@@ -4618,7 +4618,7 @@ class ZendeskSearchAutomations(Tool):
             if sort_order:
                 params["sort_order"] = sort_order
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/automations/search.json",
                     headers={"Authorization": auth},
@@ -4657,7 +4657,7 @@ class ZendeskShowAutomation(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/automations/{automation_id}.json",
                     headers={"Authorization": auth},
@@ -4698,7 +4698,7 @@ class ZendeskCreateAutomation(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/automations.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -4738,7 +4738,7 @@ class ZendeskUpdateAutomation(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/automations/{automation_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -4780,7 +4780,7 @@ class ZendeskUpdateManyAutomations(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/automations/update_many.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -4819,7 +4819,7 @@ class ZendeskDeleteAutomation(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/automations/{automation_id}.json",
                     headers={"Authorization": auth},
@@ -4857,7 +4857,7 @@ class ZendeskBulkDeleteAutomations(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/automations/destroy_many.json",
                     headers={"Authorization": auth},
@@ -4899,7 +4899,7 @@ class ZendeskSearchTags(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/autocomplete/tags.json",
                     headers={"Authorization": auth},
@@ -4941,7 +4941,7 @@ class ZendeskListTags(Tool):
             import httpx
 
             params = {"per_page": per_page, "page": page, "sort": sort}
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/tags.json",
                     headers={"Authorization": auth},
@@ -4978,7 +4978,7 @@ class ZendeskCountTags(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/tags/count.json",
                     headers={"Authorization": auth},
@@ -5016,7 +5016,7 @@ class ZendeskListResourceTags(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/tickets/{ticket_id}/tags.json",
                     headers={"Authorization": auth},
@@ -5055,7 +5055,7 @@ class ZendeskAddTags(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/tickets/{ticket_id}/tags.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -5095,7 +5095,7 @@ class ZendeskSetTags(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/tickets/{ticket_id}/tags.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -5135,7 +5135,7 @@ class ZendeskRemoveTags(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/tickets/{ticket_id}/tags.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -5181,7 +5181,7 @@ class ZendeskListSuspendedTickets(Tool):
             import httpx
 
             params = {"per_page": per_page, "page": page, "sort_by": sort_by, "sort_order": sort_order}
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/suspended_tickets.json",
                     headers={"Authorization": auth},
@@ -5220,7 +5220,7 @@ class ZendeskShowSuspendedTicket(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/suspended_tickets/{suspended_ticket_id}.json",
                     headers={"Authorization": auth},
@@ -5258,7 +5258,7 @@ class ZendeskRecoverSuspendedTicket(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/suspended_tickets/{suspended_ticket_id}/recover.json",
                     headers={"Authorization": auth},
@@ -5297,7 +5297,7 @@ class ZendeskRecoverMultipleSuspendedTickets(Tool):
             import httpx
 
             ids_param = ",".join(str(i) for i in ids)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/suspended_tickets/recover_many.json",
                     headers={"Authorization": auth},
@@ -5336,7 +5336,7 @@ class ZendeskDeleteSuspendedTicket(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/suspended_tickets/{suspended_ticket_id}.json",
                     headers={"Authorization": auth},
@@ -5375,7 +5375,7 @@ class ZendeskDeleteMultipleSuspendedTickets(Tool):
             import httpx
 
             ids_param = ",".join(str(i) for i in ids)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/suspended_tickets/destroy_many.json",
                     headers={"Authorization": auth},
@@ -5414,7 +5414,7 @@ class ZendeskSuspendedTicketAttachments(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/suspended_tickets/{suspended_ticket_id}/attachments.json",
                     headers={"Authorization": auth},
@@ -5450,7 +5450,7 @@ class ZendeskExportSuspendedTickets(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/suspended_tickets/export.json",
                     headers={"Authorization": auth},
@@ -5491,7 +5491,7 @@ class ZendeskShowOrganizationSubscription(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/organization_subscriptions/{organization_subscription_id}.json",
                     headers={"Authorization": auth},
@@ -5541,7 +5541,7 @@ class ZendeskListCustomTicketStatuses(Tool):
                 params["default"] = default
             if status_categories:
                 params["status_categories"] = status_categories
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/custom_statuses.json",
                     headers={"Authorization": auth},
@@ -5580,7 +5580,7 @@ class ZendeskShowCustomTicketStatus(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/custom_statuses/{custom_status_id}.json",
                     headers={"Authorization": auth},
@@ -5618,7 +5618,7 @@ class ZendeskCreateCustomTicketStatus(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/custom_statuses.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -5658,7 +5658,7 @@ class ZendeskUpdateCustomTicketStatus(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/custom_statuses/{custom_status_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -5698,7 +5698,7 @@ class ZendeskBulkUpdateDefaultCustomTicketStatuses(Tool):
             import httpx
 
             ids_str = ",".join(str(i) for i in ids)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/custom_status/default.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -5738,7 +5738,7 @@ class ZendeskCreateTicketFormStatusesForCustomStatus(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/custom_statuses/{custom_status_id}/ticket_form_statuses.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -5778,7 +5778,7 @@ class ZendeskListJobStatuses(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/job_statuses.json",
                     headers={"Authorization": auth},
@@ -5816,7 +5816,7 @@ class ZendeskShowJobStatus(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/job_statuses/{job_status_id}.json",
                     headers={"Authorization": auth},
@@ -5855,7 +5855,7 @@ class ZendeskShowManyJobStatuses(Tool):
             import httpx
 
             ids_param = ",".join(ids)
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/job_statuses/show_many.json",
                     headers={"Authorization": auth},
@@ -5899,7 +5899,7 @@ class ZendeskListOrganizationSubscriptions(Tool):
             import httpx
 
             params = {"per_page": per_page, "page": page}
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/organization_subscriptions.json",
                     headers={"Authorization": auth},
@@ -5939,7 +5939,7 @@ class ZendeskCreateOrganizationSubscription(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/organization_subscriptions.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -5978,7 +5978,7 @@ class ZendeskDeleteOrganizationSubscription(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/organization_subscriptions/{organization_subscription_id}.json",
                     headers={"Authorization": auth},
@@ -6017,7 +6017,7 @@ class ZendeskListSessions(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/sessions.json",
                     headers={"Authorization": auth},
@@ -6056,7 +6056,7 @@ class ZendeskShowSession(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/users/{user_id}/sessions/{session_id}.json",
                     headers={"Authorization": auth},
@@ -6092,7 +6092,7 @@ class ZendeskShowCurrentSession(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/users/me/session.json",
                     headers={"Authorization": auth},
@@ -6128,7 +6128,7 @@ class ZendeskRenewCurrentSession(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/users/me/session/renew.json",
                     headers={"Authorization": auth},
@@ -6167,7 +6167,7 @@ class ZendeskDeleteSession(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/users/{user_id}/sessions/{session_id}.json",
                     headers={"Authorization": auth},
@@ -6203,7 +6203,7 @@ class ZendeskDeleteCurrentSession(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/users/me/logout.json",
                     headers={"Authorization": auth},
@@ -6242,7 +6242,7 @@ class ZendeskListSharingAgreements(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/sharing_agreements.json",
                     headers={"Authorization": auth},
@@ -6280,7 +6280,7 @@ class ZendeskShowSharingAgreement(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/sharing_agreements/{sharing_agreement_id}.json",
                     headers={"Authorization": auth},
@@ -6318,7 +6318,7 @@ class ZendeskCreateSharingAgreement(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/sharing_agreements.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -6358,7 +6358,7 @@ class ZendeskUpdateSharingAgreement(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/sharing_agreements/{sharing_agreement_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -6397,7 +6397,7 @@ class ZendeskDeleteSharingAgreement(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/sharing_agreements/{sharing_agreement_id}.json",
                     headers={"Authorization": auth},
@@ -6436,7 +6436,7 @@ class ZendeskListSlaPolicies(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/slas/policies.json",
                     headers={"Authorization": auth},
@@ -6474,7 +6474,7 @@ class ZendeskShowSlaPolicy(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/slas/policies/{sla_policy_id}.json",
                     headers={"Authorization": auth},
@@ -6512,7 +6512,7 @@ class ZendeskCreateSlaPolicy(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/slas/policies.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -6552,7 +6552,7 @@ class ZendeskUpdateSlaPolicy(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/slas/policies/{sla_policy_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -6591,7 +6591,7 @@ class ZendeskDeleteSlaPolicy(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/slas/policies/{sla_policy_id}.json",
                     headers={"Authorization": auth},
@@ -6629,7 +6629,7 @@ class ZendeskReorderSlaPolicies(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/slas/policies/reorder.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -6666,7 +6666,7 @@ class ZendeskRetrieveSlaPolicyFilterDefinitions(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/slas/policies/definitions.json",
                     headers={"Authorization": auth},
@@ -6707,7 +6707,7 @@ class ZendeskListGroupSlaPolicies(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/groups/{group_id}/slas/policies.json",
                     headers={"Authorization": auth},
@@ -6746,7 +6746,7 @@ class ZendeskShowGroupSlaPolicy(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/groups/{group_id}/slas/policies/{sla_policy_id}.json",
                     headers={"Authorization": auth},
@@ -6785,7 +6785,7 @@ class ZendeskCreateGroupSlaPolicy(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/groups/{group_id}/slas/policies.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -6826,7 +6826,7 @@ class ZendeskUpdateGroupSlaPolicy(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/groups/{group_id}/slas/policies/{sla_policy_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -6866,7 +6866,7 @@ class ZendeskDeleteGroupSlaPolicy(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/groups/{group_id}/slas/policies/{sla_policy_id}.json",
                     headers={"Authorization": auth},
@@ -6905,7 +6905,7 @@ class ZendeskListDeletionSchedules(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/deletion_schedules.json",
                     headers={"Authorization": auth},
@@ -6943,7 +6943,7 @@ class ZendeskCreateDeletionSchedule(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/deletion_schedules.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -6982,7 +6982,7 @@ class ZendeskGetDeletionSchedule(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/deletion_schedules/{deletion_schedule_id}.json",
                     headers={"Authorization": auth},
@@ -7021,7 +7021,7 @@ class ZendeskUpdateDeletionSchedule(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/deletion_schedules/{deletion_schedule_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -7060,7 +7060,7 @@ class ZendeskDeleteDeletionSchedule(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/deletion_schedules/{deletion_schedule_id}.json",
                     headers={"Authorization": auth},
@@ -7108,7 +7108,7 @@ class ZendeskListSearchResults(Tool):
             if include:
                 params["include"] = include
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/search.json",
                     headers={"Authorization": auth},
@@ -7147,7 +7147,7 @@ class ZendeskShowSearchResultsCount(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/search/count.json",
                     headers={"Authorization": auth},
@@ -7196,7 +7196,7 @@ class ZendeskExportSearchResults(Tool):
             if include:
                 params["include"] = include
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/search/export.json",
                     headers={"Authorization": auth},
@@ -7236,7 +7236,7 @@ class ZendeskListCustomRoles(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/custom_roles.json",
                     headers={"Authorization": auth},
@@ -7274,7 +7274,7 @@ class ZendeskShowCustomRole(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/custom_roles/{custom_role_id}.json",
                     headers={"Authorization": auth},
@@ -7312,7 +7312,7 @@ class ZendeskCreateCustomRole(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/custom_roles.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -7352,7 +7352,7 @@ class ZendeskUpdateCustomRole(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/custom_roles/{custom_role_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -7391,7 +7391,7 @@ class ZendeskDeleteCustomRole(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/custom_roles/{custom_role_id}.json",
                     headers={"Authorization": auth},
@@ -7436,7 +7436,7 @@ class ZendeskListAccountAttributes(Tool):
             if include:
                 params["include"] = include
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/routing/attributes.json",
                     headers={"Authorization": auth},
@@ -7473,7 +7473,7 @@ class ZendeskListRoutingAttributeDefinitions(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/routing/attributes/definitions.json",
                     headers={"Authorization": auth},
@@ -7511,7 +7511,7 @@ class ZendeskShowRoutingAttribute(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/routing/attributes/{attribute_id}.json",
                     headers={"Authorization": auth},
@@ -7549,7 +7549,7 @@ class ZendeskCreateRoutingAttribute(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/routing/attributes.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -7589,7 +7589,7 @@ class ZendeskUpdateRoutingAttribute(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/routing/attributes/{attribute_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -7628,7 +7628,7 @@ class ZendeskDeleteRoutingAttribute(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/routing/attributes/{attribute_id}.json",
                     headers={"Authorization": auth},
@@ -7666,7 +7666,7 @@ class ZendeskListAttributeValuesForAttribute(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/routing/attributes/{attribute_id}/values.json",
                     headers={"Authorization": auth},
@@ -7705,7 +7705,7 @@ class ZendeskShowRoutingAttributeValue(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/routing/attributes/{attribute_id}/values/{attribute_value_id}.json",
                     headers={"Authorization": auth},
@@ -7744,7 +7744,7 @@ class ZendeskCreateRoutingAttributeValue(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/routing/attributes/{attribute_id}/values.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -7785,7 +7785,7 @@ class ZendeskUpdateRoutingAttributeValue(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{base_url}/routing/attributes/{attribute_id}/values/{attribute_value_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -7825,7 +7825,7 @@ class ZendeskDeleteRoutingAttributeValue(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/routing/attributes/{attribute_id}/values/{attribute_value_id}.json",
                     headers={"Authorization": auth},
@@ -7863,7 +7863,7 @@ class ZendeskListAgentAttributeValues(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/routing/agents/{user_id}/instance_values.json",
                     headers={"Authorization": auth},
@@ -7909,7 +7909,7 @@ class ZendeskListAttributeValuesForManyAgents(Tool):
             if page_after:
                 params["page[after]"] = page_after
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/routing/agents/instance_values.json",
                     headers={"Authorization": auth},
@@ -7949,7 +7949,7 @@ class ZendeskSetAgentAttributeValues(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/routing/agents/{user_id}/instance_values.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -7989,7 +7989,7 @@ class ZendeskSetTicketAttributeValues(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/routing/tickets/{ticket_id}/instance_values.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -8031,7 +8031,7 @@ class ZendeskBulkSetAgentAttributeValuesJob(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/routing/agents/instance_values/jobs.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -8073,7 +8073,7 @@ class ZendeskListTicketsFulfilledByUser(Tool):
             ids = [x.strip() for x in ticket_ids.split(",")]
             params = [("ticket_ids[]", tid) for tid in ids]
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/routing/requirements/fulfilled.json",
                     headers={"Authorization": auth},
@@ -8112,7 +8112,7 @@ class ZendeskListTicketAttributeValues(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/routing/tickets/{ticket_id}/instance_values.json",
                     headers={"Authorization": auth},
@@ -8174,7 +8174,7 @@ class ZendeskCreateTrialAccount(Tool):
             if utc_offset is not None:
                 payload["utc_offset"] = utc_offset
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     "https://zendeskaccounts.zendesk.com/api/v2/accounts",
                     headers={
@@ -8215,7 +8215,7 @@ class ZendeskVerifySubdomainAvailability(Tool):
         ) -> Any:
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     "https://zendeskaccounts.zendesk.com/api/v2/accounts/available",
                     params={"subdomain": subdomain},
@@ -8256,7 +8256,7 @@ class ZendeskListResourceCollections(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/resource_collections.json",
                     headers={"Authorization": auth},
@@ -8295,7 +8295,7 @@ class ZendeskShowResourceCollection(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/resource_collections/{resource_collection_id}.json",
                     headers={"Authorization": auth},
@@ -8333,7 +8333,7 @@ class ZendeskCreateResourceCollection(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/resource_collections.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -8373,7 +8373,7 @@ class ZendeskUpdateResourceCollection(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/resource_collections/{resource_collection_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -8412,7 +8412,7 @@ class ZendeskDeleteResourceCollection(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/resource_collections/{resource_collection_id}.json",
                     headers={"Authorization": auth},
@@ -8458,7 +8458,7 @@ class ZendeskListRequests(Tool):
 
             params: dict[str, Any] = {"per_page": per_page, "page": page, "sort_by": sort_by, "sort_order": sort_order}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/requests.json",
                     headers={"Authorization": auth},
@@ -8508,7 +8508,7 @@ class ZendeskSearchRequests(Tool):
             if organization_id is not None:
                 params["organization_id"] = organization_id
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/requests/search.json",
                     headers={"Authorization": auth},
@@ -8547,7 +8547,7 @@ class ZendeskShowRequest(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/requests/{request_id}.json",
                     headers={"Authorization": auth},
@@ -8585,7 +8585,7 @@ class ZendeskCreateRequest(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/requests.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -8625,7 +8625,7 @@ class ZendeskUpdateRequest(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/requests/{request_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -8672,7 +8672,7 @@ class ZendeskListRequestComments(Tool):
             if since:
                 params["since"] = since
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/requests/{request_id}/comments.json",
                     headers={"Authorization": auth},
@@ -8712,7 +8712,7 @@ class ZendeskShowRequestComment(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/requests/{request_id}/comments/{ticket_comment_id}.json",
                     headers={"Authorization": auth},
@@ -8764,7 +8764,7 @@ class ZendeskListSatisfactionRatings(Tool):
             if end_time is not None:
                 params["end_time"] = end_time
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/satisfaction_ratings.json",
                     headers={"Authorization": auth},
@@ -8801,7 +8801,7 @@ class ZendeskCountSatisfactionRatings(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/satisfaction_ratings/count.json",
                     headers={"Authorization": auth},
@@ -8839,7 +8839,7 @@ class ZendeskShowSatisfactionRating(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/satisfaction_ratings/{satisfaction_rating_id}.json",
                     headers={"Authorization": auth},
@@ -8878,7 +8878,7 @@ class ZendeskCreateSatisfactionRating(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/tickets/{ticket_id}/satisfaction_rating.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -8915,7 +8915,7 @@ class ZendeskListSatisfactionReasons(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/satisfaction_reasons.json",
                     headers={"Authorization": auth},
@@ -8953,7 +8953,7 @@ class ZendeskShowSatisfactionReason(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/satisfaction_reasons/{satisfaction_reason_id}.json",
                     headers={"Authorization": auth},
@@ -8996,7 +8996,7 @@ class ZendeskChangePassword(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/users/{user_id}/password.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -9036,7 +9036,7 @@ class ZendeskSetUserPassword(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/users/{user_id}/password.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -9075,7 +9075,7 @@ class ZendeskListPasswordRequirements(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/users/{user_id}/password/requirements.json",
                     headers={"Authorization": auth},
@@ -9114,7 +9114,7 @@ class ZendeskListQueues(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/queues.json",
                     headers={"Authorization": auth},
@@ -9152,7 +9152,7 @@ class ZendeskShowQueue(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/queues/{queue_id}.json",
                     headers={"Authorization": auth},
@@ -9190,7 +9190,7 @@ class ZendeskCreateQueue(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/queues.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -9230,7 +9230,7 @@ class ZendeskUpdateQueue(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/queues/{queue_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -9269,7 +9269,7 @@ class ZendeskDeleteQueue(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/queues/{queue_id}.json",
                     headers={"Authorization": auth},
@@ -9305,7 +9305,7 @@ class ZendeskListQueueDefinitions(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/queues/definitions.json",
                     headers={"Authorization": auth},
@@ -9343,7 +9343,7 @@ class ZendeskReorderQueues(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{base_url}/queues/order",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -9397,7 +9397,7 @@ class ZendeskGetSourcesByTarget(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/{target_type}/{target_id}/relationship_fields/{field_id}/{source_type}",
                     headers={"Authorization": auth},
@@ -9449,7 +9449,7 @@ class ZendeskListRelationshipFilterDefinitions(Tool):
             if source_type is not None:
                 params["source_type"] = source_type
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/relationships/definitions/{target_type}",
                     headers={"Authorization": auth},
@@ -9504,7 +9504,7 @@ class ZendeskListCustomObjectRecords(Tool):
             if page_after:
                 params["page[after]"] = page_after
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/custom_objects/{custom_object_key}/records.json",
                     headers={"Authorization": auth},
@@ -9544,7 +9544,7 @@ class ZendeskShowCustomObjectRecord(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/custom_objects/{custom_object_key}/records/{custom_object_record_id}.json",
                     headers={"Authorization": auth},
@@ -9583,7 +9583,7 @@ class ZendeskCreateCustomObjectRecord(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/custom_objects/{custom_object_key}/records.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -9624,7 +9624,7 @@ class ZendeskUpdateCustomObjectRecord(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{base_url}/custom_objects/{custom_object_key}/records/{custom_object_record_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -9664,7 +9664,7 @@ class ZendeskDeleteCustomObjectRecord(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/custom_objects/{custom_object_key}/records/{custom_object_record_id}.json",
                     headers={"Authorization": auth},
@@ -9704,7 +9704,7 @@ class ZendeskSetCustomObjectRecordByExternalId(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.patch(
                     f"{base_url}/custom_objects/{custom_object_key}/records.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -9745,7 +9745,7 @@ class ZendeskDeleteCustomObjectRecordByExternalId(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/custom_objects/{custom_object_key}/records.json",
                     headers={"Authorization": auth},
@@ -9794,7 +9794,7 @@ class ZendeskSearchCustomObjectRecords(Tool):
             if sort:
                 params["sort"] = sort
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/custom_objects/{custom_object_key}/records/search.json",
                     headers={"Authorization": auth},
@@ -9833,7 +9833,7 @@ class ZendeskCountCustomObjectRecords(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/custom_objects/{custom_object_key}/records/count.json",
                     headers={"Authorization": auth},
@@ -9878,7 +9878,7 @@ class ZendeskAutocompleteCustomObjectRecords(Tool):
             if page_after:
                 params["page[after]"] = page_after
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/custom_objects/{custom_object_key}/records/autocomplete.json",
                     headers={"Authorization": auth},
@@ -9924,7 +9924,7 @@ class ZendeskListBrands(Tool):
             if sort:
                 params["sort"] = sort
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/brands.json",
                     headers={"Authorization": auth},
@@ -9963,7 +9963,7 @@ class ZendeskShowBrand(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/brands/{brand_id}.json",
                     headers={"Authorization": auth},
@@ -10004,7 +10004,7 @@ class ZendeskCreateBrand(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/brands.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -10044,7 +10044,7 @@ class ZendeskUpdateBrand(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/brands/{brand_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -10083,7 +10083,7 @@ class ZendeskDeleteBrand(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/brands/{brand_id}.json",
                     headers={"Authorization": auth},
@@ -10122,7 +10122,7 @@ class ZendeskCheckHostMappingValidity(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/brands/check_host_mapping.json",
                     headers={"Authorization": auth},
@@ -10161,7 +10161,7 @@ class ZendeskCheckHostMappingValidityForExistingBrand(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/brands/{brand_id}/check_host_mapping.json",
                     headers={"Authorization": auth},
@@ -10209,7 +10209,7 @@ class ZendeskListOrganizations(Tool):
             if sort is not None:
                 params["sort"] = sort
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/organizations.json",
                     headers={"Authorization": auth},
@@ -10248,7 +10248,7 @@ class ZendeskShowOrganization(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/organizations/{organization_id}.json",
                     headers={"Authorization": auth},
@@ -10293,7 +10293,7 @@ class ZendeskShowManyOrganizations(Tool):
             if external_ids is not None:
                 params["external_ids"] = external_ids
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/organizations/show_many.json",
                     headers={"Authorization": auth},
@@ -10339,7 +10339,7 @@ class ZendeskSearchOrganizations(Tool):
             if external_id is not None:
                 params["external_id"] = external_id
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/organizations/search.json",
                     headers={"Authorization": auth},
@@ -10378,7 +10378,7 @@ class ZendeskShowOrganizationRelatedInformation(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/organizations/{organization_id}/related.json",
                     headers={"Authorization": auth},
@@ -10416,7 +10416,7 @@ class ZendeskCreateOrganization(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/organizations.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -10455,7 +10455,7 @@ class ZendeskCreateManyOrganizations(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/organizations/create_many.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -10497,7 +10497,7 @@ class ZendeskCreateOrUpdateOrganization(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/organizations/create_or_update.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -10537,7 +10537,7 @@ class ZendeskUpdateOrganization(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/organizations/{organization_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -10591,7 +10591,7 @@ class ZendeskUpdateManyOrganizations(Tool):
             if organizations is not None:
                 payload["organizations"] = organizations
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/organizations/update_many.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -10631,7 +10631,7 @@ class ZendeskDeleteOrganization(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/organizations/{organization_id}.json",
                     headers={"Authorization": auth},
@@ -10676,7 +10676,7 @@ class ZendeskBulkDeleteOrganizations(Tool):
             if external_ids is not None:
                 params["external_ids"] = external_ids
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/organizations/destroy_many.json",
                     headers={"Authorization": auth},
@@ -10713,7 +10713,7 @@ class ZendeskCountOrganizations(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/organizations/count.json",
                     headers={"Authorization": auth},
@@ -10759,7 +10759,7 @@ class ZendeskAutocompleteOrganizations(Tool):
             if source is not None:
                 params["source"] = source
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/organizations/autocomplete.json",
                     headers={"Authorization": auth},
@@ -10799,7 +10799,7 @@ class ZendeskMergeOrganizationWithAnotherOrganization(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/organizations/{organization_id}/merge.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -10838,7 +10838,7 @@ class ZendeskShowOrganizationMerge(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/organization_merges/{organization_merge_id}.json",
                     headers={"Authorization": auth},
@@ -10874,7 +10874,7 @@ class ZendeskListOrganizationMerges(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/organization_merges.json",
                     headers={"Authorization": auth},
@@ -10913,7 +10913,7 @@ class ZendeskListCustomObjects(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/custom_objects.json",
                     headers={"Authorization": auth},
@@ -10951,7 +10951,7 @@ class ZendeskShowCustomObject(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/custom_objects/{custom_object_key}.json",
                     headers={"Authorization": auth},
@@ -10989,7 +10989,7 @@ class ZendeskCreateCustomObject(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/custom_objects.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -11029,7 +11029,7 @@ class ZendeskUpdateCustomObject(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/custom_objects/{custom_object_key}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -11068,7 +11068,7 @@ class ZendeskDeleteCustomObject(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/custom_objects/{custom_object_key}.json",
                     headers={"Authorization": auth},
@@ -11104,7 +11104,7 @@ class ZendeskCustomObjectsLimit(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/custom_objects/limit.json",
                     headers={"Authorization": auth},
@@ -11143,7 +11143,7 @@ class ZendeskListOauthClients(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/oauth/clients.json",
                     headers={"Authorization": auth},
@@ -11179,7 +11179,7 @@ class ZendeskListGlobalOauthClients(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/oauth/global_clients.json",
                     headers={"Authorization": auth},
@@ -11217,7 +11217,7 @@ class ZendeskShowOauthClient(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/oauth/clients/{oauth_client_id}.json",
                     headers={"Authorization": auth},
@@ -11258,7 +11258,7 @@ class ZendeskCreateOauthClient(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/oauth/clients.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -11298,7 +11298,7 @@ class ZendeskUpdateOauthClient(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/oauth/clients/{oauth_client_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -11337,7 +11337,7 @@ class ZendeskDeleteOauthClient(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/oauth/clients/{oauth_client_id}.json",
                     headers={"Authorization": auth},
@@ -11375,7 +11375,7 @@ class ZendeskGenerateOauthClientSecret(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/oauth/clients/{oauth_client_id}/generate_secret.json",
                     headers={"Authorization": auth},
@@ -11423,7 +11423,7 @@ class ZendeskListOauthTokens(Tool):
             if global_client_id is not None:
                 params["global_client_id"] = global_client_id
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/oauth/tokens.json",
                     headers={"Authorization": auth},
@@ -11462,7 +11462,7 @@ class ZendeskShowOauthToken(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/oauth/tokens/{oauth_token_id}.json",
                     headers={"Authorization": auth},
@@ -11503,7 +11503,7 @@ class ZendeskCreateOauthToken(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/oauth/tokens.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -11542,7 +11542,7 @@ class ZendeskRevokeOauthToken(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/oauth/tokens/{oauth_token_id}.json",
                     headers={"Authorization": auth},
@@ -11614,7 +11614,7 @@ class ZendeskCreateTokenForGrantType(Tool):
             if refresh_token_expires_in is not None:
                 payload["refresh_token_expires_in"] = refresh_token_expires_in
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{oauth_base}/oauth/tokens",
                     headers={"Content-Type": "application/json"},
@@ -11664,7 +11664,7 @@ class ZendeskShowTicketMetrics(Tool):
             else:
                 raise ValueError("Provide ticket_id or ticket_metric_id")
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(url, headers={"Authorization": auth})
                 response.raise_for_status()
                 return response.json()
@@ -11696,7 +11696,7 @@ class ZendeskListTicketMetrics(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/ticket_metrics.json",
                     headers={"Authorization": auth},
@@ -11752,7 +11752,7 @@ class ZendeskListEmailNotifications(Tool):
             if per_page is not None:
                 params["per_page"] = per_page
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/email_notifications.json",
                     headers={"Authorization": auth},
@@ -11791,7 +11791,7 @@ class ZendeskShowEmailNotification(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/email_notifications/{email_notification_id}.json",
                     headers={"Authorization": auth},
@@ -11829,7 +11829,7 @@ class ZendeskShowManyEmailNotifications(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/email_notifications/show_many.json",
                     headers={"Authorization": auth},
@@ -11887,7 +11887,7 @@ class ZendeskListMacros(Tool):
             if per_page is not None:
                 params["per_page"] = per_page
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/macros.json",
                     headers={"Authorization": auth},
@@ -11924,7 +11924,7 @@ class ZendeskListActiveMacros(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/macros/active.json",
                     headers={"Authorization": auth},
@@ -11962,7 +11962,7 @@ class ZendeskShowMacro(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/macros/{macro_id}.json",
                     headers={"Authorization": auth},
@@ -12000,7 +12000,7 @@ class ZendeskCreateMacro(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/macros.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -12040,7 +12040,7 @@ class ZendeskUpdateMacro(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/macros/{macro_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -12079,7 +12079,7 @@ class ZendeskUpdateManyMacros(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/macros/update_many.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -12118,7 +12118,7 @@ class ZendeskDeleteMacro(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/macros/{macro_id}.json",
                     headers={"Authorization": auth},
@@ -12156,7 +12156,7 @@ class ZendeskBulkDeleteMacros(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/macros/destroy_many.json",
                     headers={"Authorization": auth},
@@ -12200,7 +12200,7 @@ class ZendeskSearchMacros(Tool):
             if active is not None:
                 params["active"] = str(active).lower()
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/macros/search.json",
                     headers={"Authorization": auth},
@@ -12237,7 +12237,7 @@ class ZendeskListMacroCategories(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/macros/categories.json",
                     headers={"Authorization": auth},
@@ -12273,7 +12273,7 @@ class ZendeskListMacroActionDefinitions(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/macros/definitions.json",
                     headers={"Authorization": auth},
@@ -12309,7 +12309,7 @@ class ZendeskListSupportedActionsForMacros(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/macros/actions.json",
                     headers={"Authorization": auth},
@@ -12347,7 +12347,7 @@ class ZendeskListMacroAttachments(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/macros/{macro_id}/attachments.json",
                     headers={"Authorization": auth},
@@ -12385,7 +12385,7 @@ class ZendeskShowMacroAttachment(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/macros/attachments/{attachment_id}.json",
                     headers={"Authorization": auth},
@@ -12432,7 +12432,7 @@ class ZendeskShowMacroReplica(Tool):
             if ticket_id is not None:
                 params["ticket_id"] = ticket_id
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/macros/new.json",
                     headers={"Authorization": auth},
@@ -12471,7 +12471,7 @@ class ZendeskShowChangesToTicket(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/macros/{macro_id}/apply.json",
                     headers={"Authorization": auth},
@@ -12510,7 +12510,7 @@ class ZendeskShowTicketAfterChanges(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/tickets/{ticket_id}/macros/{macro_id}/apply.json",
                     headers={"Authorization": auth},
@@ -12553,7 +12553,7 @@ class ZendeskListTicketMetricEvents(Tool):
             if include_changes:
                 params["include_changes"] = "true"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/incremental/ticket_metric_events.json",
                     headers={"Authorization": auth},
@@ -12600,7 +12600,7 @@ class ZendeskListGroupMemberships(Tool):
             else:
                 url = f"{base_url}/group_memberships.json"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(url, headers={"Authorization": auth})
                 response.raise_for_status()
                 return response.json()
@@ -12634,7 +12634,7 @@ class ZendeskShowGroupMembership(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/group_memberships/{group_membership_id}.json",
                     headers={"Authorization": auth},
@@ -12674,7 +12674,7 @@ class ZendeskCreateGroupMembership(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/group_memberships.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -12713,7 +12713,7 @@ class ZendeskDeleteGroupMembership(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/group_memberships/{group_membership_id}.json",
                     headers={"Authorization": auth},
@@ -12749,7 +12749,7 @@ class ZendeskListAssignableMemberships(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/group_memberships/assignable.json",
                     headers={"Authorization": auth},
@@ -12788,7 +12788,7 @@ class ZendeskSetGroupMembershipAsDefault(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/users/{user_id}/group_memberships/{group_membership_id}/make_default.json",
                     headers={"Authorization": auth},
@@ -12837,7 +12837,7 @@ class ZendeskListOrganizationMemberships(Tool):
             else:
                 url = f"{base_url}/organization_memberships.json"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(url, headers={"Authorization": auth})
                 response.raise_for_status()
                 return response.json()
@@ -12871,7 +12871,7 @@ class ZendeskShowOrganizationMembership(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/organization_memberships/{organization_membership_id}.json",
                     headers={"Authorization": auth},
@@ -12910,7 +12910,7 @@ class ZendeskCreateOrganizationMembership(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/organization_memberships.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -12952,7 +12952,7 @@ class ZendeskCreateManyMemberships(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/organization_memberships/create_many.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -12991,7 +12991,7 @@ class ZendeskDeleteOrganizationMembership(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/organization_memberships/{organization_membership_id}.json",
                     headers={"Authorization": auth},
@@ -13030,7 +13030,7 @@ class ZendeskSetOrganizationMembershipAsDefault(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/users/{user_id}/organization_memberships/{organization_membership_id}/make_default.json",
                     headers={"Authorization": auth},
@@ -13069,7 +13069,7 @@ class ZendeskSetOrganizationAsDefault(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/users/{user_id}/organizations/{organization_id}/make_default.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -13108,7 +13108,7 @@ class ZendeskBulkDeleteGroupMemberships(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/group_memberships/destroy_many.json",
                     headers={"Authorization": auth},
@@ -13150,7 +13150,7 @@ class ZendeskBulkCreateMemberships(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/group_memberships/create_many.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -13189,7 +13189,7 @@ class ZendeskBulkDeleteOrganizationMemberships(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/organization_memberships/destroy_many.json",
                     headers={"Authorization": auth},
@@ -13228,7 +13228,7 @@ class ZendeskUnassignOrganization(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/organization_memberships/{organization_membership_id}.json",
                     headers={"Authorization": auth},
@@ -13269,7 +13269,7 @@ class ZendeskListIdentities(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/users/{user_id}/identities.json",
                     headers={"Authorization": auth},
@@ -13308,7 +13308,7 @@ class ZendeskShowIdentity(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/users/{user_id}/identities/{identity_id}.json",
                     headers={"Authorization": auth},
@@ -13356,7 +13356,7 @@ class ZendeskCreateIdentity(Tool):
             if skip_verify_email:
                 identity["skip_verify_email"] = True
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/users/{user_id}/identities.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -13409,7 +13409,7 @@ class ZendeskUpdateIdentity(Tool):
             if not identity:
                 raise ValueError("At least one of value, verification_method, or verified must be provided")
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/users/{user_id}/identities/{identity_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -13449,7 +13449,7 @@ class ZendeskMakeIdentityPrimary(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/users/{user_id}/identities/{identity_id}/make_primary",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -13489,7 +13489,7 @@ class ZendeskRequestUserVerification(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/users/{user_id}/identities/{identity_id}/request_verification",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -13529,7 +13529,7 @@ class ZendeskVerifyIdentity(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/users/{user_id}/identities/{identity_id}/verify",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -13569,7 +13569,7 @@ class ZendeskDeleteIdentity(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/users/{user_id}/identities/{identity_id}.json",
                     headers={"Authorization": auth},
@@ -13615,7 +13615,7 @@ class ZendeskTicketImport(Tool):
             if archive_immediately:
                 params["archive_immediately"] = "true"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/imports/tickets.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -13660,7 +13660,7 @@ class ZendeskTicketBulkImport(Tool):
             if archive_immediately:
                 params["archive_immediately"] = "true"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/imports/tickets/create_many.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -13701,7 +13701,7 @@ class ZendeskListLocales(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/locales.json",
                     headers={"Authorization": auth},
@@ -13737,7 +13737,7 @@ class ZendeskListLocalesForAgent(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/locales/agent.json",
                     headers={"Authorization": auth},
@@ -13773,7 +13773,7 @@ class ZendeskListAvailablePublicLocales(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/locales/public.json",
                     headers={"Authorization": auth},
@@ -13809,7 +13809,7 @@ class ZendeskShowCurrentLocale(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/locales/current.json",
                     headers={"Authorization": auth},
@@ -13847,7 +13847,7 @@ class ZendeskShowLocale(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/locales/{locale_id}.json",
                     headers={"Authorization": auth},
@@ -13885,7 +13885,7 @@ class ZendeskDetectBestLanguageForUser(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/locales/detect_best_locale.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -13936,7 +13936,7 @@ class ZendeskIncrementalTicketExportCursor(Tool):
             else:
                 raise ValueError("Either start_time or cursor must be provided")
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/incremental/tickets/cursor.json",
                     headers={"Authorization": auth},
@@ -13980,7 +13980,7 @@ class ZendeskIncrementalTicketExportTimeBased(Tool):
             if per_page is not None:
                 params["per_page"] = per_page
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/incremental/tickets.json",
                     headers={"Authorization": auth},
@@ -14027,7 +14027,7 @@ class ZendeskIncrementalTicketEventExport(Tool):
             if include:
                 params["include"] = include
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/incremental/ticket_events.json",
                     headers={"Authorization": auth},
@@ -14078,7 +14078,7 @@ class ZendeskIncrementalUserExportCursor(Tool):
             if per_page is not None:
                 params["per_page"] = per_page
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/incremental/users/cursor.json",
                     headers={"Authorization": auth},
@@ -14122,7 +14122,7 @@ class ZendeskIncrementalUserExportTimeBased(Tool):
             if per_page is not None:
                 params["per_page"] = per_page
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/incremental/users.json",
                     headers={"Authorization": auth},
@@ -14166,7 +14166,7 @@ class ZendeskIncrementalOrganizationExport(Tool):
             if per_page is not None:
                 params["per_page"] = per_page
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/incremental/organizations.json",
                     headers={"Authorization": auth},
@@ -14206,7 +14206,7 @@ class ZendeskIncrementalSampleExport(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/incremental/{resource}/sample.json",
                     headers={"Authorization": auth},
@@ -14246,7 +14246,7 @@ class ZendeskCountTicketFields(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/ticket_fields/count.json",
                     headers={"Authorization": auth},
@@ -14282,7 +14282,7 @@ class ZendeskListTicketFields(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/ticket_fields.json",
                     headers={"Authorization": auth},
@@ -14320,7 +14320,7 @@ class ZendeskShowTicketField(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/ticket_fields/{ticket_field_id}.json",
                     headers={"Authorization": auth},
@@ -14358,7 +14358,7 @@ class ZendeskCreateTicketField(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/ticket_fields.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -14398,7 +14398,7 @@ class ZendeskUpdateTicketField(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/ticket_fields/{ticket_field_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -14437,7 +14437,7 @@ class ZendeskDeleteTicketField(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/ticket_fields/{ticket_field_id}.json",
                     headers={"Authorization": auth},
@@ -14475,7 +14475,7 @@ class ZendeskReorderTicketFields(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/ticket_fields/reorder.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -14514,7 +14514,7 @@ class ZendeskListTicketFieldOptions(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/ticket_fields/{ticket_field_id}/options.json",
                     headers={"Authorization": auth},
@@ -14553,7 +14553,7 @@ class ZendeskShowTicketFieldOption(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/ticket_fields/{ticket_field_id}/options/{option_id}.json",
                     headers={"Authorization": auth},
@@ -14592,7 +14592,7 @@ class ZendeskCreateOrUpdateTicketFieldOption(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/ticket_fields/{ticket_field_id}/options.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -14632,7 +14632,7 @@ class ZendeskDeleteTicketFieldOption(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/ticket_fields/{ticket_field_id}/options/{option_id}.json",
                     headers={"Authorization": auth},
@@ -14671,7 +14671,7 @@ class ZendeskListTicketForms(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/ticket_forms.json",
                     headers={"Authorization": auth},
@@ -14709,7 +14709,7 @@ class ZendeskShowTicketForm(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/ticket_forms/{ticket_form_id}.json",
                     headers={"Authorization": auth},
@@ -14747,7 +14747,7 @@ class ZendeskShowManyTicketForms(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/ticket_forms/show_many.json",
                     headers={"Authorization": auth},
@@ -14786,7 +14786,7 @@ class ZendeskCreateTicketForm(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/ticket_forms.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -14826,7 +14826,7 @@ class ZendeskUpdateTicketForm(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/ticket_forms/{ticket_form_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -14865,7 +14865,7 @@ class ZendeskDeleteTicketForm(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/ticket_forms/{ticket_form_id}.json",
                     headers={"Authorization": auth},
@@ -14904,7 +14904,7 @@ class ZendeskCloneTicketForm(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/ticket_forms/{ticket_form_id}/clone.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -14943,7 +14943,7 @@ class ZendeskReorderTicketForms(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/ticket_forms/reorder.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -14982,7 +14982,7 @@ class ZendeskListTicketFormStatuses(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/ticket_forms/{ticket_form_id}/ticket_form_statuses.json",
                     headers={"Authorization": auth},
@@ -15021,7 +15021,7 @@ class ZendeskCreateTicketFormStatuses(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/ticket_forms/{ticket_form_id}/ticket_form_statuses.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -15064,7 +15064,7 @@ class ZendeskBulkUpdateTicketFormStatuses(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/ticket_forms/{ticket_form_id}/ticket_form_statuses.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -15104,7 +15104,7 @@ class ZendeskListUserFields(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/user_fields.json",
                     headers={"Authorization": auth},
@@ -15142,7 +15142,7 @@ class ZendeskShowUserField(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/user_fields/{user_field_id}.json",
                     headers={"Authorization": auth},
@@ -15180,7 +15180,7 @@ class ZendeskCreateUserField(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/user_fields.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -15220,7 +15220,7 @@ class ZendeskUpdateUserField(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/user_fields/{user_field_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -15259,7 +15259,7 @@ class ZendeskDeleteUserField(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/user_fields/{user_field_id}.json",
                     headers={"Authorization": auth},
@@ -15297,7 +15297,7 @@ class ZendeskReorderUserField(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/user_fields/reorder.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -15336,7 +15336,7 @@ class ZendeskListUserFieldOptions(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/user_fields/{user_field_id}/options.json",
                     headers={"Authorization": auth},
@@ -15375,7 +15375,7 @@ class ZendeskShowUserFieldOption(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/user_fields/{user_field_id}/options/{option_id}.json",
                     headers={"Authorization": auth},
@@ -15414,7 +15414,7 @@ class ZendeskCreateOrUpdateUserFieldOption(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/user_fields/{user_field_id}/options.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -15454,7 +15454,7 @@ class ZendeskDeleteUserFieldOption(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/user_fields/{user_field_id}/options/{option_id}.json",
                     headers={"Authorization": auth},
@@ -15493,7 +15493,7 @@ class ZendeskListOrganizationFields(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/organization_fields.json",
                     headers={"Authorization": auth},
@@ -15531,7 +15531,7 @@ class ZendeskShowOrganizationField(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/organization_fields/{organization_field_id}.json",
                     headers={"Authorization": auth},
@@ -15569,7 +15569,7 @@ class ZendeskCreateOrganizationField(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/organization_fields.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -15609,7 +15609,7 @@ class ZendeskUpdateOrganizationField(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/organization_fields/{organization_field_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -15648,7 +15648,7 @@ class ZendeskDeleteOrganizationField(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/organization_fields/{organization_field_id}.json",
                     headers={"Authorization": auth},
@@ -15686,7 +15686,7 @@ class ZendeskReorderOrganizationField(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/organization_fields/reorder.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -15733,7 +15733,7 @@ class ZendeskListDynamicContentItems(Tool):
             if sort:
                 params["sort"] = sort
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/dynamic_content/items.json",
                     headers={"Authorization": auth},
@@ -15772,7 +15772,7 @@ class ZendeskShowDynamicContentItem(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/dynamic_content/items/{dynamic_content_item_id}.json",
                     headers={"Authorization": auth},
@@ -15810,7 +15810,7 @@ class ZendeskShowManyDynamicContentItems(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/dynamic_content/items/show_many.json",
                     headers={"Authorization": auth},
@@ -15852,7 +15852,7 @@ class ZendeskCreateDynamicContentItem(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/dynamic_content/items.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -15892,7 +15892,7 @@ class ZendeskUpdateDynamicContentItem(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/dynamic_content/items/{dynamic_content_item_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -15931,7 +15931,7 @@ class ZendeskDeleteDynamicContentItem(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/dynamic_content/items/{dynamic_content_item_id}.json",
                     headers={"Authorization": auth},
@@ -15975,7 +15975,7 @@ class ZendeskListDynamicContentVariants(Tool):
             if sort:
                 params["sort"] = sort
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/dynamic_content/items/{dynamic_content_item_id}/variants.json",
                     headers={"Authorization": auth},
@@ -16015,7 +16015,7 @@ class ZendeskShowDynamicContentVariant(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/dynamic_content/items/{dynamic_content_item_id}/variants/{dynamic_content_variant_id}.json",
                     headers={"Authorization": auth},
@@ -16057,7 +16057,7 @@ class ZendeskCreateDynamicContentVariant(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/dynamic_content/items/{dynamic_content_item_id}/variants.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -16100,7 +16100,7 @@ class ZendeskCreateManyDynamicContentVariants(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/dynamic_content/items/{dynamic_content_item_id}/variants/create_many.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -16141,7 +16141,7 @@ class ZendeskUpdateDynamicContentVariant(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/dynamic_content/items/{dynamic_content_item_id}/variants/{dynamic_content_variant_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -16184,7 +16184,7 @@ class ZendeskUpdateManyDynamicContentVariants(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/dynamic_content/items/{dynamic_content_item_id}/variants/update_many.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -16224,7 +16224,7 @@ class ZendeskDeleteDynamicContentVariant(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/dynamic_content/items/{dynamic_content_item_id}/variants/{dynamic_content_variant_id}.json",
                     headers={"Authorization": auth},
@@ -16273,7 +16273,7 @@ class ZendeskCreateTicketOrVoicemailTicket(Tool):
             if display_to_agent is not None:
                 body["display_to_agent"] = display_to_agent
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/channels/voice/tickets.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -16313,7 +16313,7 @@ class ZendeskOpenUserProfileInAgentWorkspace(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/channels/voice/agents/{agent_id}/users/{user_id}/display.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -16352,7 +16352,7 @@ class ZendeskOpenTicketInAgentBrowser(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/channels/voice/agents/{agent_id}/tickets/{ticket_id}/display.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -16391,7 +16391,7 @@ class ZendeskListMonitoredXHandles(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/channels/twitter/monitored_twitter_handles.json",
                     headers={"Authorization": auth},
@@ -16429,7 +16429,7 @@ class ZendeskShowMonitoredXHandle(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/channels/twitter/monitored_twitter_handles/{monitored_twitter_handle_id}.json",
                     headers={"Authorization": auth},
@@ -16468,7 +16468,7 @@ class ZendeskCreateTicketFromTweet(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/channels/twitter/tickets.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -16517,7 +16517,7 @@ class ZendeskListTicketStatuses(Tool):
             if ids:
                 params["ids"] = ids
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/channels/twitter/tickets/{comment_id}/statuses.json",
                     headers={"Authorization": auth},
@@ -16568,7 +16568,7 @@ class ZendeskPushContentToSupport(Tool):
             if request_id:
                 body["request_id"] = request_id
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/any_channel/push.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -16612,7 +16612,7 @@ class ZendeskValidateToken(Tool):
             if request_id:
                 body["request_id"] = request_id
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/any_channel/validate_token.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -16663,7 +16663,7 @@ class ZendeskReportChannelbackErrorToZendesk(Tool):
             if request_id:
                 body["request_id"] = request_id
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/any_channel/channelback/report_error.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -16703,7 +16703,7 @@ class ZendeskReorderGroupSlaPolicies(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/groups/{group_id}/slas/policies/reorder.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -16748,7 +16748,7 @@ class ZendeskChangeCommentFromPublicToPrivate(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/tickets/{ticket_id}/audits/{ticket_audit_id}/make_private",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -16787,7 +16787,7 @@ class ZendeskCountAuditsForTicket(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/tickets/{ticket_id}/audits/count.json",
                     headers={"Authorization": auth},
@@ -16838,7 +16838,7 @@ class ZendeskExportAuditLogs(Tool):
             if filter_source_id is not None:
                 params["filter[source_id]"] = filter_source_id
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/audit_logs/export",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -16885,7 +16885,7 @@ class ZendeskListAllTicketAudits(Tool):
             elif page_before:
                 params["page[before]"] = page_before
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/ticket_audits",
                     headers={"Authorization": auth},
@@ -16941,7 +16941,7 @@ class ZendeskListAuditLogs(Tool):
             if filter_source_id is not None:
                 params["filter[source_id]"] = filter_source_id
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/audit_logs",
                     headers={"Authorization": auth},
@@ -16985,7 +16985,7 @@ class ZendeskListAuditsForTicket(Tool):
 
             params = {"per_page": per_page, "page": page, "sort_order": sort_order}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/tickets/{ticket_id}/audits.json",
                     headers={"Authorization": auth},
@@ -17025,7 +17025,7 @@ class ZendeskShowAudit(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/tickets/{ticket_id}/audits/{ticket_audit_id}.json",
                     headers={"Authorization": auth},
@@ -17063,7 +17063,7 @@ class ZendeskShowAuditLog(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/audit_logs/{audit_log_id}.json",
                     headers={"Authorization": auth},
@@ -17111,7 +17111,7 @@ class ZendeskSearchArticles(Tool):
             if locale:
                 params["locale"] = locale
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/help_center/articles/search.json",
                     headers={"Authorization": auth},
@@ -17153,7 +17153,7 @@ class ZendeskDeleteUpload(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/uploads/{token}",
                     headers={"Authorization": auth},
@@ -17193,7 +17193,7 @@ class ZendeskRedactCommentAttachment(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/tickets/{ticket_id}/comments/{ticket_comment_id}/redact.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -17232,7 +17232,7 @@ class ZendeskShowAttachment(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/attachments/{attachment_id}.json",
                     headers={"Authorization": auth},
@@ -17271,7 +17271,7 @@ class ZendeskUpdateAttachmentForMalware(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/attachments/{attachment_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -17315,7 +17315,7 @@ class ZendeskUploadFiles(Tool):
 
             content = b64.b64decode(file_content_base64)
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/uploads.json",
                     headers={
@@ -17375,7 +17375,7 @@ class ZendeskCreateApprovalRequest(Tool):
             if message:
                 body_data["message"] = message
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/approval_requests",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -17415,7 +17415,7 @@ class ZendeskCreateApprovalWorkflowInstance(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/approval_workflow_instances.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -17459,7 +17459,7 @@ class ZendeskGetApprovalsByApprovalWorkflowId(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/approval_workflows/{approval_workflow_id}/approvals.json",
                     headers={"Authorization": auth},
@@ -17497,7 +17497,7 @@ class ZendeskShowApprovalRequest(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/approval_requests/{approval_request_id}.json",
                     headers={"Authorization": auth},
@@ -17536,7 +17536,7 @@ class ZendeskUpdateApprovalRequestStatus(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/approval_requests/{approval_request_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -17578,7 +17578,7 @@ class ZendeskListAssignableAgentsFromGroup(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/groups/{group_id}.json",
                     headers={"Authorization": auth},
@@ -17617,7 +17617,7 @@ class ZendeskListAssignableGroupsAndAgentsBasedOnSkill(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/routing/attributes/skills/{skill_id}/assignable_groups.json",
                     headers={"Authorization": auth},
@@ -17653,7 +17653,7 @@ class ZendeskListAssignableGroupsOnAssigneeField(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/groups/assignable.json",
                     headers={"Authorization": auth},
@@ -17695,7 +17695,7 @@ class ZendeskListBrandAgentMemberships(Tool):
 
             params = {"per_page": per_page, "page": page, "sort": sort}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/brand_agents.json",
                     headers={"Authorization": auth},
@@ -17734,7 +17734,7 @@ class ZendeskShowBrandAgentMembership(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/brand_agents/{brand_agent_id}.json",
                     headers={"Authorization": auth},
@@ -17782,7 +17782,7 @@ class ZendeskCreateSupportAddress(Tool):
             if brand_id is not None:
                 address_data["brand_id"] = brand_id
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     f"{base_url}/recipient_addresses.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -17821,7 +17821,7 @@ class ZendeskDeleteSupportAddress(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.delete(
                     f"{base_url}/recipient_addresses/{support_address_id}.json",
                     headers={"Authorization": auth},
@@ -17863,7 +17863,7 @@ class ZendeskListSupportAddresses(Tool):
 
             params = {"per_page": per_page, "page": page, "sort": sort}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/recipient_addresses.json",
                     headers={"Authorization": auth},
@@ -17902,7 +17902,7 @@ class ZendeskShowSupportAddress(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/recipient_addresses/{support_address_id}.json",
                     headers={"Authorization": auth},
@@ -17951,7 +17951,7 @@ class ZendeskUpdateSupportAddress(Tool):
             if brand_id is not None:
                 address_data["brand_id"] = brand_id
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/recipient_addresses/{support_address_id}.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -17990,7 +17990,7 @@ class ZendeskVerifySupportAddressForwarding(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/recipient_addresses/{support_address_id}/verify_forwarding.json",
                     headers={"Authorization": auth},
@@ -18029,7 +18029,7 @@ class ZendeskShowSettings(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/account/settings.json",
                     headers={"Authorization": auth},
@@ -18067,7 +18067,7 @@ class ZendeskUpdateAccountSettings(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     f"{base_url}/account/settings.json",
                     headers={"Authorization": auth, "Content-Type": "application/json"},
@@ -18107,7 +18107,7 @@ class ZendeskCountActivities(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/activities/count.json",
                     headers={"Authorization": auth},
@@ -18152,7 +18152,7 @@ class ZendeskListActivities(Tool):
             if since:
                 params["since"] = since
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/activities.json",
                     headers={"Authorization": auth},
@@ -18191,7 +18191,7 @@ class ZendeskShowActivity(Tool):
             base_url, auth = await _resolve_credentials(self)
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{base_url}/activities/{activity_id}.json",
                     headers={"Authorization": auth},

--- a/python/timbal/tools/zoho_crm.py
+++ b/python/timbal/tools/zoho_crm.py
@@ -39,7 +39,7 @@ async def _get_access_token(client_id: str, client_secret: str, refresh_token: s
     accounts_domain = _ZOHO_ACCOUNTS_DOMAIN.get(data_center.lower(), _ZOHO_ACCOUNTS_DOMAIN["com"])
     token_url = f"{accounts_domain}/oauth/v2/token"
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
         response = await client.post(
             token_url,
             data={
@@ -141,7 +141,7 @@ class ZohoCrmGetObject(Tool):
             if fields:
                 params["fields"] = fields
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={"Authorization": f"Zoho-oauthtoken {access_token}"},
@@ -197,7 +197,7 @@ class ZohoCrmUpdateObject(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.put(
                     url,
                     headers={
@@ -293,7 +293,7 @@ class ZohoCrmSearchObjects(Tool):
             if fields:
                 params["fields"] = fields
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={"Authorization": f"Zoho-oauthtoken {access_token}"},
@@ -366,7 +366,7 @@ class ZohoCrmListObjects(Tool):
             if sort_order:
                 params["sort_order"] = sort_order
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={"Authorization": f"Zoho-oauthtoken {access_token}"},
@@ -409,7 +409,7 @@ class ZohoCrmListModules(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={"Authorization": f"Zoho-oauthtoken {access_token}"},
@@ -456,7 +456,7 @@ class ZohoCrmListFields(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={"Authorization": f"Zoho-oauthtoken {access_token}"},
@@ -521,7 +521,7 @@ class ZohoCrmUploadAttachment(Tool):
 
             headers = {"Authorization": f"Zoho-oauthtoken {access_token}"}
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 if attachment_url:
                     response = await client.post(
                         url,
@@ -590,7 +590,7 @@ class ZohoCrmDownloadAttachment(Tool):
             access_token, api_base = await _resolve_credentials(self)
             url = f"{api_base}/{module}/{record_id}/Attachments/{attachment_id}"
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     url,
                     headers={"Authorization": f"Zoho-oauthtoken {access_token}"},
@@ -654,7 +654,7 @@ class ZohoCrmCreateObject(Tool):
 
             import httpx
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     url,
                     headers={
@@ -748,7 +748,7 @@ class ZohoCrmConvertLead(Tool):
             if deals is not None:
                 payload["Deals"] = deals
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     url,
                     headers={


### PR DESCRIPTION
…eouts

All tool HTTP clients used httpx's 5s default on every phase, which falsely timed out on slow responses (TTS, transcription, scraping, large downloads).

Replace bare httpx.AsyncClient() with explicit timeouts:
- 120s read for slow media/file tools (elevenlabs, happy_scribe, firecrawl, scraperapi, fal, replicate, google_drive, onedrive, sharepoint)
- 30s read for the remaining REST API tools
- 10s connect across the board to bound hung connections

Trade-off: longer worst-case hang on dead hosts in exchange for far fewer false timeouts on legitimately slow endpoints.