### PR TITLE
fix(types): only treat dicts with role+content as message envelopes

### DIFF
--- a/python/tests/types/test_message.py
+++ b/python/tests/types/test_message.py
@@ -21,6 +21,39 @@ def test_message_text_validation() -> None:
         Message.validate({"role": "assistant", "content": [{"type": "text", "text": 123}]})
 
 
+def test_message_non_envelope_dict_is_stringified() -> None:
+    # A payload dict (no role/content keys, e.g. a tool's output wired into a prompt)
+    # must be stringified whole, NOT silently dropped to the literal "None".
+    payload = {"emails": [{"subject": "hi"}]}
+    message = Message.validate(payload)
+    assert message.role == "user"
+    assert len(message.content) == 1
+    assert message.content[0].type == "text"
+    assert message.content[0].text == str(payload)
+    assert message.content[0].text != "None"
+
+
+def test_message_partial_envelope_dict_is_stringified() -> None:
+    # A dict with only "role" (or only "content") is NOT a valid envelope, since every
+    # real envelope carries both. Treat it as a payload and stringify it whole.
+    role_only = {"role": "user"}
+    message = Message.validate(role_only)
+    assert message.role == "user"
+    assert message.content == [TextContent(text=str(role_only))]
+
+    content_only = {"content": "hi"}
+    message = Message.validate(content_only)
+    assert message.role == "user"
+    assert message.content == [TextContent(text=str(content_only))]
+
+
+def test_message_full_envelope_dict_is_parsed() -> None:
+    # A dict with both "role" and "content" takes the envelope path.
+    message = Message.validate({"role": "assistant", "content": "hi"})
+    assert message.role == "assistant"
+    assert message.content == [TextContent(text="hi")]
+
+
 def test_message_text_to_openai_chat_completions_input() -> None:
     message = Message(role="assistant", content=[TextContent(text="Hello, World!")])
     assert message.to_openai_chat_completions_input() == {"role": "assistant", "content": [{"type": "text", "text": "Hello, World!"}]}

--- a/python/timbal/types/message.py
+++ b/python/timbal/types/message.py
@@ -165,13 +165,22 @@ class Message:
         if isinstance(value, Message):
             return value
         if isinstance(value, dict):
-            role = value.get("role", "user")
-            content = value.get("content", None)
-            stop_reason = value.get("stop_reason", None)
-            if not isinstance(content, list):
-                content = [content]
-            content = [content_factory(item) for item in content]
-            return cls(role=role, content=content, stop_reason=stop_reason)
+            # Only treat a dict as a message envelope when it actually looks like one.
+            # Every internal envelope producer (Message.serialize, collectors, agent)
+            # emits both "role" and "content", so require both to avoid misclassifying
+            # arbitrary payload dicts (which commonly carry a lone "content"/"role" key).
+            if "role" in value and "content" in value:
+                role = value.get("role", "user")
+                content = value.get("content", None)
+                stop_reason = value.get("stop_reason", None)
+                if not isinstance(content, list):
+                    content = [content]
+                content = [content_factory(item) for item in content]
+                return cls(role=role, content=content, stop_reason=stop_reason)
+            # Arbitrary payload (e.g. a tool's dict output wired straight into a prompt):
+            # stringify the whole dict via content_factory instead of silently dropping
+            # it to the literal "None" (which is what the envelope path used to produce).
+            return cls(role="user", content=[content_factory(value)])
         return cls.validate(
             {
                 "role": "user",


### PR DESCRIPTION
Message.validate assumed every dict was a message envelope, so a tool's payload dict wired into a prompt had its missing "content" key resolved to None and silently became the literal text "None", discarding the data.

Every real envelope producer (Message.serialize, collectors, agent) emits both "role" and "content", so require both before taking the envelope path. Any other dict is stringified whole via content_factory, consistent with how content_factory already handles untyped dicts.