### PR TITLE
Fix Gemini image tools auth and default models

### DIFF
--- a/python/tests/core/test_interruptions.py
+++ b/python/tests/core/test_interruptions.py
@@ -1,4 +1,5 @@
 import asyncio
+import threading
 import time
 from collections.abc import AsyncGenerator, Generator
 from unittest.mock import patch
@@ -170,13 +171,25 @@ class TestToolInterruption:
         assert result.output is None
 
     @pytest.mark.asyncio
-    async def test_sync_generator_interruption(self, sync_gen_tool):
+    async def test_sync_generator_interruption(self):
         """Test that synchronous generator tool can be interrupted while yielding."""
-        # Start generator tool execution
-        task = asyncio.create_task(sync_gen_tool(count=100, delay=0.01).collect())
+        started = threading.Event()
 
-        # Wait for some chunks to be yielded
-        await asyncio.sleep(0.1)
+        def handler(count: int = 100, delay: float = 0.01) -> Generator[str, None, None]:
+            for i in range(count):
+                time.sleep(delay)
+                if i == 0:
+                    started.set()
+                yield f"sync_chunk_{i}"
+
+        tool = Tool(name="sync_gen", handler=handler)
+        task = asyncio.create_task(tool(count=100, delay=0.01).collect())
+
+        # Wait until the sync generator has yielded at least once. On macOS CI
+        # (py3.13) run_in_executor cold-start can exceed a fixed sleep, so cancel
+        # would fire before any chunk reached the collector.
+        await asyncio.to_thread(started.wait, 2.0)
+        assert started.is_set(), "sync generator did not yield before timeout"
 
         # Cancel while still yielding
         task.cancel()
@@ -186,15 +199,24 @@ class TestToolInterruption:
         assert isinstance(result, OutputEvent)
         assert result.status.code == "cancelled"
         assert result.output is not None  # Should have partial output
+        assert "sync_chunk_" in result.output
 
     @pytest.mark.asyncio
-    async def test_async_generator_interruption(self, async_gen_tool):
+    async def test_async_generator_interruption(self):
         """Test that asynchronous generator tool can be interrupted while yielding."""
-        # Start generator tool execution
-        task = asyncio.create_task(async_gen_tool(count=100, delay=0.01).collect())
+        started = asyncio.Event()
 
-        # Wait for some chunks to be yielded
-        await asyncio.sleep(0.1)
+        async def handler(count: int = 100, delay: float = 0.01) -> AsyncGenerator[str, None]:
+            for i in range(count):
+                await asyncio.sleep(delay)
+                if i == 0:
+                    started.set()
+                yield f"async_chunk_{i}"
+
+        tool = Tool(name="async_gen", handler=handler)
+        task = asyncio.create_task(tool(count=100, delay=0.01).collect())
+
+        await asyncio.wait_for(started.wait(), timeout=2.0)
 
         # Cancel while still yielding
         task.cancel()
@@ -204,6 +226,7 @@ class TestToolInterruption:
         assert isinstance(result, OutputEvent)
         assert result.status.code == "cancelled"
         assert result.output is not None  # Should have partial output
+        assert "async_chunk_" in result.output
 
     @pytest.mark.asyncio
     async def test_tool_reusability_after_interruption(self, long_running_async_tool):

--- a/python/tests/core/test_interruptions.py
+++ b/python/tests/core/test_interruptions.py
@@ -1,5 +1,4 @@
 import asyncio
-import threading
 import time
 from collections.abc import AsyncGenerator, Generator
 from unittest.mock import patch
@@ -171,25 +170,13 @@ class TestToolInterruption:
         assert result.output is None
 
     @pytest.mark.asyncio
-    async def test_sync_generator_interruption(self):
+    async def test_sync_generator_interruption(self, sync_gen_tool):
         """Test that synchronous generator tool can be interrupted while yielding."""
-        started = threading.Event()
+        # Start generator tool execution
+        task = asyncio.create_task(sync_gen_tool(count=100, delay=0.01).collect())
 
-        def handler(count: int = 100, delay: float = 0.01) -> Generator[str, None, None]:
-            for i in range(count):
-                time.sleep(delay)
-                if i == 0:
-                    started.set()
-                yield f"sync_chunk_{i}"
-
-        tool = Tool(name="sync_gen", handler=handler)
-        task = asyncio.create_task(tool(count=100, delay=0.01).collect())
-
-        # Wait until the sync generator has yielded at least once. On macOS CI
-        # (py3.13) run_in_executor cold-start can exceed a fixed sleep, so cancel
-        # would fire before any chunk reached the collector.
-        await asyncio.to_thread(started.wait, 2.0)
-        assert started.is_set(), "sync generator did not yield before timeout"
+        # Wait for some chunks to be yielded
+        await asyncio.sleep(0.1)
 
         # Cancel while still yielding
         task.cancel()
@@ -199,24 +186,15 @@ class TestToolInterruption:
         assert isinstance(result, OutputEvent)
         assert result.status.code == "cancelled"
         assert result.output is not None  # Should have partial output
-        assert "sync_chunk_" in result.output
 
     @pytest.mark.asyncio
-    async def test_async_generator_interruption(self):
+    async def test_async_generator_interruption(self, async_gen_tool):
         """Test that asynchronous generator tool can be interrupted while yielding."""
-        started = asyncio.Event()
+        # Start generator tool execution
+        task = asyncio.create_task(async_gen_tool(count=100, delay=0.01).collect())
 
-        async def handler(count: int = 100, delay: float = 0.01) -> AsyncGenerator[str, None]:
-            for i in range(count):
-                await asyncio.sleep(delay)
-                if i == 0:
-                    started.set()
-                yield f"async_chunk_{i}"
-
-        tool = Tool(name="async_gen", handler=handler)
-        task = asyncio.create_task(tool(count=100, delay=0.01).collect())
-
-        await asyncio.wait_for(started.wait(), timeout=2.0)
+        # Wait for some chunks to be yielded
+        await asyncio.sleep(0.1)
 
         # Cancel while still yielding
         task.cancel()
@@ -226,7 +204,6 @@ class TestToolInterruption:
         assert isinstance(result, OutputEvent)
         assert result.status.code == "cancelled"
         assert result.output is not None  # Should have partial output
-        assert "async_chunk_" in result.output
 
     @pytest.mark.asyncio
     async def test_tool_reusability_after_interruption(self, long_running_async_tool):

--- a/python/tests/tools/test_gemini_images.py
+++ b/python/tests/tools/test_gemini_images.py
@@ -1,0 +1,241 @@
+"""Tests for Gemini image tools.
+
+Unit tests mock httpx. Live integration tests require GEMINI_API_KEY.
+
+Run integration tests::
+
+    uv run python -m pytest python/tests/tools/test_gemini_images.py -m integration -v
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+from timbal.tools.gemini_images import (
+    GeminiImagesAnalyzeImage,
+    GeminiImagesEditImage,
+    GeminiImagesGenerateImage,
+    GeminiImagesGenerateImageWithReference,
+    GeminiImagesImageToBase64,
+    _parse_gemini_response,
+)
+
+_TINY_PNG_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+
+
+def _mock_httpx_context(mock_client: MagicMock) -> MagicMock:
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=mock_client)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+def _image_response(b64: str = "aW1hZ2U=", mime: str = "image/png", text: str | None = None) -> dict[str, Any]:
+    parts: list[dict[str, Any]] = []
+    if text:
+        parts.append({"text": text})
+    parts.append({"inlineData": {"data": b64, "mimeType": mime}})
+    return {"candidates": [{"content": {"parts": parts}}]}
+
+
+def test_parse_gemini_response_extracts_image_and_text():
+    parsed = _parse_gemini_response(_image_response(text="done"))
+    assert parsed["text"] == "done"
+    assert parsed["image_base64"] == "aW1hZ2U="
+    assert parsed["mime_type"] == "image/png"
+
+
+@pytest.mark.asyncio
+async def test_generate_image_uses_goog_api_key_header():
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json.return_value = _image_response()
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=response)
+
+    with patch("httpx.AsyncClient", return_value=_mock_httpx_context(mock_client)):
+        tool = GeminiImagesGenerateImage(api_key=SecretStr("test-gemini-key"))
+        out = await tool(prompt="A red circle").collect()
+
+    assert out.status.code == "success"
+    assert out.output["image_base64"] == "aW1hZ2U="
+    headers = mock_client.post.call_args.kwargs["headers"]
+    assert headers["x-goog-api-key"] == "test-gemini-key"
+    assert "Authorization" not in headers
+
+
+@pytest.mark.asyncio
+async def test_analyze_image_returns_text():
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json.return_value = {
+        "candidates": [{"content": {"parts": [{"text": "Mostly red."}]}}],
+    }
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=response)
+
+    with patch("httpx.AsyncClient", return_value=_mock_httpx_context(mock_client)):
+        tool = GeminiImagesAnalyzeImage(api_key=SecretStr("test-gemini-key"))
+        out = await tool(
+            prompt="What color?",
+            image_base64=_TINY_PNG_B64,
+            image_mime_type="image/png",
+        ).collect()
+
+    assert out.status.code == "success"
+    assert out.output == {"text": "Mostly red."}
+
+
+@pytest.mark.asyncio
+async def test_edit_image_posts_inline_data():
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json.return_value = _image_response(text="edited")
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=response)
+
+    with patch("httpx.AsyncClient", return_value=_mock_httpx_context(mock_client)):
+        tool = GeminiImagesEditImage(api_key=SecretStr("test-gemini-key"))
+        out = await tool(
+            prompt="Add a border",
+            image_base64=_TINY_PNG_B64,
+            image_mime_type="image/png",
+        ).collect()
+
+    assert out.status.code == "success"
+    payload = mock_client.post.call_args.kwargs["json"]
+    parts = payload["contents"][0]["parts"]
+    assert parts[0]["text"] == "Add a border"
+    assert parts[1]["inline_data"]["data"] == _TINY_PNG_B64
+
+
+@pytest.mark.asyncio
+async def test_generate_with_reference_includes_all_images():
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json.return_value = _image_response()
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=response)
+
+    with patch("httpx.AsyncClient", return_value=_mock_httpx_context(mock_client)):
+        tool = GeminiImagesGenerateImageWithReference(api_key=SecretStr("test-gemini-key"))
+        out = await tool(
+            prompt="Make it blue",
+            reference_images_base64=[_TINY_PNG_B64, _TINY_PNG_B64],
+            reference_mime_types=["image/png", "image/jpeg"],
+        ).collect()
+
+    assert out.status.code == "success"
+    parts = mock_client.post.call_args.kwargs["json"]["contents"][0]["parts"]
+    assert len(parts) == 3
+    assert parts[1]["inline_data"]["mime_type"] == "image/png"
+    assert parts[2]["inline_data"]["mime_type"] == "image/jpeg"
+
+
+@pytest.mark.asyncio
+async def test_image_url_to_base64_fetches_url():
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.content = b"\x89PNG\r\n"
+    response.headers = {"content-type": "image/png; charset=utf-8"}
+
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(return_value=response)
+
+    with patch("httpx.AsyncClient", return_value=_mock_httpx_context(mock_client)):
+        tool = GeminiImagesImageToBase64()
+        out = await tool(url="https://example.com/logo.png").collect()
+
+    assert out.status.code == "success"
+    assert out.output["mime_type"] == "image/png"
+    assert out.output["image_base64"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_gemini_generate_image_live():
+    if not os.getenv("GEMINI_API_KEY"):
+        pytest.skip("Set GEMINI_API_KEY for Gemini image integration test")
+    tool = GeminiImagesGenerateImage()
+    prompt = "A minimalist red circle on white background, flat vector style."
+    out = None
+    for _ in range(2):
+        out = await tool(prompt=prompt).collect()
+        if out.status.code == "success" and out.output.get("image_base64"):
+            break
+    assert out is not None
+    assert out.status.code == "success", out.error
+    assert out.output.get("image_base64"), f"expected image output, got: {out.output}"
+    assert out.output.get("mime_type")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_gemini_analyze_image_live():
+    if not os.getenv("GEMINI_API_KEY"):
+        pytest.skip("Set GEMINI_API_KEY for Gemini image integration test")
+    out = await GeminiImagesAnalyzeImage()(
+        prompt="Describe this image in one short sentence.",
+        image_base64=_TINY_PNG_B64,
+        image_mime_type="image/png",
+    ).collect()
+    assert out.status.code == "success", out.error
+    assert out.output["text"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_gemini_edit_image_live():
+    if not os.getenv("GEMINI_API_KEY"):
+        pytest.skip("Set GEMINI_API_KEY for Gemini image integration test")
+    gen = await GeminiImagesGenerateImage()(
+        prompt="A red circle on white background, minimalist.",
+    ).collect()
+    assert gen.status.code == "success", gen.error
+    image_b64 = gen.output["image_base64"]
+
+    out = await GeminiImagesEditImage()(
+        prompt="Add a thin black border.",
+        image_base64=image_b64,
+        image_mime_type=gen.output.get("mime_type") or "image/jpeg",
+    ).collect()
+    assert out.status.code == "success", out.error
+    assert out.output["image_base64"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_gemini_generate_with_reference_live():
+    if not os.getenv("GEMINI_API_KEY"):
+        pytest.skip("Set GEMINI_API_KEY for Gemini image integration test")
+    gen = await GeminiImagesGenerateImage()(
+        prompt="A red circle on white background, minimalist.",
+    ).collect()
+    assert gen.status.code == "success", gen.error
+
+    out = await GeminiImagesGenerateImageWithReference()(
+        prompt="Create a similar icon but make the circle blue.",
+        reference_images_base64=[gen.output["image_base64"]],
+        reference_mime_types=[gen.output.get("mime_type") or "image/jpeg"],
+    ).collect()
+    assert out.status.code == "success", out.error
+    assert out.output["image_base64"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_gemini_image_url_to_base64_live():
+    out = await GeminiImagesImageToBase64()(
+        url="https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30dp.png",
+    ).collect()
+    assert out.status.code == "success", out.error
+    assert out.output["image_base64"]
+    assert out.output["mime_type"].startswith("image/")

--- a/python/timbal/tools/gemini_images.py
+++ b/python/timbal/tools/gemini_images.py
@@ -8,9 +8,11 @@ from ..platform.integrations import Integration
 
 _GEMINI_BASE = "https://generativelanguage.googleapis.com/v1beta/models"
 
-_DEFAULT_EDIT_MODEL = "gemini-3.1-flash-image-preview"
-_DEFAULT_GENERATE_MODEL = "gemini-3.1-flash-image-preview"
-_DEFAULT_ANALYZE_MODEL = "gemini-3.1-flash-image-preview"
+# Image generation/editing: stable GA model (listed as "Nano Banana 2" in the Gemini API).
+# Preview sibling gemini-3.1-flash-image-preview still works but is not the stable default.
+_DEFAULT_IMAGE_MODEL = "gemini-3.1-flash-image"
+# Vision analysis: general multimodal flash — no image output modality needed.
+_DEFAULT_ANALYZE_MODEL = "gemini-3.5-flash"
 
 
 async def _resolve_api_key(tool: Any) -> str:
@@ -26,6 +28,10 @@ async def _resolve_api_key(tool: Any) -> str:
         "Gemini API key not found. Set GEMINI_API_KEY environment variable, "
         "pass api_key in config, or configure an integration."
     )
+
+
+def _gemini_headers(api_key: str) -> dict[str, str]:
+    return {"x-goog-api-key": api_key, "Content-Type": "application/json"}
 
 
 def _parse_gemini_response(data: dict[str, Any]) -> dict[str, Any]:
@@ -61,10 +67,17 @@ class GeminiImagesEditImage(Tool):
 
     def __init__(self, **kwargs: Any) -> None:
         async def _edit_image(
-            prompt: str = Field(..., description="Instruction describing the desired edit, e.g. 'remove the background'."),
+            prompt: str = Field(
+                ..., description="Instruction describing the desired edit, e.g. 'remove the background'."
+            ),
             image_base64: str = Field(..., description="The source image encoded as a base64 string."),
-            image_mime_type: str = Field("image/png", description="MIME type of the input image, e.g. 'image/png', 'image/jpeg'."),
-            model: str = Field(_DEFAULT_EDIT_MODEL, description="Gemini model to use. Defaults to gemini-2.0-flash-exp-image-generation."),
+            image_mime_type: str = Field(
+                "image/png", description="MIME type of the input image, e.g. 'image/png', 'image/jpeg'."
+            ),
+            model: str = Field(
+                _DEFAULT_IMAGE_MODEL,
+                description=f"Gemini image model. Defaults to {_DEFAULT_IMAGE_MODEL}.",
+            ),
         ) -> Any:
             api_key = await _resolve_api_key(self)
             import httpx
@@ -89,7 +102,7 @@ class GeminiImagesEditImage(Tool):
             async with httpx.AsyncClient(timeout=120.0) as client:
                 response = await client.post(
                     f"{_GEMINI_BASE}/{model}:generateContent",
-                    headers={"Authorization": f"Bearer {api_key}"},
+                    headers=_gemini_headers(api_key),
                     json=payload,
                 )
                 response.raise_for_status()
@@ -101,8 +114,7 @@ class GeminiImagesEditImage(Tool):
 class GeminiImagesGenerateImage(Tool):
     name: str = "gemini_generate_image"
     description: str | None = (
-        "Generate a new image from a text prompt using Gemini. "
-        "Returns the generated image as a base64 string."
+        "Generate a new image from a text prompt using Gemini. Returns the generated image as a base64 string."
     )
     integration: Annotated[str, Integration("gemini")] | None = None
     api_key: SecretStr | None = None
@@ -116,8 +128,13 @@ class GeminiImagesGenerateImage(Tool):
     def __init__(self, **kwargs: Any) -> None:
         async def _generate_image(
             prompt: str = Field(..., description="Text description of the image to generate."),
-            negative_prompt: str | None = Field(None, description="Optional description of what to avoid in the image."),
-            model: str = Field(_DEFAULT_GENERATE_MODEL, description="Gemini model to use. Defaults to gemini-2.0-flash-exp-image-generation."),
+            negative_prompt: str | None = Field(
+                None, description="Optional description of what to avoid in the image."
+            ),
+            model: str = Field(
+                _DEFAULT_IMAGE_MODEL,
+                description=f"Gemini image model. Defaults to {_DEFAULT_IMAGE_MODEL}.",
+            ),
         ) -> Any:
             api_key = await _resolve_api_key(self)
             import httpx
@@ -127,18 +144,14 @@ class GeminiImagesGenerateImage(Tool):
                 text = f"{prompt}\n\nAvoid: {negative_prompt}"
 
             payload = {
-                "contents": [
-                    {
-                        "parts": [{"text": text}]
-                    }
-                ],
+                "contents": [{"parts": [{"text": text}]}],
                 "generationConfig": {"responseModalities": ["IMAGE", "TEXT"]},
             }
 
             async with httpx.AsyncClient(timeout=120.0) as client:
                 response = await client.post(
                     f"{_GEMINI_BASE}/{model}:generateContent",
-                    headers={"Authorization": f"Bearer {api_key}"},
+                    headers=_gemini_headers(api_key),
                     json=payload,
                 )
                 response.raise_for_status()
@@ -164,10 +177,18 @@ class GeminiImagesAnalyzeImage(Tool):
 
     def __init__(self, **kwargs: Any) -> None:
         async def _analyze_image(
-            prompt: str = Field(..., description="Question or instruction about the image, e.g. 'Describe this image', 'What text is visible?', 'List all objects'."),
+            prompt: str = Field(
+                ...,
+                description="Question or instruction about the image, e.g. 'Describe this image', 'What text is visible?', 'List all objects'.",
+            ),
             image_base64: str = Field(..., description="The image encoded as a base64 string."),
-            image_mime_type: str = Field("image/png", description="MIME type of the image, e.g. 'image/png', 'image/jpeg'."),
-            model: str = Field(_DEFAULT_ANALYZE_MODEL, description="Gemini model to use. Defaults to gemini-2.0-flash."),
+            image_mime_type: str = Field(
+                "image/png", description="MIME type of the image, e.g. 'image/png', 'image/jpeg'."
+            ),
+            model: str = Field(
+                _DEFAULT_ANALYZE_MODEL,
+                description=f"Gemini vision model. Defaults to {_DEFAULT_ANALYZE_MODEL}.",
+            ),
         ) -> Any:
             api_key = await _resolve_api_key(self)
             import httpx
@@ -192,7 +213,7 @@ class GeminiImagesAnalyzeImage(Tool):
             async with httpx.AsyncClient(timeout=60.0) as client:
                 response = await client.post(
                     f"{_GEMINI_BASE}/{model}:generateContent",
-                    headers={"Authorization": f"Bearer {api_key}"},
+                    headers=_gemini_headers(api_key),
                     json=payload,
                 )
                 response.raise_for_status()
@@ -225,8 +246,13 @@ class GeminiImagesGenerateImageWithReference(Tool):
         async def _generate_image_with_reference(
             prompt: str = Field(..., description="Text instruction describing the desired output image."),
             reference_images_base64: list[str] = Field(..., description="List of reference images as base64 strings."),
-            reference_mime_types: list[str] | None = Field(None, description="MIME type per reference image. Defaults to 'image/png' for all."),
-            model: str = Field(_DEFAULT_GENERATE_MODEL, description="Gemini model to use. Defaults to gemini-2.0-flash-exp-image-generation."),
+            reference_mime_types: list[str] | None = Field(
+                None, description="MIME type per reference image. Defaults to 'image/png' for all."
+            ),
+            model: str = Field(
+                _DEFAULT_IMAGE_MODEL,
+                description=f"Gemini image model. Defaults to {_DEFAULT_IMAGE_MODEL}.",
+            ),
         ) -> Any:
             api_key = await _resolve_api_key(self)
             import httpx
@@ -245,7 +271,7 @@ class GeminiImagesGenerateImageWithReference(Tool):
             async with httpx.AsyncClient(timeout=120.0) as client:
                 response = await client.post(
                     f"{_GEMINI_BASE}/{model}:generateContent",
-                    headers={"Authorization": f"Bearer {api_key}"},
+                    headers=_gemini_headers(api_key),
                     json=payload,
                 )
                 response.raise_for_status()
@@ -268,6 +294,7 @@ class GeminiImagesImageToBase64(Tool):
             import base64
 
             import httpx
+
             async with httpx.AsyncClient(timeout=30.0) as client:
                 response = await client.get(url)
                 response.raise_for_status()


### PR DESCRIPTION
## Summary

- Fix authentication for all `gemini_images` tools: use `x-goog-api-key` instead of `Authorization: Bearer` (API keys were returning 401).
- Update default models after validating against the live Gemini `models` list:
  - **Generate / edit / with-reference:** `gemini-3.1-flash-image` (stable GA — "Nano Banana 2")
  - **Analyze:** `gemini-3.5-flash` (stable multimodal vision; no image output modality needed)
- Add `python/tests/tools/test_gemini_images.py` with mocked unit tests and live integration tests (`GEMINI_API_KEY`).

## Model validation (live, 2026-06-26)

| Use case | Model tested | Result |
|----------|--------------|--------|
| Image generation | `gemini-3.1-flash-image` | OK (stable) |
| Image generation | `gemini-3.1-flash-image-preview` | OK (preview sibling) |
| Image generation | `gemini-3-pro-image` | OK (higher quality, slower) |
| Image generation | `gemini-2.5-flash-image` | OK (older stable) |
| Vision analyze | `gemini-3.5-flash` | OK |
| Vision analyze | `gemini-2.5-flash` | OK |

Preview models still work if passed explicitly via the `model` param.

## Test plan

- [x] `uv run python -m pytest python/tests/tools/test_gemini_images.py -m "not integration"` — 6 passed
- [x] `uv run python -m pytest python/tests/tools/test_gemini_images.py -m integration` — 5 passed (requires `GEMINI_API_KEY`)
- [x] Live smoke: generate, analyze, edit, with-reference, url-to-base64


Made with [Cursor](https://cursor.com)