### PR TITLE
feat(krea): add model enums and let errors propagate

### DIFF
--- a/python/tests/codegen/test_get_flow.py
+++ b/python/tests/codegen/test_get_flow.py
@@ -1108,3 +1108,41 @@ class TestErrors:
         (tmp_path / "timbal.yaml").write_text('fqn: "nonexistent.py::agent"\n')
         with pytest.raises(FileNotFoundError):
             get_flow(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Model-enum heuristic (x-timbal-ref="models")
+# ---------------------------------------------------------------------------
+
+
+class TestModelEnumHeuristic:
+    """_is_model_enum matches the canonical LLM model set, not any provider/name enum."""
+
+    def test_llm_models_are_refd(self):
+        import typing
+
+        from timbal.codegen.flow import _is_model_enum
+        from timbal.core.models import Model
+
+        assert _is_model_enum(list(typing.get_args(Model))) is True
+
+    def test_krea_models_stay_inline(self):
+        import typing
+
+        from timbal.codegen.flow import _is_model_enum
+        from timbal.tools.krea import KreaImageModel, KreaVideoModel
+
+        # Krea IDs share the provider/name shape but are not LLM models.
+        assert _is_model_enum(list(typing.get_args(KreaImageModel))) is False
+        assert _is_model_enum(list(typing.get_args(KreaVideoModel))) is False
+
+    def test_krea_tool_field_keeps_enum(self):
+        """A Krea generate tool's model field must keep its enum, not become a models ref."""
+        from timbal.codegen.flow import _compact_field
+        from timbal.tools.krea import KreaGenerateImage
+
+        tool = KreaGenerateImage(tracing_provider=None)
+        model_field = tool.params_model_schema["properties"]["model"]
+        compacted = _compact_field(model_field)
+        assert compacted.get("x-timbal-ref") != "models"
+        assert "bfl/flux-1-dev" in compacted["enum"]

--- a/python/tests/tools/test_krea.py
+++ b/python/tests/tools/test_krea.py
@@ -150,23 +150,22 @@ async def test_krea_generate_video_submit_and_poll():
 @pytest.mark.asyncio
 async def test_krea_generate_video_empty_prompt():
     tool = KreaGenerateVideo(api_key=SecretStr("krea-test"))
-    out = await tool.handler(
-        prompt="   ",
-        model="google/veo-3.1-fast",
-        aspect_ratio="16:9",
-        duration=4,
-        resolution="720p",
-        generate_audio=False,
-        start_image=None,
-        end_image=None,
-        reference_images=None,
-        provider_params=None,
-        webhook_url=None,
-        poll_interval=0,
-        timeout=30,
-    )
-    assert out["success"] is False
-    assert "prompt" in out["error"].lower()
+    with pytest.raises(ValueError, match="prompt is required"):
+        await tool.handler(
+            prompt="   ",
+            model="google/veo-3.1-fast",
+            aspect_ratio="16:9",
+            duration=4,
+            resolution="720p",
+            generate_audio=False,
+            start_image=None,
+            end_image=None,
+            reference_images=None,
+            provider_params=None,
+            webhook_url=None,
+            poll_interval=0,
+            timeout=30,
+        )
 
 
 @pytest.mark.asyncio
@@ -229,24 +228,26 @@ async def test_krea_generate_video_live_or_balance_error():
     if not os.getenv("KREA_API_KEY"):
         pytest.skip("Set KREA_API_KEY for Krea integration test")
     tool = KreaGenerateVideo()
-    out = await tool.handler(
-        prompt="A paper boat on calm water, macro cinematic.",
-        model="google/veo-3.1-fast",
-        aspect_ratio="16:9",
-        duration=4,
-        resolution="720p",
-        generate_audio=False,
-        start_image=None,
-        end_image=None,
-        reference_images=None,
-        provider_params=None,
-        webhook_url=None,
-        poll_interval=5,
-        timeout=600,
-    )
-    if out["success"]:
+    try:
+        out = await tool.handler(
+            prompt="A paper boat on calm water, macro cinematic.",
+            model="google/veo-3.1-fast",
+            aspect_ratio="16:9",
+            duration=4,
+            resolution="720p",
+            generate_audio=False,
+            start_image=None,
+            end_image=None,
+            reference_images=None,
+            provider_params=None,
+            webhook_url=None,
+            poll_interval=5,
+            timeout=600,
+        )
+    except (RuntimeError, TimeoutError) as exc:
+        # API errors (e.g. insufficient balance) now propagate instead of being swallowed.
+        assert str(exc)
+    else:
+        assert out["success"] is True
         assert out["video_url"]
         assert out["job_id"]
-    else:
-        assert out["error_type"] in ("RuntimeError", "TimeoutError")
-        assert out["error"]

--- a/python/timbal/codegen/flow.py
+++ b/python/timbal/codegen/flow.py
@@ -71,8 +71,20 @@ def _extract_key_from_lambda(fn: Any, source_step: str) -> str | None:
 
 
 def _is_model_enum(values: list) -> bool:
-    """Return True if a list of enum values looks like LLM model IDs (provider/name)."""
-    return len(values) > 5 and all(isinstance(v, str) and "/" in v for v in values[:5])
+    """Return True if an enum is the canonical LLM model ID set (provider/name).
+
+    Matches against ``timbal.core.models.Model`` rather than guessing from shape:
+    other registries (e.g. Krea's image/video IDs) share the ``provider/name``
+    form but must keep their enum inline so editors resolve the right options.
+    """
+    if len(values) <= 5 or not all(isinstance(v, str) and "/" in v for v in values[:5]):
+        return False
+    import typing
+
+    from timbal.core.models import Model
+
+    known = set(typing.get_args(Model))
+    return all(v in known for v in values)
 
 
 def _compact_field(field: dict) -> dict:

--- a/python/timbal/tools/krea.py
+++ b/python/timbal/tools/krea.py
@@ -26,6 +26,72 @@ _FAILED_STATUSES = frozenset({"failed", "cancelled"})
 
 MediaKind = Literal["video", "image"]
 
+# Model identifiers map directly to Krea's POST /generate/{media}/{provider}/{model} endpoints.
+# Source of truth: https://api.krea.ai/openapi.json. Update when Krea adds/removes models.
+KreaImageModel = Literal[
+    "bfl/flux-1-dev",
+    "bfl/flux-1-kontext-dev",
+    "bfl/flux-1.1-pro",
+    "bfl/flux-1.1-pro-ultra",
+    "bytedance/seededit",
+    "bytedance/seedream-4",
+    "bytedance/seedream-5-lite",
+    "google/imagen-3",
+    "google/imagen-4",
+    "google/imagen-4-fast",
+    "google/imagen-4-ultra",
+    "google/nano-banana",
+    "google/nano-banana-2",
+    "google/nano-banana-pro",
+    "ideogram/ideogram-2-turbo",
+    "ideogram/ideogram-3",
+    "krea/krea-2/large",
+    "krea/krea-2/medium",
+    "krea/krea-2/medium-turbo",
+    "luma/uni-1",
+    "openai/gpt-image",
+    "openai/gpt-image-2",
+    "qwen/2512",
+    "runway/gen-4-image",
+    "z-image/z-image",
+]
+
+KreaVideoModel = Literal[
+    "alibaba/wan-2.1",
+    "alibaba/wan-2.2",
+    "alibaba/wan-2.5",
+    "bytedance/seedance-1.0-pro",
+    "bytedance/seedance-1.0-pro-fast",
+    "bytedance/seedance-2",
+    "bytedance/seedance-2-fast",
+    "google/veo-2",
+    "google/veo-3",
+    "google/veo-3-fast",
+    "google/veo-3.1",
+    "google/veo-3.1-fast",
+    "google/veo-3.1-lite",
+    "kling/kling-1",
+    "kling/kling-1.5",
+    "kling/kling-1.6",
+    "kling/kling-2",
+    "kling/kling-2.1",
+    "kling/kling-2.5",
+    "kling/kling-2.6",
+    "kling/kling-3.0",
+    "kling/kling-o1",
+    "lightricks/ltx-video-2.3-22b",
+    "luma/ray-2",
+    "minimax/hailuo",
+    "minimax/hailuo-02",
+    "minimax/hailuo-2.3",
+    "minimax/hailuo-2.3-fast",
+    "runway/aleph",
+    "runway/gen-3",
+    "runway/gen-4-video",
+    "runway/gen-4.5",
+    "xai/grok-video",
+]
+
 
 def _krea_headers(api_key: str, *, webhook_url: str | None = None) -> dict[str, str]:
     headers = {
@@ -248,9 +314,9 @@ class KreaGenerateVideo(Tool):
     def __init__(self, **kwargs: Any) -> None:
         async def _krea_generate_video(
             prompt: str = Field(..., description="Text description of the video to generate."),
-            model: str = Field(
+            model: KreaVideoModel = Field(
                 "google/veo-3.1-fast",
-                description="Krea video model path: provider/model (e.g. google/veo-3.1-fast).",
+                description="Krea video model as provider/model (e.g. google/veo-3.1-fast, kling/kling-2.5).",
             ),
             aspect_ratio: str = Field("16:9", description="Aspect ratio when supported by the model."),
             duration: int | None = Field(None, description="Duration in seconds when supported by the model."),
@@ -279,89 +345,74 @@ class KreaGenerateVideo(Tool):
             start = time.monotonic()
             resolved_model = model.strip()
 
-            try:
-                if not prompt or not prompt.strip():
-                    raise ValueError("prompt is required and must be non-empty")
+            if not prompt or not prompt.strip():
+                raise ValueError("prompt is required and must be non-empty")
 
-                payload: dict[str, Any] = {"prompt": prompt.strip()}
-                if aspect_ratio:
-                    payload["aspect_ratio"] = aspect_ratio
-                if duration is not None:
-                    payload["duration"] = duration
-                if resolution is not None:
-                    payload["resolution"] = resolution
-                if generate_audio is not None:
-                    payload["generate_audio"] = generate_audio
-                if start_image:
-                    payload["start_image"] = start_image
-                if end_image:
-                    payload["end_image"] = end_image
-                if reference_images:
-                    payload["reference_images"] = reference_images
-                if provider_params:
-                    for key, value in provider_params.items():
-                        if value is not None:
-                            payload[key] = value
+            payload: dict[str, Any] = {"prompt": prompt.strip()}
+            if aspect_ratio:
+                payload["aspect_ratio"] = aspect_ratio
+            if duration is not None:
+                payload["duration"] = duration
+            if resolution is not None:
+                payload["resolution"] = resolution
+            if generate_audio is not None:
+                payload["generate_audio"] = generate_audio
+            if start_image:
+                payload["start_image"] = start_image
+            if end_image:
+                payload["end_image"] = end_image
+            if reference_images:
+                payload["reference_images"] = reference_images
+            if provider_params:
+                for key, value in provider_params.items():
+                    if value is not None:
+                        payload[key] = value
 
-                path = _build_generate_path("video", resolved_model)
-                api_key = await resolve_api_key(tool=self, provider_name="Krea", env_var="KREA_API_KEY")
-                import httpx
+            path = _build_generate_path("video", resolved_model)
+            api_key = await resolve_api_key(tool=self, provider_name="Krea", env_var="KREA_API_KEY")
+            import httpx
 
-                async with httpx.AsyncClient(timeout=httpx.Timeout(60.0, read=None)) as client:
-                    submit = await client.post(
-                        f"{_KREA_BASE}{path}",
-                        headers=_krea_headers(api_key, webhook_url=webhook_url),
-                        json=payload,
-                    )
-                    await _raise_for_krea_response(submit)
-                    submit_data = submit.json()
-
-                    job_id = submit_data.get("job_id")
-                    if not isinstance(job_id, str) or not job_id:
-                        raise ValueError(f"Krea video API returned no job_id: {submit_data}")
-
-                    job = await _poll_krea_job(
-                        client,
-                        api_key=api_key,
-                        job_id=job_id,
-                        poll_interval=poll_interval,
-                        timeout=timeout,
-                    )
-
-                urls = _extract_job_urls(job)
-                if not urls:
-                    raise ValueError(f"No output URLs in completed Krea job: {job}")
-
-                elapsed = time.monotonic() - start
-                logger.info(
-                    "Krea video generated",
-                    model=resolved_model,
-                    job_id=job_id,
-                    elapsed_s=round(elapsed, 2),
+            async with httpx.AsyncClient(timeout=httpx.Timeout(60.0, read=None)) as client:
+                submit = await client.post(
+                    f"{_KREA_BASE}{path}",
+                    headers=_krea_headers(api_key, webhook_url=webhook_url),
+                    json=payload,
                 )
-                return {
-                    "success": True,
-                    "model": resolved_model,
-                    "job_id": job_id,
-                    "video_url": urls[0],
-                    "urls": urls,
-                    "job": job,
-                    "elapsed_seconds": round(elapsed, 2),
-                }
+                await _raise_for_krea_response(submit)
+                submit_data = submit.json()
 
-            except Exception as exc:
-                elapsed = time.monotonic() - start
-                logger.error("Krea video generation failed", model=resolved_model, error=str(exc))
-                return {
-                    "success": False,
-                    "model": resolved_model,
-                    "job_id": None,
-                    "video_url": None,
-                    "urls": [],
-                    "error": str(exc),
-                    "error_type": type(exc).__name__,
-                    "elapsed_seconds": round(elapsed, 2),
-                }
+                job_id = submit_data.get("job_id")
+                if not isinstance(job_id, str) or not job_id:
+                    raise ValueError(f"Krea video API returned no job_id: {submit_data}")
+
+                job = await _poll_krea_job(
+                    client,
+                    api_key=api_key,
+                    job_id=job_id,
+                    poll_interval=poll_interval,
+                    timeout=timeout,
+                )
+
+            urls = _extract_job_urls(job)
+            if not urls:
+                raise ValueError(f"No output URLs in completed Krea job: {job}")
+
+            elapsed = time.monotonic() - start
+            logger.info(
+                "Krea video generated",
+                model=resolved_model,
+                job_id=job_id,
+                elapsed_s=round(elapsed, 2),
+            )
+            return {
+                "success": True,
+                "model": resolved_model,
+                "job_id": job_id,
+                "video_url": urls[0],
+                "urls": urls,
+                "job": job,
+                "elapsed_seconds": round(elapsed, 2),
+            }
 
         super().__init__(handler=_krea_generate_video, **kwargs)
 
@@ -385,9 +436,9 @@ class KreaGenerateImage(Tool):
     def __init__(self, **kwargs: Any) -> None:
         async def _krea_generate_image(
             prompt: str = Field(..., description="Text description of the image to generate."),
-            model: str = Field(
+            model: KreaImageModel = Field(
                 "bfl/flux-1-dev",
-                description="Krea image model path: provider/model (e.g. bfl/flux-1-dev).",
+                description="Krea image model as provider/model (e.g. bfl/flux-1-dev, krea/krea-2/large).",
             ),
             width: int | None = Field(None, description="Output width in pixels when supported."),
             height: int | None = Field(None, description="Output height in pixels when supported."),
@@ -407,82 +458,67 @@ class KreaGenerateImage(Tool):
             start = time.monotonic()
             resolved_model = model.strip()
 
-            try:
-                if not prompt or not prompt.strip():
-                    raise ValueError("prompt is required and must be non-empty")
+            if not prompt or not prompt.strip():
+                raise ValueError("prompt is required and must be non-empty")
 
-                payload: dict[str, Any] = {"prompt": prompt.strip()}
-                if width is not None:
-                    payload["width"] = width
-                if height is not None:
-                    payload["height"] = height
-                if seed is not None:
-                    payload["seed"] = seed
-                if image_url:
-                    payload["image_url"] = image_url
-                if provider_params:
-                    for key, value in provider_params.items():
-                        if value is not None:
-                            payload[key] = value
+            payload: dict[str, Any] = {"prompt": prompt.strip()}
+            if width is not None:
+                payload["width"] = width
+            if height is not None:
+                payload["height"] = height
+            if seed is not None:
+                payload["seed"] = seed
+            if image_url:
+                payload["image_url"] = image_url
+            if provider_params:
+                for key, value in provider_params.items():
+                    if value is not None:
+                        payload[key] = value
 
-                path = _build_generate_path("image", resolved_model)
-                api_key = await resolve_api_key(tool=self, provider_name="Krea", env_var="KREA_API_KEY")
-                import httpx
+            path = _build_generate_path("image", resolved_model)
+            api_key = await resolve_api_key(tool=self, provider_name="Krea", env_var="KREA_API_KEY")
+            import httpx
 
-                async with httpx.AsyncClient(timeout=httpx.Timeout(60.0, read=None)) as client:
-                    submit = await client.post(
-                        f"{_KREA_BASE}{path}",
-                        headers=_krea_headers(api_key, webhook_url=webhook_url),
-                        json=payload,
-                    )
-                    await _raise_for_krea_response(submit)
-                    submit_data = submit.json()
-
-                    job_id = submit_data.get("job_id")
-                    if not isinstance(job_id, str) or not job_id:
-                        raise ValueError(f"Krea image API returned no job_id: {submit_data}")
-
-                    job = await _poll_krea_job(
-                        client,
-                        api_key=api_key,
-                        job_id=job_id,
-                        poll_interval=poll_interval,
-                        timeout=timeout,
-                    )
-
-                urls = _extract_job_urls(job)
-                if not urls:
-                    raise ValueError(f"No output URLs in completed Krea job: {job}")
-
-                elapsed = time.monotonic() - start
-                logger.info(
-                    "Krea image generated",
-                    model=resolved_model,
-                    job_id=job_id,
-                    elapsed_s=round(elapsed, 2),
+            async with httpx.AsyncClient(timeout=httpx.Timeout(60.0, read=None)) as client:
+                submit = await client.post(
+                    f"{_KREA_BASE}{path}",
+                    headers=_krea_headers(api_key, webhook_url=webhook_url),
+                    json=payload,
                 )
-                return {
-                    "success": True,
-                    "model": resolved_model,
-                    "job_id": job_id,
-                    "image_url": urls[0],
-                    "urls": urls,
-                    "job": job,
-                    "elapsed_seconds": round(elapsed, 2),
-                }
+                await _raise_for_krea_response(submit)
+                submit_data = submit.json()
 
-            except Exception as exc:
-                elapsed = time.monotonic() - start
-                logger.error("Krea image generation failed", model=resolved_model, error=str(exc))
-                return {
-                    "success": False,
-                    "model": resolved_model,
-                    "job_id": None,
-                    "image_url": None,
-                    "urls": [],
-                    "error": str(exc),
-                    "error_type": type(exc).__name__,
-                    "elapsed_seconds": round(elapsed, 2),
-                }
+                job_id = submit_data.get("job_id")
+                if not isinstance(job_id, str) or not job_id:
+                    raise ValueError(f"Krea image API returned no job_id: {submit_data}")
+
+                job = await _poll_krea_job(
+                    client,
+                    api_key=api_key,
+                    job_id=job_id,
+                    poll_interval=poll_interval,
+                    timeout=timeout,
+                )
+
+            urls = _extract_job_urls(job)
+            if not urls:
+                raise ValueError(f"No output URLs in completed Krea job: {job}")
+
+            elapsed = time.monotonic() - start
+            logger.info(
+                "Krea image generated",
+                model=resolved_model,
+                job_id=job_id,
+                elapsed_s=round(elapsed, 2),
+            )
+            return {
+                "success": True,
+                "model": resolved_model,
+                "job_id": job_id,
+                "image_url": urls[0],
+                "urls": urls,
+                "job": job,
+                "elapsed_seconds": round(elapsed, 2),
+            }
 
         super().__init__(handler=_krea_generate_image, **kwargs)


### PR DESCRIPTION
Add KreaImageModel and KreaVideoModel Literal enums generated from Krea's OpenAPI spec (api.krea.ai/openapi.json) and type the generate handlers' model fields with them, so invalid provider/model slugs fail fast at validation with the full list of valid options instead of a remote 404.

Remove the broad try/except wrappers in the image and video generate handlers — errors are handled upstream. This also lets CredentialNotAvailable propagate so the tool proxy fallback runs when no KREA_API_KEY is set.