### PR TITLE
refactor(file): drop unused org_id from File.persist()

### DIFF
--- a/python/tests/types/test_file.py
+++ b/python/tests/types/test_file.py
@@ -426,6 +426,52 @@ class TestFilePersist:
         assert result is not None
         assert os.path.exists(result)
 
+    def _platform_ctx(self):
+        from timbal.state.context import RunContext
+        from timbal.state.config import (
+            PlatformAuth,
+            PlatformAuthType,
+            PlatformConfig,
+            PlatformSubject,
+        )
+
+        platform_config = PlatformConfig(
+            host="https://api.timbal.ai",
+            cdn="content.timbal.ai",
+            auth=PlatformAuth(type=PlatformAuthType.BEARER, token="token123"),
+            subject=PlatformSubject(org_id="org-1", app_id="app-9"),
+        )
+        return RunContext(platform_config=platform_config, tracing_provider=None)
+
+    async def test_persist_upload_returns_unsigned_url(self, tmp_path: pathlib.Path) -> None:
+        """POST /files returns an unsigned (public) url; the name segment is re-encoded."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+        from timbal.state import set_run_context
+
+        set_run_context(self._platform_ctx())
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "content_length": 4,
+            "content_type": "application/octet-stream",
+            "created_at": "2026-01-01T00:00:00Z",
+            "expires_at": None,
+            "name": "my file.bin",
+            "url": "https://content.timbal.ai/org-1/my file.bin",
+        }
+
+        test_file = tmp_path / "my file.bin"
+        test_file.write_bytes(b"data")
+        file = File.validate(str(test_file))
+        with patch(
+            "timbal.platform.utils._request", new_callable=AsyncMock
+        ) as mock_request:
+            mock_request.return_value = mock_response
+            result = await file.persist()
+
+        assert result == "https://content.timbal.ai/org-1/my%20file.bin"
+        assert file.__persisted__ == result
+
 
 # ---------------------------------------------------------------------------
 # TestFileSerialize — serialize() with persisted value

--- a/python/timbal/platform/types.py
+++ b/python/timbal/platform/types.py
@@ -34,7 +34,6 @@ class UploadFileResponse(BaseModel):
     created_at: datetime
     expires_at: datetime | None
     name: str
-    # Optional: POST /files (no org scope) returns a temporary upload without an id.
-    # POST /orgs/{org_id}/files returns a permanent upload with an id.
+    # POST /files (no org scope) returns a temporary upload without an id.
     id: str | int | None = None
     url: str

--- a/python/timbal/types/file.py
+++ b/python/timbal/types/file.py
@@ -371,11 +371,7 @@ class File(io.IOBase):
         bs64_content = base64.b64encode(content).decode("utf-8")
         return f"data:{self.__content_type__};base64,{bs64_content}"
 
-    async def persist(
-        self,
-        org_id: str | None = None,
-        # ? Add more resource specifiers
-    ) -> str | None:
+    async def persist(self) -> str | None:
         """Persist the file to some storage.
         If there's no run context or valid platform config, the file will be persisted to local disk.
         If there's a platform configuration, the file will be uploaded to the platform.
@@ -394,7 +390,7 @@ class File(io.IOBase):
                 object.__setattr__(self, "__persisted__", url)
                 return url
 
-        if not run_context.platform_config or (not org_id and not run_context.platform_config.subject):
+        if not run_context.platform_config or not run_context.platform_config.subject:
             if self.__source_scheme__ == "local_path":
                 local_path = str(self)
                 object.__setattr__(self, "__persisted__", local_path)


### PR DESCRIPTION
The SDK has uploaded via POST /files since v2.0.3; org_id was never wired to /orgs/{org_id}/files. Remove the dead parameter, simplify the platform-config guard, and fix the stale UploadFileResponse comment.