### PR TITLE
fix(platform): send JSON body for empty-dict payloads

### DIFF
--- a/python/timbal/platform/utils.py
+++ b/python/timbal/platform/utils.py
@@ -104,7 +104,9 @@ async def _request(
     """Utility function for making HTTP requests."""
     url, headers = _resolve_url_and_headers(service, path, headers)
     payload_kwargs = {}
-    if json:
+    # `is not None` so an empty dict still sends a JSON body + Content-Type
+    # (parameterless POSTs would otherwise 415 Unsupported Media Type).
+    if json is not None:
         payload_kwargs["json"] = json
     elif content:
         payload_kwargs["content"] = content
@@ -194,7 +196,9 @@ async def _stream(
         "Cache-Control": "no-cache",
     }
     payload_kwargs = {}
-    if json:
+    # `is not None` so an empty dict still sends a JSON body + Content-Type
+    # (parameterless POSTs would otherwise 415 Unsupported Media Type).
+    if json is not None:
         payload_kwargs["json"] = json
     elif content:
         payload_kwargs["content"] = content


### PR DESCRIPTION
_request/_stream used `if json:`, so an empty dict ({}) — e.g. a parameterless tool-proxy POST — sent no body and no Content-Type, which servers reject with 415 Unsupported Media Type. Use `is not None` so {} is sent as a valid JSON body.