### PR TITLE
feat(codegen): surface pending integrations in get-flow output

### DIFF
--- a/python/tests/codegen/test_get_flow.py
+++ b/python/tests/codegen/test_get_flow.py
@@ -51,6 +51,8 @@ class TestTopLevel:
         assert isinstance(flow["_version"], str)
         assert "nodes" in flow
         assert "edges" in flow
+        assert "pending_integrations" in flow
+        assert flow["pending_integrations"] == []
 
     def test_agent_entry_point_single_node(self, workspace):
         ws = workspace("""\
@@ -1198,6 +1200,152 @@ class TestEdgeKinds:
         assert edge is not None and edge["kind"] == "param"
         # Not redundant (no alternate path) -> still shown in compact.
         assert "agent_a → agent_b" in format_compact(flow)
+
+
+# ---------------------------------------------------------------------------
+# Pending integrations
+# ---------------------------------------------------------------------------
+
+
+class TestPendingIntegrations:
+    def test_agent_tool_without_integration_binding(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent
+        from timbal.tools.slack import SlackReadMessages
+
+        agent = Agent(
+            name="my_agent",
+            model="openai/gpt-4o-mini",
+            max_tokens=128,
+            tools=[SlackReadMessages()],
+        )
+        """)
+        flow = _flow(ws)
+        assert flow["pending_integrations"] == [
+            {
+                "node_id": "my_agent.slack_read_messages",
+                "parent_id": "my_agent",
+                "tool_name": "slack_read_messages",
+                "provider": "slack",
+            }
+        ]
+
+    def test_configured_integration_not_pending(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent
+        from timbal.tools.slack import SlackReadMessages
+
+        agent = Agent(
+            name="my_agent",
+            model="openai/gpt-4o-mini",
+            max_tokens=128,
+            tools=[SlackReadMessages(integration="org-int-123")],
+        )
+        """)
+        flow = _flow(ws)
+        assert flow["pending_integrations"] == []
+
+    def test_mixed_configured_and_pending(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent
+        from timbal.tools.slack import SlackReadMessages, SlackSendMessage
+
+        agent = Agent(
+            name="my_agent",
+            model="openai/gpt-4o-mini",
+            max_tokens=128,
+            tools=[
+                SlackReadMessages(),
+                SlackSendMessage(integration="org-int-123"),
+            ],
+        )
+        """)
+        flow = _flow(ws)
+        assert len(flow["pending_integrations"]) == 1
+        assert flow["pending_integrations"][0]["tool_name"] == "slack_read_messages"
+
+    def test_non_integration_tools_ignored(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent, Tool
+
+        def greet(name: str) -> str:
+            return f"Hello {name}"
+
+        agent = Agent(
+            name="my_agent",
+            model="openai/gpt-4o-mini",
+            max_tokens=128,
+            tools=[Tool(handler=greet)],
+        )
+        """)
+        flow = _flow(ws)
+        assert flow["pending_integrations"] == []
+
+    def test_workflow_agent_step_tools(self, workspace):
+        ws = workspace(
+            """\
+        from timbal.core import Agent, Workflow
+        from timbal.tools.slack import SlackReadMessages
+
+        inner = Agent(
+            name="summarizer",
+            model="openai/gpt-4o-mini",
+            max_tokens=128,
+            tools=[SlackReadMessages()],
+        )
+
+        agent = Workflow(name="wf")
+        agent.step(inner)
+        """,
+            fqn='fqn: "agent.py::agent"\n',
+        )
+        flow = _flow(ws)
+        assert flow["pending_integrations"] == [
+            {
+                "node_id": "wf.summarizer.slack_read_messages",
+                "parent_id": "wf.summarizer",
+                "tool_name": "slack_read_messages",
+                "provider": "slack",
+            }
+        ]
+
+    def test_agent_as_tool_does_not_recurse_into_inner_tools(self, workspace):
+        """Matches get-flow: agent-as-tool nodes omit nested tools."""
+        ws = workspace("""\
+        from timbal.core import Agent
+        from timbal.tools.slack import SlackReadMessages
+
+        inner = Agent(
+            name="inner",
+            model="openai/gpt-4o-mini",
+            max_tokens=128,
+            tools=[SlackReadMessages()],
+        )
+        agent = Agent(
+            name="outer",
+            model="openai/gpt-4o-mini",
+            max_tokens=128,
+            tools=[inner],
+        )
+        """)
+        flow = _flow(ws)
+        assert flow["pending_integrations"] == []
+
+    def test_compact_format_lists_pending(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent
+        from timbal.tools.slack import SlackReadMessages
+
+        agent = Agent(
+            name="my_agent",
+            model="openai/gpt-4o-mini",
+            max_tokens=128,
+            tools=[SlackReadMessages()],
+        )
+        """)
+        out = format_compact(_flow(ws))
+        assert "PENDING INTEGRATIONS" in out
+        assert "slack: slack_read_messages (my_agent)" in out
 
 
 # ---------------------------------------------------------------------------

--- a/python/timbal/codegen/README.md
+++ b/python/timbal/codegen/README.md
@@ -544,7 +544,7 @@ uv run python scripts/generate_models.py
 python -m timbal.codegen get-flow
 ```
 
-Outputs a JSON representation of the entry point's execution graph with `nodes` and `edges`.
+Outputs a JSON representation of the entry point's execution graph with `nodes`, `edges`, and `pending_integrations`.
 
 Each node has a top-level `position` key (`{"x": ..., "y": ...}`) for ReactFlow canvas placement, defaulting to `{"x": 0, "y": 0}` when not set. Use `set-position` to configure it.
 
@@ -574,6 +574,21 @@ Config fields that reference the model registry use `"x-timbal-ref": "models"` i
     "x-timbal-ref": "models",
     "value": "anthropic/claude-haiku-4-5"
   }
+}
+```
+
+`pending_integrations` lists tools that declare a platform integration (`x-timbal-integration` on the `integration` config field) but have no binding yet (`value` is `null`). Walk the tree yourself with `extract_pending_integrations(flow)` if you already have a flow dict.
+
+```json
+{
+  "pending_integrations": [
+    {
+      "node_id": "my_agent.slack_read_messages",
+      "parent_id": "my_agent",
+      "tool_name": "slack_read_messages",
+      "provider": "slack"
+    }
+  ]
 }
 ```
 

--- a/python/timbal/codegen/flow.py
+++ b/python/timbal/codegen/flow.py
@@ -203,6 +203,59 @@ def _build_node(runnable: Any, *, include_tools: bool = True) -> dict[str, Any]:
     return node
 
 
+def _integration_provider(field_schema: dict[str, Any]) -> str | None:
+    """Return the platform integration provider from an annotated config field."""
+    marker = field_schema.get("x-timbal-integration")
+    if isinstance(marker, dict) and marker.get("provider"):
+        return marker["provider"]
+    for item in field_schema.get("anyOf", []):
+        marker = item.get("x-timbal-integration")
+        if isinstance(marker, dict) and marker.get("provider"):
+            return marker["provider"]
+    return None
+
+
+def _pending_integrations_from_node(node: dict[str, Any], *, parent_id: str | None) -> list[dict[str, Any]]:
+    """Collect pending integration bindings from a flow node and its nested tools."""
+    node_id = node.get("id", "")
+    config = node.get("data", {}).get("config", {})
+    pending: list[dict[str, Any]] = []
+
+    if node.get("type") in ("tool", "agent"):
+        integration_field = config.get("integration")
+        if integration_field is not None:
+            provider = _integration_provider(integration_field)
+            value = integration_field.get("value")
+            if provider and (value is None or value == ""):
+                tool_name = config.get("name", {}).get("value") or _short(node_id)
+                pending.append(
+                    {
+                        "node_id": node_id,
+                        "parent_id": parent_id,
+                        "tool_name": tool_name,
+                        "provider": provider,
+                    }
+                )
+
+    for tool_node in config.get("tools") or []:
+        pending.extend(_pending_integrations_from_node(tool_node, parent_id=node_id))
+
+    return pending
+
+
+def extract_pending_integrations(flow: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return tools that declare a platform integration but have no binding yet.
+
+    Walks the ``get_flow`` node tree (including nested agent tools) and finds
+    config fields annotated with ``x-timbal-integration`` whose ``value`` is
+    ``null`` or empty.
+    """
+    pending: list[dict[str, Any]] = []
+    for node in flow.get("nodes", []):
+        pending.extend(_pending_integrations_from_node(node, parent_id=None))
+    return pending
+
+
 def _edge_kind(kinds: set[str] | None) -> str:
     """Collapse a set of edge-origin kinds into a single label for JSON output.
 
@@ -231,7 +284,7 @@ def get_flow(workspace_path: str | Path) -> dict[str, Any]:
         workspace_path: Path to directory containing timbal.yaml.
 
     Returns:
-        ``{"_version": ..., "nodes": [...], "edges": [...]}``
+        ``{"_version": ..., "nodes": [...], "edges": [...], "pending_integrations": [...]}``
     """
     workspace_path = Path(workspace_path)
     spec = parse_fqn(workspace_path)
@@ -272,11 +325,13 @@ def get_flow(workspace_path: str | Path) -> dict[str, Any]:
     else:
         nodes.append(_build_node(runnable, include_tools=isinstance(runnable, Agent)))
 
-    return {
+    flow = {
         "_version": __version__,
         "nodes": nodes,
         "edges": edges,
     }
+    flow["pending_integrations"] = extract_pending_integrations(flow)
+    return flow
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -540,5 +595,13 @@ def format_compact(flow: dict) -> str:
         lines.append("EDGES")
         for line in _build_edge_lines(edges):
             lines.append(f"  {line}")
+
+    pending = flow.get("pending_integrations") or []
+    if pending:
+        lines.append("")
+        lines.append("PENDING INTEGRATIONS")
+        for item in pending:
+            parent = _short(item.get("parent_id")) if item.get("parent_id") else "?"
+            lines.append(f"  {item['provider']}: {item['tool_name']} ({parent})")
 
     return "\n".join(lines)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`get-flow` now includes a top-level `pending_integrations` array so consumers don't have to recursively walk node config trees looking for `x-timbal-integration` fields with null values.

Also exports `extract_pending_integrations(flow)` for callers that already have a flow dict.

## Output shape

```json
{
  "pending_integrations": [
    {
      "node_id": "my_agent.slack_read_messages",
      "parent_id": "my_agent",
      "tool_name": "slack_read_messages",
      "provider": "slack"
    }
  ]
}
```

A tool is pending when its `integration` config field carries `x-timbal-integration` and `value` is `null`/empty.

## Notes

- Follows the same recursion rules as `get-flow` nodes: agent-as-tool inner tools are not walked (they aren't present in the flow graph today).
- Compact text output includes a `PENDING INTEGRATIONS` section when any are found.

## Test plan

- [x] `pytest python/tests/codegen/test_get_flow.py -q`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f17f3-5d90-7f6a-bb61-23c10ad3842f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f17f3-5d90-7f6a-bb61-23c10ad3842f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

