### PR TITLE
Add Bizneo HR tools scaffold (MVP read endpoints)

### DIFF
--- a/python/tests/tools/test_bizneo_hr.py
+++ b/python/tests/tools/test_bizneo_hr.py
@@ -1,0 +1,188 @@
+"""Tests for Bizneo HR integration tools (mocked; no network)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from timbal.platform.integrations import Integration
+from timbal.tools.bizneo_hr import (
+    BizneoHRListJobs,
+    BizneoHRRequest,
+    _auth_headers,
+    _bizneo_request,
+    _join_path,
+    _normalize_base_url,
+    _resolve_credentials,
+)
+
+
+class TestBizneoHRHelpers:
+    def test_normalize_base_url_strips_trailing_slash(self) -> None:
+        assert _normalize_base_url("https://acme.bizneohr.com/") == "https://acme.bizneohr.com"
+
+    def test_join_path_adds_api_prefix(self) -> None:
+        base = "https://acme.bizneohr.com"
+        assert _join_path(base, "jobs") == "https://acme.bizneohr.com/api/v1/jobs"
+        assert _join_path(base, "/jobs/1") == "https://acme.bizneohr.com/api/v1/jobs/1"
+        assert _join_path(base, "/api/v1/jobs") == "https://acme.bizneohr.com/api/v1/jobs"
+
+    def test_auth_headers_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BIZNEO_API_KEY_HEADER", raising=False)
+        monkeypatch.delenv("BIZNEO_API_SECRET_HEADER", raising=False)
+        headers = _auth_headers("key-id", "secret")
+        assert headers["X-API-KEY"] == "key-id"
+        assert headers["X-API-SECRET"] == "secret"
+        assert headers["Accept"] == "application/json"
+
+    def test_auth_headers_custom_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BIZNEO_API_KEY_HEADER", "Api-Key")
+        monkeypatch.setenv("BIZNEO_API_SECRET_HEADER", "Api-Secret")
+        headers = _auth_headers("k", "s")
+        assert headers["Api-Key"] == "k"
+        assert headers["Api-Secret"] == "s"
+
+
+class TestBizneoHRPackageExports:
+    def test_lazy_import_from_timbal_tools(self) -> None:
+        from timbal.tools import BizneoHRListJobs as exported
+
+        assert exported is BizneoHRListJobs
+
+
+class TestBizneoHRCredentials:
+    @pytest.mark.asyncio
+    async def test_resolve_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BIZNEO_BASE_URL", "https://tenant.bizneohr.com/")
+        monkeypatch.setenv("BIZNEO_API_KEY", "key-id")
+        monkeypatch.setenv("BIZNEO_API_SECRET", "secret")
+        tool = BizneoHRListJobs()
+        base, key, secret = await _resolve_credentials(tool)
+        assert base == "https://tenant.bizneohr.com"
+        assert key == "key-id"
+        assert secret == "secret"
+
+    @pytest.mark.asyncio
+    async def test_resolve_from_explicit_fields(self) -> None:
+        tool = BizneoHRListJobs(
+            base_url="https://co.bizneohr.com",
+            api_key=SecretStr("explicit-key"),
+            api_secret=SecretStr("explicit-secret"),
+        )
+        base, key, secret = await _resolve_credentials(tool)
+        assert base == "https://co.bizneohr.com"
+        assert key == "explicit-key"
+        assert secret == "explicit-secret"
+
+    @pytest.mark.asyncio
+    async def test_resolve_from_integration(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        tool = BizneoHRListJobs(integration=Integration("bizneo_hr", "int-1"))
+
+        async def fake_resolve() -> dict[str, str]:
+            return {
+                "base_url": "https://platform.bizneohr.com",
+                "api_key": "platform-key",
+                "api_secret": "platform-secret",
+            }
+
+        monkeypatch.setattr(tool.integration, "resolve", fake_resolve)
+        base, key, secret = await _resolve_credentials(tool)
+        assert base == "https://platform.bizneohr.com"
+        assert key == "platform-key"
+        assert secret == "platform-secret"
+
+    @pytest.mark.asyncio
+    async def test_resolve_missing_raises(self) -> None:
+        tool = BizneoHRListJobs()
+        with pytest.raises(ValueError, match="Bizneo HR credentials not found"):
+            await _resolve_credentials(tool)
+
+
+@pytest.mark.asyncio
+async def test_bizneo_request_builds_url_and_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BIZNEO_BASE_URL", "https://tenant.bizneohr.com")
+    monkeypatch.setenv("BIZNEO_API_KEY", "kid")
+    monkeypatch.setenv("BIZNEO_API_SECRET", "sec")
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b'{"items":[]}'
+    mock_response.json.return_value = {"items": []}
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = MagicMock()
+    mock_client.request = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    tool = BizneoHRListJobs()
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await _bizneo_request(
+            tool,
+            method="GET",
+            path="/jobs",
+            params={"page": 2, "per_page": 10},
+        )
+
+    assert result == {"items": []}
+    call_args = mock_client.request.call_args
+    assert call_args.args[0] == "GET"
+    assert call_args.args[1] == "https://tenant.bizneohr.com/api/v1/jobs"
+    assert call_args.kwargs["params"] == {"page": 2, "per_page": 10}
+    assert call_args.kwargs["headers"]["X-API-KEY"] == "kid"
+    assert call_args.kwargs["headers"]["X-API-SECRET"] == "sec"
+
+
+@pytest.mark.asyncio
+async def test_bizneo_hr_list_jobs_handler(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BIZNEO_BASE_URL", "https://tenant.bizneohr.com")
+    monkeypatch.setenv("BIZNEO_API_KEY", "k")
+    monkeypatch.setenv("BIZNEO_API_SECRET", "s")
+
+    async def fake_request(
+        _tool: Any,
+        *,
+        method: str,
+        path: str,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        assert method == "GET"
+        assert path == "/jobs"
+        assert params == {"page": 1, "per_page": 25}
+        assert json_body is None
+        return {"jobs": [{"id": "1"}]}
+
+    monkeypatch.setattr("timbal.tools.bizneo_hr._bizneo_request", fake_request)
+    tool = BizneoHRListJobs()
+    out = await tool(page=1, per_page=25).collect()
+    assert out.output == {"jobs": [{"id": "1"}]}
+
+
+@pytest.mark.asyncio
+async def test_bizneo_hr_request_handler(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BIZNEO_BASE_URL", "https://tenant.bizneohr.com")
+    monkeypatch.setenv("BIZNEO_API_KEY", "k")
+    monkeypatch.setenv("BIZNEO_API_SECRET", "s")
+
+    async def fake_request(
+        _tool: Any,
+        *,
+        method: str,
+        path: str,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        assert method == "POST"
+        assert path == "custom"
+        assert params == {"q": "x"}
+        assert json_body == {"name": "test"}
+        return {"ok": True}
+
+    monkeypatch.setattr("timbal.tools.bizneo_hr._bizneo_request", fake_request)
+    tool = BizneoHRRequest()
+    out = await tool(method="POST", path="custom", query_params={"q": "x"}, body={"name": "test"}).collect()
+    assert out.output == {"ok": True}

--- a/python/timbal/tools/__init__.py
+++ b/python/timbal/tools/__init__.py
@@ -25,6 +25,17 @@ if TYPE_CHECKING:
         AsanaUpdateTask,
     )
     from .bash import Bash
+    from .bizneo_hr import (
+        BizneoHRGetCandidate,
+        BizneoHRGetEmployee,
+        BizneoHRGetJob,
+        BizneoHRListCandidates,
+        BizneoHRListDepartments,
+        BizneoHRListEmployees,
+        BizneoHRListJobs,
+        BizneoHRListLocations,
+        BizneoHRRequest,
+    )
     from .cala import CalaQuery, CalaSearch
     from .cloudflare import (
         CloudflareCrawlCancel,
@@ -1155,6 +1166,15 @@ if TYPE_CHECKING:
     )
 __all__ = [
     "Bash",
+    "BizneoHRGetCandidate",
+    "BizneoHRGetEmployee",
+    "BizneoHRGetJob",
+    "BizneoHRListCandidates",
+    "BizneoHRListDepartments",
+    "BizneoHRListEmployees",
+    "BizneoHRListJobs",
+    "BizneoHRListLocations",
+    "BizneoHRRequest",
     "CalaQuery",
     "ask_user",
     "ask_user_multi",
@@ -2228,6 +2248,15 @@ __all__ = [
 
 _LAZY_IMPORTS = {
     "Bash": ".bash",
+    "BizneoHRGetCandidate": ".bizneo_hr",
+    "BizneoHRGetEmployee": ".bizneo_hr",
+    "BizneoHRGetJob": ".bizneo_hr",
+    "BizneoHRListCandidates": ".bizneo_hr",
+    "BizneoHRListDepartments": ".bizneo_hr",
+    "BizneoHRListEmployees": ".bizneo_hr",
+    "BizneoHRListJobs": ".bizneo_hr",
+    "BizneoHRListLocations": ".bizneo_hr",
+    "BizneoHRRequest": ".bizneo_hr",
     "ask_user": ".interaction",
     "ask_user_multi": ".interaction",
     "confirm": ".interaction",

--- a/python/timbal/tools/bizneo_hr.py
+++ b/python/timbal/tools/bizneo_hr.py
@@ -1,0 +1,355 @@
+"""Bizneo HR REST API tools.
+
+Auth uses API key ID + secret against a tenant base URL (e.g. https://{tenant}.bizneohr.com).
+Exact path prefixes are placeholders until Bizneo OpenAPI is available; use ``BizneoHRRequest``
+for arbitrary endpoints once credentials are configured.
+
+Integration credentials (type: credentials):
+- base_url: Tenant API base (e.g. https://acme.bizneohr.com)
+- api_key: API key ID
+- api_secret: API key secret
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Annotated, Any, Literal
+
+from pydantic import Field, SecretStr
+
+from ..core.tool import Tool
+from ..platform.integrations import Integration
+
+_API_PREFIX = "/api/v1"
+_DEFAULT_API_KEY_HEADER = "X-API-KEY"
+_DEFAULT_API_SECRET_HEADER = "X-API-SECRET"
+
+
+def _normalize_base_url(base_url: str) -> str:
+    return base_url.strip().rstrip("/")
+
+
+def _join_path(base_url: str, path: str) -> str:
+    normalized_path = path if path.startswith("/") else f"/{path}"
+    if normalized_path.startswith(_API_PREFIX):
+        return f"{base_url}{normalized_path}"
+    return f"{base_url}{_API_PREFIX}{normalized_path}"
+
+
+async def _resolve_credentials(tool: Any) -> tuple[str, str, str]:
+    creds: dict[str, Any] = {}
+    if isinstance(getattr(tool, "integration", None), Integration):
+        creds = await tool.integration.resolve()
+
+    base_url = creds.get("base_url") or getattr(tool, "base_url", None) or os.getenv("BIZNEO_BASE_URL")
+    raw_key = creds.get("api_key") or getattr(tool, "api_key", None) or os.getenv("BIZNEO_API_KEY")
+    api_key = raw_key.get_secret_value() if isinstance(raw_key, SecretStr) else raw_key
+    api_secret = creds.get("api_secret") or (
+        tool.api_secret.get_secret_value()
+        if getattr(tool, "api_secret", None) and tool.api_secret
+        else None
+    ) or os.getenv("BIZNEO_API_SECRET")
+
+    if not base_url or not api_key or not api_secret:
+        raise ValueError(
+            "Bizneo HR credentials not found. Configure integration with "
+            "base_url, api_key, api_secret, or set BIZNEO_BASE_URL, BIZNEO_API_KEY, BIZNEO_API_SECRET."
+        )
+    return _normalize_base_url(str(base_url)), str(api_key), str(api_secret)
+
+
+def _auth_headers(api_key: str, api_secret: str) -> dict[str, str]:
+    key_header = os.getenv("BIZNEO_API_KEY_HEADER", _DEFAULT_API_KEY_HEADER)
+    secret_header = os.getenv("BIZNEO_API_SECRET_HEADER", _DEFAULT_API_SECRET_HEADER)
+    return {
+        key_header: api_key,
+        secret_header: api_secret,
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+
+
+async def _bizneo_request(
+    tool: Any,
+    *,
+    method: str,
+    path: str,
+    params: dict[str, Any] | None = None,
+    json_body: dict[str, Any] | None = None,
+) -> Any:
+    import httpx
+
+    base_url, api_key, api_secret = await _resolve_credentials(tool)
+    url = _join_path(base_url, path)
+    headers = _auth_headers(api_key, api_secret)
+
+    async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
+        response = await client.request(
+            method.upper(),
+            url,
+            headers=headers,
+            params=params or None,
+            json=json_body,
+        )
+        response.raise_for_status()
+        if not response.content:
+            return {}
+        return response.json()
+
+
+def _bizneo_config_fields(tool: Any) -> dict[str, Any]:
+    return {
+        "integration": tool.integration,
+        "base_url": tool.base_url,
+        "api_key": tool.api_key,
+        "api_secret": tool.api_secret,
+    }
+
+
+class BizneoHRRequest(Tool):
+    """Call any Bizneo HR REST endpoint (escape hatch until full OpenAPI coverage)."""
+
+    name: str = "bizneo_hr_request"
+    description: str | None = (
+        "Call any Bizneo HR REST endpoint with method, path, optional query params and JSON body. "
+        "Use when no dedicated tool exists yet."
+    )
+    integration: Annotated[str, Integration("bizneo_hr")] | None = None
+    base_url: str | None = None
+    api_key: SecretStr | None = None
+    api_secret: SecretStr | None = None
+
+    def get_config(self) -> dict[str, Any]:
+        return {**super().get_config(), **self._annotate_config(_bizneo_config_fields(self))}
+
+    def __init__(self, **kwargs: Any) -> None:
+        async def _request(
+            method: Literal["GET", "POST", "PUT", "PATCH", "DELETE"] = Field(
+                "GET",
+                description="HTTP method.",
+            ),
+            path: str = Field(
+                ...,
+                description="API path relative to /api/v1 (e.g. 'jobs' or '/jobs/123').",
+            ),
+            query_params: dict[str, Any] | None = Field(
+                None,
+                description="Optional query string parameters.",
+            ),
+            body: dict[str, Any] | None = Field(None, description="Optional JSON request body."),
+        ) -> Any:
+            return await _bizneo_request(
+                self,
+                method=method,
+                path=path,
+                params=query_params,
+                json_body=body,
+            )
+
+        super().__init__(handler=_request, **kwargs)
+
+
+class BizneoHRListJobs(Tool):
+    """List job openings / vacancies in Bizneo HR ATS."""
+
+    name: str = "bizneo_hr_list_jobs"
+    description: str | None = "List job openings / vacancies in Bizneo HR ATS."
+    integration: Annotated[str, Integration("bizneo_hr")] | None = None
+    base_url: str | None = None
+    api_key: SecretStr | None = None
+    api_secret: SecretStr | None = None
+
+    def get_config(self) -> dict[str, Any]:
+        return {**super().get_config(), **self._annotate_config(_bizneo_config_fields(self))}
+
+    def __init__(self, **kwargs: Any) -> None:
+        async def _list_jobs(
+            page: int = Field(1, description="Page number (1-based)."),
+            per_page: int = Field(50, description="Results per page."),
+        ) -> Any:
+            return await _bizneo_request(
+                self,
+                method="GET",
+                path="/jobs",
+                params={"page": page, "per_page": per_page},
+            )
+
+        super().__init__(handler=_list_jobs, **kwargs)
+
+
+class BizneoHRGetJob(Tool):
+    """Get a single job opening / vacancy by ID."""
+
+    name: str = "bizneo_hr_get_job"
+    description: str | None = "Get a single job opening / vacancy by ID."
+    integration: Annotated[str, Integration("bizneo_hr")] | None = None
+    base_url: str | None = None
+    api_key: SecretStr | None = None
+    api_secret: SecretStr | None = None
+
+    def get_config(self) -> dict[str, Any]:
+        return {**super().get_config(), **self._annotate_config(_bizneo_config_fields(self))}
+
+    def __init__(self, **kwargs: Any) -> None:
+        async def _get_job(
+            job_id: str = Field(..., description="Job / vacancy ID."),
+        ) -> Any:
+            return await _bizneo_request(self, method="GET", path=f"/jobs/{job_id}")
+
+        super().__init__(handler=_get_job, **kwargs)
+
+
+class BizneoHRListDepartments(Tool):
+    """List departments in Bizneo HR."""
+
+    name: str = "bizneo_hr_list_departments"
+    description: str | None = "List departments in Bizneo HR."
+    integration: Annotated[str, Integration("bizneo_hr")] | None = None
+    base_url: str | None = None
+    api_key: SecretStr | None = None
+    api_secret: SecretStr | None = None
+
+    def get_config(self) -> dict[str, Any]:
+        return {**super().get_config(), **self._annotate_config(_bizneo_config_fields(self))}
+
+    def __init__(self, **kwargs: Any) -> None:
+        async def _list_departments(
+            page: int = Field(1, description="Page number (1-based)."),
+            per_page: int = Field(50, description="Results per page."),
+        ) -> Any:
+            return await _bizneo_request(
+                self,
+                method="GET",
+                path="/departments",
+                params={"page": page, "per_page": per_page},
+            )
+
+        super().__init__(handler=_list_departments, **kwargs)
+
+
+class BizneoHRListLocations(Tool):
+    """List office locations in Bizneo HR."""
+
+    name: str = "bizneo_hr_list_locations"
+    description: str | None = "List office locations in Bizneo HR."
+    integration: Annotated[str, Integration("bizneo_hr")] | None = None
+    base_url: str | None = None
+    api_key: SecretStr | None = None
+    api_secret: SecretStr | None = None
+
+    def get_config(self) -> dict[str, Any]:
+        return {**super().get_config(), **self._annotate_config(_bizneo_config_fields(self))}
+
+    def __init__(self, **kwargs: Any) -> None:
+        async def _list_locations(
+            page: int = Field(1, description="Page number (1-based)."),
+            per_page: int = Field(50, description="Results per page."),
+        ) -> Any:
+            return await _bizneo_request(
+                self,
+                method="GET",
+                path="/locations",
+                params={"page": page, "per_page": per_page},
+            )
+
+        super().__init__(handler=_list_locations, **kwargs)
+
+
+class BizneoHRListCandidates(Tool):
+    """List candidates in Bizneo HR talent pool."""
+
+    name: str = "bizneo_hr_list_candidates"
+    description: str | None = "List candidates in Bizneo HR talent pool."
+    integration: Annotated[str, Integration("bizneo_hr")] | None = None
+    base_url: str | None = None
+    api_key: SecretStr | None = None
+    api_secret: SecretStr | None = None
+
+    def get_config(self) -> dict[str, Any]:
+        return {**super().get_config(), **self._annotate_config(_bizneo_config_fields(self))}
+
+    def __init__(self, **kwargs: Any) -> None:
+        async def _list_candidates(
+            page: int = Field(1, description="Page number (1-based)."),
+            per_page: int = Field(50, description="Results per page."),
+        ) -> Any:
+            return await _bizneo_request(
+                self,
+                method="GET",
+                path="/candidates",
+                params={"page": page, "per_page": per_page},
+            )
+
+        super().__init__(handler=_list_candidates, **kwargs)
+
+
+class BizneoHRGetCandidate(Tool):
+    """Get a single candidate by ID."""
+
+    name: str = "bizneo_hr_get_candidate"
+    description: str | None = "Get a single candidate by ID."
+    integration: Annotated[str, Integration("bizneo_hr")] | None = None
+    base_url: str | None = None
+    api_key: SecretStr | None = None
+    api_secret: SecretStr | None = None
+
+    def get_config(self) -> dict[str, Any]:
+        return {**super().get_config(), **self._annotate_config(_bizneo_config_fields(self))}
+
+    def __init__(self, **kwargs: Any) -> None:
+        async def _get_candidate(
+            candidate_id: str = Field(..., description="Candidate ID."),
+        ) -> Any:
+            return await _bizneo_request(self, method="GET", path=f"/candidates/{candidate_id}")
+
+        super().__init__(handler=_get_candidate, **kwargs)
+
+
+class BizneoHRListEmployees(Tool):
+    """List employees in Bizneo HR core HR."""
+
+    name: str = "bizneo_hr_list_employees"
+    description: str | None = "List employees in Bizneo HR core HR."
+    integration: Annotated[str, Integration("bizneo_hr")] | None = None
+    base_url: str | None = None
+    api_key: SecretStr | None = None
+    api_secret: SecretStr | None = None
+
+    def get_config(self) -> dict[str, Any]:
+        return {**super().get_config(), **self._annotate_config(_bizneo_config_fields(self))}
+
+    def __init__(self, **kwargs: Any) -> None:
+        async def _list_employees(
+            page: int = Field(1, description="Page number (1-based)."),
+            per_page: int = Field(50, description="Results per page."),
+        ) -> Any:
+            return await _bizneo_request(
+                self,
+                method="GET",
+                path="/employees",
+                params={"page": page, "per_page": per_page},
+            )
+
+        super().__init__(handler=_list_employees, **kwargs)
+
+
+class BizneoHRGetEmployee(Tool):
+    """Get a single employee by ID."""
+
+    name: str = "bizneo_hr_get_employee"
+    description: str | None = "Get a single employee by ID."
+    integration: Annotated[str, Integration("bizneo_hr")] | None = None
+    base_url: str | None = None
+    api_key: SecretStr | None = None
+    api_secret: SecretStr | None = None
+
+    def get_config(self) -> dict[str, Any]:
+        return {**super().get_config(), **self._annotate_config(_bizneo_config_fields(self))}
+
+    def __init__(self, **kwargs: Any) -> None:
+        async def _get_employee(
+            employee_id: str = Field(..., description="Employee ID."),
+        ) -> Any:
+            return await _bizneo_request(self, method="GET", path=f"/employees/{employee_id}")
+
+        super().__init__(handler=_get_employee, **kwargs)

--- a/scripts/probe_bizneo_hr.py
+++ b/scripts/probe_bizneo_hr.py
@@ -1,0 +1,123 @@
+"""Probe Bizneo HR API auth and placeholder read paths.
+
+Run when Bizneo credentials are available:
+
+  BIZNEO_BASE_URL=https://{tenant}.bizneohr.com \\
+  BIZNEO_API_KEY=... \\
+  BIZNEO_API_SECRET=... \\
+    uv run python scripts/probe_bizneo_hr.py
+
+Optional:
+  BIZNEO_API_KEY_HEADER / BIZNEO_API_SECRET_HEADER — override auth header names
+  BIZNEO_PROBE_PATHS=jobs,departments,/api/v1/jobs — comma-separated paths to try
+"""
+# ruff: noqa: T201
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
+
+from timbal.tools.bizneo_hr import (
+    BizneoHRListCandidates,
+    BizneoHRListDepartments,
+    BizneoHRListEmployees,
+    BizneoHRListJobs,
+    BizneoHRListLocations,
+    BizneoHRRequest,
+    _auth_headers,
+    _join_path,
+    _resolve_credentials,
+)
+
+
+def _status(code: int) -> str:
+    if 200 <= code < 300:
+        return "OK"
+    if code == 401:
+        return "AUTH"
+    if code == 403:
+        return "FORBIDDEN"
+    if code == 404:
+        return "NOT_FOUND"
+    return "FAIL"
+
+
+async def _probe_raw_paths(base_url: str, api_key: str, api_secret: str) -> None:
+    import httpx
+
+    raw_paths = os.getenv("BIZNEO_PROBE_PATHS", "jobs,departments,locations,candidates,employees")
+    paths = [p.strip() for p in raw_paths.split(",") if p.strip()]
+    headers = _auth_headers(api_key, api_secret)
+
+    print("\n--- Raw GET probes ---")
+    async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
+        for path in paths:
+            url = _join_path(base_url, path)
+            try:
+                response = await client.get(url, headers=headers)
+                label = _status(response.status_code)
+                body = response.text[:200].replace("\n", " ")
+                print(f"{label:10} {response.status_code:3} GET {url}  {body}")
+            except httpx.HTTPError as exc:
+                print(f"FAIL       ERR GET {url}  {exc}")
+
+
+async def _probe_tools() -> None:
+    print("\n--- Tool collect probes ---")
+    probes: list[tuple[str, object]] = [
+        ("BizneoHRListJobs", BizneoHRListJobs()),
+        ("BizneoHRListDepartments", BizneoHRListDepartments()),
+        ("BizneoHRListLocations", BizneoHRListLocations()),
+        ("BizneoHRListCandidates", BizneoHRListCandidates()),
+        ("BizneoHRListEmployees", BizneoHRListEmployees()),
+    ]
+    for name, tool in probes:
+        try:
+            out = await tool(page=1, per_page=1).collect()
+            code = out.status.code
+            err = out.error.get("message") if out.error else ""
+            print(f"{code:10} {name}  {err or 'success'}")
+        except Exception as exc:
+            print(f"FAIL       {name}  {exc}")
+
+    try:
+        out = await BizneoHRRequest().collect(method="GET", path="jobs", query_params={"page": 1, "per_page": 1})
+        err = out.error.get("message") if out.error else ""
+        print(f"{out.status.code:10} BizneoHRRequest  {err or 'success'}")
+    except Exception as exc:
+        print(f"FAIL       BizneoHRRequest  {exc}")
+
+
+async def main() -> int:
+    missing = [
+        name
+        for name, val in (
+            ("BIZNEO_BASE_URL", os.getenv("BIZNEO_BASE_URL")),
+            ("BIZNEO_API_KEY", os.getenv("BIZNEO_API_KEY")),
+            ("BIZNEO_API_SECRET", os.getenv("BIZNEO_API_SECRET")),
+        )
+        if not (val or "").strip()
+    ]
+    if missing:
+        print("Set env vars:", ", ".join(missing))
+        return 1
+
+    tool = BizneoHRListJobs()
+    base_url, api_key, api_secret = await _resolve_credentials(tool)
+    print(f"Base URL: {base_url}")
+    print(f"Auth headers: {list(_auth_headers(api_key, api_secret).keys())}")
+
+    await _probe_raw_paths(base_url, api_key, api_secret)
+    await _probe_tools()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
## Summary
- Add `python/timbal/tools/bizneo_hr.py` with shared credential resolution (`Integration("bizneo_hr")` + env vars), auth headers (`X-API-KEY` / `X-API-SECRET`, overridable), and centralized `_bizneo_request`.
- Register 9 tools: `BizneoHRRequest` escape hatch plus read tools for jobs, departments, locations, candidates, and employees (placeholder `/api/v1` paths until Bizneo OpenAPI is available).
- Add mocked unit tests and `scripts/probe_bizneo_hr.py` for live validation once credentials exist.

## Test plan
- [x] `uv run python -m pytest python/tests/tools/test_bizneo_hr.py -q`
- [ ] With Bizneo credentials: `BIZNEO_BASE_URL=... BIZNEO_API_KEY=... BIZNEO_API_SECRET=... uv run python scripts/probe_bizneo_hr.py`
- [ ] Platform provider `bizneo_hr` (follow-up, outside this repo)


Made with [Cursor](https://cursor.com)