### PR TITLE
feat(mcp): MCP servers as agent tool sources, with codegen and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ agent = Agent(
 ```
 
 - `transport` — `"stdio"` (spawns `command` + `args` with optional `env`) or `"http"` (streamable HTTP at `url` with optional `headers`)
-- `name` — optional identifier; used by codegen (`remove-tool --name`) and useful with multiple servers
+- `name` — optional identifier; when set, tools are exposed as `{name}__{tool}` (bare name still used for `call_tool`). Required for codegen (`remove-tool --name`) and whenever multiple servers might share tool names
 - Connections are lazy; the tool list is cached until `await server.close()`
 - Results: text → str, images/audio/blobs → `File`s in a `Message`, `structuredContent` fallback, `isError` → raised so the LLM sees an error tool result
 - Codegen: `python -m timbal.codegen add-mcp --name x --url ... --headers '{"Authorization": "Bearer $API_KEY"}'` ($VAR placeholders become `os.environ` lookups; also supports `--command/--args/--env` and `--from-json` with standard `mcpServers` configs)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ timbal/
 │   │   │   ├── agent.py      # Agent execution engine
 │   │   │   ├── workflow.py   # DAG workflow engine
 │   │   │   ├── tool.py       # Tool wrapper
+│   │   │   ├── tool_set.py   # ToolSet ABC for runtime tool resolution
+│   │   │   ├── mcp.py        # MCPServer — MCP servers as tool sources
 │   │   │   ├── llm_router.py # Multi-provider LLM dispatch
 │   │   │   ├── models.py     # Model strings + context window lookup
 │   │   │   └── test_model.py # Offline TestModel for testing
@@ -156,6 +158,31 @@ tool = Tool(
 ```
 
 Schema is auto-generated from type hints and docstrings for LLM consumption.
+
+---
+
+### MCPServer
+
+Connects any MCP server as a tool source. Tools are resolved at runtime (it's a `ToolSet`) and exposed to the LLM with the server-declared JSON schemas.
+
+```python
+from timbal.core import MCPServer
+
+agent = Agent(
+    name="my_agent",
+    model="...",
+    tools=[
+        MCPServer(transport="stdio", command="npx", args=["-y", "@modelcontextprotocol/server-filesystem", "."]),
+        MCPServer(name="timbal", transport="http", url="https://api.timbal.ai/mcp", headers={"Authorization": "Bearer ..."}),
+    ],
+)
+```
+
+- `transport` — `"stdio"` (spawns `command` + `args` with optional `env`) or `"http"` (streamable HTTP at `url` with optional `headers`)
+- `name` — optional identifier; used by codegen (`remove-tool --name`) and useful with multiple servers
+- Connections are lazy; the tool list is cached until `await server.close()`
+- Results: text → str, images/audio/blobs → `File`s in a `Message`, `structuredContent` fallback, `isError` → raised so the LLM sees an error tool result
+- Codegen: `python -m timbal.codegen add-mcp --name x --url ... --headers '{"Authorization": "Bearer $API_KEY"}'` ($VAR placeholders become `os.environ` lookups; also supports `--command/--args/--env` and `--from-json` with standard `mcpServers` configs)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ See the [Quickstart](https://docs.timbal.ai/quickstart) for the full app flow (`
 | | |
 |---|---|
 | [Memory & compaction](https://docs.timbal.ai/agents/memory) | Persistent context with strategies to stay under the context window |
-| [Tools & MCP](https://docs.timbal.ai/agents/tools) | Built-in tool library, your own functions, any MCP server |
+| [Tools](https://docs.timbal.ai/agents/tools) & [MCP](https://docs.timbal.ai/agents/mcp) | Built-in tool library, your own functions, any MCP server |
 | [Structured output](https://docs.timbal.ai/agents/structured-output) | Typed Pydantic models instead of raw text |
 | [Skills](https://docs.timbal.ai/agents/skills) | Reusable tool packages the agent loads on demand |
 | [Tracing](https://docs.timbal.ai/core-concepts/tracing) | Full span traces, exportable over OTLP |

--- a/docs/agents/mcp.mdx
+++ b/docs/agents/mcp.mdx
@@ -1,0 +1,132 @@
+---
+title: "MCP Servers"
+description: "Connect any Model Context Protocol server to your agents and use its tools like native Timbal tools"
+---
+
+## What is MCP?
+
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro) is an open standard that enables communication between AI models and external tools and services. Thousands of MCP servers exist for filesystems, databases, browsers, SaaS APIs, and more.
+
+Timbal agents can connect to any MCP server with `MCPServer`. The server's tools are discovered at runtime and exposed to the LLM exactly like native tools — schemas, streaming, tracing, and error handling included.
+
+<Note>
+This page covers **consuming MCP servers from your agents**. For the reverse direction — connecting your editor to the Timbal platform's MCP server — see [MCP Integration](/mcp-integration).
+</Note>
+
+## Basic Usage
+
+Add an `MCPServer` to the agent's tools list. Two transports are supported:
+
+```python
+from timbal import Agent
+from timbal.core import MCPServer
+
+agent = Agent(
+    name="my_agent",
+    model="openai/gpt-4o-mini",
+    tools=[
+        # stdio: spawn a local server process
+        MCPServer(
+            name="filesystem",
+            transport="stdio",
+            command="npx",
+            args=["-y", "@modelcontextprotocol/server-filesystem", "."],
+        ),
+        # http: connect to a remote server (streamable HTTP)
+        MCPServer(
+            name="timbal",
+            transport="http",
+            url="https://api.timbal.ai/mcp",
+        ),
+    ],
+)
+```
+
+That's it — before each LLM call, the agent lists the server's tools and offers them to the model alongside any other tools. When the model calls one, the arguments are forwarded to the server and the result comes back as a tool result.
+
+## Configuration
+
+| Field | Transport | Description |
+|-------|-----------|-------------|
+| `name` | both | Optional identifier. Recommended when using multiple servers or the [codegen CLI](#codegen-cli). |
+| `transport` | — | `"stdio"` or `"http"` (required) |
+| `command` | stdio | Executable to spawn (e.g. `"npx"`, `"uvx"`, `"python"`) |
+| `args` | stdio | Command arguments |
+| `env` | stdio | Environment variables for the spawned process |
+| `url` | http | Server URL |
+| `headers` | http | HTTP headers sent with every request |
+
+### Authentication
+
+For servers that require auth, pass headers (http) or environment variables (stdio). Read secrets from the environment instead of hardcoding them:
+
+```python
+import os
+
+timbal_mcp = MCPServer(
+    name="timbal",
+    transport="http",
+    url="https://api.timbal.ai/mcp",
+    headers={"Authorization": f"Bearer {os.environ['TIMBAL_API_KEY']}"},
+)
+
+github_mcp = MCPServer(
+    name="github",
+    transport="stdio",
+    command="npx",
+    args=["-y", "@modelcontextprotocol/server-github"],
+    env={"GITHUB_PERSONAL_ACCESS_TOKEN": os.environ["GITHUB_TOKEN"]},
+)
+```
+
+## How Results Are Handled
+
+MCP tool results are converted so the LLM always receives something useful:
+
+- **Text content** becomes a plain string (or a list of strings for multiple blocks)
+- **Images, audio, and binary resources** become Timbal [`File`](/core-concepts/runnables#files)s, forwarded to the model as file content — vision models can see returned images directly
+- **Structured content** is returned as-is when the server sends no text representation
+- **Errors** (`isError`) raise inside the tool call, so the model receives a proper error tool result and can self-correct
+
+## Connection Lifecycle
+
+Connections are **lazy**: nothing is spawned or contacted until the agent first needs the server's tools. The tool list is fetched once and cached for the life of the connection.
+
+Close the connection when you're done:
+
+```python
+server = MCPServer(transport="stdio", command="npx", args=["-y", "@modelcontextprotocol/server-filesystem", "."])
+agent = Agent(name="my_agent", model="openai/gpt-4o-mini", tools=[server])
+
+result = await agent(prompt="List the files in the current directory").collect()
+
+await server.close()
+```
+
+<Warning>
+For long-running processes (servers, bots), create the `MCPServer` once and reuse it across runs — reconnecting per request adds latency, especially for stdio servers that spawn a subprocess.
+</Warning>
+
+## Dynamic Resolution
+
+`MCPServer` is a [`ToolSet`](/agents/dynamic#dynamic-tools): tools are resolved at runtime, not import time. This means the available tools always reflect what the server currently offers, and you can mix MCP servers freely with functions, built-in tools, and other agents in the same `tools` list.
+
+## Codegen CLI
+
+The [codegen CLI](https://github.com/timbal-ai/timbal/tree/main/python/timbal/codegen) can add MCP servers to an agent's source file:
+
+```bash
+# stdio server
+python -m timbal.codegen add-mcp --name fs \
+  --command npx --args '["-y", "@modelcontextprotocol/server-filesystem", "."]'
+
+# http server — $VARS are emitted as os.environ lookups, never hardcoded
+python -m timbal.codegen add-mcp --name timbal \
+  --url https://api.timbal.ai/mcp \
+  --headers '{"Authorization": "Bearer $TIMBAL_API_KEY"}'
+
+# import a standard mcpServers JSON config (claude-desktop / cursor style)
+python -m timbal.codegen add-mcp --from-json @mcp.json
+```
+
+Re-running `add-mcp` with the same `--name` replaces the server spec. Remove a server with `remove-tool --name <server_name>` — the assignment and import are cleaned up automatically.

--- a/docs/agents/mcp.mdx
+++ b/docs/agents/mcp.mdx
@@ -44,11 +44,13 @@ agent = Agent(
 
 That's it — before each LLM call, the agent lists the server's tools and offers them to the model alongside any other tools. When the model calls one, the arguments are forwarded to the server and the result comes back as a tool result.
 
+With `name=` set, a tool declared as `list_files` on the `filesystem` server appears to the LLM as `filesystem__list_files`. The bare name is still used on the wire.
+
 ## Configuration
 
 | Field | Transport | Description |
 |-------|-----------|-------------|
-| `name` | both | Optional identifier. Recommended when using multiple servers or the [codegen CLI](#codegen-cli). |
+| `name` | both | Optional identifier. When set, tools are exposed as `{name}__{tool}` so multiple servers don't collide in the agent's flat tool registry. Recommended whenever you attach more than one server (and required by the [codegen CLI](#codegen-cli)). |
 | `transport` | — | `"stdio"` or `"http"` (required) |
 | `command` | stdio | Executable to spawn (e.g. `"npx"`, `"uvx"`, `"python"`) |
 | `args` | stdio | Command arguments |

--- a/docs/agents/tools.mdx
+++ b/docs/agents/tools.mdx
@@ -210,6 +210,30 @@ Tool(handler=get_weather, command="weather")
 
 See [Commands](/agents/commands) for argument parsing, nested agents, and workflows.
 
+## MCP Servers
+
+Connect any [Model Context Protocol](https://modelcontextprotocol.io/docs/getting-started/intro) server and use its tools like native ones:
+
+```python
+from timbal import Agent
+from timbal.core import MCPServer
+
+agent = Agent(
+    name="my_agent",
+    model="openai/gpt-4o-mini",
+    tools=[
+        MCPServer(
+            name="filesystem",
+            transport="stdio",
+            command="npx",
+            args=["-y", "@modelcontextprotocol/server-filesystem", "."],
+        ),
+    ],
+)
+```
+
+The server's tools are discovered at runtime and offered to the LLM alongside your other tools. See [MCP Servers](/agents/mcp) for transports, authentication, result handling, and connection lifecycle.
+
 ## Dynamic Tools
 
 When tool availability depends on runtime conditions (user role, permissions, input parameters), you need dynamic tool resolution.
@@ -236,6 +260,7 @@ See [Dynamic Agents](/agents/dynamic#dynamic-tools) for implementation details a
 - **Performance**: Concurrent execution and optimized patterns
 - **Robustness**: Improved error handling and tracing
 - **Tool Sets**: Dynamic tool resolution
+- **MCP Servers**: Any Model Context Protocol server as a tool source — see [MCP Servers](/agents/mcp)
 - **Commands**: Slash-command shortcuts for direct tool invocation — see [Commands](/agents/commands)
 
 For more advanced patterns, see [Dynamic Agents](/agents/dynamic) and explore the built-in tools in the Timbal library.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -34,6 +34,7 @@
             "pages": [
               "agents/index",
               "agents/tools",
+              "agents/mcp",
               "agents/structured-output",
               "agents/memory",
               "agents/memory-compaction",

--- a/docs/mcp-integration/index.mdx
+++ b/docs/mcp-integration/index.mdx
@@ -9,6 +9,10 @@ description: "Learn how to integrate Timbal with MCP on supported servers."
 
 By exposing **Timbal as an MCP server**, AI-powered editors and applications can interact with Timbal’s functionality directly.
 
+<Note>
+Looking for the other direction — connecting MCP servers **to your Timbal agents** as tool sources? See [MCP Servers](/agents/mcp).
+</Note>
+
 ## Connecting Timbal via MCP
 
 To use Timbal with MCP, you first need to configure your editor or client to connect to Timbal’s MCP endpoint:

--- a/python/tests/codegen/test_add_mcp.py
+++ b/python/tests/codegen/test_add_mcp.py
@@ -217,7 +217,7 @@ class TestNameCollisions:
         agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[fs])
         """)
         stderr = _run(ws, "--name", "fs", "--command", "npx", expect_error=True)
-        assert "already used by a non-MCP tool" in stderr
+        assert "already exists and is not MCP server" in stderr or "already used by a non-MCP tool" in stderr
         # Source untouched.
         assert 'Tool(name="fs"' in (ws / "agent.py").read_text()
 
@@ -278,6 +278,26 @@ class TestNameCollisions:
         output = _run(ws, "--name", "fs", "--command", "npx")
         assert output.count("MCPServer(") == 1
         ns = _exec_agent(output)
+        assert ns["agent"].tools[0].command == "npx"
+
+    def test_nameless_mcp_server_updates_by_variable(self, workspace):
+        """MCPServer without name= must still be an update target for --name == var.
+
+        resolve_runnable_name falls back to the class name \"MCPServer\", which
+        used to make the pre-check treat the assignment as a non-MCP collision.
+        """
+        ws = workspace("""\
+        from timbal.core import Agent, MCPServer
+
+        fs = MCPServer(transport="stdio", command="old-command")
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[fs])
+        """)
+        output = _run(ws, "--name", "fs", "--command", "npx")
+        assert output.count("MCPServer(") == 1
+        assert "tools=[fs]" in output
+        ns = _exec_agent(output)
+        assert ns["agent"].tools[0].name == "fs"
         assert ns["agent"].tools[0].command == "npx"
 
 

--- a/python/tests/codegen/test_add_mcp.py
+++ b/python/tests/codegen/test_add_mcp.py
@@ -201,6 +201,86 @@ class TestRemoval:
         assert "tools=[]" in output
 
 
+class TestNameCollisions:
+    """A same-named non-MCP runnable must never be replaced or rewired by add-mcp."""
+
+    def test_tool_assignment_with_same_name_rejected(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent, Tool
+
+        def list_files(path: str) -> str:
+            \"\"\"List files.\"\"\"
+            return path
+
+        fs = Tool(name="fs", handler=list_files)
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[fs])
+        """)
+        stderr = _run(ws, "--name", "fs", "--command", "npx", expect_error=True)
+        assert "already used by a non-MCP tool" in stderr
+        # Source untouched.
+        assert 'Tool(name="fs"' in (ws / "agent.py").read_text()
+
+    def test_inline_tool_with_same_name_rejected(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent, Tool
+
+        def list_files(path: str) -> str:
+            \"\"\"List files.\"\"\"
+            return path
+
+        agent = Agent(
+            name="a",
+            model="openai/gpt-4o-mini",
+            tools=[Tool(name="fs", handler=list_files)],
+        )
+        """)
+        stderr = _run(ws, "--name", "fs", "--command", "npx", expect_error=True)
+        assert "already used by a non-MCP tool" in stderr
+
+    def test_bare_function_with_same_name_rejected(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        def fs(path: str) -> str:
+            \"\"\"List files.\"\"\"
+            return path
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[fs])
+        """)
+        stderr = _run(ws, "--name", "fs", "--command", "npx", expect_error=True)
+        assert "already exists" in stderr
+
+    def test_unrelated_variable_shadowing_rejected(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent, Tool
+
+        def list_files(path: str) -> str:
+            \"\"\"List files.\"\"\"
+            return path
+
+        fs = Tool(name="lister", handler=list_files)
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[fs])
+        """)
+        stderr = _run(ws, "--name", "fs", "--command", "npx", expect_error=True)
+        assert "already exists and is not MCP server" in stderr
+
+    def test_existing_mcp_server_still_updates(self, workspace):
+        """The legit idempotent path must keep working after the collision guard."""
+        ws = workspace("""\
+        from timbal.core import Agent, MCPServer
+
+        fs = MCPServer(name="fs", transport="stdio", command="old-command")
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[fs])
+        """)
+        output = _run(ws, "--name", "fs", "--command", "npx")
+        assert output.count("MCPServer(") == 1
+        ns = _exec_agent(output)
+        assert ns["agent"].tools[0].command == "npx"
+
+
 class TestErrors:
     def test_name_required(self, workspace):
         ws = workspace(AGENT_SOURCE)

--- a/python/tests/codegen/test_add_mcp.py
+++ b/python/tests/codegen/test_add_mcp.py
@@ -1,0 +1,239 @@
+import json
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from .conftest import codegen_cmd
+
+TIMBAL_YAML = 'fqn: "agent.py::agent"\n'
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    """Write a source file + timbal.yaml and return the workspace directory."""
+
+    def _write(source: str) -> Path:
+        (tmp_path / "agent.py").write_text(textwrap.dedent(source))
+        (tmp_path / "timbal.yaml").write_text(TIMBAL_YAML)
+        return tmp_path
+
+    return _write
+
+
+AGENT_SOURCE = """\
+from timbal.core import Agent
+
+agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[])
+"""
+
+
+def _run(workspace_path: Path, *cli_args: str, dry_run: bool = True, expect_error: bool = False) -> str:
+    argv = ["--path", str(workspace_path)]
+    if dry_run:
+        argv.append("--dry-run")
+    result = subprocess.run(
+        codegen_cmd(*argv, "add-mcp", *cli_args),
+        capture_output=True,
+        text=True,
+    )
+    if expect_error:
+        assert result.returncode != 0, f"expected failure but succeeded:\n{result.stdout}"
+        return result.stderr
+    assert result.returncode == 0, f"codegen failed:\n{result.stderr}"
+    return result.stdout
+
+
+def _exec_agent(code: str) -> dict:
+    ns = {}
+    exec(code, ns)
+    return ns
+
+
+class TestAddStdioServer:
+    def test_basic(self, workspace):
+        ws = workspace(AGENT_SOURCE)
+        output = _run(
+            ws,
+            "--name", "fs",
+            "--command", "npx",
+            "--args", '["-y", "@modelcontextprotocol/server-filesystem", "."]',
+        )
+        # Ruff may merge this into the existing `from timbal.core import ...` import.
+        assert "MCPServer" in output.split("\n\n")[0]
+        assert "tools=[fs]" in output
+
+        ns = _exec_agent(output)
+        server = ns["agent"].tools[0]
+        assert server.name == "fs"
+        assert server.transport == "stdio"
+        assert server.args == ["-y", "@modelcontextprotocol/server-filesystem", "."]
+
+    def test_transport_inferred_from_command(self, workspace):
+        ws = workspace(AGENT_SOURCE)
+        output = _run(ws, "--name", "fs", "--command", "npx")
+        ns = _exec_agent(output)
+        assert ns["agent"].tools[0].transport == "stdio"
+
+    def test_env_placeholder_becomes_environ_lookup(self, workspace, monkeypatch):
+        ws = workspace(AGENT_SOURCE)
+        output = _run(
+            ws,
+            "--name", "gh",
+            "--command", "npx",
+            "--env", '{"GITHUB_TOKEN": "$MY_GH_TOKEN"}',
+        )
+        assert 'os.environ["MY_GH_TOKEN"]' in output
+        assert "import os" in output
+
+        monkeypatch.setenv("MY_GH_TOKEN", "secret-token")
+        ns = _exec_agent(output)
+        assert ns["agent"].tools[0].env == {"GITHUB_TOKEN": "secret-token"}
+
+
+class TestAddHttpServer:
+    def test_basic(self, workspace):
+        ws = workspace(AGENT_SOURCE)
+        output = _run(ws, "--name", "timbal", "--url", "https://api.timbal.ai/mcp")
+        assert "tools=[timbal]" in output
+        ns = _exec_agent(output)
+        server = ns["agent"].tools[0]
+        assert server.transport == "http"
+        assert server.url == "https://api.timbal.ai/mcp"
+
+    def test_header_with_embedded_placeholder_becomes_fstring(self, workspace, monkeypatch):
+        ws = workspace(AGENT_SOURCE)
+        output = _run(
+            ws,
+            "--name", "timbal",
+            "--url", "https://api.timbal.ai/mcp",
+            "--headers", '{"Authorization": "Bearer $TIMBAL_API_KEY"}',
+        )
+        # The secret must never be hardcoded — only the env lookup.
+        assert "os.environ['TIMBAL_API_KEY']" in output
+        assert 'f"Bearer {' in output
+
+        monkeypatch.setenv("TIMBAL_API_KEY", "sk-123")
+        ns = _exec_agent(output)
+        assert ns["agent"].tools[0].headers == {"Authorization": "Bearer sk-123"}
+
+    def test_braced_placeholder(self, workspace, monkeypatch):
+        ws = workspace(AGENT_SOURCE)
+        output = _run(
+            ws,
+            "--name", "timbal",
+            "--url", "https://api.timbal.ai/mcp",
+            "--headers", '{"x-key": "${API_KEY}"}',
+        )
+        assert 'os.environ["API_KEY"]' in output
+        monkeypatch.setenv("API_KEY", "k1")
+        ns = _exec_agent(output)
+        assert ns["agent"].tools[0].headers == {"x-key": "k1"}
+
+
+class TestFromJson:
+    def test_adds_all_servers(self, workspace, tmp_path, monkeypatch):
+        ws = workspace(AGENT_SOURCE)
+        config = {
+            "mcpServers": {
+                "fs": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "."]},
+                "timbal": {"url": "https://api.timbal.ai/mcp", "headers": {"Authorization": "Bearer $TIMBAL_API_KEY"}},
+            }
+        }
+        config_path = tmp_path / "mcp.json"
+        config_path.write_text(json.dumps(config))
+
+        output = _run(ws, "--from-json", f"@{config_path}")
+        assert "tools=[fs, timbal]" in output
+
+        monkeypatch.setenv("TIMBAL_API_KEY", "sk-123")
+        ns = _exec_agent(output)
+        servers = {s.name: s for s in ns["agent"].tools}
+        assert servers["fs"].transport == "stdio"
+        assert servers["timbal"].transport == "http"
+        assert servers["timbal"].headers == {"Authorization": "Bearer sk-123"}
+
+    def test_type_alias_streamable_http(self, workspace):
+        ws = workspace(AGENT_SOURCE)
+        config = json.dumps({"mcpServers": {"remote": {"type": "streamable-http", "url": "https://x.dev/mcp"}}})
+        output = _run(ws, "--from-json", config)
+        ns = _exec_agent(output)
+        assert ns["agent"].tools[0].transport == "http"
+
+    def test_mutually_exclusive_with_flags(self, workspace):
+        ws = workspace(AGENT_SOURCE)
+        config = json.dumps({"mcpServers": {"fs": {"command": "npx"}}})
+        stderr = _run(ws, "--from-json", config, "--name", "fs", expect_error=True)
+        assert "mutually exclusive" in stderr
+
+
+class TestIdempotency:
+    def test_rerun_does_not_duplicate(self, workspace):
+        ws = workspace(AGENT_SOURCE)
+        _run(ws, "--name", "fs", "--command", "npx", dry_run=False)
+        output = _run(ws, "--name", "fs", "--command", "npx")
+        assert output.count("MCPServer(") == 1
+        assert output.count("tools=[fs]") == 1
+
+    def test_rerun_replaces_spec(self, workspace):
+        ws = workspace(AGENT_SOURCE)
+        _run(ws, "--name", "timbal", "--url", "https://api.dev.timbal.ai/mcp", dry_run=False)
+        output = _run(ws, "--name", "timbal", "--url", "https://api.timbal.ai/mcp")
+        assert output.count("MCPServer(") == 1
+        ns = _exec_agent(output)
+        assert ns["agent"].tools[0].url == "https://api.timbal.ai/mcp"
+
+
+class TestRemoval:
+    def test_remove_tool_cleans_up_server(self, workspace):
+        ws = workspace(AGENT_SOURCE)
+        _run(ws, "--name", "fs", "--command", "npx", dry_run=False)
+
+        result = subprocess.run(
+            codegen_cmd("--path", str(ws), "--dry-run", "remove-tool", "--name", "fs"),
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        output = result.stdout
+        assert "MCPServer" not in output  # assignment and import both cleaned up
+        assert "tools=[]" in output
+
+
+class TestErrors:
+    def test_name_required(self, workspace):
+        ws = workspace(AGENT_SOURCE)
+        stderr = _run(ws, "--command", "npx", expect_error=True)
+        assert "--name is required" in stderr
+
+    def test_no_transport_inferable(self, workspace):
+        ws = workspace(AGENT_SOURCE)
+        stderr = _run(ws, "--name", "x", expect_error=True)
+        assert "Cannot infer transport" in stderr
+
+    def test_command_and_url_ambiguous(self, workspace):
+        ws = workspace(AGENT_SOURCE)
+        stderr = _run(ws, "--name", "x", "--command", "npx", "--url", "https://x.dev/mcp", expect_error=True)
+        assert "disambiguate" in stderr
+
+    def test_invalid_config_rejected(self, workspace):
+        ws = workspace(AGENT_SOURCE)
+        # transport=stdio without command is invalid at the MCPServer model level.
+        stderr = _run(ws, "--name", "x", "--transport", "stdio", "--url", "https://x.dev/mcp", expect_error=True)
+        assert "Invalid MCP server config" in stderr
+
+    def test_workflow_entry_point_rejected(self, tmp_path):
+        (tmp_path / "agent.py").write_text(
+            textwrap.dedent("""\
+            from timbal.core import Workflow
+
+            def a() -> str:
+                return "a"
+
+            workflow = Workflow(name="wf").step(a)
+            """)
+        )
+        (tmp_path / "timbal.yaml").write_text('fqn: "agent.py::workflow"\n')
+        stderr = _run(tmp_path, "--name", "x", "--command", "npx", expect_error=True)
+        assert "requires an Agent entry point" in stderr

--- a/python/tests/core/test_mcp.py
+++ b/python/tests/core/test_mcp.py
@@ -1,5 +1,8 @@
+import asyncio
 import os
 import sys
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
 
 import pytest
 from pydantic import ValidationError
@@ -95,6 +98,71 @@ class TestMCPServerResolve:
         await stdio_server.close()
         assert stdio_server._tools_cache is None
         assert stdio_server._session is None
+
+
+class TestMCPConnectConcurrency:
+    @pytest.mark.asyncio
+    async def test_parallel_connect_opens_session_once(self):
+        """Two concurrent _connect() calls must not each open a transport."""
+        server = MCPServer(transport="http", url="https://example.com/mcp")
+        opens = 0
+        gate = asyncio.Event()
+
+        @asynccontextmanager
+        async def slow_connect():
+            nonlocal opens
+            opens += 1
+            await gate.wait()
+            yield AsyncMock(name="session")
+
+        server._connect_http = slow_connect  # type: ignore[method-assign]
+
+        t1 = asyncio.create_task(server._connect())
+        t2 = asyncio.create_task(server._connect())
+        # Let both tasks reach the lock / check before releasing the open.
+        await asyncio.sleep(0.05)
+        gate.set()
+        s1, s2 = await asyncio.gather(t1, t2)
+
+        assert opens == 1
+        assert s1 is s2
+        assert server._session is s1
+        await server.close()
+
+    @pytest.mark.asyncio
+    async def test_parallel_resolve_lists_tools_once(self):
+        server = MCPServer(transport="http", url="https://example.com/mcp")
+        opens = 0
+        list_calls = 0
+
+        class FakeSession:
+            async def list_tools(self):
+                nonlocal list_calls
+                list_calls += 1
+                await asyncio.sleep(0.05)
+                return mcp_types.ListToolsResult(
+                    tools=[
+                        mcp_types.Tool(
+                            name="ping",
+                            description="ping",
+                            inputSchema={"type": "object", "properties": {}},
+                        )
+                    ]
+                )
+
+        @asynccontextmanager
+        async def instant_connect():
+            nonlocal opens
+            opens += 1
+            yield FakeSession()
+
+        server._connect_http = instant_connect  # type: ignore[method-assign]
+
+        tools1, tools2 = await asyncio.gather(server.resolve(), server.resolve())
+        assert opens == 1
+        assert list_calls == 1
+        assert tools1 is tools2
+        await server.close()
 
 
 class TestMCPToolExecution:

--- a/python/tests/core/test_mcp.py
+++ b/python/tests/core/test_mcp.py
@@ -100,6 +100,113 @@ class TestMCPServerResolve:
         assert stdio_server._session is None
 
 
+class TestMCPToolNamespacing:
+    def test_unnamed_server_keeps_bare_tool_names(self):
+        server = MCPServer(transport="http", url="https://example.com/mcp")
+        tool = server._make_tool(
+            mcp_types.Tool(
+                name="greet",
+                description="Greet someone.",
+                inputSchema={"type": "object", "properties": {}},
+            )
+        )
+        assert tool.name == "greet"
+        assert tool.description == "Greet someone."
+
+    def test_named_server_prefixes_tool_names(self):
+        server = MCPServer(name="alpha", transport="http", url="https://example.com/mcp")
+        tool = server._make_tool(
+            mcp_types.Tool(
+                name="greet",
+                description="Greet someone.",
+                inputSchema={"type": "object", "properties": {}},
+            )
+        )
+        assert tool.name == "alpha__greet"
+        assert tool.description == "[alpha] Greet someone."
+
+    @pytest.mark.asyncio
+    async def test_two_named_servers_with_same_tool_both_register(self):
+        """Two MCPServers exposing the same bare tool name must both be usable."""
+        from timbal.core.test_model import TestModel
+        from timbal.types.events import OutputEvent
+
+        calls: list[tuple[str, str]] = []
+
+        def _fake_server(name: str) -> MCPServer:
+            server = MCPServer(name=name, transport="http", url=f"https://{name}.example/mcp")
+
+            async def resolve() -> list:
+                tool = server._make_tool(
+                    mcp_types.Tool(
+                        name="greet",
+                        description=f"Greet via {name}.",
+                        inputSchema={
+                            "type": "object",
+                            "properties": {"who": {"type": "string"}},
+                            "required": ["who"],
+                        },
+                    )
+                )
+
+                # Replace the real MCP handler with one that records which server ran.
+                async def _handler(**kwargs):
+                    calls.append((name, kwargs["who"]))
+                    return f"{name}:{kwargs['who']}"
+
+                tool.handler = _handler
+                return [tool]
+
+            server.resolve = resolve  # type: ignore[method-assign]
+            return server
+
+        alpha = _fake_server("alpha")
+        beta = _fake_server("beta")
+
+        tool_calls = Message(
+            role="assistant",
+            content=[
+                ToolUseContent(id="c1", name="alpha__greet", input={"who": "A"}),
+                ToolUseContent(id="c2", name="beta__greet", input={"who": "B"}),
+            ],
+            stop_reason="tool_use",
+        )
+        agent = Agent(
+            name="multi_mcp",
+            model=TestModel(responses=[tool_calls, "done"]),
+            tools=[alpha, beta],
+            max_iter=3,
+        )
+        events = [event async for event in agent(prompt="greet both")]
+        final = events[-1]
+        assert isinstance(final, OutputEvent)
+        assert final.status.code == "success"
+
+        paths = {e.path for e in events if isinstance(e, OutputEvent)}
+        assert "multi_mcp.alpha__greet" in paths
+        assert "multi_mcp.beta__greet" in paths
+        assert sorted(calls) == [("alpha", "A"), ("beta", "B")]
+
+    @pytest.mark.asyncio
+    async def test_qualified_name_still_calls_bare_mcp_tool(self, stdio_server):
+        """Wire call must use the bare MCP name even when the agent sees a prefix."""
+        named = MCPServer(
+            name="demo",
+            transport="stdio",
+            command=sys.executable,
+            args=stdio_server.args,
+        )
+        try:
+            tools = {t.name: t for t in await named.resolve()}
+            assert "demo__greet" in tools
+            assert "greet" not in tools
+            result = await tools["demo__greet"](name="Zed").collect()
+            assert result.status.code == "success"
+            assert result.output == "Hello, Zed!"
+        finally:
+            await named.close()
+
+
 class TestMCPConnectConcurrency:
     @pytest.mark.asyncio
     async def test_parallel_connect_opens_session_once(self):

--- a/python/tests/core/test_mcp.py
+++ b/python/tests/core/test_mcp.py
@@ -1,0 +1,303 @@
+import os
+import sys
+
+import pytest
+from pydantic import ValidationError
+from timbal import Agent
+from timbal.core.mcp import MCPServer, MCPTool, _convert_call_tool_result
+from timbal.types.content import FileContent, TextContent, ToolUseContent
+from timbal.types.message import Message
+
+try:
+    from mcp import types as mcp_types
+except ImportError:  # pragma: no cover
+    mcp_types = None
+
+pytestmark = pytest.mark.skipif(mcp_types is None, reason="mcp package not installed")
+
+
+SERVER_SCRIPT = '''
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("test-server")
+
+
+@mcp.tool()
+def add(a: int, b: int) -> int:
+    """Add two integers."""
+    return a + b
+
+
+@mcp.tool()
+def greet(name: str) -> str:
+    """Greet someone by name."""
+    return f"Hello, {name}!"
+
+
+@mcp.tool()
+def boom() -> str:
+    """Always fails."""
+    raise ValueError("kaboom")
+
+
+mcp.run()
+'''
+
+
+@pytest.fixture
+def stdio_server(tmp_path):
+    script = tmp_path / "server.py"
+    script.write_text(SERVER_SCRIPT)
+    return MCPServer(transport="stdio", command=sys.executable, args=[str(script)])
+
+
+class TestMCPServerValidation:
+    def test_stdio_requires_command(self):
+        with pytest.raises(ValidationError, match="'command' is required"):
+            MCPServer(transport="stdio")
+
+    def test_http_requires_url(self):
+        with pytest.raises(ValidationError, match="'url' is required"):
+            MCPServer(transport="http")
+
+
+class TestMCPServerResolve:
+    @pytest.mark.asyncio
+    async def test_resolve_returns_tools_with_server_schema(self, stdio_server):
+        try:
+            tools = await stdio_server.resolve()
+            by_name = {t.name: t for t in tools}
+            assert set(by_name) == {"add", "greet", "boom"}
+            assert all(isinstance(t, MCPTool) for t in tools)
+
+            add = by_name["add"]
+            assert add.description == "Add two integers."
+            schema = add.anthropic_schema["input_schema"]
+            assert schema["properties"]["a"]["type"] == "integer"
+            assert schema["properties"]["b"]["type"] == "integer"
+            assert set(schema["required"]) == {"a", "b"}
+        finally:
+            await stdio_server.close()
+
+    @pytest.mark.asyncio
+    async def test_resolve_caches_tools(self, stdio_server):
+        try:
+            tools1 = await stdio_server.resolve()
+            tools2 = await stdio_server.resolve()
+            assert tools1 is tools2
+        finally:
+            await stdio_server.close()
+
+    @pytest.mark.asyncio
+    async def test_close_clears_cache(self, stdio_server):
+        tools = await stdio_server.resolve()
+        assert tools
+        await stdio_server.close()
+        assert stdio_server._tools_cache is None
+        assert stdio_server._session is None
+
+
+class TestMCPToolExecution:
+    @pytest.mark.asyncio
+    async def test_call_text_tool(self, stdio_server):
+        try:
+            tools = {t.name: t for t in await stdio_server.resolve()}
+            result = await tools["greet"](name="Alice").collect()
+            assert result.status.code == "success"
+            assert result.output == "Hello, Alice!"
+        finally:
+            await stdio_server.close()
+
+    @pytest.mark.asyncio
+    async def test_call_structured_tool(self, stdio_server):
+        try:
+            tools = {t.name: t for t in await stdio_server.resolve()}
+            result = await tools["add"](a=2, b=3).collect()
+            assert result.status.code == "success"
+            # The text block carries the canonical serialized result.
+            assert result.output == "5"
+        finally:
+            await stdio_server.close()
+
+    @pytest.mark.asyncio
+    async def test_call_error_tool(self, stdio_server):
+        try:
+            tools = {t.name: t for t in await stdio_server.resolve()}
+            result = await tools["boom"]().collect()
+            assert result.status.code == "error"
+            assert "kaboom" in result.error["message"]
+        finally:
+            await stdio_server.close()
+
+
+class TestAgentIntegration:
+    @pytest.mark.asyncio
+    async def test_agent_calls_mcp_tool(self, stdio_server):
+        from timbal.core.test_model import TestModel
+
+        tool_call = Message(
+            role="assistant",
+            content=[ToolUseContent(id="c1", name="greet", input={"name": "Bob"})],
+            stop_reason="tool_use",
+        )
+        agent = Agent(
+            name="mcp_agent",
+            model=TestModel(responses=[tool_call, "done"]),
+            tools=[stdio_server],
+            max_iter=3,
+        )
+        try:
+            from timbal.types.events import OutputEvent
+
+            events = [event async for event in agent(prompt="Greet Bob")]
+            final = events[-1]
+            assert isinstance(final, OutputEvent)
+            assert final.status.code == "success"
+            assert final.output.collect_text() == "done"
+
+            tool_events = [e for e in events if isinstance(e, OutputEvent) and e.path == "mcp_agent.greet"]
+            assert len(tool_events) == 1
+            assert tool_events[0].output == "Hello, Bob!"
+        finally:
+            await stdio_server.close()
+
+
+@pytest.mark.integration
+class TestTimbalPlatformMCP:
+    """Live integration tests against the real Timbal platform MCP server.
+
+    Run explicitly (requires TIMBAL_API_KEY in the environment or .env):
+
+        uv run pytest python/tests/core/test_mcp.py -m integration -v
+    """
+
+    @pytest.fixture
+    def platform_server(self):
+        api_key = os.getenv("TIMBAL_API_KEY")
+        if not api_key:
+            pytest.skip("Timbal MCP integration: set TIMBAL_API_KEY in the environment or .env")
+        url = os.getenv("TIMBAL_MCP_URL", "https://api.timbal.ai/mcp")
+        return MCPServer(
+            transport="http",
+            url=url,
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_resolve_platform_tools(self, platform_server):
+        try:
+            tools = await platform_server.resolve()
+            by_name = {t.name: t for t in tools}
+            assert "whoami" in by_name
+            assert "search_tools" in by_name
+            # Server-declared schemas must survive the MCPTool wrapping.
+            search_schema = by_name["search_tools"].anthropic_schema["input_schema"]
+            assert search_schema["properties"]
+        finally:
+            await platform_server.close()
+
+    @pytest.mark.asyncio
+    async def test_call_whoami(self, platform_server):
+        try:
+            tools = {t.name: t for t in await platform_server.resolve()}
+            result = await tools["whoami"]().collect()
+            assert result.status.code == "success"
+            assert result.output
+        finally:
+            await platform_server.close()
+
+    @pytest.mark.asyncio
+    async def test_agent_with_platform_mcp(self, platform_server):
+        """Full agent loop against the live server, no LLM key needed (TestModel)."""
+        from timbal.core.test_model import TestModel
+        from timbal.types.events import OutputEvent
+
+        tool_call = Message(
+            role="assistant",
+            content=[ToolUseContent(id="c1", name="whoami", input={})],
+            stop_reason="tool_use",
+        )
+        agent = Agent(
+            name="timbal_mcp_agent",
+            model=TestModel(responses=[tool_call, "done"]),
+            tools=[platform_server],
+            max_iter=3,
+        )
+        try:
+            events = [event async for event in agent(prompt="Who am I?")]
+            final = events[-1]
+            assert isinstance(final, OutputEvent)
+            assert final.status.code == "success"
+            assert final.output.collect_text() == "done"
+
+            tool_events = [
+                e for e in events if isinstance(e, OutputEvent) and e.path == "timbal_mcp_agent.whoami"
+            ]
+            assert len(tool_events) == 1
+            assert tool_events[0].status.code == "success"
+            assert tool_events[0].output
+        finally:
+            await platform_server.close()
+
+
+class TestConvertCallToolResult:
+    def test_single_text(self):
+        result = mcp_types.CallToolResult(
+            content=[mcp_types.TextContent(type="text", text="hi")],
+        )
+        assert _convert_call_tool_result("t", result) == "hi"
+
+    def test_multiple_texts(self):
+        result = mcp_types.CallToolResult(
+            content=[
+                mcp_types.TextContent(type="text", text="a"),
+                mcp_types.TextContent(type="text", text="b"),
+            ],
+        )
+        assert _convert_call_tool_result("t", result) == ["a", "b"]
+
+    def test_empty_content(self):
+        result = mcp_types.CallToolResult(content=[])
+        assert _convert_call_tool_result("t", result) is None
+
+    def test_text_wins_over_structured_content(self):
+        # Text blocks are the spec's canonical serialization of structuredContent.
+        result = mcp_types.CallToolResult(
+            content=[mcp_types.TextContent(type="text", text='{"x": 1}')],
+            structuredContent={"x": 1},
+        )
+        assert _convert_call_tool_result("t", result) == '{"x": 1}'
+
+    def test_structured_content_without_text(self):
+        result = mcp_types.CallToolResult(content=[], structuredContent={"x": 1})
+        assert _convert_call_tool_result("t", result) == {"x": 1}
+
+    def test_error_raises(self):
+        result = mcp_types.CallToolResult(
+            content=[mcp_types.TextContent(type="text", text="bad input")],
+            isError=True,
+        )
+        with pytest.raises(RuntimeError, match="bad input"):
+            _convert_call_tool_result("t", result)
+
+    def test_error_without_text_raises_generic(self):
+        result = mcp_types.CallToolResult(content=[], isError=True)
+        with pytest.raises(RuntimeError, match="MCP tool 'mytool' call failed"):
+            _convert_call_tool_result("mytool", result)
+
+    def test_image_content_becomes_message_with_file(self):
+        # 1x1 transparent PNG
+        png_b64 = (
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk"
+            "YPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+        )
+        result = mcp_types.CallToolResult(
+            content=[
+                mcp_types.TextContent(type="text", text="here is your image"),
+                mcp_types.ImageContent(type="image", data=png_b64, mimeType="image/png"),
+            ],
+        )
+        converted = _convert_call_tool_result("t", result)
+        assert isinstance(converted, Message)
+        assert any(isinstance(c, TextContent) and c.text == "here is your image" for c in converted.content)
+        assert any(isinstance(c, FileContent) for c in converted.content)

--- a/python/timbal/codegen/README.md
+++ b/python/timbal/codegen/README.md
@@ -91,6 +91,52 @@ python -m timbal.codegen add-tool --type WebSearch --step agent_a
 
 ---
 
+### `add-mcp` — Add an MCP server to an Agent
+
+```bash
+# stdio server (transport inferred from --command)
+python -m timbal.codegen add-mcp --name fs \
+  --command npx --args '["-y", "@modelcontextprotocol/server-filesystem", "."]'
+
+# http server (transport inferred from --url), secret via env placeholder
+python -m timbal.codegen add-mcp --name timbal \
+  --url https://api.timbal.ai/mcp \
+  --headers '{"Authorization": "Bearer $TIMBAL_API_KEY"}'
+
+# import every server from a standard mcpServers config (claude-desktop/cursor style)
+python -m timbal.codegen add-mcp --from-json @mcp.json
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `--name` | yes (unless `--from-json`) | Server identifier. Used as the variable name and for `remove-tool` targeting. |
+| `--transport` | no | `stdio` or `http`. Inferred from `--command` / `--url` when omitted. |
+| `--command` | stdio | Executable to spawn (e.g. `npx`). |
+| `--args` | no | Command arguments as a JSON array. |
+| `--env` | no | Environment variables as a JSON object. |
+| `--url` | http | Server URL. |
+| `--headers` | no | HTTP headers as a JSON object. |
+| `--from-json` | no | `{"mcpServers": {...}}` JSON config; adds every server in it. Mutually exclusive with the per-server flags. Accepts the `type` aliases `streamable-http`/`sse` for `http`. |
+| `--step` | no | Target step name within a Workflow (adds the server to that step's tools list) |
+
+**Requires**: Agent entry point, or Workflow entry point when using `--step`.
+
+**What it does**:
+- Adds the import (`from timbal.core import MCPServer`)
+- Creates a variable assignment (`fs = MCPServer(name="fs", transport="stdio", ...)`)
+- Adds the variable to the Agent's `tools=[...]` list
+- Idempotent — re-running with the same `--name` replaces the server spec (full spec each time, no merge)
+
+**Secrets are never hardcoded**: `$VAR` / `${VAR}` placeholders inside `--env` and `--headers` values are emitted as `os.environ` lookups (adding `import os` when needed). A value that is exactly one placeholder becomes `os.environ["VAR"]`; embedded placeholders become f-strings:
+
+```python
+headers={"Authorization": f"Bearer {os.environ['TIMBAL_API_KEY']}"}
+```
+
+The config is validated against the `MCPServer` model at codegen time, so transport mismatches fail immediately instead of when the generated file first runs. Use `remove-tool --name <server_name>` to remove a server — the assignment and import are cleaned up automatically.
+
+---
+
 ### `remove-tool` — Remove a tool from an Agent
 
 ```bash

--- a/python/timbal/codegen/transformers/add_mcp.py
+++ b/python/timbal/codegen/transformers/add_mcp.py
@@ -200,12 +200,14 @@ def run(entry_point: str, args: argparse.Namespace, *, tree: cst.Module | None =
 
     # Reject variable-name shadowing upfront: the generated `<var> = MCPServer(...)`
     # must not silently rebind an existing function or unrelated assignment.
-    # (Same-named *runnables* are caught inside MCPAdder, which sees the calls.)
+    # An existing MCPServer at that variable (even without name=) is our update
+    # target — leave_Assign will replace it. Same-named non-MCP runnables are
+    # caught inside MCPAdder.
     if tree is not None:
         for server_name, _kwargs in servers:
             var_name = _var_name_for(server_name)
             existing = assignments.get(var_name)
-            if existing is not None and resolve_runnable_name(existing) != server_name:
+            if existing is not None and not _is_mcp_call(existing):
                 raise ValueError(
                     f"Variable '{var_name}' already exists and is not MCP server '{server_name}'. "
                     "Pick a different --name."
@@ -284,6 +286,32 @@ def _is_mcp_call(call: cst.Call) -> bool:
     return False
 
 
+def _explicit_mcp_name(call: cst.Call) -> str | None:
+    """Return the string value of ``name=`` on an MCPServer call, if present."""
+    for arg in call.args:
+        if isinstance(arg.keyword, cst.Name) and arg.keyword.value == "name":
+            if isinstance(arg.value, (cst.SimpleString, cst.ConcatenatedString)):
+                return arg.value.evaluated_value
+            return None
+    return None
+
+
+def _mcp_server_id(call: cst.Call, var_name: str | None = None) -> str | None:
+    """Stable identity for an MCPServer call.
+
+    Prefer the explicit ``name=`` kwarg. When omitted, ``resolve_runnable_name``
+    falls back to the class name ``"MCPServer"``, which is useless for matching
+    ``--name``. In that case the variable name is the stable handle (codegen
+    always emits ``name=``, but hand-written / older code may omit it).
+    """
+    if not _is_mcp_call(call):
+        return None
+    explicit = _explicit_mcp_name(call)
+    if explicit is not None:
+        return explicit
+    return var_name
+
+
 def _name_collision_error(runtime_name: str) -> ValueError:
     return ValueError(
         f"Name '{runtime_name}' is already used by a non-MCP tool. "
@@ -311,16 +339,21 @@ class MCPAdder(cst.CSTTransformer):
 
             # Existing MCPServer assignment for one of the servers — replace it
             # wholesale (add-mcp takes the full spec each time, no merge semantics).
+            # Match by explicit name= OR by the variable slot for this server
+            # (nameless MCPServer(...) resolves to "MCPServer", not --name).
             # A same-named non-MCP runnable is a collision, never an update target.
             if target_name != self.target and isinstance(updated_node.value, cst.Call):
-                resolved = resolve_runnable_name(updated_node.value)
-                for _var, runtime_name, kwargs in self.servers:
-                    if resolved == runtime_name:
-                        if not _is_mcp_call(updated_node.value):
-                            raise _name_collision_error(runtime_name)
+                for var_name, runtime_name, kwargs in self.servers:
+                    mcp_id = _mcp_server_id(updated_node.value, target_name)
+                    if mcp_id == runtime_name or (
+                        _is_mcp_call(updated_node.value) and target_name == var_name
+                    ):
                         self._updated.add(runtime_name)
                         call_code, _ = _server_call_code(kwargs)
                         return updated_node.with_changes(value=cst.parse_expression(call_code))
+                    resolved = resolve_runnable_name(updated_node.value)
+                    if resolved == runtime_name and not _is_mcp_call(updated_node.value):
+                        raise _name_collision_error(runtime_name)
         return updated_node
 
     def leave_Module(self, original_node: cst.Module, updated_node: cst.Module) -> cst.Module:
@@ -376,6 +409,20 @@ class MCPAdder(cst.CSTTransformer):
             call = self._add_one_to_tools(call, var_name, runtime_name)
         return call
 
+    def _tools_entry_matches(self, el_value: cst.BaseExpression, var_name: str, runtime_name: str) -> bool:
+        """True when a tools=[...] element already refers to this MCP server."""
+        if isinstance(el_value, cst.Call):
+            mcp_id = _mcp_server_id(el_value)
+            return mcp_id == runtime_name
+        if isinstance(el_value, cst.Name):
+            if el_value.value == var_name:
+                existing = self.assignments.get(el_value.value)
+                return existing is not None and _is_mcp_call(existing)
+            existing = self.assignments.get(el_value.value)
+            if existing is not None and _is_mcp_call(existing):
+                return _mcp_server_id(existing, el_value.value) == runtime_name
+        return False
+
     def _add_one_to_tools(self, call: cst.Call, var_name: str, runtime_name: str) -> cst.Call:
         new_ref = cst.Name(var_name)
 
@@ -383,25 +430,25 @@ class MCPAdder(cst.CSTTransformer):
             if isinstance(arg.keyword, cst.Name) and arg.keyword.value == "tools":
                 if isinstance(arg.value, cst.List):
                     for j, el in enumerate(arg.value.elements):
-                        name = resolve_runnable_name(el.value, self.assignments)
-                        if name == runtime_name:
+                        if self._tools_entry_matches(el.value, var_name, runtime_name):
                             if isinstance(el.value, cst.Call):
-                                if not _is_mcp_call(el.value):
-                                    raise _name_collision_error(runtime_name)
                                 # Migrate inline MCPServer Call → Name reference.
                                 updated_el = el.with_changes(value=new_ref)
                                 new_elements = [*arg.value.elements[:j], updated_el, *arg.value.elements[j + 1 :]]
                                 new_list = arg.value.with_changes(elements=new_elements)
                                 new_arg = arg.with_changes(value=new_list)
                                 return call.with_changes(args=[*call.args[:i], new_arg, *call.args[i + 1 :]])
-                            # Name reference: only an existing MCPServer assignment counts
-                            # as "already present" — anything else (bare function, Tool,
-                            # Agent, ...) with the same name is a collision.
+                            return call
+
+                        # Same resolved runtime name on a non-MCP entry is a collision.
+                        name = resolve_runnable_name(el.value, self.assignments)
+                        if name == runtime_name:
+                            if isinstance(el.value, cst.Call) and not _is_mcp_call(el.value):
+                                raise _name_collision_error(runtime_name)
                             if isinstance(el.value, cst.Name):
                                 existing = self.assignments.get(el.value.value)
                                 if existing is None or not _is_mcp_call(existing):
                                     raise _name_collision_error(runtime_name)
-                            return call
 
                     new_element = cst.Element(value=new_ref)
                     new_list = arg.value.with_changes(elements=[*arg.value.elements, new_element])

--- a/python/timbal/codegen/transformers/add_mcp.py
+++ b/python/timbal/codegen/transformers/add_mcp.py
@@ -197,6 +197,24 @@ def run(entry_point: str, args: argparse.Namespace, *, tree: cst.Module | None =
             )
 
     servers = _servers_from_args(args)
+
+    # Reject variable-name shadowing upfront: the generated `<var> = MCPServer(...)`
+    # must not silently rebind an existing function or unrelated assignment.
+    # (Same-named *runnables* are caught inside MCPAdder, which sees the calls.)
+    if tree is not None:
+        for server_name, _kwargs in servers:
+            var_name = _var_name_for(server_name)
+            existing = assignments.get(var_name)
+            if existing is not None and resolve_runnable_name(existing) != server_name:
+                raise ValueError(
+                    f"Variable '{var_name}' already exists and is not MCP server '{server_name}'. "
+                    "Pick a different --name."
+                )
+            if any(isinstance(stmt, cst.FunctionDef) and stmt.name.value == var_name for stmt in tree.body):
+                raise ValueError(
+                    f"A function named '{var_name}' already exists in the source. Pick a different --name."
+                )
+
     return MCPAdder(assignments, target=target, servers=servers)
 
 
@@ -257,6 +275,22 @@ def _server_call_code(kwargs: dict) -> tuple[str, bool]:
     return f"MCPServer({', '.join(parts)})", uses_env
 
 
+def _is_mcp_call(call: cst.Call) -> bool:
+    """True when the Call constructs an MCPServer (plain or attribute-qualified)."""
+    if isinstance(call.func, cst.Name):
+        return call.func.value == "MCPServer"
+    if isinstance(call.func, cst.Attribute):
+        return call.func.attr.value == "MCPServer"
+    return False
+
+
+def _name_collision_error(runtime_name: str) -> ValueError:
+    return ValueError(
+        f"Name '{runtime_name}' is already used by a non-MCP tool. "
+        f"Pick a different --name, or remove the existing tool first with: remove-tool --name {runtime_name}"
+    )
+
+
 class MCPAdder(cst.CSTTransformer):
     def __init__(self, assignments: dict[str, cst.Call], *, target: str, servers: list[tuple[str, dict]]):
         self.assignments = assignments
@@ -275,12 +309,15 @@ class MCPAdder(cst.CSTTransformer):
             if target_name == self.target and isinstance(updated_node.value, cst.Call):
                 return updated_node.with_changes(value=self._add_to_tools(updated_node.value))
 
-            # Existing assignment for one of the servers — replace it wholesale
-            # (add-mcp takes the full spec each time, so no merge semantics).
+            # Existing MCPServer assignment for one of the servers — replace it
+            # wholesale (add-mcp takes the full spec each time, no merge semantics).
+            # A same-named non-MCP runnable is a collision, never an update target.
             if target_name != self.target and isinstance(updated_node.value, cst.Call):
                 resolved = resolve_runnable_name(updated_node.value)
                 for _var, runtime_name, kwargs in self.servers:
                     if resolved == runtime_name:
+                        if not _is_mcp_call(updated_node.value):
+                            raise _name_collision_error(runtime_name)
                         self._updated.add(runtime_name)
                         call_code, _ = _server_call_code(kwargs)
                         return updated_node.with_changes(value=cst.parse_expression(call_code))
@@ -349,12 +386,21 @@ class MCPAdder(cst.CSTTransformer):
                         name = resolve_runnable_name(el.value, self.assignments)
                         if name == runtime_name:
                             if isinstance(el.value, cst.Call):
-                                # Migrate inline Call → Name reference.
+                                if not _is_mcp_call(el.value):
+                                    raise _name_collision_error(runtime_name)
+                                # Migrate inline MCPServer Call → Name reference.
                                 updated_el = el.with_changes(value=new_ref)
                                 new_elements = [*arg.value.elements[:j], updated_el, *arg.value.elements[j + 1 :]]
                                 new_list = arg.value.with_changes(elements=new_elements)
                                 new_arg = arg.with_changes(value=new_list)
                                 return call.with_changes(args=[*call.args[:i], new_arg, *call.args[i + 1 :]])
+                            # Name reference: only an existing MCPServer assignment counts
+                            # as "already present" — anything else (bare function, Tool,
+                            # Agent, ...) with the same name is a collision.
+                            if isinstance(el.value, cst.Name):
+                                existing = self.assignments.get(el.value.value)
+                                if existing is None or not _is_mcp_call(existing):
+                                    raise _name_collision_error(runtime_name)
                             return call
 
                     new_element = cst.Element(value=new_ref)

--- a/python/timbal/codegen/transformers/add_mcp.py
+++ b/python/timbal/codegen/transformers/add_mcp.py
@@ -1,0 +1,380 @@
+"""add-mcp — add an MCPServer to an Agent's tools list.
+
+Generates a declarative ``MCPServer(...)`` variable assignment and references it
+in ``tools=[...]``. Secrets are never hardcoded: ``$VAR`` / ``${VAR}``
+placeholders inside string values are emitted as ``os.environ[...]`` lookups so
+the generated source reads the value at runtime.
+"""
+
+import argparse
+import keyword
+import re
+
+import libcst as cst
+
+from ..cli_utils import arg_input, parse_json_arg
+from ..cst_utils import (
+    collect_assignments,
+    collect_step_names,
+    has_import,
+    is_bare_function_step,
+    resolve_entry_point_type,
+    resolve_runnable_name,
+)
+
+_ENV_PLACEHOLDER = re.compile(r"\$\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)\}|\$(?P<plain>[A-Za-z_][A-Za-z0-9_]*)")
+
+# Ordered constructor kwargs per transport, mirroring MCPServer's field order.
+_STDIO_KEYS = ("command", "args", "env")
+_HTTP_KEYS = ("url", "headers")
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:
+    sp = subparsers.add_parser(
+        "add-mcp",
+        help="Add an MCP server to the agent's tools list.",
+    )
+    sp.add_argument(
+        "--name",
+        default=None,
+        help="Identifier for the server. Used as the variable name and for remove-tool/set-config targeting.",
+    )
+    sp.add_argument(
+        "--transport",
+        choices=["stdio", "http"],
+        default=None,
+        help="Transport type. Inferred from --command (stdio) or --url (http) when omitted.",
+    )
+    sp.add_argument("--command", default=None, help="Executable for stdio transport. E.g. 'npx'.")
+    sp.add_argument(
+        "--args",
+        default=None,
+        dest="server_args",
+        type=arg_input,
+        help='Command arguments as a JSON array. E.g. \'["-y", "@modelcontextprotocol/server-filesystem", "."]\'.',
+    )
+    sp.add_argument(
+        "--env",
+        default=None,
+        type=arg_input,
+        help='Environment variables as a JSON object. Values may use $VAR / ${VAR} placeholders, '
+        "emitted as os.environ lookups instead of hardcoded secrets.",
+    )
+    sp.add_argument("--url", default=None, help="Server URL for http transport.")
+    sp.add_argument(
+        "--headers",
+        default=None,
+        type=arg_input,
+        help='HTTP headers as a JSON object. E.g. \'{"Authorization": "Bearer $TIMBAL_API_KEY"}\'. '
+        "Values may use $VAR / ${VAR} placeholders, emitted as os.environ lookups instead of hardcoded secrets.",
+    )
+    sp.add_argument(
+        "--from-json",
+        default=None,
+        dest="from_json",
+        type=arg_input,
+        help="Standard 'mcpServers' JSON config (claude-desktop/cursor style); adds every server in it. "
+        "Mutually exclusive with the per-server flags. Use '@path' to read from file or '-' to read from stdin.",
+    )
+    sp.add_argument(
+        "--step",
+        default=None,
+        help="Target step name within a Workflow. When provided, the server is added to the step's tools list.",
+    )
+
+
+def _var_name_for(server_name: str) -> str:
+    """Derive a valid Python identifier from the server name."""
+    var = re.sub(r"\W", "_", server_name)
+    if not var or var[0].isdigit():
+        var = f"mcp_{var}"
+    if keyword.iskeyword(var):
+        var = f"{var}_mcp"
+    return var
+
+
+def _infer_transport(spec: dict) -> str:
+    explicit = spec.get("transport") or spec.get("type")
+    if explicit is not None:
+        # Accept the common aliases used by mcpServers configs.
+        aliases = {"stdio": "stdio", "http": "http", "streamable-http": "http", "streamable_http": "http", "sse": "http"}
+        transport = aliases.get(explicit)
+        if transport is None:
+            raise ValueError(f"Unknown MCP transport '{explicit}'. Use 'stdio' or 'http'.")
+        return transport
+    if spec.get("command") and spec.get("url"):
+        raise ValueError("Both --command and --url given; pass --transport to disambiguate.")
+    if spec.get("command"):
+        return "stdio"
+    if spec.get("url"):
+        return "http"
+    raise ValueError("Cannot infer transport: provide --command (stdio) or --url (http).")
+
+
+def _build_server_kwargs(name: str, spec: dict) -> dict:
+    """Normalize a raw spec (CLI flags or an mcpServers entry) into MCPServer kwargs."""
+    transport = _infer_transport(spec)
+    kwargs: dict = {"name": name, "transport": transport}
+    keys = _STDIO_KEYS if transport == "stdio" else _HTTP_KEYS
+    for key in keys:
+        value = spec.get(key)
+        if value is not None:
+            kwargs[key] = value
+
+    # Validate the full spec against the runtime model so errors surface at
+    # codegen time, not when the generated file first runs. $VAR placeholders
+    # are plain strings, so they pass through validation unchanged.
+    from timbal.core.mcp import MCPServer
+
+    try:
+        MCPServer(**kwargs)
+    except Exception as e:
+        raise ValueError(f"Invalid MCP server config for '{name}': {e}") from e
+
+    return kwargs
+
+
+def _servers_from_args(args: argparse.Namespace) -> list[tuple[str, dict]]:
+    """Return a list of (server_name, constructor_kwargs)."""
+    if args.from_json is not None:
+        per_server_flags = [args.name, args.transport, args.command, args.server_args, args.env, args.url, args.headers]
+        if any(f is not None for f in per_server_flags):
+            raise ValueError("--from-json is mutually exclusive with the per-server flags.")
+        config = parse_json_arg(args.from_json, "--from-json")
+        servers = config.get("mcpServers") if isinstance(config, dict) else None
+        if not isinstance(servers, dict) or not servers:
+            raise ValueError('--from-json must be a JSON object with a non-empty "mcpServers" key.')
+        return [(name, _build_server_kwargs(name, spec)) for name, spec in servers.items()]
+
+    if not args.name:
+        raise ValueError("--name is required (or use --from-json).")
+
+    spec: dict = {"transport": args.transport, "command": args.command, "url": args.url}
+    if args.server_args is not None:
+        server_args = parse_json_arg(args.server_args, "--args")
+        if not isinstance(server_args, list):
+            raise ValueError("--args must be a JSON array.")
+        spec["args"] = server_args
+    for flag, key in ((args.env, "env"), (args.headers, "headers")):
+        if flag is not None:
+            value = parse_json_arg(flag, f"--{key}")
+            if not isinstance(value, dict):
+                raise ValueError(f"--{key} must be a JSON object.")
+            spec[key] = value
+    return [(args.name, _build_server_kwargs(args.name, spec))]
+
+
+def run(entry_point: str, args: argparse.Namespace, *, tree: cst.Module | None = None) -> cst.CSTTransformer:
+    step = getattr(args, "step", None)
+    if tree is not None:
+        ep_type = resolve_entry_point_type(tree, entry_point)
+        if step:
+            if ep_type is not None and ep_type != "Workflow":
+                raise ValueError(f"--step requires a Workflow entry point, but '{entry_point}' is a {ep_type}.")
+        else:
+            if ep_type is not None and ep_type != "Agent":
+                raise ValueError(f"add-mcp requires an Agent entry point, but '{entry_point}' is a {ep_type}.")
+
+    target = step if step else entry_point
+    assignments = collect_assignments(tree) if tree else {}
+
+    if tree is not None:
+        if step:
+            step_names = collect_step_names(tree, entry_point, assignments)
+            if (
+                step not in step_names
+                and step not in assignments
+                and not is_bare_function_step(tree, entry_point, step, assignments)
+            ):
+                raise ValueError(
+                    f"Workflow step '{step}' not found. "
+                    "Use the step variable name from .step(...), not the runtime name."
+                )
+        elif entry_point not in assignments:
+            raise ValueError(
+                f"Entry point variable '{entry_point}' not found in source. "
+                "Ensure timbal.yaml fqn matches the Agent/Workflow variable name."
+            )
+
+    servers = _servers_from_args(args)
+    return MCPAdder(assignments, target=target, servers=servers)
+
+
+# -- Code emission ------------------------------------------------------------
+
+
+def _string_expr(value: str) -> tuple[str, bool]:
+    """Return (python_expression, uses_os_environ) for a string value.
+
+    ``$VAR`` / ``${VAR}`` placeholders become ``os.environ`` lookups; a string
+    that is exactly one placeholder becomes a bare lookup, otherwise an f-string.
+    """
+    matches = list(_ENV_PLACEHOLDER.finditer(value))
+    if not matches:
+        return repr(value), False
+
+    def env_var(m: re.Match) -> str:
+        return m.group("braced") or m.group("plain")
+
+    if len(matches) == 1 and matches[0].span() == (0, len(value)):
+        return f'os.environ["{env_var(matches[0])}"]', True
+
+    parts: list[str] = []
+    last = 0
+    for m in matches:
+        literal = value[last : m.start()]
+        parts.append(literal.replace("\\", "\\\\").replace('"', '\\"').replace("{", "{{").replace("}", "}}"))
+        parts.append(f"{{os.environ['{env_var(m)}']}}")
+        last = m.end()
+    parts.append(value[last:].replace("\\", "\\\\").replace('"', '\\"').replace("{", "{{").replace("}", "}}"))
+    return 'f"' + "".join(parts) + '"', True
+
+
+def _value_expr(value: object) -> tuple[str, bool]:
+    """Return (python_expression, uses_os_environ) for any JSON value."""
+    if isinstance(value, str):
+        return _string_expr(value)
+    if isinstance(value, list):
+        exprs = [_value_expr(v) for v in value]
+        return "[" + ", ".join(e for e, _ in exprs) + "]", any(env for _, env in exprs)
+    if isinstance(value, dict):
+        items = [(repr(k), _value_expr(v)) for k, v in value.items()]
+        return (
+            "{" + ", ".join(f"{k}: {e}" for k, (e, _) in items) + "}",
+            any(env for _, (_, env) in items),
+        )
+    return repr(value), False
+
+
+def _server_call_code(kwargs: dict) -> tuple[str, bool]:
+    """Build the ``MCPServer(...)`` call source and whether it needs ``import os``."""
+    parts: list[str] = []
+    uses_env = False
+    for key, value in kwargs.items():
+        expr, env = _value_expr(value)
+        uses_env = uses_env or env
+        parts.append(f"{key}={expr}")
+    return f"MCPServer({', '.join(parts)})", uses_env
+
+
+class MCPAdder(cst.CSTTransformer):
+    def __init__(self, assignments: dict[str, cst.Call], *, target: str, servers: list[tuple[str, dict]]):
+        self.assignments = assignments
+        self.target = target
+        # (var_name, runtime_name, constructor_kwargs)
+        self.servers = [(_var_name_for(name), name, kwargs) for name, kwargs in servers]
+        self._updated: set[str] = set()  # runtime names whose assignment was updated in place
+        self._uses_env = any(_server_call_code(kwargs)[1] for _, _, kwargs in self.servers)
+
+    def leave_Assign(self, original_node: cst.Assign, updated_node: cst.Assign) -> cst.Assign:  # noqa: ARG002
+        for target in updated_node.targets:
+            if not isinstance(target.target, cst.Name):
+                continue
+            target_name = target.target.value
+
+            if target_name == self.target and isinstance(updated_node.value, cst.Call):
+                return updated_node.with_changes(value=self._add_to_tools(updated_node.value))
+
+            # Existing assignment for one of the servers — replace it wholesale
+            # (add-mcp takes the full spec each time, so no merge semantics).
+            if target_name != self.target and isinstance(updated_node.value, cst.Call):
+                resolved = resolve_runnable_name(updated_node.value)
+                for _var, runtime_name, kwargs in self.servers:
+                    if resolved == runtime_name:
+                        self._updated.add(runtime_name)
+                        call_code, _ = _server_call_code(kwargs)
+                        return updated_node.with_changes(value=cst.parse_expression(call_code))
+        return updated_node
+
+    def leave_Module(self, original_node: cst.Module, updated_node: cst.Module) -> cst.Module:
+        imports_to_add: list[cst.BaseStatement] = []
+        stmts_to_add: list[cst.BaseStatement] = []
+
+        if not has_import(original_node, "timbal.core", "MCPServer"):
+            imports_to_add.append(cst.parse_statement("from timbal.core import MCPServer\n"))
+        if self._uses_env and not _has_os_import(original_node):
+            imports_to_add.append(cst.parse_statement("import os\n"))
+
+        for var_name, runtime_name, kwargs in self.servers:
+            if runtime_name in self._updated:
+                continue
+            call_code, _ = _server_call_code(kwargs)
+            stmts_to_add.append(cst.parse_statement(f"{var_name} = {call_code}\n"))
+
+        if not imports_to_add and not stmts_to_add:
+            return updated_node
+
+        body = list(updated_node.body)
+
+        if imports_to_add:
+            import_insert_idx = 0
+            for i, stmt in enumerate(body):
+                if isinstance(stmt, cst.SimpleStatementLine):
+                    for item in stmt.body:
+                        if isinstance(item, (cst.Import, cst.ImportFrom)):
+                            import_insert_idx = i + 1
+            for stmt in reversed(imports_to_add):
+                body.insert(import_insert_idx, stmt)
+
+        if stmts_to_add:
+            insert_idx = len(body)
+            runtime_names = {rn for _, rn, _ in self.servers}
+            for i, stmt in enumerate(body):
+                if isinstance(stmt, cst.SimpleStatementLine):
+                    for item in stmt.body:
+                        if isinstance(item, cst.Assign) and isinstance(item.value, cst.Call):
+                            if resolve_runnable_name(item.value) in runtime_names:
+                                insert_idx = min(insert_idx, i)
+                            for t in item.targets:
+                                if isinstance(t.target, cst.Name) and t.target.value == self.target:
+                                    insert_idx = min(insert_idx, i)
+            for stmt in reversed(stmts_to_add):
+                body.insert(insert_idx, stmt)
+
+        return updated_node.with_changes(body=body)
+
+    def _add_to_tools(self, call: cst.Call) -> cst.Call:
+        """Add or update all server references in the tools=[...] list."""
+        for var_name, runtime_name, _kwargs in self.servers:
+            call = self._add_one_to_tools(call, var_name, runtime_name)
+        return call
+
+    def _add_one_to_tools(self, call: cst.Call, var_name: str, runtime_name: str) -> cst.Call:
+        new_ref = cst.Name(var_name)
+
+        for i, arg in enumerate(call.args):
+            if isinstance(arg.keyword, cst.Name) and arg.keyword.value == "tools":
+                if isinstance(arg.value, cst.List):
+                    for j, el in enumerate(arg.value.elements):
+                        name = resolve_runnable_name(el.value, self.assignments)
+                        if name == runtime_name:
+                            if isinstance(el.value, cst.Call):
+                                # Migrate inline Call → Name reference.
+                                updated_el = el.with_changes(value=new_ref)
+                                new_elements = [*arg.value.elements[:j], updated_el, *arg.value.elements[j + 1 :]]
+                                new_list = arg.value.with_changes(elements=new_elements)
+                                new_arg = arg.with_changes(value=new_list)
+                                return call.with_changes(args=[*call.args[:i], new_arg, *call.args[i + 1 :]])
+                            return call
+
+                    new_element = cst.Element(value=new_ref)
+                    new_list = arg.value.with_changes(elements=[*arg.value.elements, new_element])
+                    new_arg = arg.with_changes(value=new_list)
+                    return call.with_changes(args=[*call.args[:i], new_arg, *call.args[i + 1 :]])
+
+        new_arg = cst.Arg(
+            keyword=cst.Name("tools"),
+            value=cst.List(elements=[cst.Element(value=new_ref)]),
+        )
+        return call.with_changes(args=[*call.args, new_arg])
+
+
+def _has_os_import(tree: cst.Module) -> bool:
+    for stmt in tree.body:
+        if isinstance(stmt, cst.SimpleStatementLine):
+            for item in stmt.body:
+                if isinstance(item, cst.Import):
+                    for alias in item.names:
+                        if isinstance(alias.name, cst.Name) and alias.name.value == "os":
+                            return True
+    return False

--- a/python/timbal/core/mcp.py
+++ b/python/timbal/core/mcp.py
@@ -1,3 +1,4 @@
+import asyncio
 from contextlib import asynccontextmanager
 from functools import cached_property
 from typing import Any, Literal
@@ -117,6 +118,13 @@ class MCPServer(ToolSet):
     _session: Any | None = PrivateAttr(default=None)
     _tools_cache: list[Runnable] | None = PrivateAttr(default=None)
     _context: Any | None = PrivateAttr(default=None)
+    _lock: asyncio.Lock | None = PrivateAttr(default=None)
+
+    def _get_lock(self) -> asyncio.Lock:
+        # Lazily create so model construction doesn't require a running loop.
+        if self._lock is None:
+            self._lock = asyncio.Lock()
+        return self._lock
 
     @model_validator(mode="after")
     def _validate_transport_fields(self) -> "MCPServer":
@@ -152,11 +160,8 @@ class MCPServer(ToolSet):
                     logger.info("Connected to MCP server via http", url=self.url)
                     yield session
 
-    async def _connect(self) -> ClientSession:
-        """Establish connection and store session for reuse."""
-        if self._session is not None:
-            return self._session
-
+    async def _open_session(self) -> ClientSession:
+        """Open the transport. Caller must hold ``_get_lock()`` and check ``_session`` first."""
         if self.transport == "stdio":
             ctx = self._connect_stdio()
         else:
@@ -166,6 +171,20 @@ class MCPServer(ToolSet):
         self._session = session
         self._context = ctx
         return session
+
+    async def _connect(self) -> ClientSession:
+        """Establish connection and store session for reuse.
+
+        Synchronized so parallel tool calls (agent multiplexing) don't each
+        open a duplicate stdio subprocess / HTTP session and orphan the first.
+        """
+        if self._session is not None:
+            return self._session
+
+        async with self._get_lock():
+            if self._session is not None:
+                return self._session
+            return await self._open_session()
 
     def _make_tool(self, mcp_tool: mcp_types.Tool) -> MCPTool:
         tool_name = mcp_tool.name
@@ -187,23 +206,31 @@ class MCPServer(ToolSet):
         if self._tools_cache is not None:
             return self._tools_cache
 
-        session = await self._connect()
-        result = await session.list_tools()
-        tools: list[Runnable] = [self._make_tool(mcp_tool) for mcp_tool in result.tools]
-        logger.info("Resolved MCP tools", tools=[t.name for t in tools])
-        self._tools_cache = tools
-        return tools
+        async with self._get_lock():
+            if self._tools_cache is not None:
+                return self._tools_cache
+
+            if self._session is None:
+                await self._open_session()
+            assert self._session is not None
+
+            result = await self._session.list_tools()
+            tools: list[Runnable] = [self._make_tool(mcp_tool) for mcp_tool in result.tools]
+            logger.info("Resolved MCP tools", tools=[t.name for t in tools])
+            self._tools_cache = tools
+            return tools
 
     async def close(self) -> None:
         """Close the MCP server connection."""
-        if self._context is not None:
-            try:
-                await self._context.__aexit__(None, None, None)
-            except Exception as e:
-                logger.error("Error closing MCP connection", error=str(e))
-            self._session = None
-            self._context = None
-            self._tools_cache = None
+        async with self._get_lock():
+            if self._context is not None:
+                try:
+                    await self._context.__aexit__(None, None, None)
+                except Exception as e:
+                    logger.error("Error closing MCP connection", error=str(e))
+                self._session = None
+                self._context = None
+                self._tools_cache = None
 
     def __del__(self):
         session = getattr(self, "_session", None)

--- a/python/timbal/core/mcp.py
+++ b/python/timbal/core/mcp.py
@@ -102,9 +102,13 @@ class MCPServer(ToolSet):
     """
 
     name: str | None = None
-    """Optional identifier for this server. Not used at runtime; it gives codegen
-    and tooling a stable handle (e.g. ``remove-tool --name``) when multiple
-    MCPServer instances exist in one agent."""
+    """Optional identifier for this server.
+
+    When set, each resolved tool is exposed to the agent as
+    ``{name}__{tool}`` so two servers that declare the same bare tool name
+    don't collide in the agent's flat registry. The bare name is still used
+    for ``session.call_tool``. Also used by codegen (``remove-tool --name``).
+    """
 
     transport: Literal["stdio", "http"]
 
@@ -186,17 +190,36 @@ class MCPServer(ToolSet):
                 return self._session
             return await self._open_session()
 
+    def _qualified_tool_name(self, tool_name: str) -> str:
+        """Name exposed to the agent/LLM for an MCP tool.
+
+        Prefix with ``{server}__`` when this server has a ``name``, so multiple
+        MCPServer instances can coexist without their tools clobbering each
+        other in the agent's flat registry. Without a server name the bare
+        MCP tool name is kept (fine for a single unnamed server).
+        """
+        if self.name:
+            return f"{self.name}__{tool_name}"
+        return tool_name
+
     def _make_tool(self, mcp_tool: mcp_types.Tool) -> MCPTool:
-        tool_name = mcp_tool.name
+        # Bare name for the wire call; qualified name for the agent registry.
+        bare_name = mcp_tool.name
+        exposed_name = self._qualified_tool_name(bare_name)
+        description = mcp_tool.description or ""
+        if self.name and description:
+            description = f"[{self.name}] {description}"
+        elif self.name:
+            description = f"[{self.name}] {bare_name}"
 
         async def _handler(**kwargs: Any) -> Any:
             session = await self._connect()
-            result = await session.call_tool(tool_name, arguments=kwargs)
-            return _convert_call_tool_result(tool_name, result)
+            result = await session.call_tool(bare_name, arguments=kwargs)
+            return _convert_call_tool_result(bare_name, result)
 
         return MCPTool(
-            name=tool_name,
-            description=mcp_tool.description or "",
+            name=exposed_name,
+            description=description,
             handler=_handler,
             input_schema=mcp_tool.inputSchema or {},
         )

--- a/python/timbal/core/mcp.py
+++ b/python/timbal/core/mcp.py
@@ -1,17 +1,93 @@
 from contextlib import asynccontextmanager
+from functools import cached_property
 from typing import Any, Literal
+
+# `override` was introduced in Python 3.12; use `typing_extensions` for compatibility with older versions
+try:
+    from typing import override
+except ImportError:
+    from typing_extensions import override
 
 import httpx
 import structlog
 from mcp import ClientSession, StdioServerParameters
+from mcp import types as mcp_types
 from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamable_http_client
-from pydantic import Field, PrivateAttr, model_validator
+from pydantic import Field, PrivateAttr, computed_field, model_validator
 
+from ..types.content import FileContent, TextContent
+from ..types.file import File
+from ..types.message import Message
 from .runnable import Runnable
+from .tool import Tool
 from .tool_set import ToolSet
 
 logger = structlog.get_logger("timbal.core.mcp")
+
+
+def _convert_call_tool_result(tool_name: str, result: mcp_types.CallToolResult) -> Any:
+    """Convert an MCP CallToolResult into a value Timbal can feed back to the LLM.
+
+    Text-only results collapse to a plain string, structured results return the
+    structured payload, and binary content (images, audio, blob resources) is
+    wrapped in Timbal Files inside a Message so the agent forwards them as
+    FileContent tool results.
+    """
+    texts: list[str] = []
+    files: list[File] = []
+    for block in result.content:
+        if isinstance(block, mcp_types.TextContent):
+            texts.append(block.text)
+        elif isinstance(block, mcp_types.ImageContent | mcp_types.AudioContent):
+            files.append(File(f"data:{block.mimeType};base64,{block.data}"))
+        elif isinstance(block, mcp_types.EmbeddedResource):
+            resource = block.resource
+            if isinstance(resource, mcp_types.TextResourceContents):
+                texts.append(resource.text)
+            else:
+                mime_type = resource.mimeType or "application/octet-stream"
+                files.append(File(f"data:{mime_type};base64,{resource.blob}"))
+        elif isinstance(block, mcp_types.ResourceLink):
+            texts.append(str(block.uri))
+
+    if result.isError:
+        raise RuntimeError("\n".join(texts) or f"MCP tool '{tool_name}' call failed.")
+
+    if files:
+        content: list[Any] = [TextContent(text=text) for text in texts]
+        content.extend(FileContent(file=file) for file in files)
+        return Message(role="assistant", content=content)
+    # Per the MCP spec, text blocks carry the canonical serialized result even when
+    # structuredContent is present (e.g. FastMCP wraps returns as {"result": ...}),
+    # so prefer text and only fall back to the structured payload.
+    if len(texts) == 1:
+        return texts[0]
+    if texts:
+        return texts
+    return result.structuredContent
+
+
+class MCPTool(Tool):
+    """A Tool whose parameter schema comes from an MCP server instead of handler introspection.
+
+    The handler is a ``**kwargs`` passthrough that forwards the arguments to the
+    MCP session, so ``params_model`` accepts anything; the schema the LLM sees is
+    the server-declared JSON schema.
+    """
+
+    input_schema: dict[str, Any] = Field(default_factory=dict)
+    """The JSON schema declared by the MCP server for this tool's arguments."""
+
+    @override
+    @computed_field
+    @cached_property
+    def params_model_schema(self) -> dict[str, Any]:
+        """See base class."""
+        schema = dict(self.input_schema)
+        schema.setdefault("type", "object")
+        schema.setdefault("properties", {})
+        return schema
 
 
 class MCPServer(ToolSet):
@@ -23,6 +99,11 @@ class MCPServer(ToolSet):
         MCPServer(transport="stdio", command="npx", args=["-y", "@modelcontextprotocol/server-filesystem", "."])
         MCPServer(transport="http", url="https://api.timbal.ai/mcp")
     """
+
+    name: str | None = None
+    """Optional identifier for this server. Not used at runtime; it gives codegen
+    and tooling a stable handle (e.g. ``remove-tool --name``) when multiple
+    MCPServer instances exist in one agent."""
 
     transport: Literal["stdio", "http"]
 
@@ -86,12 +167,32 @@ class MCPServer(ToolSet):
         self._context = ctx
         return session
 
+    def _make_tool(self, mcp_tool: mcp_types.Tool) -> MCPTool:
+        tool_name = mcp_tool.name
+
+        async def _handler(**kwargs: Any) -> Any:
+            session = await self._connect()
+            result = await session.call_tool(tool_name, arguments=kwargs)
+            return _convert_call_tool_result(tool_name, result)
+
+        return MCPTool(
+            name=tool_name,
+            description=mcp_tool.description or "",
+            handler=_handler,
+            input_schema=mcp_tool.inputSchema or {},
+        )
+
     async def resolve(self) -> list[Runnable]:
+        """See base class. Lists the server's tools once and caches them until close()."""
+        if self._tools_cache is not None:
+            return self._tools_cache
+
         session = await self._connect()
         result = await session.list_tools()
-        print(result)
-        # TODO
-        return []
+        tools: list[Runnable] = [self._make_tool(mcp_tool) for mcp_tool in result.tools]
+        logger.info("Resolved MCP tools", tools=[t.name for t in tools])
+        self._tools_cache = tools
+        return tools
 
     async def close(self) -> None:
         """Close the MCP server connection."""


### PR DESCRIPTION
Runtime — MCPServer.resolve() now wraps each server-declared tool as an MCPTool: a Tool whose LLM-facing schema is the server's inputSchema instead of handler introspection, with a passthrough handler that forwards arguments to session.call_tool(). Results are converted for the agent loop (text → str, images/audio/blobs → Files in a Message, structuredContent fallback, isError → raised so the LLM sees an error tool result). Resolved tools are cached until close(). MCPServer also gains an optional `name` field as a stable identity handle.

Codegen — new `add-mcp` operation generates a declarative MCPServer(...) assignment and wires it into tools=[...]. Transport is inferred from --command/--url; $VAR / ${VAR} placeholders in --env and --headers are emitted as os.environ lookups so secrets are never hardcoded; --from-json imports standard mcpServers configs (claude-desktop/cursor style, including streamable-http/sse aliases). Idempotent with replace semantics; remove-tool --name cleans up the assignment and import. Config is validated against the MCPServer model at codegen time.

Docs — new docs/agents/mcp.mdx (transports, auth, result handling, lifecycle, codegen), cross-links from the tools page and mcp-integration overview, codegen README section, and CLAUDE.md coverage.

Tests: stdio round-trip against a real FastMCP subprocess, live Timbal platform MCP integration tests (marked integration, gated on TIMBAL_API_KEY), and 17 codegen tests for add-mcp.