### PR TITLE
feat(voice): VAD endpointing, streaming TTS contexts, and barge-in ha…

### DIFF
--- a/python/tests/core/test_silero_vad.py
+++ b/python/tests/core/test_silero_vad.py
@@ -1,0 +1,150 @@
+"""Tests for the Silero VAD ONNX streaming wrapper (``timbal[voice]`` extra)."""
+
+import os
+
+import pytest
+
+np = pytest.importorskip("numpy", reason="timbal[voice] extra not installed")
+pytest.importorskip("onnxruntime", reason="timbal[voice] extra not installed")
+
+from timbal.voice.vad import (  # noqa: E402
+    _CONTEXT_SAMPLES,
+    _VAD_SAMPLE_RATE,
+    FRAME_SAMPLES,
+    SileroVad,
+)
+
+
+class _FakeVadOrtSession:
+    """Stands in for the Silero ort session; records inputs, returns fixed probs."""
+
+    def __init__(self, probability: float = 0.7):
+        self.probability = probability
+        self.calls: list[dict] = []
+
+    def run(self, output_names, feeds):
+        assert output_names is None
+        assert feeds["input"].shape == (1, _CONTEXT_SAMPLES + FRAME_SAMPLES)
+        assert feeds["state"].shape == (2, 1, 128)
+        assert feeds["sr"].dtype == np.int64
+        self.calls.append({k: v.copy() for k, v in feeds.items()})
+        return [
+            np.array([[self.probability]], dtype=np.float32),
+            np.ones((2, 1, 128), dtype=np.float32) * len(self.calls),
+        ]
+
+
+def _vad_with_fake(probability: float = 0.7, sample_rate: int = _VAD_SAMPLE_RATE) -> tuple[SileroVad, _FakeVadOrtSession]:
+    vad = SileroVad()
+    fake = _FakeVadOrtSession(probability)
+    vad._session = fake
+    vad._sample_rate = sample_rate
+    return vad, fake
+
+
+def _pcm(n_samples: int, value: int = 1000) -> bytes:
+    return np.full(n_samples, value, dtype=np.int16).tobytes()
+
+
+class TestFraming:
+    def test_exact_frame_yields_one_prob(self):
+        vad, fake = _vad_with_fake(0.9)
+        probs = vad.process(_pcm(FRAME_SAMPLES))
+        assert probs == [pytest.approx(0.9)]
+        assert len(fake.calls) == 1
+
+    def test_partial_chunks_buffer_until_full_frame(self):
+        vad, fake = _vad_with_fake()
+        assert vad.process(_pcm(FRAME_SAMPLES // 2)) == []
+        assert len(fake.calls) == 0
+        probs = vad.process(_pcm(FRAME_SAMPLES // 2))
+        assert len(probs) == 1
+        assert len(fake.calls) == 1
+
+    def test_large_chunk_yields_multiple_probs(self):
+        vad, fake = _vad_with_fake()
+        probs = vad.process(_pcm(FRAME_SAMPLES * 3 + 10))
+        assert len(probs) == 3
+        assert len(fake.calls) == 3
+        # The 10 leftover samples stay buffered.
+        assert vad._buf.size == 10
+
+    def test_empty_and_odd_byte_input(self):
+        vad, _ = _vad_with_fake()
+        assert vad.process(b"") == []
+        assert vad.process(b"\x01") == []  # odd trailing byte dropped
+
+    def test_process_before_start_raises(self):
+        vad = SileroVad()
+        with pytest.raises(RuntimeError):
+            vad.process(_pcm(FRAME_SAMPLES))
+
+
+class TestContextAndState:
+    def test_first_frame_has_zero_context(self):
+        vad, fake = _vad_with_fake()
+        vad.process(_pcm(FRAME_SAMPLES, value=1000))
+        first_input = fake.calls[0]["input"][0]
+        assert not first_input[:_CONTEXT_SAMPLES].any()
+        assert first_input[_CONTEXT_SAMPLES:].all()
+
+    def test_context_carries_previous_frame_tail(self):
+        vad, fake = _vad_with_fake()
+        vad.process(_pcm(FRAME_SAMPLES, value=1000))
+        vad.process(_pcm(FRAME_SAMPLES, value=2000))
+        second_input = fake.calls[1]["input"][0]
+        expected_ctx = 1000 / 32768.0
+        assert second_input[:_CONTEXT_SAMPLES] == pytest.approx(expected_ctx, abs=1e-6)
+
+    def test_recurrent_state_threads_between_calls(self):
+        vad, fake = _vad_with_fake()
+        vad.process(_pcm(FRAME_SAMPLES))
+        vad.process(_pcm(FRAME_SAMPLES))
+        # Second call must receive the state returned by the first (all ones).
+        assert fake.calls[1]["state"].mean() == pytest.approx(1.0)
+
+    def test_reset_clears_state_context_and_buffer(self):
+        vad, fake = _vad_with_fake()
+        vad.process(_pcm(FRAME_SAMPLES + 100))
+        vad.reset()
+        assert vad._buf.size == 0
+        vad.process(_pcm(FRAME_SAMPLES))
+        assert not fake.calls[-1]["input"][0][:_CONTEXT_SAMPLES].any()
+        assert not fake.calls[-1]["state"].any()
+
+
+class TestResampling:
+    def test_48k_stride_down_to_16k(self):
+        vad, fake = _vad_with_fake(sample_rate=48_000)
+        # 3x the frame at 48k → exactly one 512-sample frame at 16k.
+        probs = vad.process(_pcm(FRAME_SAMPLES * 3))
+        assert len(probs) == 1
+        assert len(fake.calls) == 1
+
+    def test_44100_no_drift_over_many_chunks(self):
+        vad, _ = _vad_with_fake(sample_rate=44_100)
+        chunk = _pcm(4410)  # 100ms at 44.1k → 1600 samples at 16k
+        total_probs = 0
+        for _ in range(20):
+            total_probs += len(vad.process(chunk))
+        # 2 seconds of audio → 32000 samples at 16k → 62 full frames (+256 buffered).
+        produced = total_probs * FRAME_SAMPLES + vad._buf.size
+        assert produced == 32_000
+
+    def test_16k_passthrough_no_counters(self):
+        vad, _ = _vad_with_fake()
+        vad.process(_pcm(FRAME_SAMPLES))
+        assert vad._in_total == 0 and vad._out_total == 0
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TIMBAL_SMART_TURN_INTEGRATION"),
+    reason="set TIMBAL_SMART_TURN_INTEGRATION=1 to download and run the real checkpoint",
+)
+class TestRealSileroCheckpoint:
+    async def test_silence_scores_low(self):
+        vad = SileroVad()
+        await vad.start(sample_rate=_VAD_SAMPLE_RATE)
+        probs = vad.process(b"\x00\x00" * (FRAME_SAMPLES * 10))
+        assert len(probs) == 10
+        assert max(probs) < 0.3

--- a/python/tests/core/test_turn_detection.py
+++ b/python/tests/core/test_turn_detection.py
@@ -137,6 +137,28 @@ class TestOnPartial:
         )
         assert decision is PartialDecision.IGNORE
 
+    async def test_single_short_word_partial_does_not_barge_in(self) -> None:
+        """A lone short partial ("Nice.") while the assistant speaks is a mic
+        blip / mis-transcribed speaker echo far more often than a barge-in —
+        a false positive cancels TTS and erases the reply (min-words gate,
+        same as Pipecat MinWordsInterruptionStrategy / LiveKit
+        min_interruption_words)."""
+        det = HeuristicTurnDetector()
+        for blip in ("Nice.", "Okay.", "What now"):
+            decision = await det.on_partial(
+                blip,
+                _state(audio_playing=True, assistant_active=True, assistant_text="I'm just a program"),
+            )
+            assert decision is PartialDecision.IGNORE, blip
+
+    async def test_three_word_partial_barges_in(self) -> None:
+        det = HeuristicTurnDetector()
+        decision = await det.on_partial(
+            "no stop that",
+            _state(audio_playing=True, assistant_active=True, assistant_text="I'm just a program"),
+        )
+        assert decision is PartialDecision.BARGE_IN
+
 
 class TestOnCommitted:
     async def test_plain_commit_starts_new_turn(self) -> None:
@@ -565,7 +587,7 @@ class TestHoldDecisions:
         assert decision.text == "I was wondering about the weather tomorrow"
 
     async def test_hold_does_not_merge_long_new_utterance(self) -> None:
-        """A separate long commit while holding must not be concatenated."""
+        """A separate long commit while holding starts NOW — but keeps the fragment."""
         det = HeuristicTurnDetector()
         new = "Actually what is the capital of France please tell me"
         assert len(new) >= HeuristicTurnDetector.CONTINUATION_MAX_CHARS
@@ -581,10 +603,10 @@ class TestHoldDecisions:
         )
         assert decision.action is CommitAction.NEW_TURN
         assert decision.reason == "hold_supersede"
-        assert decision.text == new
+        assert decision.text == "I was wondering about " + new
 
     async def test_heuristic_hold_supersedes_stop_command(self) -> None:
-        """Heuristic must not glue a self-contained short commit onto a HOLD."""
+        """A self-contained short commit starts the turn now — fragment preserved."""
         det = HeuristicTurnDetector()
         decision = await det.on_committed(
             "stop",
@@ -598,10 +620,10 @@ class TestHoldDecisions:
         )
         assert decision.action is CommitAction.NEW_TURN
         assert decision.reason == "hold_supersede"
-        assert decision.text == "stop"
+        assert decision.text == "I was wondering about stop"
 
     async def test_lexical_hold_supersedes_stop_command(self) -> None:
-        """Complete short command while holding must not produce garbled merge text."""
+        """Complete short command while holding starts now, fragment preserved."""
         det = LexicalTurnDetector()  # real punctuation EOU
         decision = await det.on_committed(
             "stop",
@@ -614,7 +636,7 @@ class TestHoldDecisions:
             ),
         )
         assert decision.action is CommitAction.NEW_TURN
-        assert decision.text == "stop"
+        assert decision.text == "I was wondering about stop"
         assert decision.reason == "hold_supersede"
 
     async def test_lexical_does_not_rehold_parent_supersede(self) -> None:
@@ -632,7 +654,7 @@ class TestHoldDecisions:
         )
         assert decision.action is CommitAction.NEW_TURN
         assert decision.reason == "hold_supersede"
-        assert decision.text == "stop"
+        assert decision.text == "I was wondering about stop"
 
     async def test_local_does_not_rehold_parent_supersede(self) -> None:
         """Incomplete audio must not convert hold_supersede back into HOLD."""
@@ -651,7 +673,7 @@ class TestHoldDecisions:
         )
         assert decision.action is CommitAction.NEW_TURN
         assert decision.reason == "hold_supersede"
-        assert decision.text == "stop"
+        assert decision.text == "I was wondering about stop"
         await det.close()
 
     async def test_hallucination_guard_skips_while_holding(self) -> None:
@@ -733,6 +755,29 @@ class TestLocalHoldMerge:
         assert decision.text.startswith("Hello. Uh, I was thinking about...")
         await det.close()
 
+    async def test_forced_split_continuation_preserves_fragment(self) -> None:
+        """Live failure: VAD endpointing split "…thinking about" / "Something.".
+
+        STT capitalizes each committed segment, so the continuation looks
+        "fresh" and supersedes the hold — the turn must still carry the full
+        utterance, not just "Something.".
+        """
+        det = await self._det(0.9)
+        decision = await det.on_committed(
+            "Something.",
+            _state(
+                holding=True,
+                active_user_text="Uh, I, I was thinking about...",
+                assistant_active=False,
+                seconds_since_last_commit=1.6,
+                partials_since_last_commit=2,
+            ),
+        )
+        assert decision.action is CommitAction.NEW_TURN
+        assert decision.reason == "hold_supersede"
+        assert decision.text == "Uh, I, I was thinking about... Something."
+        await det.close()
+
     async def test_fresh_utterance_still_supersedes(self) -> None:
         det = await self._det(0.9)
         decision = await det.on_committed(
@@ -741,7 +786,11 @@ class TestLocalHoldMerge:
         )
         assert decision.action is CommitAction.NEW_TURN
         assert decision.reason == "hold_supersede"
-        assert decision.text == "Stop. Forget it, new question entirely about something else okay"
+        # Immediate start; held fragment prepended, not dropped.
+        assert decision.text == (
+            "Hello. Uh, I was thinking about... "
+            "Stop. Forget it, new question entirely about something else okay"
+        )
         await det.close()
 
 

--- a/python/tests/core/test_turn_detection_adversarial.py
+++ b/python/tests/core/test_turn_detection_adversarial.py
@@ -14,7 +14,6 @@ from timbal import Agent
 from timbal.core.test_model import TestModel
 from timbal.voice.eou import AudioEouModel
 from timbal.voice.session import TranscriptEvent, VoiceSession, VoiceSessionEvent
-from timbal.voice.eou import PunctuationEouPredictor
 from timbal.voice.turn_detection import (
     CommitAction,
     CommitDecision,
@@ -208,7 +207,9 @@ class TestLocalHoldMergeLiveFailure:
         )
         assert decision.action is CommitAction.NEW_TURN
         assert decision.reason == "hold_supersede"
-        assert decision.text.startswith("Stop.")
+        # Starts immediately, but the held fragment is preserved in the turn
+        # text (never drop transcribed user speech).
+        assert decision.text == "Hello. Uh, I was thinking about... Stop. Forget the previous question entirely please"
         await det.close()
 
 

--- a/python/tests/core/test_vad_endpointing.py
+++ b/python/tests/core/test_vad_endpointing.py
@@ -1,0 +1,509 @@
+"""Tests for the VAD endpointing fast path.
+
+Covers :func:`endpointing_delay`, the :class:`VadEndpointer` state machine
+(with a fake VAD — no onnxruntime needed), and the full VoiceSession
+integration: Silero speech-stop → audio EOU score → forced ``stt.commit()`` →
+normal committed-transcript turn flow.
+"""
+# ruff: noqa: ARG002
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+
+import pytest
+from timbal import Agent
+from timbal.core.test_model import TestModel
+from timbal.voice import (
+    AudioInputConfig,
+    LocalAudioTurnDetector,
+    VadEndpointer,
+    VoiceSession,
+    endpointing_delay,
+)
+from timbal.voice.eou import AudioEouModel
+from timbal.voice.metrics import TurnMetricsEvent
+from timbal.voice.session import (
+    AudioOutputConfig,
+    SpeechToText,
+    TextToSpeech,
+    TranscriptEvent,
+)
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeVad:
+    """One VAD frame per input byte: ``S`` → speech (1.0), anything else → 0.0."""
+
+    def __init__(self) -> None:
+        self.started_with: int | None = None
+
+    async def start(self, *, sample_rate: int) -> None:
+        self.started_with = sample_rate
+
+    def reset(self) -> None:
+        pass
+
+    def process(self, chunk: bytes) -> list[float]:
+        return [1.0 if b == ord("S") else 0.0 for b in chunk]
+
+
+class _FixedEou(AudioEouModel):
+    def __init__(self, p: float = 0.95) -> None:
+        self.p = p
+        self.calls = 0
+
+    async def predict_complete(self, pcm: bytes, *, sample_rate: int) -> float:
+        self.calls += 1
+        return self.p
+
+
+def _endpointer(vad: FakeVad | None = None, **knobs) -> VadEndpointer:
+    defaults = dict(
+        stop_silence_secs=0.064,  # 2 frames
+        min_speech_secs=0.064,  # 2 frames
+        min_delay_secs=0.0,
+        max_delay_secs=0.05,
+        min_commit_interval_secs=0.0,
+    )
+    defaults.update(knobs)
+    return VadEndpointer(vad or FakeVad(), **defaults)
+
+
+class _Recorder:
+    """Bind targets that record calls and return scripted values."""
+
+    def __init__(self, *, p: float | None = 0.95, gate: bool = True) -> None:
+        self.p = p
+        self.gate = gate
+        self.score_calls = 0
+        self.commit_calls = 0
+
+    async def score(self) -> float | None:
+        self.score_calls += 1
+        return self.p
+
+    async def commit(self) -> None:
+        self.commit_calls += 1
+
+    def should_commit(self) -> bool:
+        return self.gate
+
+
+async def _started(ep: VadEndpointer, rec: _Recorder) -> VadEndpointer:
+    ep.bind(score=rec.score, commit=rec.commit, should_commit=rec.should_commit)
+    await ep.start(sample_rate=16_000)
+    return ep
+
+
+async def _settle(secs: float = 0.15) -> None:
+    await asyncio.sleep(secs)
+
+
+# ---------------------------------------------------------------------------
+# endpointing_delay
+# ---------------------------------------------------------------------------
+
+
+class TestEndpointingDelay:
+    def test_confident_maps_to_min(self):
+        assert endpointing_delay(1.0, min_delay=0.0, max_delay=3.0) == 0.0
+
+    def test_zero_maps_to_max(self):
+        assert endpointing_delay(0.0, min_delay=0.0, max_delay=3.0) == 3.0
+
+    def test_monotonic_decreasing(self):
+        delays = [endpointing_delay(p / 10) for p in range(11)]
+        assert delays == sorted(delays, reverse=True)
+
+    def test_clamps_out_of_range(self):
+        assert endpointing_delay(1.7) == endpointing_delay(1.0)
+        assert endpointing_delay(-0.5) == endpointing_delay(0.0)
+
+    def test_incomplete_exceeds_provider_debounce(self):
+        # p below the completion threshold must compute a delay longer than
+        # the ~1.2s ElevenLabs VAD debounce — the provider commit wins and the
+        # existing HOLD machinery handles the incomplete utterance.
+        assert endpointing_delay(0.4) > 1.0
+
+    def test_confident_is_fast(self):
+        assert endpointing_delay(0.95) < 0.05
+
+
+# ---------------------------------------------------------------------------
+# VadEndpointer state machine
+# ---------------------------------------------------------------------------
+
+
+class TestVadEndpointer:
+    async def test_speech_then_silence_commits(self):
+        rec = _Recorder(p=0.95)
+        ep = await _started(_endpointer(), rec)
+        ep.push(b"SSS")  # 3 speech frames ≥ min_speech
+        ep.push(b"\x00\x00")  # 2 silence frames ≥ stop_silence
+        await _settle()
+        assert rec.score_calls == 1
+        assert rec.commit_calls == 1
+
+    async def test_phoneme_dips_still_accumulate_speech(self):
+        # Silero routinely dips below threshold between phonemes. A short word
+        # ("work.") is 0.1–0.3s of speech with dips — the min_speech
+        # accumulator must survive them (live failure: "Um, work." never
+        # armed, session stalled until the user spoke again).
+        rec = _Recorder(p=0.9)
+        ep = await _started(_endpointer(min_speech_secs=0.12, stop_silence_secs=0.096), rec)
+        # 4 speech frames (0.128s total) interleaved with 1-frame dips.
+        ep.push(b"S\x00S\x00S\x00S")
+        ep.push(b"\x00\x00\x00")  # 3 silence frames ≥ stop_silence
+        await _settle()
+        assert rec.score_calls == 1
+        assert rec.commit_calls == 1
+
+    async def test_separated_blips_do_not_accumulate_into_phantom_utterance(self):
+        # Isolated noise blips separated by real silence must not sum up to
+        # min_speech across utterance boundaries.
+        rec = _Recorder(p=0.9)
+        ep = await _started(_endpointer(min_speech_secs=0.12, stop_silence_secs=0.096), rec)
+        for _ in range(4):
+            ep.push(b"S")  # one frame of "speech"
+            ep.push(b"\x00" * 6)  # real silence resets the accumulator
+        await _settle()
+        assert rec.score_calls == 0
+        assert rec.commit_calls == 0
+
+    async def test_short_blip_never_endpoints(self):
+        rec = _Recorder()
+        ep = await _started(_endpointer(min_speech_secs=0.2), rec)
+        ep.push(b"S")  # 1 frame (0.032s) < min_speech
+        ep.push(b"\x00\x00\x00")
+        await _settle()
+        assert rec.score_calls == 0
+        assert rec.commit_calls == 0
+
+    async def test_one_attempt_per_speech_stop(self):
+        rec = _Recorder(p=0.95)
+        ep = await _started(_endpointer(), rec)
+        ep.push(b"SSS")
+        ep.push(b"\x00" * 20)  # long silence — still one endpoint
+        await _settle()
+        assert rec.score_calls == 1
+        assert rec.commit_calls == 1
+
+    async def test_resumed_speech_cancels_pending(self):
+        rec = _Recorder(p=0.1)  # incomplete → long delay
+        ep = await _started(_endpointer(max_delay_secs=5.0), rec)
+        ep.push(b"SSS")
+        ep.push(b"\x00\x00")
+        await _settle(0.05)  # score happened, now sleeping the long delay
+        assert rec.score_calls == 1
+        ep.push(b"SS")  # user resumes → pending cancelled
+        await _settle(0.05)
+        assert rec.commit_calls == 0
+
+    async def test_single_noise_frame_does_not_cancel(self):
+        rec = _Recorder(p=0.5)
+        # delay(0.5) = 0.25 * max → 0.1s with max 0.4: long enough to inject a blip.
+        ep = await _started(_endpointer(max_delay_secs=0.4), rec)
+        ep.push(b"SSS")
+        ep.push(b"\x00\x00")
+        await _settle(0.02)
+        ep.push(b"S")  # 1 frame < SPEECH_RESUME_SECS (2 frames) — must not cancel
+        await _settle(0.3)
+        assert rec.commit_calls == 1
+
+    async def test_session_gate_blocks_commit(self):
+        rec = _Recorder(p=0.95, gate=False)
+        ep = await _started(_endpointer(), rec)
+        ep.push(b"SSS")
+        ep.push(b"\x00\x00")
+        await _settle()
+        assert rec.score_calls == 0  # gated before scoring
+        assert rec.commit_calls == 0
+
+    async def test_none_score_never_commits(self):
+        rec = _Recorder(p=None)
+        ep = await _started(_endpointer(), rec)
+        ep.push(b"SSS")
+        ep.push(b"\x00\x00")
+        await _settle()
+        assert rec.score_calls == 1
+        assert rec.commit_calls == 0
+
+    async def test_notify_committed_cancels_pending(self):
+        rec = _Recorder(p=0.1)
+        ep = await _started(_endpointer(max_delay_secs=5.0), rec)
+        ep.push(b"SSS")
+        ep.push(b"\x00\x00")
+        await _settle(0.05)
+        ep.notify_committed()  # provider debounce beat us
+        await _settle(0.05)
+        assert rec.commit_calls == 0
+
+    async def test_min_commit_interval_suppresses_second(self):
+        rec = _Recorder(p=0.95)
+        ep = await _started(_endpointer(min_commit_interval_secs=60.0), rec)
+        ep.push(b"SSS")
+        ep.push(b"\x00\x00")
+        await _settle()
+        ep.push(b"SSS")
+        ep.push(b"\x00\x00")
+        await _settle()
+        assert rec.commit_calls == 1
+
+    async def test_close_stops_everything(self):
+        rec = _Recorder(p=0.1)
+        ep = await _started(_endpointer(max_delay_secs=5.0), rec)
+        ep.push(b"SSS")
+        ep.push(b"\x00\x00")
+        await _settle(0.05)
+        await ep.close()
+        ep.push(b"SSS")
+        ep.push(b"\x00\x00")
+        await _settle(0.05)
+        assert rec.commit_calls == 0
+
+    async def test_start_requires_bind(self):
+        ep = _endpointer()
+        with pytest.raises(RuntimeError):
+            await ep.start(sample_rate=16_000)
+
+
+class TestSpeechWindow:
+    """``speech_secs_in_window`` — the barge-in hallucination-veto signal."""
+
+    _FRAME = 512 / 16_000
+
+    async def test_none_before_start(self):
+        ep = _endpointer()
+        assert ep.speech_secs_in_window(2.0) is None
+
+    async def test_none_when_no_frames_processed(self):
+        """Started but starved (no mic audio) → no evidence, must not veto."""
+        ep = await _started(_endpointer(), _Recorder())
+        assert ep.speech_secs_in_window(2.0) is None
+        await ep.close()
+
+    async def test_counts_recent_speech_frames(self):
+        ep = await _started(_endpointer(), _Recorder())
+        ep.push(b"SSSSSSSS")  # 8 speech frames
+        assert ep.speech_secs_in_window(2.0) == pytest.approx(8 * self._FRAME)
+        await ep.close()
+
+    async def test_silence_counts_zero(self):
+        """Frames flowing but all sub-threshold → 0.0 (veto-able), not None."""
+        ep = await _started(_endpointer(), _Recorder())
+        ep.push(b"\x00" * 8)
+        assert ep.speech_secs_in_window(2.0) == 0.0
+        await ep.close()
+
+
+# ---------------------------------------------------------------------------
+# VoiceSession integration
+# ---------------------------------------------------------------------------
+
+
+class EndpointSTT(SpeechToText):
+    """STT with externally injected events; ``commit()`` finalizes ``pending_text``."""
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[TranscriptEvent | None] = asyncio.Queue()
+        self.pending_text = ""
+        self.commit_calls = 0
+
+    async def connect(self, config: AudioInputConfig) -> None:
+        pass
+
+    async def push_audio(self, chunk: bytes) -> None:
+        pass
+
+    async def commit(self) -> None:
+        self.commit_calls += 1
+        if self.pending_text:
+            await self._queue.put(TranscriptEvent(type="committed", text=self.pending_text))
+            self.pending_text = ""
+
+    async def inject_partial(self, text: str) -> None:
+        self.pending_text = text
+        await self._queue.put(TranscriptEvent(type="partial", text=text))
+
+    async def finish(self) -> None:
+        await self._queue.put(None)
+
+    async def events(self) -> AsyncIterator[TranscriptEvent]:
+        while True:
+            item = await self._queue.get()
+            if item is None:
+                break
+            if item.text:
+                yield item
+
+    async def close(self) -> None:
+        pass
+
+
+class _SilentTTS(TextToSpeech):
+    async def connect(self, config: AudioOutputConfig) -> None:
+        pass
+
+    async def synthesize(self, text: str) -> AsyncIterator[bytes]:
+        yield b"\x00\x01" * 8
+
+    async def close(self) -> None:
+        pass
+
+
+class TestVoiceSessionEndpointing:
+    async def _run_endpointed_session(self, eou_p: float = 0.95):
+        stt = EndpointSTT()
+        detector = LocalAudioTurnDetector(audio_eou=_FixedEou(eou_p))
+        endpointer = _endpointer(FakeVad())
+        session = VoiceSession(
+            agent=Agent(name="t", model=TestModel(responses=["Sure thing."]), tools=[]),
+            stt=stt,
+            tts=_SilentTTS(),
+            turn_detector=detector,
+            vad_endpointing=endpointer,
+        )
+
+        audio_queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+
+        async def _audio() -> AsyncIterator[bytes]:
+            while True:
+                chunk = await audio_queue.get()
+                if chunk is None:
+                    return
+                yield chunk
+
+        events = []
+
+        async def _consume() -> None:
+            async for ev in session.run(_audio()):
+                events.append(ev)
+
+        consumer = asyncio.create_task(_consume())
+        await asyncio.sleep(0.05)  # session + endpointer started
+
+        # Enough buffered PCM for score_recent_audio (≥ sample_rate bytes),
+        # all mapped to VAD silence by FakeVad.
+        await audio_queue.put(b"\x00" * 20_000)
+        # The gate requires a partial newer than the last commit.
+        await stt.inject_partial("what's the weather like today?")
+        await asyncio.sleep(0.02)
+        # Speech, then silence → endpoint fires.
+        await audio_queue.put(b"S" * 4)
+        await audio_queue.put(b"\x00" * 4)
+
+        # Give the endpointer time to score + commit and the turn to run.
+        for _ in range(100):
+            await asyncio.sleep(0.02)
+            if any(isinstance(e, TurnMetricsEvent) for e in events):
+                break
+
+        await stt.finish()
+        await audio_queue.put(None)
+        await asyncio.wait_for(consumer, timeout=5.0)
+        return session, stt, events
+
+    async def test_endpointer_forces_commit_and_runs_turn(self):
+        session, stt, events = await self._run_endpointed_session(eou_p=0.95)
+        assert stt.commit_calls >= 1
+        user_entries = [e for e in session.transcript if e.role == "user"]
+        assert [e.text for e in user_entries] == ["what's the weather like today?"]
+        metrics = [e.metrics for e in events if isinstance(e, TurnMetricsEvent)]
+        assert metrics and metrics[0].vad_endpointed is True
+
+    async def test_incomplete_score_defers_to_provider(self):
+        # p=0.1 → delay ≈ 0.81 * max(3.0) ≈ 2.4s — far longer than this test
+        # waits, so no forced commit happens.
+        stt = EndpointSTT()
+        detector = LocalAudioTurnDetector(audio_eou=_FixedEou(0.1))
+        endpointer = _endpointer(FakeVad(), max_delay_secs=3.0)
+        session = VoiceSession(
+            agent=Agent(name="t", model=TestModel(responses=["ok"]), tools=[]),
+            stt=stt,
+            tts=_SilentTTS(),
+            turn_detector=detector,
+            vad_endpointing=endpointer,
+        )
+
+        audio_queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+
+        async def _audio() -> AsyncIterator[bytes]:
+            while True:
+                chunk = await audio_queue.get()
+                if chunk is None:
+                    return
+                yield chunk
+
+        async def _consume() -> None:
+            async for _ in session.run(_audio()):
+                pass
+
+        consumer = asyncio.create_task(_consume())
+        await asyncio.sleep(0.05)
+        await audio_queue.put(b"\x00" * 20_000)
+        await stt.inject_partial("so I was thinking about")
+        await asyncio.sleep(0.02)
+        await audio_queue.put(b"S" * 4)
+        await audio_queue.put(b"\x00" * 4)
+        await asyncio.sleep(0.3)
+
+        assert stt.commit_calls == 0  # incomplete → endpointer stays quiet
+
+        await stt.finish()
+        await audio_queue.put(None)
+        await asyncio.wait_for(consumer, timeout=5.0)
+
+    async def test_auto_mode_off_without_audio_eou(self):
+        # Default heuristic detector has no audio EOU → endpointer never arms,
+        # even when explicitly requested.
+        stt = EndpointSTT()
+        session = VoiceSession(
+            agent=Agent(name="t", model=TestModel(responses=["ok"]), tools=[]),
+            stt=stt,
+            tts=_SilentTTS(),
+            vad_endpointing=True,
+        )
+
+        async def _audio() -> AsyncIterator[bytes]:
+            return
+            yield  # noqa: RET504
+
+        async def _consume() -> None:
+            async for _ in session.run(_audio()):
+                pass
+
+        consumer = asyncio.create_task(_consume())
+        await asyncio.sleep(0.05)
+        assert session._endpointer is None
+        await stt.finish()
+        await asyncio.wait_for(consumer, timeout=5.0)
+
+    async def test_disabled_by_config(self):
+        stt = EndpointSTT()
+        detector = LocalAudioTurnDetector(audio_eou=_FixedEou(0.95))
+        session = VoiceSession(
+            agent=Agent(name="t", model=TestModel(responses=["ok"]), tools=[]),
+            stt=stt,
+            tts=_SilentTTS(),
+            turn_detector=detector,
+            vad_endpointing=False,
+        )
+
+        async def _audio() -> AsyncIterator[bytes]:
+            return
+            yield  # noqa: RET504
+
+        async def _consume() -> None:
+            async for _ in session.run(_audio()):
+                pass
+
+        consumer = asyncio.create_task(_consume())
+        await asyncio.sleep(0.05)
+        assert session._endpointer is None
+        await stt.finish()
+        await asyncio.wait_for(consumer, timeout=5.0)

--- a/python/tests/core/test_voice_session.py
+++ b/python/tests/core/test_voice_session.py
@@ -25,6 +25,7 @@ from timbal.voice.session import (
     TranscriptCommitted,
     TranscriptEvent,
     TranscriptPartial,
+    TTSStream,
     VoiceSession,
     VoiceSessionEvent,
     _strip_markdown,
@@ -128,6 +129,74 @@ class DelayedMockSTT(SpeechToText):
                 raise RuntimeError(item.text)
             if item.text:
                 yield item
+
+    async def close(self) -> None:
+        self._closed = True
+
+
+class MockTTSStream(TTSStream):
+    """In-memory TTSStream: each feed enqueues len(text)*bytes_per_char of PCM."""
+
+    def __init__(self, bytes_per_char: int = 10, chunk_delay: float = 0.0) -> None:
+        self.fed: list[str] = []
+        self.ended = False
+        self.aborted = False
+        self._bytes_per_char = bytes_per_char
+        self._chunk_delay = chunk_delay
+        self._queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+
+    async def feed(self, text: str) -> None:
+        if self.ended or self.aborted:
+            return
+        self.fed.append(text)
+        data = b"\x00" * (len(text) * self._bytes_per_char)
+        # Emit in sub-chunks so tests can interrupt mid-drain.
+        step = 100
+        for i in range(0, len(data), step):
+            await self._queue.put(data[i : i + step])
+
+    async def end(self) -> None:
+        if self.ended or self.aborted:
+            return
+        self.ended = True
+        await self._queue.put(None)
+
+    async def abort(self) -> None:
+        self.aborted = True
+        self._queue.put_nowait(None)
+
+    async def audio(self) -> AsyncIterator[bytes]:
+        while True:
+            item = await self._queue.get()
+            if item is None:
+                return
+            if self._chunk_delay:
+                await asyncio.sleep(self._chunk_delay)
+            yield item
+
+
+class StreamingMockTTS(TextToSpeech):
+    """TTS advertising ``open_stream``; per-segment ``synthesize`` should never run."""
+
+    def __init__(self, bytes_per_char: int = 10, chunk_delay: float = 0.0) -> None:
+        self.streams: list[MockTTSStream] = []
+        self.synthesize_calls: list[str] = []
+        self._bytes_per_char = bytes_per_char
+        self._chunk_delay = chunk_delay
+        self._connected = False
+        self._closed = False
+
+    async def connect(self, config: AudioOutputConfig) -> None:
+        self._connected = True
+
+    def open_stream(self) -> MockTTSStream:
+        stream = MockTTSStream(bytes_per_char=self._bytes_per_char, chunk_delay=self._chunk_delay)
+        self.streams.append(stream)
+        return stream
+
+    async def synthesize(self, text: str) -> AsyncIterator[bytes]:
+        self.synthesize_calls.append(text)
+        yield b"\x00" * 4
 
     async def close(self) -> None:
         self._closed = True
@@ -1086,7 +1155,13 @@ class TestInterruptionTruncation:
         # assistant message, so assistant-count-based TestModel would replay
         # response[0] for the merged turn.
         replies = iter([self.RESPONSE, "Second reply"])
-        agent = Agent(name="t", model=TestModel(handler=lambda _m: next(replies)), tools=[])
+        seen_messages: list[list] = []
+
+        def _handler(messages) -> str:
+            seen_messages.append(list(messages))
+            return next(replies)
+
+        agent = Agent(name="t", model=TestModel(handler=_handler), tools=[])
         stt = DelayedMockSTT()
         tts = SlowMockTTS(delay=0.03, chunk=b"\x00\x01" * 50, num_chunks=4)
         session = VoiceSession(
@@ -1128,9 +1203,17 @@ class TestInterruptionTruncation:
         assert [e.role for e in session.transcript] == ["user", "assistant"]
         assert session.transcript[0].text == combined
         assert session.transcript[1].text == "Second reply"
+        # The merged turn's LLM input must contain the combined utterance
+        # exactly once — the old memory *rewrite* (instead of pop) left it in
+        # both the parent memory and the new prompt.
+        merged_input = seen_messages[-1]
+        user_texts = [m.collect_text() for m in merged_input if m.role == "user"]
+        assert user_texts.count(combined) == 1, user_texts
 
     async def test_align_continue_memory_drops_heard_assistant(self) -> None:
-        """Unit: CONTINUE rewrite must pop assistant:heard and rewrite user."""
+        """Unit: CONTINUE cleanup must pop assistant:heard AND the fragment user
+        entry — the merged turn re-sends the combined text as its prompt, so a
+        rewritten (instead of popped) user entry ends up in the LLM input twice."""
         from timbal.state.context import RunContext
         from timbal.state.tracing.span import Span
         from timbal.types.content import TextContent
@@ -1152,14 +1235,8 @@ class TestInterruptionTruncation:
         ctx._trace[root.call_id] = root
         session._last_run_context = ctx
 
-        await session._align_continue_memory(
-            fragment_user_text="hello can",
-            combined_user_text="hello can you help me with something",
-        )
-        mem = root.memory
-        assert len(mem) == 1
-        assert mem[0].role == "user"
-        assert mem[0].collect_text() == "hello can you help me with something"
+        await session._align_continue_memory(fragment_user_text="hello can")
+        assert root.memory == []
 
     async def test_interrupt_cancels_orphan_turn_before_speaking(self) -> None:
         """``interrupt()`` must cancel a scheduled turn even if ``_is_speaking``
@@ -1307,3 +1384,174 @@ class TestProviderCleanup:
         await session.close()
         assert stt._closed
         assert tts._closed
+
+
+class _FakeEndpointer:
+    """Stands in for VadEndpointer: scripted speech-energy window."""
+
+    def __init__(self, speech_secs: float | None) -> None:
+        self.speech_secs = speech_secs
+
+    def speech_secs_in_window(self, window_secs: float) -> float | None:
+        return self.speech_secs
+
+    def push(self, chunk: bytes) -> None:
+        pass
+
+    def notify_committed(self) -> None:
+        pass
+
+    async def close(self) -> None:
+        pass
+
+
+class TestVadBargeInVeto:
+    """STT hallucinates plausible phrases from silence (observed live:
+    'Not, not too bad, mate.' while nobody spoke) — they pass every text gate
+    but carry no mic energy. Partial barge-ins must be corroborated by the
+    local VAD when it's armed."""
+
+    def test_veto_matrix(self) -> None:
+        session, _, _ = _make_session()
+        # No endpointer (heuristic mode, no Silero) → never veto.
+        session._endpointer = None
+        assert session._vad_vetoes_barge_in("no stop that") is False
+        # VAD armed but unhealthy/starved (None) → no evidence, never veto.
+        session._endpointer = _FakeEndpointer(None)
+        assert session._vad_vetoes_barge_in("no stop that") is False
+        # Real speech energy present → allow the barge-in.
+        session._endpointer = _FakeEndpointer(1.0)
+        assert session._vad_vetoes_barge_in("no stop that") is False
+        # Armed, healthy, and the mic was silent → hallucination, veto.
+        session._endpointer = _FakeEndpointer(0.0)
+        assert session._vad_vetoes_barge_in("no stop that") is True
+
+    async def _run_barge_in_scenario(self, speech_secs: float | None) -> tuple[VoiceSession, list[VoiceSessionEvent]]:
+        agent = Agent(
+            name="t",
+            model=TestModel(responses=["This is a fairly long reply that keeps on playing for a while."]),
+            tools=[],
+        )
+        stt = DelayedMockSTT()
+        tts = SlowMockTTS(delay=0.05, num_chunks=6)
+        tracker = FakePlaybackTracker()
+        session = VoiceSession(agent=agent, stt=stt, tts=tts, playback_tracker=tracker)
+        session._endpointer = _FakeEndpointer(speech_secs)
+
+        events: list[VoiceSessionEvent] = []
+
+        async def _empty_audio() -> AsyncIterator[bytes]:
+            return
+            yield  # noqa: RET504
+
+        async def _drive() -> None:
+            while not any(isinstance(e, SessionStarted) for e in events):
+                await asyncio.sleep(0.01)
+            await stt.inject(TranscriptEvent(type="committed", text="hi there"))
+            while not any(isinstance(e, AudioOutput) for e in events):
+                await asyncio.sleep(0.01)
+            tracker.playing = True
+            # Multi-word partial mid-reply: passes all text gates.
+            await stt.inject(TranscriptEvent(type="partial", text="not not too bad mate"))
+            await asyncio.sleep(0.15)
+            # Playback done — otherwise session close() sees audio_playing and
+            # emits its own SessionInterrupted, polluting the assertion.
+            tracker.playing = False
+            await stt.finish()
+
+        async def _run() -> None:
+            async with aclosing(session.run(_empty_audio())) as stream:
+                driver = asyncio.create_task(_drive())
+                async for ev in stream:
+                    events.append(ev)
+                await driver
+
+        await asyncio.wait_for(_run(), timeout=10)
+        return session, events
+
+    async def test_hallucinated_partial_does_not_interrupt(self) -> None:
+        session, events = await self._run_barge_in_scenario(speech_secs=0.0)
+        assert not any(isinstance(e, SessionInterrupted) for e in events)
+        # Reply survived intact.
+        assert session.transcript[-1].role == "assistant"
+        assert session.transcript[-1].text == "This is a fairly long reply that keeps on playing for a while."
+
+    async def test_real_speech_partial_still_interrupts(self) -> None:
+        _, events = await self._run_barge_in_scenario(speech_secs=1.0)
+        assert any(isinstance(e, SessionInterrupted) for e in events)
+
+
+class TestStreamingTTS:
+    """Providers with ``open_stream``: one context per reply, fed incrementally."""
+
+    RESPONSE = "Here is the first sentence of the reply. And here comes a second sentence to force another flush."
+
+    def _session(self, tts: StreamingMockTTS, responses: list[str] | None = None) -> VoiceSession:
+        agent = Agent(
+            name="t",
+            model=TestModel(responses=responses or [self.RESPONSE]),
+            tools=[],
+        )
+        return VoiceSession(agent=agent, stt=MockSTT(script=[TranscriptEvent(type="committed", text="hi")]), tts=tts)
+
+    async def test_single_stream_per_reply(self) -> None:
+        """All flushes of one reply feed the SAME stream (no per-segment
+        synthesize → no prosody seam), and the stream is properly ended."""
+        tts = StreamingMockTTS(bytes_per_char=10)
+        session = self._session(tts)
+        events = await _collect_events(session)
+
+        assert tts.synthesize_calls == []
+        assert len(tts.streams) == 1
+        stream = tts.streams[0]
+        assert stream.ended is True
+        assert stream.aborted is False
+        # Every flushed piece landed in the context, in order, covering the
+        # whole reply text.
+        assert len(stream.fed) >= 1
+        assert "".join(stream.fed) == self.RESPONSE
+        # Pump emitted the synthesized bytes as AudioOutput.
+        audio_bytes = sum(len(e.data) for e in events if isinstance(e, AudioOutput))
+        assert audio_bytes == len(self.RESPONSE) * 10
+        assert session.transcript[-1].text == self.RESPONSE
+        # Metrics carry the stream accounting.
+        metrics = [e.metrics for e in events if isinstance(e, TurnMetricsEvent)]
+        assert metrics and metrics[0].audio_bytes == audio_bytes
+        assert metrics[0].tts_segments == len(stream.fed)
+
+    async def test_interrupt_aborts_stream(self) -> None:
+        """Barge-in must close the streaming context and stop its pump."""
+        tts = StreamingMockTTS(bytes_per_char=10, chunk_delay=0.2)
+        agent = Agent(name="t", model=TestModel(responses=[self.RESPONSE, "second"]), tools=[])
+        stt = DelayedMockSTT()
+        session = VoiceSession(agent=agent, stt=stt, tts=tts)
+
+        events: list[VoiceSessionEvent] = []
+
+        async def _empty_audio() -> AsyncIterator[bytes]:
+            return
+            yield  # noqa: RET504
+
+        async def _drive() -> None:
+            while not any(isinstance(e, SessionStarted) for e in events):
+                await asyncio.sleep(0.01)
+            await stt.inject(TranscriptEvent(type="committed", text="hi"))
+            while not any(isinstance(e, AudioOutput) for e in events):
+                await asyncio.sleep(0.01)
+            await session.interrupt()
+            await stt.finish()
+
+        async def _run() -> None:
+            async with aclosing(session.run(_empty_audio())) as stream:
+                driver = asyncio.create_task(_drive())
+                async for ev in stream:
+                    events.append(ev)
+                await driver
+
+        await asyncio.wait_for(_run(), timeout=10)
+
+        assert len(tts.streams) == 1
+        assert tts.streams[0].aborted is True
+        assert session._turn_tts_stream is None
+        assert session._turn_tts_pump is None
+        assert any(isinstance(e, SessionInterrupted) for e in events)

--- a/python/tests/server/test_voice_ws.py
+++ b/python/tests/server/test_voice_ws.py
@@ -294,6 +294,9 @@ class TestVoiceWsPlaybackAck:
 
         started = next(m for m in messages if m["type"] == "session_started")
         assert started["playback_acks"] == "recommended"
+        # Default heuristic detector has no audio EOU model → the local VAD
+        # endpointing fast path never arms, and session_started must say so.
+        assert started["vad_endpointing"] is False
 
     def test_interrupted_message_carries_heard_text_field(
         self,

--- a/python/timbal/core/agent.py
+++ b/python/timbal/core/agent.py
@@ -479,6 +479,10 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
         Server tool_use (e.g. web_search) gets an inline error block; regular tool_use
         gets a new tool-role message appended.
         """
+        if not memory:
+            # A voice CONTINUE merge can pop every entry of a one-turn memory
+            # (fragment user + interrupted assistant) — nothing to fulfill.
+            return
         model_provider = str(self.model).split("/", 1)[0]
         # Iterate in reverse: if any non-tool_use content follows a server_tool_use,
         # the LLM already continued past it — no synthetic result needed.

--- a/python/timbal/core/llm_router.py
+++ b/python/timbal/core/llm_router.py
@@ -13,6 +13,7 @@ import asyncio
 import os
 import random
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any, Literal
 
 import structlog
@@ -223,6 +224,37 @@ def _resolve_client(
     if config.client_type == "anthropic":
         return _get_client(AsyncAnthropic, api_key, base_url, "anthropic"), base_url
     return _get_client(AsyncOpenAI, api_key, base_url or config.default_base_url, provider), base_url
+
+
+async def warmup_llm_connection(model: str) -> None:
+    """Pre-establish the provider's HTTPS connection pool for ``model``.
+
+    The first LLM call of a process pays TCP+TLS(+HTTP/2) setup before any
+    token arrives — measured ~1.3s extra TTFT cold vs warm against
+    api.openai.com. This issues one lightweight authenticated GET
+    (``/models``) through the same cached SDK client the real calls will use,
+    so the pool is hot by the time the first request fires.
+
+    Best-effort and side-effect free: any failure (no API key, unsupported
+    endpoint on OpenAI-compatible providers, timeout) is logged at DEBUG and
+    ignored. Callers fire-and-forget (e.g. voice sessions at startup).
+    """
+    try:
+        provider, _ = model.split("/", 1)
+    except ValueError:
+        return
+    config = _PROVIDERS.get(provider)
+    if config is None:
+        return
+    try:
+        # _resolve_client only reads run_context.platform_config; don't create
+        # a real RunContext here (warmup must not touch tracing state).
+        ctx = SimpleNamespace(platform_config=None)
+        client, _ = _resolve_client(provider, config, None, None, ctx)
+        await asyncio.wait_for(client.models.list(), timeout=5.0)
+        logger.debug("llm_connection_warmed", model=model)
+    except Exception as e:
+        logger.debug("llm_warmup_skipped", model=model, error=str(e))
 
 
 # ---------------------------------------------------------------------------

--- a/python/timbal/server/README.md
+++ b/python/timbal/server/README.md
@@ -69,6 +69,7 @@ Only send keys you need; omitted keys keep server defaults.
 | `stt_extra`   | Object merged with default STT options (e.g. VAD). |
 | `tts_extra`   | Object merged with default TTS options. |
 | `turn_detector` | A mode name: `"heuristic"` (default), `"provider"` (trust STT/realtime endpointing), `"local"` (audio EOU — auto-loads the Smart Turn v3 ONNX model when `timbal[voice]` is installed, heuristic degradation otherwise; set `TIMBAL_SMART_TURN_CHECKPOINT=int8` to trade ~1pp accuracy for ~2x faster inference), `"lexical"` (punctuation HOLD), or `"raw"` (debug: no silence/noise/echo filtering — every STT commit becomes a turn, including the agent's own speech leaking through the mic; never use in production). The client JSON may only send a mode name string (the playground page has a dropdown for this); it takes precedence over the server value for that session. Server-side `runnable.voice_config` may additionally supply a zero-arg factory returning a `TurnDetector`, or an instance — instances are `clone()`d per WebSocket session so concurrent clients never share buffers or lifecycle; custom detectors with per-session mutable state should override `TurnDetector.clone()`. |
+| `vad_endpointing` | Bool. The **local VAD endpointing fast path**: Silero VAD (auto-downloaded with `timbal[voice]`, MIT) runs on the mic PCM; ~0.2s after you stop speaking, the audio EOU model (Smart Turn) scores the utterance and the EOU probability maps to a variable extra wait — confident-complete commits in ~0.3s of silence instead of waiting the STT provider's ~1.2s debounce; incomplete utterances compute a delay longer than the debounce so the provider commit + HOLD machinery win untouched. Default (key absent) is **auto**: active when the effective turn detector has an audio EOU model (i.e. `"local"` mode with the extra installed), off otherwise. Send `false` to force off, `true` to force on (logs a warning when unavailable). Turns committed by this path have `vad_endpointed: true` in [Turn metrics](#turn-metrics). |
 
 Example — align server with the browser capture rate (only if that rate is supported end-to-end):
 
@@ -84,7 +85,7 @@ All downlink messages are **text JSON** with a **`type`** field.
 
 | `type`                  | Fields        | Meaning |
 |-------------------------|---------------|--------|
-| `session_started`       | `playback_acks`, `turn_detector` | Voice session is live; safe to show “listening”. `playback_acks: "recommended"` advertises the [playback ack](#playback-acks-client--server) protocol. `turn_detector` is the class name of the detector actually in effect (e.g. `LocalAudioTurnDetector`), so clients can verify their requested mode. |
+| `session_started`       | `playback_acks`, `turn_detector`, `vad_endpointing` | Voice session is live; safe to show “listening”. `playback_acks: "recommended"` advertises the [playback ack](#playback-acks-client--server) protocol. `turn_detector` is the class name of the detector actually in effect (e.g. `LocalAudioTurnDetector`), so clients can verify their requested mode. `vad_endpointing` is a bool: whether the local [VAD endpointing](#config-overrides) fast path actually armed for this session (not merely what was requested). |
 | `transcript_partial`    | `text`        | Live STT (may change). |
 | `transcript_committed`  | `text`        | Final user transcript for the utterance. |
 | `agent_text_delta`      | `text`        | Streaming assistant text (captions / UI). |
@@ -148,12 +149,13 @@ Once per turn — after `agent_text_done`, and also when the turn is interrupted
     "tts_segments": 3,
     "audio_bytes": 96000,
     "playback_acks_received": true,
-    "heard_bytes": null
+    "heard_bytes": null,
+    "vad_endpointed": false
   }
 }
 ```
 
-`eou_to_first_audio_ms` is the headline voice latency: user end-of-utterance (committed transcript) to the first TTS byte emitted. Duration fields are `null` when the stage never happened (e.g. an interrupted turn with no audio). `playback_acks_received` says whether the heard position was client-truth (acks) or the wall-clock estimate; interrupted turns set `heard_bytes` to the PCM bytes the user actually heard (`null` on uninterrupted turns). Server-side, the same metrics are available as `session.metrics` (Python API) and are attached to the run trace as `voice_turn_metrics` on the root span metadata.
+`eou_to_first_audio_ms` is the headline voice latency: user end-of-utterance (committed transcript) to the first TTS byte emitted. Duration fields are `null` when the stage never happened (e.g. an interrupted turn with no audio). `playback_acks_received` says whether the heard position was client-truth (acks) or the wall-clock estimate; interrupted turns set `heard_bytes` to the PCM bytes the user actually heard (`null` on uninterrupted turns). `vad_endpointed` is `true` when the turn's transcript was force-committed by the local [VAD endpointing](#config-overrides) fast path instead of the provider's silence debounce. Server-side, the same metrics are available as `session.metrics` (Python API) and are attached to the run trace as `voice_turn_metrics` on the root span metadata.
 
 ### Frontend notes
 

--- a/python/timbal/server/http.py
+++ b/python/timbal/server/http.py
@@ -1,4 +1,5 @@
 import argparse
+import asyncio
 import json
 import os
 import sys
@@ -39,7 +40,20 @@ async def lifespan(
     app.state.runnable = runnable
     app.state.job_store = JobStore()
     app.state.voice_config = merge_voice_config(runnable)
-    yield
+    # Voice warmup off the boot path: pre-import the voice stack (and pre-load
+    # the local turn-detection models when server-configured) so the first
+    # voice session doesn't pay those costs. No-op-ish for non-voice usage.
+    from ..core.agent import Agent
+    from .voice import warmup_voice_stack
+
+    warmup_task = (
+        asyncio.create_task(warmup_voice_stack(app.state.voice_config)) if isinstance(runnable, Agent) else None
+    )
+    try:
+        yield
+    finally:
+        if warmup_task is not None and not warmup_task.done():
+            warmup_task.cancel()
 
 
 def create_app() -> FastAPI:

--- a/python/timbal/server/voice.html
+++ b/python/timbal/server/voice.html
@@ -941,7 +941,7 @@ async function start() {
       case 'session_started':
         sessionReady = true;
         setConn('live', 'Listening', msg.turn_detector
-          ? `Speak naturally — turn detection: ${msg.turn_detector}.`
+          ? `Speak naturally — turn detection: ${msg.turn_detector}${msg.vad_endpointing ? ' + VAD endpointing' : ''}.`
           : 'Speak naturally — audio streams to your Timbal agent.');
         updateEmptyState();
         break;

--- a/python/timbal/server/voice.py
+++ b/python/timbal/server/voice.py
@@ -45,7 +45,10 @@ def default_voice_config_from_env() -> dict[str, Any]:
         "sample_rate": 16_000,
         "stt_extra": {
             "commit_strategy": "vad",
-            "min_speech_duration_ms": 300,
+            # 100ms is what ElevenLabs' own realtime examples use. 300ms made
+            # short replies ("work.", "yes.") transcribe as partials but never
+            # commit — the session then stalls until the user speaks again.
+            "min_speech_duration_ms": 100,
             "vad_silence_threshold_secs": 1.2,
             "vad_threshold": 0.4,
         },
@@ -91,6 +94,56 @@ def runnable_meta_for_voice_page(runnable: Any, import_spec: str) -> dict[str, s
 
 
 _VOICE_HTML_META_TOKEN = "__TIMBAL_VOICE_RUNNABLE_META_JSON__"
+
+
+async def warmup_voice_stack(voice_config: dict[str, Any]) -> None:
+    """Background warmup at server boot so the first voice session starts fast.
+
+    Two tiers, both best-effort:
+
+    * **Imports** (always): ``timbal.voice`` + the ElevenLabs adapter pull in
+      websockets/pydantic machinery, and the ``timbal[voice]`` extra adds
+      numpy + onnxruntime — together ~1s of import time that otherwise lands
+      on the first WebSocket connection.
+    * **Models** (only when the *server-side* default ``turn_detector`` is a
+      "local" mode string): resolve the detector, load Smart Turn + Silero,
+      and run their warmup inference. Skipped otherwise — a client can still
+      pick "local" from the playground dropdown, in which case the load
+      happens at that session's startup (before "listening", off the
+      first-reply path).
+    """
+    loop = asyncio.get_running_loop()
+
+    def _import_stack() -> None:
+        import importlib
+
+        importlib.import_module("timbal.voice.elevenlabs")
+        try:
+            importlib.import_module("timbal.voice.smart_turn")
+            importlib.import_module("timbal.voice.vad")
+        except ImportError:
+            pass  # timbal[voice] extra not installed — heuristics only
+
+    try:
+        await loop.run_in_executor(None, _import_stack)
+    except Exception as e:
+        logger.debug("voice_warmup_import_failed", error=str(e))
+        return
+
+    td = voice_config.get("turn_detector")
+    if not (isinstance(td, str) and td.strip().lower() in ("local", "audio", "smart_turn")):
+        return
+    try:
+        from ..voice.turn_detection import LocalAudioTurnDetector, resolve_turn_detector
+        from ..voice.vad import SileroVad
+
+        detector = resolve_turn_detector(td)
+        if isinstance(detector, LocalAudioTurnDetector) and detector.audio_eou is not None:
+            await detector.audio_eou.start(sample_rate=16_000)
+        await SileroVad().start(sample_rate=16_000)
+        logger.info("voice_models_warmed")
+    except Exception as e:
+        logger.debug("voice_warmup_models_failed", error=str(e))
 
 
 @router.get("/")
@@ -224,7 +277,18 @@ async def voice_ws(ws: WebSocket) -> None:
         except (TypeError, ValueError) as e:
             logger.warning("voice_ws_bad_turn_detector", error=str(e))
     turn_detector_label = type(turn_detector).__name__ if turn_detector is not None else "HeuristicTurnDetector"
-    logger.info("voice_ws_session_config", turn_detector=turn_detector_label)
+
+    # Optional bool: force the local VAD endpointing fast path on/off. Default
+    # (absent / non-bool) is auto — on when the detector has an audio EOU model
+    # and timbal[voice] is installed. Client hello may override the server value.
+    vad_endpointing = merged.get("vad_endpointing")
+    if not isinstance(vad_endpointing, bool):
+        vad_endpointing = None
+    logger.info(
+        "voice_ws_session_config",
+        turn_detector=turn_detector_label,
+        vad_endpointing="auto" if vad_endpointing is None else vad_endpointing,
+    )
 
     # TODO(tool-filler): read a server-side `filler_phrases` voice_config key
     # (list of phrases or `(tool_name) -> str | None` callable) and pass it to
@@ -236,6 +300,7 @@ async def voice_ws(ws: WebSocket) -> None:
         audio_input=audio_in,
         audio_output=audio_out,
         turn_detector=turn_detector,
+        vad_endpointing=vad_endpointing,
     )
 
     async def _recv_loop() -> None:
@@ -310,6 +375,10 @@ async def voice_ws(ws: WebSocket) -> None:
                     "type": "session_started",
                     "playback_acks": "recommended",
                     "turn_detector": turn_detector_label,
+                    # The endpointer arms during session startup (before this
+                    # event is emitted), so this reflects the real state — not
+                    # the requested config.
+                    "vad_endpointing": session._endpointer is not None,
                 }
             )
         elif isinstance(event, TranscriptPartial):

--- a/python/timbal/voice/__init__.py
+++ b/python/timbal/voice/__init__.py
@@ -1,5 +1,9 @@
 """timbal.voice — voice pipeline: VoiceSession, STT/TTS ABCs, turn detection, metrics, and provider implementations."""
 
+from .endpointing import (
+    VadEndpointer,
+    endpointing_delay,
+)
 from .eou import (
     AudioEouModel,
     EouPredictor,
@@ -35,6 +39,7 @@ from .session import (
     TranscriptEntry,
     TranscriptEvent,
     TranscriptPartial,
+    TTSStream,
     VoiceSession,
     VoiceSessionEvent,
 )
@@ -55,12 +60,16 @@ from .turn_detection import (
 
 
 def __getattr__(name: str):
-    # Lazy: importing smart_turn pulls numpy/onnxruntime (timbal[voice] extra),
-    # which must not be required just to import timbal.voice.
+    # Lazy: importing smart_turn / vad pulls numpy/onnxruntime (timbal[voice]
+    # extra), which must not be required just to import timbal.voice.
     if name == "SmartTurnEouModel":
         from .smart_turn import SmartTurnEouModel
 
         return SmartTurnEouModel
+    if name == "SileroVad":
+        from .vad import SileroVad
+
+        return SileroVad
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -88,6 +97,7 @@ __all__ = [
     "RealtimeSession",
     "SemanticTurnDetector",
     "SessionEnded",
+    "SileroVad",
     "SessionError",
     "SessionInterrupted",
     "SessionStarted",
@@ -99,11 +109,14 @@ __all__ = [
     "TranscriptEntry",
     "TranscriptEvent",
     "TranscriptPartial",
+    "TTSStream",
     "TurnDetector",
     "TurnMetrics",
     "TurnMetricsEvent",
     "TurnState",
+    "VadEndpointer",
     "VoiceSession",
     "VoiceSessionEvent",
+    "endpointing_delay",
     "resolve_turn_detector",
 ]

--- a/python/timbal/voice/elevenlabs.py
+++ b/python/timbal/voice/elevenlabs.py
@@ -30,6 +30,7 @@ from .session import (
     SpeechToText,
     TextToSpeech,
     TranscriptEvent,
+    TTSStream,
 )
 
 logger = structlog.get_logger("timbal.voice.elevenlabs")
@@ -272,17 +273,38 @@ class ElevenLabsStreamTTS(TextToSpeech):
         self._active_contexts: set[str] = set()
         self._ctx_counter: int = 0
         self._last_ws_error: str | None = None
+        self._ws_lock = asyncio.Lock()
+        self._preconnect_task: asyncio.Task[None] | None = None
 
     async def connect(self, config: AudioOutputConfig) -> None:
         self._api_key = _resolve_api_key(self._api_key_explicit)
         if not config.voice:
             raise ValueError("AudioOutputConfig.voice (ElevenLabs voice_id) is required.")
         self._out = config
+        # Pre-open the multi-context WS in the background so the first
+        # synthesize of the session doesn't pay the TCP+TLS+WS handshake
+        # (~0.5-1s of the first reply's audio latency). Failures are logged
+        # and ignored — the first synthesize retries via _ensure_ws anyway.
+        self._preconnect_task = asyncio.create_task(self._preconnect())
+
+    async def _preconnect(self) -> None:
+        try:
+            await self._ensure_ws()
+        except Exception as e:
+            logger.debug("el_tts_preconnect_failed", error=str(e))
 
     # -- persistent WS lifecycle --------------------------------------------
 
     async def _ensure_ws(self) -> None:
-        """Lazily open the multi-context WS if not already connected."""
+        """Lazily open the multi-context WS if not already connected.
+
+        Lock-guarded: the connect() pre-warm task and the first synthesize can
+        race here — without the lock they would open two sockets and leak one.
+        """
+        async with self._ws_lock:
+            await self._ensure_ws_locked()
+
+    async def _ensure_ws_locked(self) -> None:
         if self._ws is not None and self._ws_open:
             return
         if self._ws is not None:
@@ -392,6 +414,15 @@ class ElevenLabsStreamTTS(TextToSpeech):
 
     # -- public interface ---------------------------------------------------
 
+    def open_stream(self) -> _ElevenLabsTTSStream:
+        """One streaming *context* per agent reply.
+
+        Feeding every flush into a single context keeps prosody continuous —
+        one context per segment gives each fragment independent "final
+        sentence" intonation and an audible seam (the "choppy" feel).
+        """
+        return _ElevenLabsTTSStream(self)
+
     async def synthesize(self, text: str) -> AsyncIterator[bytes]:
         if not self._api_key or not self._out:
             raise RuntimeError("Call connect() before synthesize().")
@@ -461,5 +492,114 @@ class ElevenLabsStreamTTS(TextToSpeech):
             )
 
     async def close(self) -> None:
+        if self._preconnect_task is not None and not self._preconnect_task.done():
+            self._preconnect_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._preconnect_task
+        self._preconnect_task = None
         await self._teardown_ws()
         self._out = None
+
+
+class _ElevenLabsTTSStream(TTSStream):
+    """One multi-context WS *context* fed incrementally over an agent reply.
+
+    Text chunks are appended server-side to the same context, so ElevenLabs
+    synthesizes them as one continuous utterance (``auto_mode`` generates at
+    sentence boundaries). Contrast with ``synthesize``, which opens a fresh
+    context per segment and gives each one independent final-sentence prosody.
+    """
+
+    def __init__(self, tts: ElevenLabsStreamTTS) -> None:
+        self._tts = tts
+        self._ctx_id: str | None = None
+        # Created eagerly so ``audio()`` can be iterated before the first feed
+        # opens the context (the session starts the pump task immediately).
+        self._queue: asyncio.Queue[dict | None] = asyncio.Queue()
+        self._ended = False
+        self._aborted = False
+        self._chunks = 0
+
+    async def _open_context(self) -> None:
+        tts = self._tts
+        if not tts._api_key or not tts._out:
+            raise RuntimeError("Call connect() before open_stream().")
+        await tts._ensure_ws()
+        tts._ctx_counter += 1
+        self._ctx_id = f"ctx_{tts._ctx_counter}"
+        tts._audio_queues[self._ctx_id] = self._queue
+        tts._active_contexts.add(self._ctx_id)
+        logger.debug("el_tts_stream_context_opened", context_id=self._ctx_id)
+
+    async def feed(self, text: str) -> None:
+        if self._ended or self._aborted or not text.strip():
+            return
+        if self._ctx_id is None:
+            await self._open_context()
+        assert self._tts._ws is not None
+        logger.debug(
+            "el_tts_stream_feed",
+            context_id=self._ctx_id,
+            text_chars=len(text),
+            text_preview=text[:120],
+        )
+        await self._tts._ws.send(json.dumps({"text": text, "context_id": self._ctx_id}))
+
+    async def end(self) -> None:
+        if self._ended or self._aborted:
+            return
+        self._ended = True
+        if self._ctx_id is None:
+            # Nothing was ever fed — unblock audio() directly.
+            self._queue.put_nowait(None)
+            return
+        tts = self._tts
+        try:
+            assert tts._ws is not None
+            # close_context finishes generating audio for buffered text and
+            # then emits is_final, which terminates audio(). Flush first for
+            # parity with synthesize (harmless if auto_mode already flushed).
+            await tts._ws.send(json.dumps({"text": " ", "context_id": self._ctx_id, "flush": True}))
+            await tts._ws.send(json.dumps({"context_id": self._ctx_id, "close_context": True}))
+        except Exception as e:
+            logger.warning("el_tts_stream_end_failed", context_id=self._ctx_id, error=str(e))
+            self._queue.put_nowait(None)
+
+    async def abort(self) -> None:
+        if self._aborted:
+            return
+        self._aborted = True
+        tts = self._tts
+        if self._ctx_id is not None:
+            # Unroute first so in-flight audio for this context is dropped.
+            tts._audio_queues.pop(self._ctx_id, None)
+            tts._active_contexts.discard(self._ctx_id)
+            if tts._ws is not None and tts._ws_open:
+                with contextlib.suppress(Exception):
+                    await tts._ws.send(json.dumps({"context_id": self._ctx_id, "close_context": True}))
+        self._queue.put_nowait(None)
+
+    async def audio(self) -> AsyncIterator[bytes]:
+        try:
+            while True:
+                msg = await self._queue.get()
+                if msg is None:
+                    if self._chunks == 0 and not self._aborted and self._tts._last_ws_error:
+                        raise RuntimeError(f"ElevenLabs TTS closed: {self._tts._last_ws_error}")
+                    return
+                if msg.get("error"):
+                    raise RuntimeError(f"ElevenLabs TTS error: {msg.get('error')}")
+                if msg.get("audio"):
+                    self._chunks += 1
+                    yield base64.b64decode(msg["audio"])
+                if msg.get("is_final") or msg.get("isFinal"):
+                    return
+        finally:
+            if self._ctx_id is not None:
+                self._tts._audio_queues.pop(self._ctx_id, None)
+                self._tts._active_contexts.discard(self._ctx_id)
+            logger.debug(
+                "el_tts_stream_context_done",
+                context_id=self._ctx_id,
+                audio_chunks=self._chunks,
+            )

--- a/python/timbal/voice/endpointing.py
+++ b/python/timbal/voice/endpointing.py
@@ -1,0 +1,314 @@
+"""Local VAD endpointing — cut STT commit latency with Silero + Smart Turn.
+
+The cascaded pipeline's latency floor is the STT provider's commit debounce:
+ElevenLabs Scribe VAD waits ~1.2s of silence before emitting a committed
+transcript, and only then does turn detection run. LiveKit and Pipecat instead
+run a local VAD on raw PCM and score their EOU model ~200ms after speech
+stops — their entire responsiveness game happens in that 300–600ms budget.
+
+:class:`VadEndpointer` closes that gap without touching the turn-taking
+machinery:
+
+1. Silero VAD (:class:`~timbal.voice.vad.SileroVad`) runs on the mic PCM
+   inside :meth:`~timbal.voice.VoiceSession._forward_audio`.
+2. On speech-stop (:attr:`~VadEndpointer.STOP_SILENCE_SECS` of silence after
+   real speech), Smart Turn scores the buffered audio window immediately.
+3. The EOU probability maps to a **variable** extra wait
+   (:func:`endpointing_delay`): confident-complete → commit almost
+   immediately; unsure → wait longer; incomplete → the computed delay exceeds
+   the provider's own debounce, so the provider commit (and the existing HOLD
+   machinery) wins automatically.
+4. When the delay elapses with no new speech, the endpointer force-commits the
+   provider buffer via ``stt.commit()`` — the committed transcript then flows
+   through the session's normal ``_handle_committed`` path. No parallel
+   commit/dedup state machine.
+
+The endpointer is a *fast path* only: disabling it (or the ``timbal[voice]``
+extra being absent) restores exactly today's provider-debounce behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import deque
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+import structlog
+
+if TYPE_CHECKING:
+    from .vad import SileroVad
+
+logger = structlog.get_logger("timbal.voice.endpointing")
+
+# Must match timbal.voice.vad.FRAME_SECS without importing it (that module
+# needs numpy/onnxruntime; this one must import bare so VoiceSession can
+# reference VadEndpointer in type hints and degrade at start()).
+_FRAME_SECS = 512 / 16_000
+
+
+def endpointing_delay(
+    p: float,
+    *,
+    min_delay: float = 0.0,
+    max_delay: float = 3.0,
+    curve: float = 2.0,
+) -> float:
+    """Map EOU probability to extra silence to wait before force-committing.
+
+    ``delay = min + (max - min) * (1 - p) ** curve`` — smooth, monotonic
+    decreasing in ``p``. With the defaults (fired ~0.3s after speech stop:
+    0.2s VAD silence + ~0.1s Smart Turn inference):
+
+    ========  =========  ==========================================
+    p         delay      total silence before commit
+    ========  =========  ==========================================
+    0.95      ~0.01s     ~0.3s   (confident: LiveKit-class response)
+    0.7       ~0.27s     ~0.6s
+    0.5       0.75s      ~1.05s  (unsure: still beats the provider)
+    <0.4      >1.1s      provider debounce (~1.2s) commits first —
+                         incomplete utterances fall through to the
+                         existing HOLD machinery untouched
+    ========  =========  ==========================================
+    """
+    p = min(1.0, max(0.0, p))
+    return min_delay + (max_delay - min_delay) * (1.0 - p) ** curve
+
+
+class VadEndpointer:
+    """Silero speech-stop → Smart Turn score → variable delay → ``stt.commit()``.
+
+    Wire-up (done by :class:`~timbal.voice.VoiceSession`):
+
+    * :meth:`bind` supplies the session callbacks — ``score`` (audio EOU
+      probability for the buffered mic window, e.g.
+      :meth:`~timbal.voice.LocalAudioTurnDetector.score_recent_audio`),
+      ``commit`` (force the STT provider to finalize), and ``should_commit``
+      (session gating: not closed, real transcribed speech since the last
+      commit).
+    * :meth:`push` receives every mic PCM chunk (inline; Silero is <1ms/frame).
+    * :meth:`notify_committed` cancels any pending endpoint when a commit
+      arrives through the provider path (ours or its own debounce).
+
+    All timing knobs are class attributes overridable per instance via the
+    constructor.
+    """
+
+    SPEECH_THRESHOLD = 0.5
+    """Per-frame Silero probability at/above which a frame counts as speech."""
+    STOP_SILENCE_SECS = 0.20
+    """Silence after speech before the EOU model is scored (Pipecat's stop_secs)."""
+    MIN_SPEECH_SECS = 0.10
+    """Minimum accumulated speech for an utterance to be endpoint-eligible
+    (filters clicks/echo blips that STT never transcribes). Accumulated over
+    the whole utterance — Silero routinely dips below threshold between
+    phonemes, so this must NOT require consecutive frames (a short "work."
+    would otherwise never arm; LiveKit's equivalent is 0.05s)."""
+    SPEECH_RESUME_SECS = 0.064
+    """Consecutive speech (2 frames) that cancels a pending endpoint — a single
+    noise-spike frame must not kill a valid pending commit."""
+    MIN_DELAY_SECS = 0.0
+    MAX_DELAY_SECS = 3.0
+    DELAY_CURVE = 2.0
+    """See :func:`endpointing_delay`."""
+    MIN_COMMIT_INTERVAL_SECS = 2.0
+    """Floor between force-commits (ElevenLabs throttles rapid commits)."""
+
+    def __init__(
+        self,
+        vad: SileroVad | None = None,
+        *,
+        speech_threshold: float | None = None,
+        stop_silence_secs: float | None = None,
+        min_speech_secs: float | None = None,
+        min_delay_secs: float | None = None,
+        max_delay_secs: float | None = None,
+        delay_curve: float | None = None,
+        min_commit_interval_secs: float | None = None,
+    ) -> None:
+        self._vad = vad
+        self.speech_threshold = speech_threshold if speech_threshold is not None else self.SPEECH_THRESHOLD
+        self.stop_silence_secs = stop_silence_secs if stop_silence_secs is not None else self.STOP_SILENCE_SECS
+        self.min_speech_secs = min_speech_secs if min_speech_secs is not None else self.MIN_SPEECH_SECS
+        self.min_delay_secs = min_delay_secs if min_delay_secs is not None else self.MIN_DELAY_SECS
+        self.max_delay_secs = max_delay_secs if max_delay_secs is not None else self.MAX_DELAY_SECS
+        self.delay_curve = delay_curve if delay_curve is not None else self.DELAY_CURVE
+        self.min_commit_interval_secs = (
+            min_commit_interval_secs if min_commit_interval_secs is not None else self.MIN_COMMIT_INTERVAL_SECS
+        )
+
+        self._score: Callable[[], Awaitable[float | None]] | None = None
+        self._commit: Callable[[], Awaitable[None]] | None = None
+        self._should_commit: Callable[[], bool] | None = None
+
+        self._started = False
+        self._closed = False
+        self._speech_run = 0.0
+        self._silence_run = 0.0
+        # Total speech in the current utterance. Deliberately NOT reset by a
+        # single silence frame (unlike _speech_run): Silero dips between
+        # phonemes and short words would never reach min_speech otherwise.
+        self._utterance_speech = 0.0
+        self._utterance_active = False
+        self._pending: asyncio.Task[None] | None = None
+        self._last_commit_sent_at = 0.0
+        # Timestamps of recent speech frames (p >= threshold), pruned to
+        # _SPEECH_HISTORY_SECS. Lets the session corroborate STT partials with
+        # real mic energy (hallucination veto for barge-ins).
+        self._recent_speech: deque[float] = deque()
+        self._last_frame_at = 0.0
+
+    _SPEECH_HISTORY_SECS = 3.0
+    """How far back :meth:`speech_secs_in_window` can look."""
+
+    def bind(
+        self,
+        *,
+        score: Callable[[], Awaitable[float | None]],
+        commit: Callable[[], Awaitable[None]],
+        should_commit: Callable[[], bool],
+    ) -> None:
+        """Attach the session callbacks. Must run before :meth:`start`."""
+        self._score = score
+        self._commit = commit
+        self._should_commit = should_commit
+
+    async def start(self, *, sample_rate: int) -> None:
+        """Load Silero (downloading/instantiating off the event loop) and arm.
+
+        Raises ``ImportError`` when the ``timbal[voice]`` extra is missing —
+        the session catches it and leaves endpointing off.
+        """
+        if self._score is None or self._commit is None or self._should_commit is None:
+            raise RuntimeError("Call bind() before start().")
+        if self._vad is None:
+            from .vad import SileroVad  # requires timbal[voice]
+
+            self._vad = SileroVad()
+        await self._vad.start(sample_rate=sample_rate)
+        self._started = True
+
+    async def close(self) -> None:
+        self._closed = True
+        self._started = False
+        self._cancel_pending()
+
+    def push(self, chunk: bytes) -> None:
+        """Feed mic PCM; runs the VAD state machine inline (called per chunk)."""
+        if not self._started or self._closed:
+            return
+        try:
+            probs = self._vad.process(chunk)
+        except Exception as e:
+            logger.warning("vad_process_failed", error=str(e))
+            return
+        now = time.monotonic()
+        self._last_frame_at = now
+        cutoff = now - self._SPEECH_HISTORY_SECS
+        while self._recent_speech and self._recent_speech[0] < cutoff:
+            self._recent_speech.popleft()
+        for p in probs:
+            if p >= self.speech_threshold:
+                self._recent_speech.append(now)
+                self._speech_run += _FRAME_SECS
+                self._silence_run = 0.0
+                # Real resumed speech invalidates a pending endpoint: the user
+                # was not done. (Two-frame debounce; see SPEECH_RESUME_SECS.)
+                if self._speech_run >= self.SPEECH_RESUME_SECS:
+                    self._cancel_pending()
+                self._utterance_speech += _FRAME_SECS
+                if self._utterance_speech >= self.min_speech_secs:
+                    self._utterance_active = True
+            else:
+                self._silence_run += _FRAME_SECS
+                self._speech_run = 0.0
+                if self._silence_run >= self.stop_silence_secs:
+                    if self._utterance_active:
+                        # Consume the utterance: one endpoint attempt per speech-stop.
+                        logger.debug(
+                            "vad_speech_stop",
+                            utterance_secs=round(self._utterance_speech, 2),
+                        )
+                        self._utterance_active = False
+                        self._spawn_pending()
+                    # Real silence ends the utterance either way — sub-threshold
+                    # blips that never reached min_speech must not accumulate
+                    # across separate noises into a phantom utterance.
+                    self._utterance_speech = 0.0
+
+    def notify_committed(self) -> None:
+        """A committed transcript arrived (ours or provider debounce) — any
+        pending endpoint is now stale."""
+        self._cancel_pending()
+
+    def speech_secs_in_window(self, window_secs: float) -> float | None:
+        """Total Silero speech seconds in the trailing ``window_secs``.
+
+        Returns ``None`` when the VAD hasn't processed mic audio in the last
+        second (not started, starved, or failing) — callers must treat that as
+        "no evidence either way" and NOT veto on it, or a broken VAD would
+        make the assistant uninterruptible.
+        """
+        now = time.monotonic()
+        if not self._started or now - self._last_frame_at > 1.0:
+            return None
+        window_secs = min(window_secs, self._SPEECH_HISTORY_SECS)
+        cutoff = now - window_secs
+        return sum(_FRAME_SECS for t in self._recent_speech if t >= cutoff)
+
+    # -- internal -----------------------------------------------------------
+
+    def _cancel_pending(self) -> None:
+        if self._pending is not None and not self._pending.done():
+            self._pending.cancel()
+        self._pending = None
+
+    def _spawn_pending(self) -> None:
+        if self._pending is not None and not self._pending.done():
+            return
+        self._pending = asyncio.create_task(self._run_endpoint())
+
+    async def _run_endpoint(self) -> None:
+        try:
+            if not self._should_commit():
+                logger.debug("vad_endpoint_skipped", reason="session_gate")
+                return
+            t0 = time.monotonic()
+            p = await self._score()
+            if p is None:
+                # No audio EOU available / not enough buffered signal: never
+                # force-commit blind — the provider debounce handles it.
+                logger.debug("vad_endpoint_skipped", reason="no_eou_score")
+                return
+            delay = endpointing_delay(
+                p,
+                min_delay=self.min_delay_secs,
+                max_delay=self.max_delay_secs,
+                curve=self.delay_curve,
+            )
+            # INFO on purpose: fires once per speech-stop and is the whole
+            # observable behaviour of the endpointing fast path.
+            logger.info(
+                "vad_eou_score",
+                p=round(p, 3),
+                delay_secs=round(delay, 3),
+                score_ms=round((time.monotonic() - t0) * 1000, 1),
+            )
+            remaining = delay - (time.monotonic() - t0)
+            if remaining > 0:
+                await asyncio.sleep(remaining)
+            if self._closed or not self._should_commit():
+                logger.debug("vad_endpoint_skipped", reason="session_gate_post_delay")
+                return
+            now = time.monotonic()
+            if now - self._last_commit_sent_at < self.min_commit_interval_secs:
+                logger.debug("vad_endpoint_skipped", reason="commit_interval")
+                return
+            self._last_commit_sent_at = now
+            logger.info("vad_endpoint_commit", p=round(p, 3))
+            await self._commit()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning("vad_endpoint_failed", error=str(e))

--- a/python/timbal/voice/metrics.py
+++ b/python/timbal/voice/metrics.py
@@ -46,6 +46,10 @@ class TurnMetrics(BaseModel):
     """PCM bytes of this turn the user actually heard before an interruption
     (``None`` for uninterrupted turns or when the position is unknown).
     Compare against ``audio_bytes`` to measure estimate-vs-ack drift."""
+    vad_endpointed: bool = False
+    """True when this turn's committed transcript was forced by the local VAD
+    endpointing fast path (Silero + audio EOU) rather than the STT provider's
+    own silence debounce — the ``eou_to_*`` numbers then start earlier."""
 
 
 class TurnMetricsEvent(VoiceSessionEvent):

--- a/python/timbal/voice/session.py
+++ b/python/timbal/voice/session.py
@@ -46,6 +46,7 @@ from .turn_detection import (
 )
 
 if TYPE_CHECKING:
+    from .endpointing import VadEndpointer
     from .metrics import TurnMetrics
 
 logger = structlog.get_logger("timbal.voice.session")
@@ -266,6 +267,32 @@ class SpeechToText(ABC):
     async def close(self) -> None: ...
 
 
+class TTSStream(ABC):
+    """One streaming synthesis unit (e.g. an ElevenLabs *context*): text is fed
+    incrementally while audio is read concurrently from :meth:`audio`.
+
+    Contract:
+
+    * ``feed`` may be called any number of times (in order).
+    * ``end`` signals no more text; ``audio()`` finishes once the provider
+      drains the remaining synthesis.
+    * ``abort`` (barge-in) stops generation ASAP and unblocks ``audio()``.
+    * All methods are idempotent-safe after ``end``/``abort``.
+    """
+
+    @abstractmethod
+    async def feed(self, text: str) -> None: ...
+
+    @abstractmethod
+    async def end(self) -> None: ...
+
+    @abstractmethod
+    async def abort(self) -> None: ...
+
+    @abstractmethod
+    def audio(self) -> AsyncIterator[bytes]: ...
+
+
 class TextToSpeech(ABC):
     """Abstract TTS provider.
 
@@ -277,6 +304,19 @@ class TextToSpeech(ABC):
 
     @abstractmethod
     def synthesize(self, text: str) -> AsyncIterator[bytes]: ...
+
+    def open_stream(self) -> TTSStream | None:
+        """Optional capability: a per-reply streaming context.
+
+        Providers that support incremental text input with prosody continuity
+        (ElevenLabs multi-context WS) return a fresh :class:`TTSStream` per
+        call; the session then feeds each flush into ONE context instead of
+        synthesizing independent segments — independent segments each get
+        "final sentence" intonation and an audible seam between them.
+        Default ``None`` → the session falls back to per-segment
+        ``synthesize``.
+        """
+        return None
 
     @abstractmethod
     async def close(self) -> None: ...
@@ -331,6 +371,7 @@ class VoiceSession:
         playback_tracker: PlaybackTracker | None = None,
         record_audio: bool = False,
         hold_timeout_secs: float = 1.5,
+        vad_endpointing: bool | VadEndpointer | None = None,
     ):
         self.agent = agent
         self.stt = stt
@@ -350,6 +391,17 @@ class VoiceSession:
         # a per-decision override. Heuristic/provider never HOLD, so this is inert
         # unless an opt-in detector (local / lexical) is used.
         self.hold_timeout_secs = hold_timeout_secs
+        # VAD endpointing fast path (Silero speech-stop → audio EOU → stt.commit()).
+        # None = auto: on when the detector exposes an audio EOU model and the
+        # timbal[voice] extra is installed; False = off; True = on (warn when
+        # unavailable); a VadEndpointer instance = use as-is (custom knobs).
+        self._vad_endpointing = vad_endpointing
+        self._endpointer: VadEndpointer | None = None
+        # time.monotonic() of the last endpointer-forced stt.commit(); the next
+        # committed transcript within a short window is attributed to it.
+        self._endpoint_commit_sent_at: float | None = None
+        self._turn_vad_endpointed = False
+        self._llm_warmup_task: asyncio.Task[None] | None = None
         # TODO(tool-filler): re-add the `filler` constructor param (phrases
         # rotated across turns, or a `(tool_name) -> str | None` callable) to
         # mask tool-call dead air with spoken filler. Removed for now to keep
@@ -391,6 +443,12 @@ class VoiceSession:
         self._tts_tasks: set[asyncio.Task] = set()
         # Concatenation of all strings passed to ``_schedule_tts`` this turn (OUTPUT tail catch-up).
         self._turn_tts_scheduled_text: str = ""
+        # Streaming TTS (providers with ``open_stream``): one context per reply,
+        # fed incrementally, drained by one pump task. ``None`` → per-segment
+        # ``synthesize`` fallback.
+        self._turn_tts_stream: TTSStream | None = None
+        self._turn_tts_pump: asyncio.Task | None = None
+        self._turn_stream_record: list | None = None
 
         # Per-turn playback accounting for interruption truncation: played bytes
         # at turn start, spoken (text, bytes) records per TTS segment, and the
@@ -460,9 +518,11 @@ class VoiceSession:
     async def run(self, audio_in: AsyncIterable[bytes]) -> AsyncIterator[VoiceSessionEvent]:
         """Main loop.  Yields events until the session is closed or errors out."""
         try:
+            self._start_llm_warmup()
             await self.stt.connect(self.audio_input)
             await self.tts.connect(self.audio_output)
             await self.turn_detector.start(self.audio_input)
+            await self._maybe_start_endpointer()
             await self._emit(SessionStarted())
 
             audio_task = asyncio.create_task(self._forward_audio(audio_in))
@@ -534,6 +594,9 @@ class VoiceSession:
             await asyncio.gather(*self._tts_tasks, return_exceptions=True)
         self._tts_tasks.clear()
         self._tts_tail = None
+        # Streaming TTS: closing the context stops generation server-side and
+        # unblocks the pump (which the turn task may be draining right now).
+        await self._abort_tts_stream()
         if has_turn:
             self._current_turn_task.cancel()
             try:
@@ -578,9 +641,18 @@ class VoiceSession:
         if was_active:
             # The cancelled turn's finally (or the in-place path above) computed
             # what the user actually heard.
-            await self._emit(SessionInterrupted(heard_text=self._last_interruption_heard_text))
+            heard = self._last_interruption_heard_text
+            await self._emit(SessionInterrupted(heard_text=heard))
             self._last_interruption_heard_text = None
-            logger.debug("session_interrupt_emitted", **_trace_debug_fields())
+            # INFO on purpose: this event makes the client rewrite (or remove,
+            # when heard_text is empty) the displayed reply — essential context
+            # when a reply "disappears" in the UI.
+            logger.info(
+                "session_interrupt_emitted",
+                heard_text_preview=(heard[:120] if heard else heard),
+                heard_bytes=self._turn_heard_bytes,
+                **_trace_debug_fields(),
+            )
 
     async def close(self) -> None:
         """Gracefully shut down the session."""
@@ -592,6 +664,129 @@ class VoiceSession:
         await self.interrupt(truncate_completed=False)
         await self._emit(None)  # sentinel stops the run() iterator
 
+    # -- Internal: first-reply warmup -----------------------------------------
+
+    def _start_llm_warmup(self) -> None:
+        """Fire-and-forget: pre-establish the LLM provider's connection pool.
+
+        The first turn of a session otherwise pays the provider's TCP+TLS
+        handshake inside its TTFT (measured: 1.84s cold vs 0.54s warm against
+        OpenAI). Only applies to string model specs — a ``TestModel`` (or any
+        custom model object) has no provider connection to warm.
+        """
+        model = getattr(self.agent, "model", None)
+        if not (isinstance(model, str) and "/" in model):
+            return
+
+        from ..core.llm_router import warmup_llm_connection
+
+        self._llm_warmup_task = asyncio.create_task(warmup_llm_connection(model))
+
+    # -- Internal: VAD endpointing fast path ---------------------------------
+
+    async def _maybe_start_endpointer(self) -> None:
+        """Arm the local VAD endpointing loop when the pieces exist.
+
+        Requires a turn detector exposing an audio EOU (``score_recent_audio``
+        with a non-None ``audio_eou``) and the ``timbal[voice]`` extra for
+        Silero. Silently stays off otherwise (warning when explicitly
+        requested). See :mod:`timbal.voice.endpointing`.
+        """
+        spec = self._vad_endpointing
+        if spec is False:
+            return
+        explicit = spec is not None
+        score_fn = getattr(self.turn_detector, "score_recent_audio", None)
+        audio_eou = getattr(self.turn_detector, "audio_eou", None)
+        if score_fn is None or audio_eou is None:
+            if explicit:
+                logger.warning(
+                    "vad_endpointing_unavailable",
+                    reason="turn detector has no audio EOU model",
+                    detector=type(self.turn_detector).__name__,
+                )
+            return
+        if spec is None or spec is True:
+            from .endpointing import VadEndpointer
+
+            endpointer = VadEndpointer()
+        else:
+            endpointer = spec
+        endpointer.bind(
+            score=score_fn,
+            commit=self._endpoint_commit,
+            should_commit=self._endpoint_should_commit,
+        )
+        try:
+            await endpointer.start(sample_rate=self.audio_input.sample_rate)
+        except ImportError as e:
+            log = logger.warning if explicit else logger.debug
+            log(
+                "vad_endpointing_unavailable",
+                reason="timbal[voice] extra not installed",
+                error=str(e),
+            )
+            return
+        except Exception as e:
+            logger.warning("vad_endpointer_start_failed", error=str(e))
+            return
+        self._endpointer = endpointer
+        logger.info(
+            "vad_endpointing_active",
+            stop_silence_secs=endpointer.stop_silence_secs,
+            max_delay_secs=endpointer.max_delay_secs,
+        )
+
+    def _endpoint_should_commit(self) -> bool:
+        """Gate for the endpointer: only force-commit real transcribed speech.
+
+        VAD alone can trigger on echo/noise the STT never heard; requiring a
+        partial newer than the last commit means ElevenLabs actually has words
+        in its buffer.
+        """
+        if self._closed:
+            return False
+        return self._last_partial_at > self._last_commit_at
+
+    async def _endpoint_commit(self) -> None:
+        self._endpoint_commit_sent_at = time.monotonic()
+        await self.stt.commit()
+
+    # Corroboration window for partial barge-ins: a real >=3-word interruption
+    # means >=~1s of actual speech shortly before the partial arrives, so the
+    # local VAD must have seen at least this much energy recently. STT can
+    # hallucinate plausible multi-word phrases from silence/room noise (Whisper
+    # -family behaviour) and those pass every *text* gate — but they carry no
+    # mic energy. Same idea as LiveKit's min_interruption_duration / Pipecat's
+    # volume-based interruption strategy.
+    MIN_BARGE_IN_VAD_SPEECH_SECS = 0.25
+    BARGE_IN_VAD_WINDOW_SECS = 2.0
+
+    def _vad_vetoes_barge_in(self, text: str) -> bool:
+        """True when the local VAD saw no real speech energy recently.
+
+        Only active when the endpointer (Silero on the mic feed) is armed and
+        healthy; otherwise returns False — never make the assistant
+        uninterruptible on missing evidence. Speaker echo DOES carry energy, so
+        this gate never vetoes echo; the text-similarity check handles that.
+        """
+        if self._endpointer is None:
+            return False
+        speech_secs = self._endpointer.speech_secs_in_window(self.BARGE_IN_VAD_WINDOW_SECS)
+        if speech_secs is None or speech_secs >= self.MIN_BARGE_IN_VAD_SPEECH_SECS:
+            return False
+        # INFO on purpose: a vetoed barge-in is invisible otherwise, and "why
+        # didn't it interrupt" / "why did it interrupt" are the two sides of
+        # the same debugging session.
+        logger.info(
+            "stt_partial_barge_in_vetoed",
+            reason="no_recent_vad_speech",
+            vad_speech_secs=round(speech_secs, 3),
+            text_preview=text[:80],
+            audio_playing=self._assistant_audio_playing,
+        )
+        return True
+
     # -- Internal: audio → STT ---------------------------------------------
 
     async def _forward_audio(self, audio_in: AsyncIterable[bytes]) -> None:
@@ -600,6 +795,8 @@ class VoiceSession:
                 if self._record_audio:
                     self._input_audio_chunks.append(chunk)
                 self.turn_detector.push_audio(chunk)
+                if self._endpointer is not None:
+                    self._endpointer.push(chunk)
                 await self.stt.push_audio(chunk)
         except asyncio.CancelledError:
             pass
@@ -619,8 +816,13 @@ class VoiceSession:
                         self._last_partial_at = time.monotonic()
                     await self._emit(TranscriptPartial(text=text))
                     decision = await self.turn_detector.on_partial(text, self._turn_state())
+                    if decision is PartialDecision.BARGE_IN and self._vad_vetoes_barge_in(text):
+                        decision = PartialDecision.IGNORE
                     if decision is PartialDecision.BARGE_IN:
-                        logger.debug(
+                        # INFO on purpose: a barge-in cancels TTS and truncates the
+                        # committed reply — when debugging "the agent went silent /
+                        # the reply vanished", this is the first thing to look for.
+                        logger.info(
                             "stt_partial_barge_in",
                             text_preview=text[:80],
                             assistant_chars=len(self._turn_assistant_text),
@@ -719,7 +921,9 @@ class VoiceSession:
             **_trace_debug_fields(),
         )
 
-    async def _begin_user_turn(self, final_text: str, *, replace_user_entry: bool) -> None:
+    async def _begin_user_turn(
+        self, final_text: str, *, replace_user_entry: bool, vad_endpointed: bool = False
+    ) -> None:
         """Record ``final_text`` and start an agent turn.
 
         Caller is responsible for ``interrupt()`` / clearing ``_cancel_turn``
@@ -731,6 +935,7 @@ class VoiceSession:
             # _closed checks and here; never start an agent turn after close().
             logger.debug("stt_turn_dropped_session_closed", text_preview=final_text[:80])
             return
+        self._turn_vad_endpointed = vad_endpointed
         self._last_commit_at = time.monotonic()
         if replace_user_entry and self._transcript and self._transcript[-1].role == "user":
             self._transcript[-1] = TranscriptEntry(role="user", text=final_text)
@@ -749,6 +954,23 @@ class VoiceSession:
     async def _handle_committed(self, text: str) -> None:
         if self._closed:
             return
+        # Any commit (endpointer-forced or provider debounce) makes a pending
+        # VAD endpoint stale — the STT segment it targeted is already closed.
+        if self._endpointer is not None:
+            self._endpointer.notify_committed()
+        vad_endpointed = (
+            self._endpoint_commit_sent_at is not None
+            and time.monotonic() - self._endpoint_commit_sent_at < 2.0
+        )
+        if vad_endpointed:
+            # INFO: the observable payoff of the fast path — how much sooner
+            # this commit landed than the provider's own debounce would have.
+            logger.info(
+                "vad_endpointed_commit",
+                commit_latency_ms=round((time.monotonic() - self._endpoint_commit_sent_at) * 1000, 1),
+                text_preview=text[:80],
+            )
+        self._endpoint_commit_sent_at = None
         state = self._turn_state()
         self._partials_since_last_commit = 0
         # Cancel the hold *timer* before awaiting the detector. Local audio EOU
@@ -849,12 +1071,9 @@ class VoiceSession:
             replace = bool(self._transcript and self._transcript[-1].role == "user")
             # Transcript cleanup alone is not enough — parent-chain memory still
             # has user:fragment + assistant:heard unless we mirror the rewrite.
-            await self._align_continue_memory(
-                fragment_user_text=state.active_user_text,
-                combined_user_text=final_text,
-            )
+            await self._align_continue_memory(fragment_user_text=state.active_user_text)
 
-        await self._begin_user_turn(final_text, replace_user_entry=replace)
+        await self._begin_user_turn(final_text, replace_user_entry=replace, vad_endpointed=vad_endpointed)
 
     # -- Internal: agent turn → TTS ----------------------------------------
 
@@ -874,6 +1093,9 @@ class VoiceSession:
         self._turn_tts_segment_records = []
         self._turn_heard_bytes = None
         self._turn_finalized_ok = False
+        self._turn_tts_stream = None
+        self._turn_tts_pump = None
+        self._turn_stream_record = None
         agen = None
         # Where we were when cancel / finally ran (loop_exit is only set on break/else/exception;
         # CancelledError inside ``await _speak`` left the old code stuck at "not_started").
@@ -1119,6 +1341,10 @@ class VoiceSession:
                             )
                         except asyncio.CancelledError:
                             pass
+                    try:
+                        await asyncio.shield(self._abort_tts_stream())
+                    except asyncio.CancelledError:
+                        pass
                 self._tts_tasks.clear()
                 # Metrics: finalize and emit exactly once per turn attempt (interrupted included).
                 # Runs before ``agen.aclose()`` so interrupted turns still get final metrics
@@ -1224,6 +1450,23 @@ class VoiceSession:
         if not text:
             return
         self._turn_tts_scheduled_text += text
+        # First flush of the turn: providers with a streaming context (ElevenLabs
+        # multi-context WS) get ONE context per reply — every subsequent flush is
+        # *fed* into it instead of synthesized as an independent segment. Separate
+        # segments each get final-sentence intonation and an audible seam between
+        # them ("choppy" speech); one context keeps prosody continuous.
+        if self._turn_tts_stream is None and self._turn_tts_pump is None and not self._cancel_turn.is_set():
+            stream = self.tts.open_stream()
+            if stream is not None:
+                self._turn_tts_stream = stream
+                record: list = ["", 0]
+                self._turn_stream_record = record
+                self._turn_tts_segment_records.append(record)
+                if self._turn_tts_started_at is None:
+                    self._turn_tts_started_at = time.monotonic()
+                self._turn_tts_pump = asyncio.create_task(self._pump_tts_stream(stream, record))
+        stream = self._turn_tts_stream
+        record = self._turn_stream_record
         prev = self._tts_tail
 
         async def chain() -> None:
@@ -1234,6 +1477,19 @@ class VoiceSession:
                     pass
             if self._cancel_turn.is_set():
                 return
+            if stream is not None:
+                clean = _strip_markdown(text)
+                if not clean.strip():
+                    return
+                self._turn_tts_segments += 1
+                if record is not None:
+                    record[0] += clean
+                try:
+                    await stream.feed(clean)
+                except Exception as e:
+                    logger.error("tts_feed_error", error=str(e), text_preview=clean[:80], exc_info=True)
+                    await self._emit(SessionError(message=f"TTS failed: {e}"))
+                return
             await self._speak(text)
 
         t = asyncio.create_task(chain())
@@ -1242,13 +1498,103 @@ class VoiceSession:
         self._tts_tail = t
 
     async def _await_tts_chain(self) -> None:
-        """Wait for all segments scheduled with :meth:`_schedule_tts` for this turn."""
+        """Wait for all segments scheduled with :meth:`_schedule_tts` for this turn.
+
+        Streaming mode: after the last feed, close the context (``end``) and
+        drain the pump until the provider signals the reply is fully
+        synthesized.
+        """
         if self._tts_tail is not None and not self._tts_tail.done():
             try:
                 await self._tts_tail
             except (asyncio.CancelledError, Exception):
                 pass
         self._tts_tail = None
+        stream = self._turn_tts_stream
+        if stream is not None:
+            try:
+                await stream.end()
+            except Exception as e:
+                logger.debug("tts_stream_end_failed", error=str(e))
+        pump = self._turn_tts_pump
+        if pump is not None and not pump.done():
+            # Shielded: a barge-in cancels this turn task while we drain — the
+            # pump itself is stopped via interrupt() → _abort_tts_stream(),
+            # and this method (like the chain await above) swallows the
+            # cancellation so the turn's normal finalize path runs.
+            try:
+                await asyncio.wait_for(asyncio.shield(pump), timeout=30.0)
+            except TimeoutError:
+                logger.warning("tts_stream_drain_timeout")
+                await self._abort_tts_stream()
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._turn_tts_stream = None
+        self._turn_tts_pump = None
+
+    async def _pump_tts_stream(self, stream: TTSStream, record: list) -> None:
+        """Drain one streaming TTS context; mirrors ``_speak``'s accounting."""
+        chunk_count = 0
+        total_bytes = 0
+        try:
+            async for chunk in stream.audio():
+                if self._cancel_turn.is_set():
+                    # INFO on purpose: explains truncated audio_bytes in metrics.
+                    logger.info(
+                        "turn_tts_stream_break",
+                        chunks_sent=chunk_count,
+                        audio_bytes=total_bytes,
+                        cancel_turn_set=True,
+                        **_trace_debug_fields(),
+                    )
+                    break
+                chunk_count += 1
+                total_bytes += len(chunk)
+                if self._turn_first_audio_at is None:
+                    self._turn_first_audio_at = time.monotonic()
+                self._turn_audio_bytes += len(chunk)
+                if self._record_audio:
+                    self._output_audio_chunks.append(chunk)
+                record[1] += len(chunk)
+                await self._emit(AudioOutput(data=chunk))
+                self.playback.on_audio_emitted(len(chunk))
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error("tts_error", error=str(e), chunks_so_far=chunk_count, exc_info=True)
+            await self._emit(SessionError(message=f"TTS failed: {e}"))
+        else:
+            # INFO on purpose: chars-in vs bytes-out is the only signal that
+            # catches a TTS provider returning truncated audio.
+            logger.info(
+                "turn_tts_stream_end",
+                text_chars=len(record[0]),
+                text_preview=record[0][:120],
+                audio_chunks=chunk_count,
+                audio_bytes=total_bytes,
+                cancel_turn_set=self._cancel_turn.is_set(),
+                **_trace_debug_fields(),
+            )
+        finally:
+            self._turn_tts_ended_at = time.monotonic()
+
+    async def _abort_tts_stream(self) -> None:
+        """Barge-in / teardown: stop the streaming context and its pump task."""
+        stream = self._turn_tts_stream
+        pump = self._turn_tts_pump
+        self._turn_tts_stream = None
+        self._turn_tts_pump = None
+        if stream is not None:
+            try:
+                await stream.abort()
+            except Exception as e:
+                logger.debug("tts_stream_abort_failed", error=str(e))
+        if pump is not None and not pump.done():
+            pump.cancel()
+            try:
+                await pump
+            except (asyncio.CancelledError, Exception):
+                pass
 
     async def _speak(self, text: str) -> None:
         text = _strip_markdown(text)
@@ -1269,7 +1615,8 @@ class VoiceSession:
         try:
             async for chunk in self.tts.synthesize(text):
                 if self._cancel_turn.is_set():
-                    logger.debug(
+                    # INFO on purpose: explains truncated audio_bytes in metrics.
+                    logger.info(
                         "turn_tts_synthesize_break",
                         chunks_sent=chunk_count,
                         audio_bytes=total_bytes,
@@ -1297,7 +1644,10 @@ class VoiceSession:
             )
             await self._emit(SessionError(message=f"TTS failed: {e}"))
         else:
-            logger.debug(
+            # INFO on purpose: chars-in vs bytes-out is the only signal that
+            # catches a TTS provider returning truncated audio (is_final too
+            # early) — at ~16kHz PCM expect very roughly >1.5KB per char.
+            logger.info(
                 "turn_tts_synthesize_end",
                 text_chars=len(text),
                 text_preview=text[:120],
@@ -1311,13 +1661,18 @@ class VoiceSession:
 
     # -- Internal: interruption truncation ------------------------------------
 
-    async def _align_continue_memory(self, *, fragment_user_text: str, combined_user_text: str) -> None:
+    async def _align_continue_memory(self, *, fragment_user_text: str) -> None:
         """Mirror CONTINUE_TURN transcript cleanup onto parent-chain memory.
 
         ``interrupt()`` truncation writes ``assistant:heard`` into
         ``_last_run_context`` memory. Transcript pops that entry before merging
-        the user line; without the same rewrite here the next turn still
+        the user line; without the same cleanup here the next turn still
         "remembers" answering the fragment.
+
+        The fragment *user* entry is popped too (not rewritten to the combined
+        text): the merged turn passes the combined text as its prompt, which
+        the agent appends to this memory — rewriting left the combined
+        utterance in the LLM input twice.
         """
         if not fragment_user_text:
             return
@@ -1336,10 +1691,7 @@ class VoiceSession:
                     last = root.memory[-1] if root.memory else None
         if last is not None and getattr(last, "role", None) == "user":
             if (last.collect_text() or "") == fragment_user_text:
-                root.memory[-1] = Message(
-                    role="user",
-                    content=[TextContent(text=combined_user_text)],
-                )
+                root.memory.pop()
         try:
             await asyncio.shield(ctx._save_trace())
         except asyncio.CancelledError:
@@ -1374,7 +1726,9 @@ class VoiceSession:
         heard_text = map_played_bytes_to_text(segments, heard_bytes)
         # "" means "nothing was heard"; None (never set) means "unknown".
         self._last_interruption_heard_text = heard_text
-        logger.debug(
+        # INFO on purpose: this rewrite decides what the transcript/memory keep
+        # of an interrupted reply (heard_chars == 0 erases it entirely).
+        logger.info(
             "turn_interruption_truncation",
             heard_bytes=heard_bytes,
             heard_chars=len(heard_text),
@@ -1443,6 +1797,7 @@ class VoiceSession:
             audio_bytes=self._turn_audio_bytes,
             playback_acks_received=self.playback.ack_received,
             heard_bytes=self._turn_heard_bytes if interrupted else None,
+            vad_endpointed=self._turn_vad_endpointed,
         )
 
     def _attach_metrics_to_trace(self, metrics: TurnMetrics) -> None:
@@ -1465,6 +1820,12 @@ class VoiceSession:
     async def _cleanup(self) -> None:
         self._cancel_hold()
         self._held_user_text = None
+        if self._llm_warmup_task is not None and not self._llm_warmup_task.done():
+            self._llm_warmup_task.cancel()
+        self._llm_warmup_task = None
+        if self._endpointer is not None:
+            await self._endpointer.close()
+            self._endpointer = None
         for t in list(self._tts_tasks):
             if not t.done():
                 t.cancel()
@@ -1472,6 +1833,7 @@ class VoiceSession:
             await asyncio.gather(*self._tts_tasks, return_exceptions=True)
         self._tts_tasks.clear()
         self._tts_tail = None
+        await self._abort_tts_stream()
         if self._current_turn_task and not self._current_turn_task.done():
             self._current_turn_task.cancel()
             try:

--- a/python/timbal/voice/smart_turn.py
+++ b/python/timbal/voice/smart_turn.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 
 import asyncio
 import os
-from functools import partial
+from functools import lru_cache, partial
 
 import numpy as np
 import onnxruntime as ort
@@ -49,6 +49,23 @@ from ._whisper_features import compute_whisper_log_mel_features
 from .eou import AudioEouModel
 
 logger = structlog.get_logger("timbal.voice.smart_turn")
+
+
+def _hf_download_cached_first(repo_id: str, filename: str) -> str:
+    """Resolve an HF Hub file from the local cache before touching the network.
+
+    ``hf_hub_download`` issues a HEAD request (etag check) even on cache hits —
+    a few hundred ms per *session* start, and a hard failure offline. Model
+    checkpoints are immutable for our purposes; prefer the cached copy.
+    """
+    from huggingface_hub import hf_hub_download
+    from huggingface_hub.errors import LocalEntryNotFoundError
+
+    try:
+        return hf_hub_download(repo_id=repo_id, filename=filename, local_files_only=True)
+    except LocalEntryNotFoundError:
+        return hf_hub_download(repo_id=repo_id, filename=filename)
+
 
 _MODEL_SAMPLE_RATE = 16_000
 _AUDIO_SECONDS = 8
@@ -67,6 +84,34 @@ QUANTIZED_FILENAME = "smart-turn-v3.2-cpu.onnx"
 _TAIL_SILENCE_SECS = 0.2
 # Amplitude below this (|sample| of int16-normalized float) counts as silence.
 _SILENCE_AMPLITUDE = 0.006
+
+
+@lru_cache(maxsize=4)
+def _load_ort_session(path: str, cpu_count: int) -> ort.InferenceSession:
+    """One ort session per (checkpoint, thread count), shared process-wide.
+
+    ``InferenceSession.run`` is thread-safe and holds no per-call state, so
+    every ``SmartTurnEouModel`` instance (one per voice session) can share it —
+    previously each session re-loaded the ~50MB graph. Sharing also makes the
+    server-boot warmup effective: the pre-loaded session is the exact object
+    later sessions get.
+    """
+    logger.debug("smart_turn_loading_model", path=path)
+    so = ort.SessionOptions()
+    so.execution_mode = ort.ExecutionMode.ORT_SEQUENTIAL
+    so.inter_op_num_threads = 1
+    so.intra_op_num_threads = cpu_count
+    so.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
+    session = ort.InferenceSession(path, sess_options=so)
+    # Warm the graph: the first ort run pays one-time allocations / kernel
+    # setup (~100ms+) — do it at load time (already off the event loop)
+    # instead of on the first real EOU score.
+    features = compute_whisper_log_mel_features(np.zeros(_MODEL_SAMPLES, dtype=np.float32))
+    session.run(None, {"input_features": np.expand_dims(features, axis=0)})
+    # INFO on purpose: "is the audio EOU model actually engaged?" is the
+    # first question when debugging turn-taking, and this fires once.
+    logger.info("smart_turn_model_loaded", path=path)
+    return session
 
 
 class SmartTurnEouModel(AudioEouModel):
@@ -134,20 +179,8 @@ class SmartTurnEouModel(AudioEouModel):
     def _load_session(self) -> ort.InferenceSession:
         path = self.model_path
         if path is None:
-            from huggingface_hub import hf_hub_download
-
-            path = hf_hub_download(repo_id=DEFAULT_REPO_ID, filename=self.checkpoint)
-        logger.debug("smart_turn_loading_model", path=str(path))
-        so = ort.SessionOptions()
-        so.execution_mode = ort.ExecutionMode.ORT_SEQUENTIAL
-        so.inter_op_num_threads = 1
-        so.intra_op_num_threads = self.cpu_count
-        so.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
-        session = ort.InferenceSession(str(path), sess_options=so)
-        # INFO on purpose: "is the audio EOU model actually engaged?" is the
-        # first question when debugging turn-taking, and this fires once.
-        logger.info("smart_turn_model_loaded", path=str(path))
-        return session
+            path = _hf_download_cached_first(DEFAULT_REPO_ID, self.checkpoint)
+        return _load_ort_session(str(path), self.cpu_count)
 
     async def predict_complete(self, pcm: bytes, *, sample_rate: int) -> float:
         if self._session is None:

--- a/python/timbal/voice/turn_detection.py
+++ b/python/timbal/voice/turn_detection.py
@@ -252,6 +252,14 @@ def _is_same_user_utterance_refinement(active: str, new: str) -> bool:
     return False
 
 
+def _join_held(held: str, text: str) -> str:
+    """Held fragment + follow-up as one utterance (used by hold_supersede)."""
+    held = held.strip()
+    if not held:
+        return text
+    return held + " " + text
+
+
 def _looks_like_fresh_hold_utterance(text: str) -> bool:
     """True if ``text`` looks like its own utterance, not a VAD-split continuation.
 
@@ -281,6 +289,15 @@ class HeuristicTurnDetector(TurnDetector):
     """
 
     MIN_BARGE_IN_PARTIAL_CHARS = 4
+    # A single short partial while the assistant is speaking is far more often
+    # a mic blip / mis-transcribed speaker echo (e.g. "Nice.") than a real
+    # interruption — and a false barge-in cancels TTS mid-reply and truncates
+    # the committed transcript to what was heard (possibly nothing). Require a
+    # few words before interrupting on a *partial*; real short commands
+    # ("Stop.") still interrupt ~1s later via their *commit* (NEW_TURN path).
+    # Same knob as Pipecat's MinWordsInterruptionStrategy(min_words=3) and
+    # LiveKit's min_interruption_words.
+    MIN_BARGE_IN_PARTIAL_WORDS = 3
     HALLUCINATION_MIN_CHARS = 41
     EARLY_DUPLICATE_WINDOW_SECS = 1.5
     EARLY_DUPLICATE_MIN_CHARS = 5
@@ -294,7 +311,10 @@ class HeuristicTurnDetector(TurnDetector):
         is_noise = _is_noise(text)
         is_hesitation = _is_hesitation_only(text)
         is_echo = _likely_stt_echo(text, state.assistant_text) if not is_noise else False
-        too_short = len(text) < self.MIN_BARGE_IN_PARTIAL_CHARS
+        too_short = (
+            len(text) < self.MIN_BARGE_IN_PARTIAL_CHARS
+            or len(text.split()) < self.MIN_BARGE_IN_PARTIAL_WORDS
+        )
         if not is_noise and not is_hesitation and not is_echo and not too_short:
             return PartialDecision.BARGE_IN
         logger.debug(
@@ -348,7 +368,19 @@ class HeuristicTurnDetector(TurnDetector):
             ):
                 combined = state.active_user_text.rstrip(", ") + " " + text
                 return CommitDecision(action=CommitAction.HOLD, text=combined, reason="hold_merge")
-            return CommitDecision(action=CommitAction.NEW_TURN, text=text, reason="hold_supersede")
+            # Supersede = start the turn NOW, but never DROP the held fragment:
+            # it is speech the user actually said and was never answered. STT
+            # capitalizes every committed segment, so a mid-thought
+            # continuation after a forced/VAD split ("…thinking about" +
+            # "Something.") systematically looks "fresh" — discarding the
+            # fragment here loses half the utterance. Prepending is right for
+            # true supersedes too ("what's the weather… actually tell me a
+            # joke" reads as a natural self-correction).
+            return CommitDecision(
+                action=CommitAction.NEW_TURN,
+                text=_join_held(state.active_user_text, text),
+                reason="hold_supersede",
+            )
         if state.assistant_active and state.active_user_text:
             if _is_same_user_utterance_refinement(state.active_user_text, text):
                 return CommitDecision(action=CommitAction.IGNORE, text=text, reason="refinement")
@@ -414,7 +446,9 @@ class ProviderTurnDetector(TurnDetector):
             return PartialDecision.IGNORE
         if _likely_stt_echo(text, state.assistant_text):
             return PartialDecision.IGNORE
-        if len(text.strip()) < 4:
+        # Same min-words gate as HeuristicTurnDetector: one short partial while
+        # the assistant is speaking is more often a mic blip than a barge-in.
+        if len(text.strip()) < 4 or len(text.split()) < HeuristicTurnDetector.MIN_BARGE_IN_PARTIAL_WORDS:
             return PartialDecision.IGNORE
         return PartialDecision.BARGE_IN
 
@@ -480,9 +514,11 @@ class LexicalTurnDetector(HeuristicTurnDetector):
         ):
             p_new = await self.text_eou.predict_eou(text)
             if p_new >= self.completion_threshold:
+                # Start now, but keep the held fragment (see the parent's
+                # hold_supersede: never drop transcribed user speech).
                 return CommitDecision(
                     action=CommitAction.NEW_TURN,
-                    text=text,
+                    text=_join_held(state.active_user_text, text),
                     reason="lexical_hold_supersede",
                 )
 
@@ -620,20 +656,46 @@ class LocalAudioTurnDetector(HeuristicTurnDetector):
             return b""
         return b"".join(self._pcm)
 
+    async def score_recent_audio(self) -> float | None:
+        """``P(complete)`` for the buffered mic window, or ``None``.
+
+        The VAD endpointing fast path (:class:`~timbal.voice.endpointing.VadEndpointer`)
+        calls this right after Silero detects speech-stop — before any STT
+        commit exists. Returns ``None`` when there is no audio EOU model, not
+        enough buffered signal (< ~0.5s), or inference fails; the endpointer
+        then does nothing and the provider debounce commits as usual.
+        """
+        if self.audio_eou is None:
+            return None
+        pcm = self._recent_pcm()
+        if len(pcm) < self._sample_rate:  # < ~0.5s of PCM16 — not enough signal
+            return None
+        try:
+            return await self.audio_eou.predict_complete(pcm, sample_rate=self._sample_rate)
+        except Exception as e:
+            logger.warning("audio_eou_predict_failed", error=str(e))
+            return None
+
     async def on_committed(self, text: str, state: TurnState) -> CommitDecision:
         decision = await super().on_committed(text, state)
         if decision.action is CommitAction.IGNORE:
             return decision
         if decision.action is CommitAction.CONTINUE_TURN:
             return decision
-        # Parent hold_merge of a self-contained commit → don't glue onto held text.
+        # Parent hold_merge of a self-contained commit → start the turn now
+        # instead of re-holding, but keep the held fragment in the turn text
+        # (never drop transcribed user speech; see parent hold_supersede).
         if (
             state.holding
             and decision.action is CommitAction.HOLD
             and decision.reason == "hold_merge"
             and _looks_like_fresh_hold_utterance(text)
         ):
-            decision = CommitDecision(action=CommitAction.NEW_TURN, text=text, reason="hold_supersede")
+            decision = CommitDecision(
+                action=CommitAction.NEW_TURN,
+                text=_join_held(state.active_user_text, text),
+                reason="hold_supersede",
+            )
         # The parent's continuation gates (<3s, <30 chars) are tuned for mid-turn
         # VAD splits. While HOLDing, the audio model has explicitly judged the
         # held fragment incomplete — a non-fresh follow-up is the rest of that

--- a/python/timbal/voice/vad.py
+++ b/python/timbal/voice/vad.py
@@ -1,0 +1,157 @@
+"""Silero VAD (ONNX) — local streaming voice-activity detection.
+
+Runs the open `Silero VAD v5 <https://huggingface.co/onnx-community/silero-vad>`_
+checkpoint (MIT, ~2MB, <1ms per frame on CPU) on raw mic PCM. Used by
+:class:`~timbal.voice.endpointing.VadEndpointer` to detect end of speech
+locally (~0.2s after the user stops) instead of waiting for the STT
+provider's commit debounce (~1.2s+).
+
+Requires the ``timbal[voice]`` extra (``onnxruntime`` + ``huggingface_hub``,
+same as Smart Turn). This module import fails without it; callers degrade
+gracefully (endpointing simply stays off).
+
+The model is stateful and streaming: it consumes fixed 512-sample frames at
+16 kHz (32ms hop) plus 64 samples of context carried between frames, and
+returns ``P(speech)`` per frame. :class:`SileroVad` handles the framing,
+context, resampling, and recurrent state so callers just push arbitrary PCM
+chunks and receive per-frame probabilities.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from functools import lru_cache
+
+import numpy as np
+import onnxruntime as ort
+import structlog
+
+logger = structlog.get_logger("timbal.voice.vad")
+
+DEFAULT_REPO_ID = "onnx-community/silero-vad"
+DEFAULT_FILENAME = "onnx/model.onnx"
+
+_VAD_SAMPLE_RATE = 16_000
+# Fixed by the model: 512 new samples (32ms) per inference at 16 kHz...
+FRAME_SAMPLES = 512
+FRAME_SECS = FRAME_SAMPLES / _VAD_SAMPLE_RATE  # 0.032
+# ...preceded by 64 samples of context from the previous frame (the official
+# wrapper concatenates them; the recurrent state alone is not enough).
+_CONTEXT_SAMPLES = 64
+
+
+@lru_cache(maxsize=4)
+def _load_ort_session(path: str) -> ort.InferenceSession:
+    """One ort session per checkpoint path, shared across all SileroVad instances.
+
+    ``InferenceSession.run`` is thread-safe and holds no per-call state; the
+    recurrent state lives in :class:`SileroVad`, so sharing is safe.
+    """
+    so = ort.SessionOptions()
+    so.inter_op_num_threads = 1
+    so.intra_op_num_threads = 1
+    session = ort.InferenceSession(path, sess_options=so)
+    # Warm the graph so the first mic frame doesn't pay one-time allocations.
+    session.run(
+        None,
+        {
+            "input": np.zeros((1, _CONTEXT_SAMPLES + FRAME_SAMPLES), dtype=np.float32),
+            "state": np.zeros((2, 1, 128), dtype=np.float32),
+            "sr": np.array(_VAD_SAMPLE_RATE, dtype=np.int64),
+        },
+    )
+    logger.info("silero_vad_model_loaded", path=path)
+    return session
+
+
+class SileroVad:
+    """Streaming Silero VAD: push PCM16LE chunks, get per-frame ``P(speech)``.
+
+    Parameters
+    ----------
+    model_path:
+        Path to a local ``.onnx`` file. When ``None`` (default), the checkpoint
+        is downloaded once via ``huggingface_hub`` (standard HF cache) from
+        :data:`DEFAULT_REPO_ID`.
+
+    Instances hold per-stream mutable state (recurrent state, context, sample
+    residual) — use one per audio stream / session. The underlying ort session
+    is cached at module level and shared.
+    """
+
+    def __init__(self, model_path: str | None = None) -> None:
+        self.model_path = model_path
+        self._session: ort.InferenceSession | None = None
+        self._sample_rate = _VAD_SAMPLE_RATE
+        self._sr_input = np.array(_VAD_SAMPLE_RATE, dtype=np.int64)
+        self._state = np.zeros((2, 1, 128), dtype=np.float32)
+        self._context = np.zeros(_CONTEXT_SAMPLES, dtype=np.float32)
+        self._buf = np.zeros(0, dtype=np.float32)
+        # Drift-free resampling counters (native samples in, 16k samples out).
+        self._in_total = 0
+        self._out_total = 0
+
+    async def start(self, *, sample_rate: int) -> None:
+        """Resolve the checkpoint (downloading off the event loop) and reset state."""
+        self._sample_rate = int(sample_rate) or _VAD_SAMPLE_RATE
+        if self._session is None:
+            loop = asyncio.get_running_loop()
+            self._session = await loop.run_in_executor(None, self._resolve_session)
+        self.reset()
+
+    def _resolve_session(self) -> ort.InferenceSession:
+        path = self.model_path
+        if path is None:
+            from .smart_turn import _hf_download_cached_first
+
+            path = _hf_download_cached_first(DEFAULT_REPO_ID, DEFAULT_FILENAME)
+        return _load_ort_session(str(path))
+
+    def reset(self) -> None:
+        """Clear recurrent state, context, and buffered samples."""
+        self._state = np.zeros((2, 1, 128), dtype=np.float32)
+        self._context = np.zeros(_CONTEXT_SAMPLES, dtype=np.float32)
+        self._buf = np.zeros(0, dtype=np.float32)
+        self._in_total = 0
+        self._out_total = 0
+
+    def process(self, pcm: bytes) -> list[float]:
+        """Consume a PCM16LE mono chunk; return ``P(speech)`` per complete 32ms frame.
+
+        Chunks of any size are fine — leftover samples are buffered until the
+        next call. Non-16 kHz input is linearly resampled per chunk with
+        drift-free sample accounting (VAD probabilities are insensitive to the
+        minor chunk-edge interpolation artifacts this introduces).
+        """
+        if self._session is None:
+            raise RuntimeError("Call start() before process().")
+        if len(pcm) % 2:
+            pcm = pcm[:-1]
+        if not pcm:
+            return []
+        x = np.frombuffer(pcm, dtype=np.int16).astype(np.float32) / 32768.0
+        if self._sample_rate != _VAD_SAMPLE_RATE:
+            self._in_total += x.size
+            target_total = int(self._in_total * _VAD_SAMPLE_RATE / self._sample_rate)
+            n_out = target_total - self._out_total
+            if n_out <= 0:
+                return []
+            x = np.interp(
+                np.linspace(0.0, x.size - 1, n_out),
+                np.arange(x.size),
+                x,
+            ).astype(np.float32)
+            self._out_total = target_total
+        self._buf = np.concatenate([self._buf, x]) if self._buf.size else x
+        probs: list[float] = []
+        while self._buf.size >= FRAME_SAMPLES:
+            frame = self._buf[:FRAME_SAMPLES]
+            self._buf = self._buf[FRAME_SAMPLES:]
+            model_input = np.concatenate([self._context, frame])[None, :]
+            out, self._state = self._session.run(
+                None,
+                {"input": model_input, "state": self._state, "sr": self._sr_input},
+            )
+            self._context = frame[-_CONTEXT_SAMPLES:]
+            probs.append(float(out[0, 0]))
+        return probs


### PR DESCRIPTION
…rdening

Latency — local endpointing fast path (Silero + Smart Turn):
- SileroVad: streaming Silero VAD ONNX wrapper (resampling, 512-sample framing w/ context, recurrent state, warm ONNX session shared per path)
- VadEndpointer: speech-stop (0.2s) -> Smart Turn score -> variable delay (quadratic p->delay map) -> force stt.commit(); incomplete utterances fall through to the provider debounce + existing HOLD machinery
- confident completions commit in ~0.3-0.5s vs the provider's ~1.2s; `vad_endpointed` flag in turn metrics + session_started

Latency — cold start (first reply was ~2s slower than warm):
- warmup_llm_connection(): pre-establish provider TLS pool at session start
- ElevenLabs TTS: pre-open the multi-context WS in connect() (lock-guarded)
- ONNX warmup inference at load; HF Hub cache-first checkpoint resolution
- server boot warmup: pre-import voice stack, pre-load local models when the server default turn deor is local

Quality — one streaming TTS context per reply (was: context per segment):
- TTSStream ABC (feed/end/abort/audio) + TextToSpeech.open_stream()
- ElevenLabs feeds every flush into a single multi-context WS context, so prosody stays continuous instead of each segment getting final-sentence intonation with an audible seam; providers without open_stream keep the per-segment synthesize fallback

Correctness — barge-in and turn merging:
- partial barge-ins need >=3 words (mic blips/echo cancelled replies)
- VAD corroboration: when Silero is armed, a barge-in partial requires
  >=0.25s of real speech energy in the last 2s — kills STT hallucinations
  from silence ("Not, not too bad, mate.") that pass every text gate
- hold_supersede prepends the held fragment instead of discarding it
- CONTINUE merge pops the fragment user entry from parent memory (rewrite left the combined utterance duplicated in the next LLM input); guard _synthesize_missing_tool_results against the now-possible emptyy

Also: tool-call filler speech removed for now (TODO with design notes), key turn/TTS events promoted to INFO for live debugging.