### PR TITLE
Add Claude Opus 5 to the model registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,6 +271,7 @@ class OutputEvent(BaseEvent):
 Provider-prefixed strings. Examples:
 ```
 anthropic/claude-fable-5
+anthropic/claude-opus-5
 anthropic/claude-sonnet-5
 anthropic/claude-opus-4-8
 anthropic/claude-opus-4-7

--- a/docs/models/anthropic.mdx
+++ b/docs/models/anthropic.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Anthropic"
-description: "Claude Fable 5, Sonnet 5, Opus, and Haiku models with specs, pricing, and capabilities"
+description: "Claude Fable 5, Opus 5, Sonnet 5, and Haiku models with specs, pricing, and capabilities"
 ---
 
-<Note>Source: [Anthropic model docs](https://docs.anthropic.com/en/docs/about-claude/models) · [Opus 4.8 pricing](https://docs.anthropic.com/en/about-claude/pricing)</Note>
+<Note>Source: [Anthropic model docs](https://docs.anthropic.com/en/docs/about-claude/models) · [What's new in Opus 5](https://platform.claude.com/docs/en/about-claude/models/whats-new-opus-5) · [Pricing](https://docs.anthropic.com/en/about-claude/pricing)</Note>
 
 ## Latest
 
@@ -22,6 +22,22 @@ description: "Claude Fable 5, Sonnet 5, Opus, and Haiku models with specs, prici
   - <Icon icon="brain" size={14} /> Adaptive thinking (always on)
   - <Icon icon="globe" size={14} /> Web search
   - <Icon icon="calendar" size={14} /> Knowledge cutoff Jan 2026
+  </Card>
+
+  <Card title="claude-opus-5">
+  <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> Reasoning · <Icon icon="bolt" size={14} /> <Icon icon="bolt" size={14} /> Speed
+
+  `anthropic/claude-opus-5`
+
+  Latest Opus and the recommended default for complex agentic coding and enterprise work — near-Fable-5 intelligence at half the price, with large gains in deep reasoning, long-horizon tool loops, and test-time compute scaling.
+
+  - &#36;5 / &#36;25 per 1M tokens (input / output; Fast mode &#36;10 / &#36;50 at ~2.5x speed)
+  - <Icon icon="window-maximize" size={14} /> 1M context (default and maximum)
+  - <Icon icon="right-from-bracket" size={14} /> 128K max output
+  - <Icon icon="keyboard" size={14} /> Text, Image input
+  - <Icon icon="brain" size={14} /> Adaptive thinking (on by default)
+  - <Icon icon="globe" size={14} /> Web search
+  - <Icon icon="calendar" size={14} /> Knowledge cutoff May 2026
   </Card>
 
   <Card title="claude-sonnet-5">
@@ -45,7 +61,7 @@ description: "Claude Fable 5, Sonnet 5, Opus, and Haiku models with specs, prici
 
   `anthropic/claude-opus-4-8`
 
-  Latest Opus for agentic coding, long-running tasks, and complex reasoning. Builds on 4.7 with stronger consistency and autonomy across coding, agents, and professional work.
+  Previous Opus generation for agentic coding, long-running tasks, and complex reasoning. Same price as Opus 5 — migrate unless you depend on thinking being off by default.
 
   - &#36;5 / &#36;25 per 1M tokens (input / output)
   - <Icon icon="window-maximize" size={14} /> 1M context

--- a/docs/models/overview.mdx
+++ b/docs/models/overview.mdx
@@ -7,7 +7,7 @@ Every model supported by Timbal with full specs, pricing, capability scores, and
 
 <CardGroup cols={3}>
   <Card title="Anthropic" icon="https://timbalusercontent.com/assets/claude_favicon.svg" href="/models/anthropic">
-    Claude Fable 5, Sonnet 5, Opus, and Haiku
+    Claude Fable 5, Opus 5, Sonnet 5, and Haiku
   </Card>
   <Card title="BytePlus" icon="https://timbalusercontent.com/assets/byteplus_favicon.svg" href="/models/byteplus">
     Seed 2.0 and Seed 1.8 models

--- a/python/tests/core/test_frontier_models_integration.py
+++ b/python/tests/core/test_frontier_models_integration.py
@@ -20,6 +20,12 @@ PROMPT = "Reply with exactly one word: ok"
 
 LIVE_MODELS = [
     pytest.param(
+        "anthropic/claude-opus-5",
+        "ANTHROPIC_API_KEY",
+        None,
+        id="anthropic-claude-opus-5",
+    ),
+    pytest.param(
         "google/gemini-3.6-flash",
         "GEMINI_API_KEY",
         None,
@@ -76,8 +82,9 @@ async def test_frontier_model_agent_collect(model: str, env_key: str, fallback_e
     _skip_if_no_key(env_key, fallback_env)
 
     # Reasoning models (MiniMax / Qwen) spend many tokens on reasoning_content
-    # before visible text — 64 is often exhausted with an empty content array.
-    agent = Agent(name=f"probe_{model.replace('/', '_')}", model=model, max_tokens=512, tools=[])
+    # before visible text, and Opus 5 thinks by default — a small budget is
+    # often exhausted with an empty content array.
+    agent = Agent(name=f"probe_{model.replace('/', '_')}", model=model, max_tokens=2048, tools=[])
     result: OutputEvent = await agent(prompt=PROMPT).collect()
 
     assert result.status.code == "success", result.error
@@ -99,7 +106,7 @@ async def test_frontier_model_llm_router_streams(model: str, env_key: str, fallb
     async for chunk in _llm_router(
         model=model,
         messages=[Message(role="user", content=[TextContent(text=PROMPT)])],
-        max_tokens=512,
+        max_tokens=2048,
     ):
         chunks.append(chunk)
 

--- a/python/timbal/core/models.py
+++ b/python/timbal/core/models.py
@@ -44,6 +44,7 @@ def get_context_window(model_id: str) -> int | None:
 # Model type with provider prefixes
 Model = Literal[
     "anthropic/claude-fable-5",
+    "anthropic/claude-opus-5",
     "anthropic/claude-opus-4-8",
     "anthropic/claude-sonnet-5",
     "anthropic/claude-opus-4-7",

--- a/python/timbal/models.yaml
+++ b/python/timbal/models.yaml
@@ -14,16 +14,27 @@ models:
   display_name: Claude Fable 5
   description: Anthropic's most capable widely released model for long-horizon agentic work, complex reasoning, and ambitious
     coding tasks.
-  notes: Includes safety classifiers; blocked requests return stop_reason refusal. Configure Opus 4.8 fallback for production
+  notes: Includes safety classifiers; blocked requests return stop_reason refusal. Configure Opus 5 fallback for production
     workloads.
   input_price: 10.0
   output_price: 50.0
   context_window: 1000000
   capabilities: [vision, tools, reasoning]
+- id: anthropic/claude-opus-5
+  provider: anthropic
+  display_name: Claude Opus 5
+  description: Anthropic's latest Opus — near-frontier intelligence at half the price of Fable 5, with step-change gains in
+    deep reasoning, agentic coding, and long-horizon tasks.
+  notes: Thinking is on by default; effort defaults to high and `thinking.type=disabled` is rejected at xhigh/max effort.
+    Fast mode (~2.5x speed) is $10/$50 per 1M tokens on the Claude API only.
+  input_price: 5.0
+  output_price: 25.0
+  context_window: 1000000
+  capabilities: [vision, tools, reasoning]
 - id: anthropic/claude-opus-4-8
   provider: anthropic
   display_name: Claude Opus 4.8
-  description: Anthropic's latest Opus — improved coding, agents, and long-context reasoning.
+  description: Previous-generation Opus for coding, agents, and long-context reasoning. Superseded by Opus 5 at the same price.
   input_price: 5.0
   output_price: 25.0
   context_window: 1000000
@@ -67,7 +78,7 @@ models:
   provider: anthropic
   display_name: Claude Opus 4.1
   description: Previous-generation Opus model with high intelligence for complex reasoning tasks.
-  notes: Deprecated; retires August 5, 2026. Prefer claude-opus-4-8 or claude-fable-5.
+  notes: Deprecated; retires August 5, 2026. Prefer claude-opus-5 or claude-fable-5.
   input_price: 15.0
   output_price: 75.0
   context_window: 200000


### PR DESCRIPTION
Register anthropic/claude-opus-5 in models.yaml at $5/$25 with 1M context, regenerate the Model Literal, and document it in the Anthropic model reference. Demote Opus 4.8 from "latest" and repoint the Fable 5 and Opus 4.1 fallback notes at Opus 5.

Add live integration coverage via Agent.collect and llm_router streaming, and raise the probe budget to 2048 tokens — Opus 5 thinks by default, so a 512-token cap can be exhausted before any visible text.