### PR TITLE
feat(server): standalone voice playground with platform target and lo…

### DIFF
--- a/examples/voice_turn_modes.py
+++ b/examples/voice_turn_modes.py
@@ -10,7 +10,7 @@ Usage (from repo root)::
 Then open http://127.0.0.1:4444/voice
 
 Modes:
-  heuristic  — default; today's regex/similarity behavior
+  heuristic  — holdless regex/similarity (opt-in; default is local)
   provider   — trust ElevenLabs VAD commits (minimal filtering)
   lexical    — punctuation/dangling HOLD (noticeable mid-thought pauses)
   local      — audio EOU (Smart Turn v3 ONNX with `timbal[voice]`; else == heuristic)
@@ -27,7 +27,7 @@ from timbal import Agent
 from timbal.core.tool import Tool
 from timbal.voice import resolve_turn_detector
 
-_MODE = os.environ.get("TIMBAL_VOICE_TURN_DETECTOR", "heuristic").strip().lower()
+_MODE = os.environ.get("TIMBAL_VOICE_TURN_DETECTOR", "local").strip().lower()
 
 
 async def get_datetime() -> str:

--- a/python/tests/server/test_voice_detector_choice.py
+++ b/python/tests/server/test_voice_detector_choice.py
@@ -52,6 +52,14 @@ class TestFluxOwnsEndpointing:
 class TestSilenceEndpointingDefault:
     """Nova / ElevenLabs / anything that commits on a silence timeout."""
 
+    def test_voice_config_leaves_the_detector_unset(self):
+        # Regression: pinning "local" in VoiceConfig would make sessions take
+        # the explicit-spec path, skipping the lexical degradation below when
+        # timbal[voice] is absent (a degraded "local" is holdless).
+        from timbal.voice.config import VoiceConfig
+
+        assert VoiceConfig().turn_detector is None
+
     def test_defaults_to_local_with_the_extra(self, monkeypatch):
         _with_extra(monkeypatch, available=True)
         assert select_turn_detector_spec(None, None, stt_is_flux=False) == "local"

--- a/python/tests/server/test_voice_ws.py
+++ b/python/tests/server/test_voice_ws.py
@@ -551,7 +551,7 @@ class TestVoiceWsClientTurnDetector:
 
     def test_unknown_mode_name_falls_back_to_default(self, monkeypatch, tmp_path: Path) -> None:
         started = self._run_session(monkeypatch, tmp_path, {"turn_detector": "quantum"})
-        assert started["turn_detector"] == "HeuristicTurnDetector"
+        assert started["turn_detector"] in self._HOLDS
 
     def test_racing_playback_ack_does_not_eat_config(self, monkeypatch, tmp_path: Path) -> None:
         """A playback ack sent before the hello must not be mistaken for config."""

--- a/python/tests/voice/test_endpointing.py
+++ b/python/tests/voice/test_endpointing.py
@@ -510,6 +510,7 @@ class TestVoiceSessionEndpointing:
             agent=Agent(name="t", model=TestModel(responses=["ok"]), tools=[]),
             stt=stt,
             tts=_SilentTTS(),
+            turn_detector="heuristic",  # no audio EOU — the premise of this test
             vad_endpointing=True,
         )
 

--- a/python/tests/voice/test_recording.py
+++ b/python/tests/voice/test_recording.py
@@ -193,6 +193,7 @@ class TestSessionIntegration:
             tts=MockTTS(chunk=b"\x01\x02" * 800, num_chunks=2),
             recorder=recorder,
             session_id="fixed-session-id",
+            turn_detector="heuristic",
         )
         session.recording_meta = {"transport": "test", "model": "test/model"}
 
@@ -259,6 +260,7 @@ class TestSessionBargeIn:
             stt=stt,
             tts=MockTTS(chunk=b"\x01\x02" * (SR // 2), num_chunks=int(emitted_secs)),
             recorder=recorder,
+            turn_detector="heuristic",
         )
 
         started = asyncio.Event()

--- a/python/tests/voice/test_session.py
+++ b/python/tests/voice/test_session.py
@@ -271,6 +271,10 @@ def _make_session(
         stt=stt,
         tts=tts,
         record_audio=record_audio,
+        # These tests exercise session mechanics with scripted STT text and no
+        # real mic audio — pin the holdless heuristic so the default ("local",
+        # Smart Turn HOLD + VAD endpointing) doesn't shape their timing.
+        turn_detector="heuristic",
     )
     return session, stt, tts
 
@@ -391,7 +395,7 @@ class TestAudioRecording:
         agent = Agent(name="t", model=TestModel(responses=["ok"]), tools=[])
         stt = MockSTT(script=[])
         tts = MockTTS()
-        session = VoiceSession(agent=agent, stt=stt, tts=tts, record_audio=True)
+        session = VoiceSession(agent=agent, stt=stt, tts=tts, record_audio=True, turn_detector="heuristic")
 
         audio_chunks = [b"\x00\x01" * 10, b"\x02\x03" * 10]
 
@@ -409,7 +413,7 @@ class TestAudioRecording:
         agent = Agent(name="t", model=TestModel(responses=["ok"]), tools=[])
         stt = MockSTT(script=[])
         tts = MockTTS()
-        session = VoiceSession(agent=agent, stt=stt, tts=tts, record_audio=False)
+        session = VoiceSession(agent=agent, stt=stt, tts=tts, record_audio=False, turn_detector="heuristic")
 
         async def _audio_source() -> AsyncIterator[bytes]:
             yield b"\x00\x01" * 10
@@ -441,6 +445,7 @@ class TestLlmWarmup:
             stt=MockSTT(),
             tts=MockTTS(),
             model="openai/gpt-4o-mini",
+            turn_detector="heuristic",
         )
         session._start_llm_warmup()
         assert session._llm_warmup_task is not None
@@ -455,7 +460,7 @@ class TestLlmWarmup:
 
         monkeypatch.setattr("timbal.core.llm_router.warmup_llm_connection", _fake_warmup)
         agent = Agent(name="t", model="groq/llama-3.1-8b-instant", tools=[])
-        session = VoiceSession(agent=agent, stt=MockSTT(), tts=MockTTS())
+        session = VoiceSession(agent=agent, stt=MockSTT(), tts=MockTTS(), turn_detector="heuristic")
         session._start_llm_warmup()
         assert session._llm_warmup_task is not None
         await session._llm_warmup_task
@@ -463,7 +468,7 @@ class TestLlmWarmup:
 
     def test_warmup_skips_test_model(self) -> None:
         agent = Agent(name="t", model=TestModel(responses=["ok"]), tools=[])
-        session = VoiceSession(agent=agent, stt=MockSTT(), tts=MockTTS())
+        session = VoiceSession(agent=agent, stt=MockSTT(), tts=MockTTS(), turn_detector="heuristic")
         session._start_llm_warmup()
         assert session._llm_warmup_task is None
 
@@ -583,6 +588,7 @@ class TestTurnTimeout:
             agent=_HungAgent(),  # type: ignore[arg-type]
             stt=stt,
             tts=tts,
+            turn_detector="heuristic",
             turn_timeout_secs=0.15,
             turn_timeout_fallback="Sorry, try again.",
         )
@@ -647,6 +653,7 @@ class TestTurnTimeout:
             agent=_HungAgent(),  # type: ignore[arg-type]
             stt=stt,
             tts=tts,
+            turn_detector="heuristic",
             turn_timeout_secs=0.15,
         )
         events: list[VoiceSessionEvent] = []
@@ -747,7 +754,7 @@ class TestMultiTurn:
         agent = Agent(name="t", model=TestModel(responses=["Answer 1", "Answer 2"]), tools=[])
         stt = DelayedMockSTT()
         tts = MockTTS()
-        session = VoiceSession(agent=agent, stt=stt, tts=tts)
+        session = VoiceSession(agent=agent, stt=stt, tts=tts, turn_detector="heuristic")
 
         events: list[VoiceSessionEvent] = []
 
@@ -796,7 +803,7 @@ class TestMultiTurn:
         # far in the future so _assistant_active stays True after the agent turn finishes.
         big_chunk = b"\x00\x01" * 16_000
         tts = SlowMockTTS(delay=0.05, chunk=big_chunk, num_chunks=3)
-        session = VoiceSession(agent=agent, stt=stt, tts=tts)
+        session = VoiceSession(agent=agent, stt=stt, tts=tts, turn_detector="heuristic")
 
         events: list[VoiceSessionEvent] = []
 
@@ -884,7 +891,7 @@ class TestTurnMetrics:
             tracing_provider=provider,
         )
         stt = MockSTT(script=[TranscriptEvent(type="committed", text="What time is it?")])
-        session = VoiceSession(agent=agent, stt=stt, tts=MockTTS())
+        session = VoiceSession(agent=agent, stt=stt, tts=MockTTS(), turn_detector="heuristic")
         await _collect_events(session)
 
         assert len(session.metrics) == 1
@@ -918,7 +925,7 @@ class TestTurnMetrics:
         stt = DelayedMockSTT()
         big_chunk = b"\x00\x01" * 16_000
         tts = SlowMockTTS(delay=0.05, chunk=big_chunk, num_chunks=3)
-        session = VoiceSession(agent=agent, stt=stt, tts=tts)
+        session = VoiceSession(agent=agent, stt=stt, tts=tts, turn_detector="heuristic")
 
         events: list[VoiceSessionEvent] = []
 
@@ -1019,7 +1026,7 @@ class TestInterruptionTruncation:
         stt = DelayedMockSTT()
         chunk = b"\x00\x01" * 50  # 100 bytes per chunk
         tts = SlowMockTTS(delay=0.03, chunk=chunk, num_chunks=4) if not interrupt_after_done else MockTTS(chunk=chunk, num_chunks=4)
-        session = VoiceSession(agent=agent, stt=stt, tts=tts, playback_tracker=tracker)
+        session = VoiceSession(agent=agent, stt=stt, tts=tts, turn_detector="heuristic", playback_tracker=tracker)
 
         events: list[VoiceSessionEvent] = []
 
@@ -1121,7 +1128,7 @@ class TestInterruptionTruncation:
         """TTS can enqueue far more AudioOutput than the WS drains. Barge-in must
         not wait behind that backlog or long replies keep playing after interrupt."""
         agent = Agent(name="t", model=TestModel(responses=["ok"]), tools=[])
-        session = VoiceSession(agent=agent, stt=MockSTT(), tts=MockTTS())
+        session = VoiceSession(agent=agent, stt=MockSTT(), tts=MockTTS(), turn_detector="heuristic")
         await session._emit(AudioOutput(data=b"\x00" * 64))
         await session._emit(AudioOutput(data=b"\x01" * 64))
         await session._emit(AgentTextDone(text="already spoken"))
@@ -1169,7 +1176,7 @@ class TestInterruptionTruncation:
         )
         stt = DelayedMockSTT()
         tts = MockTTS(chunk=b"\x00\x01" * 50, num_chunks=4)
-        session = VoiceSession(agent=agent, stt=stt, tts=tts, playback_tracker=tracker)
+        session = VoiceSession(agent=agent, stt=stt, tts=tts, turn_detector="heuristic", playback_tracker=tracker)
 
         events: list[VoiceSessionEvent] = []
         first_run_id: str | None = None
@@ -1323,7 +1330,7 @@ class TestInterruptionTruncation:
         )
         stt = DelayedMockSTT()
         tts = MockTTS(chunk=b"\x00\x01" * 50, num_chunks=4)
-        session = VoiceSession(agent=agent, stt=stt, tts=tts, playback_tracker=tracker)
+        session = VoiceSession(agent=agent, stt=stt, tts=tts, turn_detector="heuristic", playback_tracker=tracker)
 
         events: list[VoiceSessionEvent] = []
 
@@ -1470,7 +1477,7 @@ class TestInterruptionTruncation:
         from timbal.types.message import Message
 
         agent = Agent(name="t", model=TestModel(responses=["x"]), tools=[])
-        session = VoiceSession(agent=agent, stt=MockSTT(), tts=MockTTS())
+        session = VoiceSession(agent=agent, stt=MockSTT(), tts=MockTTS(), turn_detector="heuristic")
         ctx = RunContext(tracing_provider=None, platform_config=None)
         root = Span(
             path="t",
@@ -1615,7 +1622,7 @@ class TestInterruptionTruncation:
         agent = Agent(name="t", model=TestModel(responses=[self.RESPONSE]), tools=[])
         stt = MockSTT(script=[TranscriptEvent(type="committed", text="Hello there, how are you doing?")])
         tts = MockTTS(chunk=b"\x00\x01" * 50, num_chunks=4)
-        session = VoiceSession(agent=agent, stt=stt, tts=tts, playback_tracker=tracker)
+        session = VoiceSession(agent=agent, stt=stt, tts=tts, turn_detector="heuristic", playback_tracker=tracker)
         # Simulate audio still playing (and only partially heard) at close time:
         # close() must NOT rewrite the committed transcript entry.
         tracker.playing = True
@@ -1772,7 +1779,7 @@ class TestVadBargeInVeto:
         stt = DelayedMockSTT()
         tts = SlowMockTTS(delay=0.05, num_chunks=6)
         tracker = FakePlaybackTracker()
-        session = VoiceSession(agent=agent, stt=stt, tts=tts, playback_tracker=tracker)
+        session = VoiceSession(agent=agent, stt=stt, tts=tts, turn_detector="heuristic", playback_tracker=tracker)
         _arm_vad(session, _FakeEndpointer(speech_secs))
 
         events: list[VoiceSessionEvent] = []
@@ -1839,7 +1846,12 @@ class TestStreamingTTS:
             model=TestModel(responses=responses or [self.RESPONSE]),
             tools=[],
         )
-        return VoiceSession(agent=agent, stt=MockSTT(script=[TranscriptEvent(type="committed", text="hi")]), tts=tts)
+        return VoiceSession(
+            agent=agent,
+            stt=MockSTT(script=[TranscriptEvent(type="committed", text="hi")]),
+            tts=tts,
+            turn_detector="heuristic",
+        )
 
     async def test_single_stream_per_reply(self) -> None:
         """All flushes of one reply feed the SAME stream (no per-segment
@@ -1871,7 +1883,7 @@ class TestStreamingTTS:
         tts = StreamingMockTTS(bytes_per_char=10, chunk_delay=0.2)
         agent = Agent(name="t", model=TestModel(responses=[self.RESPONSE, "second"]), tools=[])
         stt = DelayedMockSTT()
-        session = VoiceSession(agent=agent, stt=stt, tts=tts)
+        session = VoiceSession(agent=agent, stt=stt, tts=tts, turn_detector="heuristic")
 
         events: list[VoiceSessionEvent] = []
 
@@ -2129,7 +2141,7 @@ class TestStalePartialSweeper:
         agent = Agent(name="t", model=TestModel(responses=["ok"]), tools=[])
         stt = _StuckPartialSTT()
         tts = MockTTS()
-        session = VoiceSession(agent=agent, stt=stt, tts=tts)
+        session = VoiceSession(agent=agent, stt=stt, tts=tts, turn_detector="heuristic")
         session._stale_partial_poll_secs = 0.05
         session._stale_partial_commit_secs = 0.2
 
@@ -2167,7 +2179,7 @@ class TestStalePartialSweeper:
         agent = Agent(name="t", model=TestModel(responses=["ok"]), tools=[])
         stt = _StuckPartialSTT()
         tts = MockTTS()
-        session = VoiceSession(agent=agent, stt=stt, tts=tts)
+        session = VoiceSession(agent=agent, stt=stt, tts=tts, turn_detector="heuristic")
         session._stale_partial_poll_secs = 0.05
         session._stale_partial_commit_secs = 0.15
 
@@ -2205,7 +2217,7 @@ class TestStalePartialSweeper:
         agent = Agent(name="t", model=TestModel(responses=["ok"]), tools=[])
         stt = DelayedMockSTT()
         tts = MockTTS()
-        session = VoiceSession(agent=agent, stt=stt, tts=tts)
+        session = VoiceSession(agent=agent, stt=stt, tts=tts, turn_detector="heuristic")
         session._stale_partial_poll_secs = 0.05
         session._stale_partial_commit_secs = 0.15
 
@@ -2241,7 +2253,7 @@ class TestStalePartialSweeper:
         """
         agent = Agent(name="t", model=TestModel(responses=["ok"]), tools=[])
         stt = _StuckPartialSTT()
-        session = VoiceSession(agent=agent, stt=stt, tts=MockTTS())
+        session = VoiceSession(agent=agent, stt=stt, tts=MockTTS(), turn_detector="heuristic")
         session._stale_partial_poll_secs = 0.05
         session._stale_partial_commit_secs = 0.4
         _arm_vad(session, endpointer)

--- a/python/tests/voice/test_session.py
+++ b/python/tests/voice/test_session.py
@@ -1581,7 +1581,7 @@ class TestInterruptionTruncation:
 
         agent = Agent(name="t", model=TestModel(responses=["should not speak", "ok"]), tools=[])
         stt = DelayedMockSTT()
-        session = _GatedSession(agent=agent, stt=stt, tts=MockTTS())
+        session = _GatedSession(agent=agent, stt=stt, tts=MockTTS(), turn_detector="heuristic")
         events: list[VoiceSessionEvent] = []
 
         async def _empty_audio() -> AsyncIterator[bytes]:

--- a/python/tests/voice/test_turn_detection.py
+++ b/python/tests/voice/test_turn_detection.py
@@ -892,9 +892,17 @@ class TestRawTurnDetector:
 
 
 class TestResolveTurnDetector:
-    def test_none_and_heuristic(self) -> None:
-        assert isinstance(resolve_turn_detector(None), HeuristicTurnDetector)
-        assert isinstance(resolve_turn_detector("heuristic"), HeuristicTurnDetector)
+    def test_none_defaults_to_local_or_lexical(self) -> None:
+        # With timbal[voice]: LocalAudioTurnDetector (Smart Turn). Without: lexical.
+        # Note: LocalAudioTurnDetector subclasses HeuristicTurnDetector — check
+        # the concrete type, not isinstance(..., HeuristicTurnDetector).
+        for key in (None, "default", ""):
+            got = type(resolve_turn_detector(key))
+            assert got in (LocalAudioTurnDetector, LexicalTurnDetector), got
+            assert got is not HeuristicTurnDetector
+
+    def test_explicit_heuristic(self) -> None:
+        assert type(resolve_turn_detector("heuristic")) is HeuristicTurnDetector
 
     def test_named_modes(self) -> None:
         assert isinstance(resolve_turn_detector("provider"), ProviderTurnDetector)

--- a/python/tests/voice/test_turn_detection.py
+++ b/python/tests/voice/test_turn_detection.py
@@ -1510,7 +1510,7 @@ class TestHoldInSession:
         import asyncio
 
         agent = Agent(name="t", model=TestModel(responses=["ok"]), tools=[])
-        session = VoiceSession(agent=agent, stt=MockSTT(script=[]), tts=MockTTS())
+        session = VoiceSession(agent=agent, stt=MockSTT(script=[]), tts=MockTTS(), turn_detector="heuristic")
 
         await session._arm_hold("I was wondering about", 0.01)
         stale = session._hold_task

--- a/python/timbal/server/README.md
+++ b/python/timbal/server/README.md
@@ -7,7 +7,7 @@ This README documents how a **custom frontend** integrates with the **voice agen
 ### Bundled voice playground
 
 - **Embedded** (served by a running agent): `GET /voice` on a `timbal.server` — auto-dials that agent; the page injects the runnable meta at serve time.
-- **Standalone** (no agent required): `python -m timbal.server.playground` — serves the same HTML raw, opens a Target panel, and can spawn a local `uv run python -m timbal.server --import_spec …` child on demand, or point at a platform workforce (`api.dev.timbal.ai` / `api.timbal.ai`) via ticket-authenticated WS / bearer-authenticated RTC. Fields persist in `localStorage`.
+- **Standalone** (no agent required): `python -m timbal.server.playground` — serves the same HTML raw and opens a Target panel. Local target: enter an agent path (`path/to/agent.py::object`, optional fixed port) and press Start — the launcher spawns `uv run python -m timbal.server --import_spec …` from the agent file's directory, waits for the healthcheck, and the page dials it (changing agent/port respawns on the next Start). Platform target: a deployed workforce (`api.dev.timbal.ai` / `api.timbal.ai`) via ticket-authenticated WS / bearer-authenticated RTC. Fields persist in `localStorage`.
 
 ---
 

--- a/python/timbal/server/README.md
+++ b/python/timbal/server/README.md
@@ -4,6 +4,11 @@ FastAPI app factory and CLI live in `http.py` (`python -m timbal.server`, or `ru
 
 This README documents how a **custom frontend** integrates with the **voice agent** over WebSocket (not the bundled `voice.html` playground).
 
+### Bundled voice playground
+
+- **Embedded** (served by a running agent): `GET /voice` on a `timbal.server` — auto-dials that agent; the page injects the runnable meta at serve time.
+- **Standalone** (no agent required): `python -m timbal.server.playground` — serves the same HTML raw, opens a Target panel, and can spawn a local `uv run python -m timbal.server --import_spec …` child on demand, or point at a platform workforce (`api.dev.timbal.ai` / `api.timbal.ai`) via ticket-authenticated WS / bearer-authenticated RTC. Fields persist in `localStorage`.
+
 ---
 
 ## Voice WebSocket: `/voice/ws`
@@ -69,7 +74,7 @@ Only send keys you need; omitted keys keep server defaults. Client keys are allo
 | `encoding`    | Default `"pcm_s16le"`. |
 | `stt_extra`   | Object merged with default STT options (e.g. VAD). |
 | `tts_extra`   | Object merged with default TTS options. |
-| `turn_detector` | A mode name: `"heuristic"` (default), `"provider"` (trust STT/realtime endpointing), `"local"` (audio EOU — auto-loads the Smart Turn v3 ONNX model when `timbal[voice]` is installed, heuristic degradation otherwise; set `TIMBAL_SMART_TURN_CHECKPOINT=int8` to trade ~1pp accuracy for ~2x faster inference), `"lexical"` (punctuation HOLD), or `"raw"` (debug: no silence/noise/echo filtering — every STT commit becomes a turn, including the agent's own speech leaking through the mic; never use in production). The client JSON may only send a mode name string (the playground page has a dropdown for this); it takes precedence over the server value for that session. Server-side `runnable.voice_config` may additionally supply a zero-arg factory returning a `TurnDetector`, or an instance — instances are `clone()`d per WebSocket session so concurrent clients never share buffers or lifecycle; custom detectors with per-session mutable state should override `TurnDetector.clone()`. |
+| `turn_detector` | A mode name: `"local"` (default — Smart Turn v3 + Namo DistilBERT + Silero VAD endpointing when `timbal[voice]` is installed; falls back to `"lexical"` without the extra), `"provider"` (trust STT/realtime endpointing; auto-forced for Deepgram Flux), `"lexical"` (punctuation HOLD), `"heuristic"` (no holds — opt-in), or `"raw"` (debug: no silence/noise/echo filtering — every STT commit becomes a turn, including the agent's own speech leaking through the mic; never use in production). Set `TIMBAL_SMART_TURN_CHECKPOINT=int8` to trade ~1pp accuracy for ~2x faster inference on Smart Turn. The client JSON may only send a mode name string (the playground page has a dropdown for this); it takes precedence over the server value for that session. Server-side `runnable.voice_config` may additionally supply a zero-arg factory returning a `TurnDetector`, or an instance — instances are `clone()`d per WebSocket session so concurrent clients never share buffers or lifecycle; custom detectors with per-session mutable state should override `TurnDetector.clone()`. |
 | `vad_endpointing` | Bool. The **local VAD endpointing fast path**: Silero VAD (auto-downloaded with `timbal[voice]`, MIT) runs on the mic PCM; ~0.2s after you stop speaking, the audio EOU model (Smart Turn) scores the utterance and the EOU probability maps to a variable extra wait — confident-complete commits in ~0.3s of silence instead of waiting the STT provider's ~1.2s debounce; incomplete utterances compute a delay longer than the debounce so the provider commit + HOLD machinery win untouched. Default (key absent) is **auto**: active when the effective turn detector has an audio EOU model (i.e. `"local"` mode with the extra installed), off otherwise. Send `false` to force off, `true` to force on (logs a warning when unavailable). Turns committed by this path have `vad_endpointed: true` in [Turn metrics](#turn-metrics). |
 
 Example — align server with the browser capture rate (only if that rate is supported end-to-end):

--- a/python/timbal/server/playground.py
+++ b/python/timbal/server/playground.py
@@ -4,11 +4,12 @@ Serves ``voice.html`` *without* a running agent underneath. The page detects it
 was served raw (no injected runnable meta) and switches to standalone mode,
 where you pick a target:
 
-* **Local server** — a ``timbal.server`` process. The page can dial one that is
-  already running (by URL), or ask *this* launcher to spawn one: the launcher
-  runs ``uv run python -m timbal.server --import_spec … --port …`` from the
-  agent file's directory (so ``uv`` resolves that project's environment and
-  ``.env``) and reports its state/logs back to the page.
+* **Local server** — pick an agent file (``path/to/agent.py::object``) and
+  press Start: the page asks *this* launcher to spawn ``uv run python -m
+  timbal.server --import_spec … --port …`` from the agent file's directory (so
+  ``uv`` resolves that project's environment and ``.env``), waits for the
+  healthcheck, and dials it. The port is picked automatically unless fixed in
+  the form. Changing the agent or port respawns on the next Start.
 * **Platform** — a deployed workforce through ``api.timbal.ai`` /
   ``api.dev.timbal.ai``. The page talks to the platform directly (ticket mint
   for WS, bearer-authenticated POST for RTC); the launcher is not involved.

--- a/python/timbal/server/playground.py
+++ b/python/timbal/server/playground.py
@@ -62,6 +62,10 @@ class ChildServer:
         self._proc: subprocess.Popen | None = None
         self._port: int | None = None
         self._import_spec: str | None = None
+        self._requested_spec: str | None = None
+        """The spec exactly as the client sent it — echoed in status so the page
+        can tell whether the running child matches its form without having to
+        replicate the launcher's path resolution."""
         self._logs: deque[str] = deque(maxlen=_LOG_LINES)
 
     def _reader(self, proc: subprocess.Popen) -> None:
@@ -115,6 +119,7 @@ class ChildServer:
             self._proc = proc
             self._port = child_port
             self._import_spec = resolved_spec
+            self._requested_spec = spec
             threading.Thread(target=self._reader, args=(proc,), daemon=True).start()
             return self.status_locked()
 
@@ -137,6 +142,7 @@ class ChildServer:
         self._proc = None
         self._port = None
         self._import_spec = None
+        self._requested_spec = None
 
     def status(self) -> dict:
         with self._lock:
@@ -154,6 +160,7 @@ class ChildServer:
                 "exit_code": exit_code,
                 "port": self._port,
                 "import_spec": self._import_spec,
+                "requested_import_spec": self._requested_spec,
                 "logs": list(self._logs),
             }
         state = "running" if _healthy(self._port) else "starting"
@@ -162,6 +169,7 @@ class ChildServer:
             "pid": proc.pid,
             "port": self._port,
             "import_spec": self._import_spec,
+            "requested_import_spec": self._requested_spec,
             "logs": list(self._logs),
         }
 

--- a/python/timbal/server/playground.py
+++ b/python/timbal/server/playground.py
@@ -1,0 +1,268 @@
+"""Standalone voice playground launcher: ``python -m timbal.server.playground``.
+
+Serves ``voice.html`` *without* a running agent underneath. The page detects it
+was served raw (no injected runnable meta) and switches to standalone mode,
+where you pick a target:
+
+* **Local server** — a ``timbal.server`` process. The page can dial one that is
+  already running (by URL), or ask *this* launcher to spawn one: the launcher
+  runs ``uv run python -m timbal.server --import_spec … --port …`` from the
+  agent file's directory (so ``uv`` resolves that project's environment and
+  ``.env``) and reports its state/logs back to the page.
+* **Platform** — a deployed workforce through ``api.timbal.ai`` /
+  ``api.dev.timbal.ai``. The page talks to the platform directly (ticket mint
+  for WS, bearer-authenticated POST for RTC); the launcher is not involved.
+
+Deliberately stdlib-only: the launcher must work even when no agent project
+(and therefore no fastapi/uvicorn environment) is set up yet.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import socket
+import subprocess
+import threading
+import webbrowser
+from collections import deque
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.request import urlopen
+
+from .. import __version__
+
+_HTML_PATH = Path(__file__).parent / "voice.html"
+
+_LOG_LINES = 400
+_STOP_GRACE_SECS = 5.0
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _healthy(port: int) -> bool:
+    try:
+        with urlopen(f"http://127.0.0.1:{port}/healthcheck", timeout=0.5) as resp:
+            return resp.status in (200, 204)
+    except Exception:
+        return False
+
+
+class ChildServer:
+    """The single ``timbal.server`` subprocess this launcher manages."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._proc: subprocess.Popen | None = None
+        self._port: int | None = None
+        self._import_spec: str | None = None
+        self._logs: deque[str] = deque(maxlen=_LOG_LINES)
+
+    def _reader(self, proc: subprocess.Popen) -> None:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            self._logs.append(line.rstrip("\n"))
+
+    def spawn(self, import_spec: str, port: int | None = None) -> dict:
+        spec = import_spec.strip()
+        parts = spec.split("::")
+        if len(parts) != 2 or not parts[0] or not parts[1]:
+            raise ValueError("Import spec must look like 'path/to/agent.py::object_name'.")
+        spec_path = Path(parts[0]).expanduser()
+        if not spec_path.is_absolute():
+            spec_path = Path.cwd() / spec_path
+        spec_path = spec_path.resolve()
+        if not spec_path.is_file():
+            raise ValueError(f"No such file: {spec_path}")
+        if shutil.which("uv") is None:
+            raise ValueError("'uv' was not found on PATH — install uv or start the server manually.")
+        resolved_spec = f"{spec_path}::{parts[1]}"
+
+        with self._lock:
+            self._stop_locked()
+            child_port = port or _free_port()
+            cmd = [
+                "uv",
+                "run",
+                "python",
+                "-m",
+                "timbal.server",
+                "--import_spec",
+                resolved_spec,
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(child_port),
+            ]
+            self._logs.clear()
+            self._logs.append(f"$ {' '.join(cmd)}  (cwd: {spec_path.parent})")
+            # cwd = the agent file's directory: `uv run` walks up from there to
+            # find the agent project's pyproject/venv, and load_dotenv picks up
+            # that project's .env — not the launcher's.
+            proc = subprocess.Popen(  # noqa: S603
+                cmd,
+                cwd=spec_path.parent,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            self._proc = proc
+            self._port = child_port
+            self._import_spec = resolved_spec
+            threading.Thread(target=self._reader, args=(proc,), daemon=True).start()
+            return self.status_locked()
+
+    def stop(self) -> dict:
+        with self._lock:
+            self._stop_locked()
+            return self.status_locked()
+
+    def _stop_locked(self) -> None:
+        proc = self._proc
+        if proc is None:
+            return
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=_STOP_GRACE_SECS)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=_STOP_GRACE_SECS)
+        self._proc = None
+        self._port = None
+        self._import_spec = None
+
+    def status(self) -> dict:
+        with self._lock:
+            return self.status_locked()
+
+    def status_locked(self) -> dict:
+        proc = self._proc
+        if proc is None:
+            # Keep the last logs around so a crash is inspectable after stop.
+            return {"state": "stopped", "logs": list(self._logs)}
+        exit_code = proc.poll()
+        if exit_code is not None:
+            return {
+                "state": "exited",
+                "exit_code": exit_code,
+                "port": self._port,
+                "import_spec": self._import_spec,
+                "logs": list(self._logs),
+            }
+        state = "running" if _healthy(self._port) else "starting"
+        return {
+            "state": state,
+            "pid": proc.pid,
+            "port": self._port,
+            "import_spec": self._import_spec,
+            "logs": list(self._logs),
+        }
+
+
+def _make_handler(child: ChildServer, default_import_spec: str) -> type[BaseHTTPRequestHandler]:
+    class Handler(BaseHTTPRequestHandler):
+        server_version = f"timbal-playground/{__version__}"
+
+        def log_message(self, format: str, *args) -> None:  # noqa: A002
+            pass  # keep the terminal usable; the page shows child logs itself
+
+        def _send_json(self, status: int, payload: dict) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self) -> None:  # noqa: N802
+            path = self.path.split("?", 1)[0].rstrip("/") or "/"
+            if path in ("/", "/voice"):
+                body = _HTML_PATH.read_bytes()
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            if path == "/launcher/status":
+                self._send_json(
+                    200,
+                    {
+                        "launcher": {"version": __version__, "default_import_spec": default_import_spec},
+                        "child": child.status(),
+                    },
+                )
+                return
+            self._send_json(404, {"error": "not found"})
+
+        def do_POST(self) -> None:  # noqa: N802
+            path = self.path.split("?", 1)[0].rstrip("/")
+            length = int(self.headers.get("Content-Length") or 0)
+            try:
+                body = json.loads(self.rfile.read(length) or b"{}")
+            except json.JSONDecodeError:
+                self._send_json(400, {"error": "invalid JSON body"})
+                return
+            if path == "/launcher/spawn":
+                import_spec = str(body.get("import_spec") or "").strip()
+                if not import_spec:
+                    self._send_json(400, {"error": "import_spec is required"})
+                    return
+                port = body.get("port")
+                try:
+                    status = child.spawn(import_spec, port=int(port) if port else None)
+                except ValueError as e:
+                    self._send_json(400, {"error": str(e)})
+                    return
+                except OSError as e:
+                    self._send_json(500, {"error": f"spawn failed: {e}"})
+                    return
+                self._send_json(200, {"child": status})
+                return
+            if path == "/launcher/stop":
+                self._send_json(200, {"child": child.stop()})
+                return
+            self._send_json(404, {"error": "not found"})
+
+    return Handler
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Standalone Timbal voice playground.")
+    parser.add_argument("--host", type=str, default="127.0.0.1", help="Host to bind the playground to.")
+    parser.add_argument("--port", type=int, default=7777, help="Port to bind the playground to.")
+    parser.add_argument(
+        "--import_spec",
+        "--import-spec",
+        dest="import_spec",
+        type=str,
+        default="",
+        help="Default import spec prefilled in the page's spawn field (path/to/agent.py::object).",
+    )
+    parser.add_argument("--no-open", action="store_true", help="Don't open the browser automatically.")
+    args = parser.parse_args(argv)
+
+    child = ChildServer()
+    handler = _make_handler(child, args.import_spec)
+    httpd = ThreadingHTTPServer((args.host, args.port), handler)
+    url = f"http://{'localhost' if args.host in ('0.0.0.0', '127.0.0.1') else args.host}:{args.port}/"
+    print(f"Voice playground at {url}")  # noqa: T201
+    if not args.no_open:
+        webbrowser.open(url)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        child.stop()
+        httpd.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/timbal/server/voice.html
+++ b/python/timbal/server/voice.html
@@ -84,6 +84,14 @@
     padding-top: 0.7rem;
     border-top: 1px solid var(--border);
   }
+  /* Standalone: Target is the panel header — no Agent title, no leading rule. */
+  .panel-section.panel-section--top {
+    padding-top: 0;
+    border-top: none;
+  }
+  .panel-title[hidden] {
+    display: none !important;
+  }
   .panel-section-title {
     font-size: 0.625rem;
     font-weight: 700;
@@ -107,6 +115,25 @@
     font-size: 0.6875rem;
     font-weight: 600;
     color: var(--text-muted);
+  }
+  .panel-section[hidden] { display: none !important; }
+  .target-fields {
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+  }
+  .target-fields[hidden] { display: none !important; }
+  .launcher-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .launcher-state {
+    font-size: 0.65625rem;
+    color: var(--text-muted);
+    line-height: 1.35;
+    min-width: 0;
+    word-break: break-word;
   }
   .panel select {
     width: 100%;
@@ -138,6 +165,7 @@
     cursor: pointer;
   }
   .panel input[type="text"],
+  .panel input[type="password"],
   .panel input[type="number"] {
     width: 100%;
     min-width: 0;
@@ -151,11 +179,13 @@
     outline: none;
   }
   .panel input[type="text"]:focus,
+  .panel input[type="password"]:focus,
   .panel input[type="number"]:focus {
     border-color: var(--primary);
     box-shadow: 0 0 0 3px rgba(0,0,0,.07);
   }
   .panel input[type="text"]:disabled,
+  .panel input[type="password"]:disabled,
   .panel input[type="number"]:disabled {
     color: var(--text-muted);
     background: var(--bg);
@@ -240,14 +270,18 @@
     flex-direction: column;
     align-items: flex-start;
     gap: 0.35rem;
-    padding-bottom: 0.75rem;
-    border-bottom: 1px solid var(--border);
+  }
+  .conn-strip[hidden] {
+    display: none !important;
   }
   .conn-version {
     font-size: 0.75rem;
     font-weight: 500;
     color: var(--text-muted);
     letter-spacing: -0.02em;
+  }
+  .conn-version[hidden] {
+    display: none !important;
   }
   .conn-agent {
     text-align: left;
@@ -576,36 +610,98 @@
     <div class="brand">
       <img class="brand-mark" src="https://content.timbal.ai/assets/timbal_favicon.png" alt="" width="28" height="28" decoding="async" />
       <div>
-        <span class="logo">Timbal AI</span><span class="sep">/</span><span class="title">Voice playground</span>
+        <span class="logo">Voice playground</span>
       </div>
     </div>
   </header>
 
   <div class="layout">
     <aside class="panel" aria-label="Agent configuration">
-      <h2 class="panel-title">Agent</h2>
-      <div id="conn-strip" class="conn-strip">
-        <span id="conn-version" class="conn-version"></span>
-        <div id="conn-agent" class="conn-agent" hidden>
-          <div id="conn-runnable-title" class="conn-runnable-title"></div>
-          <span id="conn-runnable-spec" class="conn-runnable-spec" hidden></span>
+      <h2 id="agent-panel-title" class="panel-title">Agent</h2>
+      <section id="target-section" class="panel-section" aria-label="Agent target" hidden>
+        <h3 id="target-heading" class="panel-section-title">Target</h3>
+        <label class="field">
+          <span class="field-label">Run against</span>
+          <select id="target-mode" aria-label="Agent target" title="Where the agent runs. Local = a timbal.server process on this machine; Platform = a workforce deployed on the Timbal platform.">
+            <option value="local">Local server</option>
+            <option value="platform">Platform</option>
+          </select>
+        </label>
+        <div id="target-local" class="target-fields">
+          <label class="field">
+            <span class="field-label">Server URL</span>
+            <input type="text" id="local-url" placeholder="http://localhost:4444" title="A running timbal.server — spawn one below or point at one you started yourself.">
+          </label>
+          <div id="launcher-box" class="target-fields" hidden>
+            <label class="field">
+              <span class="field-label">Import spec</span>
+              <input type="text" id="launcher-spec" placeholder="path/to/agent.py::agent" title="Runs `uv run python -m timbal.server --import_spec …` from the file's directory (relative paths resolve against the launcher's cwd).">
+            </label>
+            <div class="launcher-row">
+              <button type="button" id="btn-launcher" data-action="spawn">Spawn server</button>
+              <span id="launcher-state" class="launcher-state"></span>
+            </div>
+          </div>
         </div>
-      </div>
-      <div class="model-picker" title="Agent LLM — applied on the next Start. Needs the matching provider API key on the server.">
-        <label class="field">
-          <span class="field-label">Provider</span>
-          <select id="model-provider-select" aria-label="LLM provider">
-            <option value="">All providers</option>
-          </select>
-        </label>
-        <label class="field">
-          <span class="field-label">Model</span>
-          <select id="model-select" aria-label="LLM model">
-            <option value="">Agent default</option>
-          </select>
-        </label>
-        <span id="model-count" class="model-count"></span>
-      </div>
+        <div id="target-platform" class="target-fields" hidden>
+          <label class="field">
+            <span class="field-label">API base</span>
+            <input type="text" id="pf-api" placeholder="https://api.dev.timbal.ai">
+          </label>
+          <label class="field">
+            <span class="field-label">Org ID</span>
+            <input type="text" id="pf-org">
+          </label>
+          <label class="field">
+            <span class="field-label">Project ID</span>
+            <input type="text" id="pf-project">
+          </label>
+          <label class="field">
+            <span class="field-label">Workforce</span>
+            <input type="text" id="pf-workforce" placeholder="app id · uid · slug">
+          </label>
+          <label class="field">
+            <span class="field-label">Branch (rev)</span>
+            <input type="text" id="pf-rev" placeholder="main">
+          </label>
+          <label class="field">
+            <span class="field-label">Token</span>
+            <input type="password" id="pf-token" placeholder="API key or OAuth token" autocomplete="off" title="Stored in this browser's localStorage — use a revocable dev key.">
+          </label>
+          <label class="field">
+            <span class="field-label">Endpoint</span>
+            <select id="pf-endpoint" title="Deployed dials the running deployment for the branch. Preview runs the branch worktree instead (WS only; first connect after a source change pays uv sync).">
+              <option value="deployed">Deployed</option>
+              <option value="preview">Preview (branch worktree)</option>
+            </select>
+          </label>
+        </div>
+      </section>
+      <section id="agent-section" class="panel-section panel-section--top" aria-label="Agent">
+        <h3 id="agent-section-title" class="panel-section-title" hidden>Agent</h3>
+        <div id="conn-strip" class="conn-strip" hidden>
+          <span id="conn-version" class="conn-version" hidden></span>
+          <div id="conn-agent" class="conn-agent" hidden>
+            <div id="conn-runnable-title" class="conn-runnable-title"></div>
+            <span id="conn-runnable-spec" class="conn-runnable-spec" hidden></span>
+          </div>
+        </div>
+        <div class="model-picker" title="Agent LLM — applied on the next Start. Needs the matching provider API key on the server.">
+          <label class="field">
+            <span class="field-label">Provider</span>
+            <select id="model-provider-select" aria-label="LLM provider">
+              <option value="">All providers</option>
+            </select>
+          </label>
+          <label class="field">
+            <span class="field-label">Model</span>
+            <select id="model-select" aria-label="LLM model">
+              <option value="">Agent default</option>
+            </select>
+          </label>
+          <span id="model-count" class="model-count"></span>
+        </div>
+      </section>
       <p class="panel-note">Changes apply on the next session Start. Model overrides need the matching provider API key on the server.</p>
     </aside>
 
@@ -753,6 +849,18 @@ const SAMPLE_RATE = 16000;
 // Flux wants ~80ms frames; Nova/Scribe are fine at the same cadence.
 const CHUNK_MS = 80;
 
+// Embedded vs standalone: timbal.server injects the runnable meta into the
+// script tag below when it serves this page. If the placeholder is intact
+// (served by the playground launcher, or opened from the filesystem), the
+// JSON parse fails and the page runs standalone — a Target section appears
+// and every server URL routes through the selected target instead of this
+// page's own origin.
+let META = null;
+try {
+  META = JSON.parse(document.getElementById('timbal-voice-runnable-meta').textContent);
+} catch (_) {}
+const EMBEDDED = META !== null;
+
 const cardEl = document.getElementById('card');
 const footStatus = document.getElementById('foot-status');
 const footStatusTitle = document.getElementById('foot-status-title');
@@ -767,8 +875,11 @@ const nsSelect = document.getElementById('ns-select');
 const micViz = document.getElementById('mic-viz');
 
 const TD_STORAGE_KEY = 'timbal-voice-turn-detector';
-// Unknown stored values leave the select on '' (server default) automatically.
-tdSelect.value = localStorage.getItem(TD_STORAGE_KEY) || '';
+// Default: Smart Turn + Namo (+ Silero VAD endpointing). Unknown stored values
+// fall back to that too (empty string used to mean "server default", which is
+// the same mode on a voice install).
+tdSelect.value = localStorage.getItem(TD_STORAGE_KEY) || 'local';
+if (![...tdSelect.options].some((o) => o.value === tdSelect.value)) tdSelect.value = 'local';
 tdSelect.onchange = () => {
   // Applied on the next Start (no reload) — modes are fixed per WebSocket hello.
   localStorage.setItem(TD_STORAGE_KEY, tdSelect.value);
@@ -808,8 +919,10 @@ fillerMax.onchange = () => localStorage.setItem(FILLER_MAX_STORAGE_KEY, fillerMa
 const transportSelect = document.getElementById('transport-select');
 const TRANSPORT_STORAGE_KEY = 'timbal-voice-transport';
 transportSelect.value = new URLSearchParams(location.search).get('transport')
-  || localStorage.getItem(TRANSPORT_STORAGE_KEY) || 'ws';
-if (!transportSelect.value) transportSelect.value = 'ws';
+  || localStorage.getItem(TRANSPORT_STORAGE_KEY) || 'webrtc';
+if (![...transportSelect.options].some((o) => o.value === transportSelect.value && !o.disabled)) {
+  transportSelect.value = 'webrtc';
+}
 function syncNsForTransport() {
   // WebRTC sends the raw mic track, so the worklet's RNNoise output never
   // reaches the wire — the transport forces browser noise suppression
@@ -949,6 +1062,121 @@ function renderModelOptions(preferred, agentDefault) {
   }
 }
 
+// --- Agent target (standalone mode) ---------------------------------------
+// Embedded pages keep dialing their own origin exactly as before. Standalone
+// pages route everything through one of two targets:
+//   local    — a timbal.server at an arbitrary URL, optionally spawned via
+//              the launcher endpoints on this page's own origin.
+//   platform — a deployed workforce through the Timbal platform API. Same
+//              wire protocol; the platform tunnels WS (ticket-authenticated)
+//              and relays RTC signaling (bearer-authenticated).
+const targetSection = document.getElementById('target-section');
+const targetModeSelect = document.getElementById('target-mode');
+const targetLocalBox = document.getElementById('target-local');
+const targetPlatformBox = document.getElementById('target-platform');
+const localUrlInput = document.getElementById('local-url');
+const launcherBox = document.getElementById('launcher-box');
+const launcherSpecInput = document.getElementById('launcher-spec');
+const btnLauncher = document.getElementById('btn-launcher');
+const launcherStateEl = document.getElementById('launcher-state');
+const pf = {
+  api: document.getElementById('pf-api'),
+  org: document.getElementById('pf-org'),
+  project: document.getElementById('pf-project'),
+  workforce: document.getElementById('pf-workforce'),
+  rev: document.getElementById('pf-rev'),
+  token: document.getElementById('pf-token'),
+  endpoint: document.getElementById('pf-endpoint'),
+};
+const TGT_KEY = (k) => `timbal-voice-target-${k}`;
+
+function targetMode() {
+  return EMBEDDED ? 'embedded' : (targetModeSelect.value || 'local');
+}
+
+function localBase() {
+  let u = (localUrlInput.value || '').trim() || 'http://localhost:4444';
+  if (!/^https?:\/\//i.test(u)) u = 'http://' + u;
+  return u.replace(/\/+$/, '');
+}
+
+function platformValues() {
+  return {
+    api: ((pf.api.value || '').trim() || 'https://api.dev.timbal.ai').replace(/\/+$/, ''),
+    org: (pf.org.value || '').trim(),
+    project: (pf.project.value || '').trim(),
+    workforce: (pf.workforce.value || '').trim(),
+    rev: (pf.rev.value || '').trim() || 'main',
+    token: (pf.token.value || '').trim(),
+    endpoint: pf.endpoint.value === 'preview' ? 'preview' : 'deployed',
+  };
+}
+
+function platformBase(v) {
+  v = v || platformValues();
+  return `${v.api}/orgs/${encodeURIComponent(v.org)}/projects/${encodeURIComponent(v.project)}`
+    + `/workforce/${encodeURIComponent(v.workforce)}`;
+}
+
+function validatePlatform(v) {
+  const missing = [];
+  if (!v.org) missing.push('org ID');
+  if (!v.project) missing.push('project ID');
+  if (!v.workforce) missing.push('workforce');
+  if (!v.token) missing.push('token');
+  if (missing.length) throw new Error(`Platform target needs: ${missing.join(', ')}.`);
+}
+
+/**
+ * Origin prefix for plain /voice/* fetches (meta, ambience), or null when the
+ * target can't serve them — the platform tunnels only ws/preview/rtc/ticket.
+ */
+function voiceHttpBase() {
+  const m = targetMode();
+  if (m === 'embedded') return '';
+  if (m === 'local') return localBase();
+  return null;
+}
+
+/** Tickets are single-use and 60s-lived — mint one immediately before each dial. */
+async function mintPlatformTicket(v) {
+  const resp = await fetch(`${platformBase(v)}/voice/ticket?rev=${encodeURIComponent(v.rev)}`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${v.token}` },
+  });
+  if (!resp.ok) {
+    let detail = '';
+    try { detail = (await resp.json()).error || ''; } catch (_) {}
+    const hint = resp.status === 401 || resp.status === 403 ? ' Check the token.'
+      : resp.status === 400 ? ' Check the branch (rev).'
+      : resp.status === 404 ? ' Check org/project/workforce, and that the branch is deployed.'
+      : '';
+    throw new Error(`Ticket mint failed (${resp.status})${detail ? `: ${detail}` : '.'}${hint}`);
+  }
+  return (await resp.json()).ticket;
+}
+
+/** URL + subprotocols for the WebSocket dial of the current target. */
+async function buildWsConnect() {
+  const m = targetMode();
+  if (m === 'embedded') {
+    const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+    return { url: `${proto}://${location.host}/voice/ws`, protocols: undefined };
+  }
+  if (m === 'local') {
+    return { url: localBase().replace(/^http/i, 'ws') + '/voice/ws', protocols: undefined };
+  }
+  const v = platformValues();
+  validatePlatform(v);
+  const ticket = await mintPlatformTicket(v);
+  const path = v.endpoint === 'preview' ? 'voice/preview' : 'voice/ws';
+  const wsBase = platformBase(v).replace(/^http/i, 'ws');
+  return {
+    url: `${wsBase}/${path}?rev=${encodeURIComponent(v.rev)}&ticket=${encodeURIComponent(ticket)}`,
+    protocols: ['timbal.v1'],
+  };
+}
+
 const NS_STORAGE_KEY = 'timbal-voice-noise-suppression';
 nsSelect.value = localStorage.getItem(NS_STORAGE_KEY) || 'browser';
 if (!nsSelect.value) nsSelect.value = 'browser'; // unknown stored value
@@ -972,16 +1200,21 @@ let ambientSource = null, ambientGain = null, ambientToken = 0;
 /** `ambient` config from the last session_started, or null. */
 let serverAmbient = null;
 
-(async () => {
+/** Base URL the current preset options were fetched from (avoid refetch loops). */
+let ambienceCatalogBase;
+
+async function loadAmbienceCatalog() {
+  const base = voiceHttpBase();
+  if (base === null || base === ambienceCatalogBase) return;
   const stored = localStorage.getItem(AMBIENT_SRC_STORAGE_KEY) || '';
-  // 'off' exists before the catalog arrives — restore it now so an
-  // auto-started session can't play the server default over a saved "Off"
-  // (and so it survives the catalog fetch failing).
-  if (stored === 'off') ambientSelect.value = 'off';
   try {
-    const resp = await fetch('/voice/ambience');
+    const resp = await fetch(base + '/voice/ambience');
     if (!resp.ok) return;
-    for (const name of (await resp.json()).presets || []) {
+    const presets = (await resp.json()).presets || [];
+    ambienceCatalogBase = base;
+    // Rebuild presets; the first two options ('' and 'off') are fixed markup.
+    while (ambientSelect.options.length > 2) ambientSelect.remove(2);
+    for (const name of presets) {
       const opt = document.createElement('option');
       opt.value = name;
       opt.textContent = name;
@@ -989,12 +1222,22 @@ let serverAmbient = null;
     }
     ambientSelect.value = stored;
     if (ambientSelect.selectedIndex < 0) ambientSelect.value = ''; // stale stored preset
-    // The session auto-starts on load and may have mixed before the catalog
-    // arrived, with the picker still on "server default". Setting .value
-    // fires no change event, so re-apply if the restore changed anything.
+    // The session may auto-start on load and mix before the catalog arrived,
+    // with the picker still on "server default". Setting .value fires no
+    // change event, so re-apply if the restore changed anything.
     // (No-ops before session_started — applyAmbience bails without audioCtx.)
     if (ambientSelect.value) void applyAmbience();
   } catch (_) {}
+}
+
+(() => {
+  const stored = localStorage.getItem(AMBIENT_SRC_STORAGE_KEY) || '';
+  // 'off' exists before the catalog arrives — restore it now so an
+  // auto-started session can't play the server default over a saved "Off"
+  // (and so it survives the catalog fetch failing).
+  if (stored === 'off') ambientSelect.value = 'off';
+  // Standalone pages load the catalog lazily once a local target answers.
+  if (EMBEDDED) void loadAmbienceCatalog();
 })();
 
 function stopAmbience() {
@@ -1008,7 +1251,9 @@ async function applyAmbience() {
   if (!audioCtx) return;
   const sel = ambientSelect.value;
   if (sel === 'off' || (!sel && !serverAmbient)) return;
-  const url = sel ? `/voice/ambience/${encodeURIComponent(sel)}` : '/voice/ambience/current';
+  const base = voiceHttpBase();
+  if (base === null) return; // platform target — ambience assets aren't tunneled
+  const url = base + (sel ? `/voice/ambience/${encodeURIComponent(sel)}` : '/voice/ambience/current');
   const stored = localStorage.getItem(AMBIENT_STORAGE_KEY);
   const volume = stored !== null ? Number(stored) / 100 : (serverAmbient?.volume ?? 0.25);
   ambientSlider.value = String(Math.round(volume * 100));
@@ -1065,7 +1310,9 @@ async function startThinkingSound() {
   const token = ++thinkingToken;
   try {
     if (!thinkingBuf) {
-      const resp = await fetch('/voice/ambience/typing');
+      const base = voiceHttpBase();
+      if (base === null) return; // platform target — ambience assets aren't tunneled
+      const resp = await fetch(base + '/voice/ambience/typing');
       if (!resp.ok) return;
       thinkingBuf = await audioCtx.decodeAudioData(await resp.arrayBuffer());
     }
@@ -1103,42 +1350,46 @@ function truncateMiddle(s, max) {
   return s.slice(0, front) + '…' + s.slice(s.length - back);
 }
 
-function initRunnableStrip() {
-  const raw = document.getElementById('timbal-voice-runnable-meta');
+/** Render the runnable strip + model picker from a meta blob (injected or fetched); null clears both. */
+function applyMeta(meta) {
+  const strip = document.getElementById('conn-strip');
   const verEl = document.getElementById('conn-version');
   const wrap = document.getElementById('conn-agent');
   const titleEl = document.getElementById('conn-runnable-title');
   const specEl = document.getElementById('conn-runnable-spec');
-  if (!raw || !verEl || !wrap || !titleEl || !specEl) return;
-  let meta;
-  try {
-    meta = JSON.parse(raw.textContent);
-  } catch {
+  if (!strip || !verEl || !wrap || !titleEl || !specEl) return;
+  if (!meta) {
     initModelPicker([], '');
+    verEl.textContent = '';
+    verEl.hidden = true;
+    wrap.hidden = true;
+    strip.hidden = true; // no bare "Timbal" + no stacked border with TARGET
     return;
   }
   initModelPicker(meta.models || [], (meta.model || '').trim());
   const v = (meta.version || '').trim();
-  verEl.textContent = v ? `Timbal ${v}` : 'Timbal';
+  verEl.textContent = v;
+  verEl.hidden = !v;
   const spec = (meta.import_spec || '').trim();
   const nm = (meta.name || '').trim();
   const kind = (meta.kind || '').trim();
   const title = nm ? (kind ? `${nm} · ${kind}` : nm) : kind;
-  if (!title && !spec) {
-    wrap.hidden = true;
-    return;
-  }
-  wrap.hidden = false;
-  titleEl.textContent = title || 'Runnable';
-  if (spec) {
-    specEl.textContent = truncateMiddle(spec, 44);
-    specEl.title = spec;
-    specEl.hidden = false;
+  if (title || spec) {
+    wrap.hidden = false;
+    titleEl.textContent = title || 'Runnable';
+    if (spec) {
+      specEl.textContent = truncateMiddle(spec, 44);
+      specEl.title = spec;
+      specEl.hidden = false;
+    } else {
+      specEl.textContent = '';
+      specEl.removeAttribute('title');
+      specEl.hidden = true;
+    }
   } else {
-    specEl.textContent = '';
-    specEl.removeAttribute('title');
-    specEl.hidden = true;
+    wrap.hidden = true;
   }
+  strip.hidden = verEl.hidden && wrap.hidden;
 }
 
 let ws, audioCtx, micStream, worklet, analyser, currentSource, meterRAF;
@@ -1682,6 +1933,8 @@ function resetSessionUi() {
 
 async function start() {
   const gen = startGen;
+  // Fail on incomplete platform config before prompting for the microphone.
+  if (targetMode() === 'platform') validatePlatform(platformValues());
   setConn('connecting', 'Getting ready', 'Microphone and server connection…');
   userEndedSession = false;
   sessionReady = false;
@@ -1702,10 +1955,15 @@ async function start() {
     return;
   }
 
-  setConn('connecting', 'Connecting', 'Opening WebSocket to this server…');
-  const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+  const isPlatform = targetMode() === 'platform';
+  setConn('connecting', 'Connecting', isPlatform
+    ? 'Minting ticket and dialing the platform (cold start can take several seconds)…'
+    : 'Opening WebSocket to the server…');
   micAudioToWs = false;
-  ws = new WebSocket(`${proto}://${location.host}/voice/ws`);
+  // Platform: mint-then-dial, fresh single-use ticket per attempt.
+  const dial = await buildWsConnect();
+  if (gen !== startGen) return;
+  ws = new WebSocket(dial.url, dial.protocols);
   ws.binaryType = 'arraybuffer';
   if (gen !== startGen) {
     try { ws.close(); } catch (_) {}
@@ -1780,7 +2038,9 @@ async function start() {
   };
 
   ws.onerror = () => {
-    setConn('error', 'Connection error', 'Could not keep the WebSocket open. Is the server running?');
+    setConn('error', 'Connection error', isPlatform
+      ? 'Could not open the socket. Check the token, IDs and rev, and that the branch is deployed (browsers hide the HTTP status of a failed upgrade).'
+      : 'Could not keep the WebSocket open. Is the server running?');
   };
 
   ws.onmessage = (e) => {
@@ -1923,7 +2183,13 @@ function handleServerMessage(msg) {
 }
 
 async function startRtc(gen) {
-  setConn('connecting', 'Connecting', 'Negotiating WebRTC with this server…');
+  const isPlatform = targetMode() === 'platform';
+  if (isPlatform && platformValues().endpoint === 'preview') {
+    throw new Error('WebRTC is not available on voice/preview — switch the transport to WebSocket.');
+  }
+  setConn('connecting', 'Connecting', isPlatform
+    ? 'Negotiating WebRTC through the platform (box spawn can take up to ~30 s)…'
+    : 'Negotiating WebRTC with the server…');
   pc = new RTCPeerConnection();
   const conn = pc;
 
@@ -1974,11 +2240,12 @@ async function startRtc(gen) {
 
   const offer = await pc.createOffer();
   await pc.setLocalDescription(offer);
-  // One-round-trip signaling: wait for ICE gathering so the offer is complete
-  // (bounded — host candidates alone are enough against a local server).
+  // One-round-trip signaling: wait for ICE gathering so the offer is complete.
+  // Local servers accept a bounded wait (host candidates alone are enough);
+  // the platform is no-trickle, so give gathering longer to finish there.
   if (pc.iceGatheringState !== 'complete') {
     await new Promise((resolve) => {
-      const timer = setTimeout(resolve, 2000);
+      const timer = setTimeout(resolve, isPlatform ? 8000 : 2000);
       pc.addEventListener('icegatheringstatechange', () => {
         if (conn.iceGatheringState === 'complete') { clearTimeout(timer); resolve(); }
       });
@@ -1986,9 +2253,19 @@ async function startRtc(gen) {
   }
   if (gen !== startGen) return;
 
-  const resp = await fetch('/voice/rtc', {
+  let rtcUrl = '/voice/rtc';
+  const rtcHeaders = { 'Content-Type': 'application/json' };
+  if (targetMode() === 'local') {
+    rtcUrl = localBase() + '/voice/rtc';
+  } else if (isPlatform) {
+    const v = platformValues();
+    validatePlatform(v);
+    rtcUrl = `${platformBase(v)}/voice/rtc?rev=${encodeURIComponent(v.rev)}`;
+    rtcHeaders.Authorization = `Bearer ${v.token}`;
+  }
+  const resp = await fetch(rtcUrl, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: rtcHeaders,
     body: JSON.stringify({
       sdp: conn.localDescription.sdp,
       type: 'offer',
@@ -1998,7 +2275,12 @@ async function startRtc(gen) {
   if (!resp.ok) {
     let detail = `Server answered ${resp.status}.`;
     try { detail = (await resp.json()).error || detail; } catch (_) {}
-    if (resp.status === 501) detail += ' Install it: uv pip install "timbal[voice]".';
+    if (resp.status === 501) {
+      detail += isPlatform
+        ? ' The deployed timbal lacks the voice extra (needs timbal[voice] >= 2.3.2).'
+        : ' Install it: uv pip install "timbal[voice]".';
+    }
+    if (isPlatform && resp.status === 404) detail += ' No running deployment for that branch?';
     throw new Error(detail);
   }
   const answer = await resp.json();
@@ -2010,12 +2292,213 @@ async function startRtc(gen) {
   updateEmptyState();
 }
 
-initRunnableStrip();
+// --- Standalone bootstrap --------------------------------------------------
+
+function syncTransportForTarget() {
+  // Preview tunnels WebSocket only — there is no RTC preview today.
+  const preview = !EMBEDDED && targetModeSelect.value === 'platform' && pf.endpoint.value === 'preview';
+  const rtcOpt = [...transportSelect.options].find((o) => o.value === 'webrtc');
+  if (rtcOpt) rtcOpt.disabled = preview;
+  if (preview && transportSelect.value === 'webrtc') transportSelect.value = 'ws';
+  syncNsForTransport();
+}
+
+function syncTargetVisibility() {
+  const m = targetModeSelect.value;
+  targetLocalBox.hidden = m !== 'local';
+  targetPlatformBox.hidden = m !== 'platform';
+  syncTransportForTarget();
+}
+
+/** Guards stale async probe results after the target changed under them. */
+let probeSeq = 0;
+
+/** Healthcheck + meta fetch against the local target; drives the strip and idle status. */
+async function probeLocal() {
+  if (targetMode() !== 'local') return;
+  const seq = ++probeSeq;
+  const base = localBase();
+  const idle = () => connVisual !== 'live' && connVisual !== 'connecting';
+  try {
+    const r = await fetch(base + '/healthcheck');
+    if (seq !== probeSeq) return;
+    if (!r.ok) throw new Error(`healthcheck ${r.status}`);
+    let meta = null;
+    try {
+      const mr = await fetch(base + '/voice/meta');
+      if (mr.ok) meta = await mr.json(); // older servers lack /voice/meta — fine
+    } catch (_) {}
+    if (seq !== probeSeq) return;
+    applyMeta(meta);
+    void loadAmbienceCatalog();
+    if (idle()) setConn('ended', 'Ready', `Server answering at ${base} — press Start.`);
+  } catch (_) {
+    if (seq !== probeSeq) return;
+    applyMeta(null);
+    if (idle()) setConn('ended', 'No server', `Nothing answering at ${base}. Spawn one below or start it yourself, then press Start.`);
+  }
+}
+
+// --- Launcher client (spawns `uv run python -m timbal.server` children) ----
+// Only reachable when this page is served by `python -m timbal.server.playground`
+// — the launcher endpoints live on the page's own origin. Opened from the
+// filesystem or elsewhere, the status probe fails and the spawn UI stays hidden.
+let lastChildState = null;
+
+async function fetchLauncherStatus() {
+  try {
+    const r = await fetch('/launcher/status');
+    if (!r.ok) return null;
+    return await r.json();
+  } catch (_) {
+    return null;
+  }
+}
+
+function renderLauncherChild(child) {
+  const state = child?.state || 'stopped';
+  const stoppable = state === 'running' || state === 'starting';
+  btnLauncher.dataset.action = stoppable ? 'stop' : 'spawn';
+  btnLauncher.textContent = stoppable ? 'Stop server' : 'Spawn server';
+  if (state === 'starting') {
+    launcherStateEl.textContent = `Starting on port ${child.port}… (first run may pay a uv sync)`;
+  } else if (state === 'running') {
+    launcherStateEl.textContent = `Running on port ${child.port} (pid ${child.pid})`;
+  } else if (state === 'exited') {
+    const lastLog = (child.logs || []).filter(Boolean).slice(-1)[0] || '';
+    launcherStateEl.textContent = `Exited (code ${child.exit_code}).${lastLog ? ` Last log: ${lastLog}` : ''}`;
+  } else {
+    launcherStateEl.textContent = '';
+  }
+}
+
+function adoptSpawnedChild(child) {
+  if (!child?.port) return;
+  localUrlInput.value = `http://${location.hostname || 'localhost'}:${child.port}`;
+  localStorage.setItem(TGT_KEY('local-url'), localUrlInput.value);
+}
+
+function startLauncherPolling() {
+  setInterval(async () => {
+    const st = await fetchLauncherStatus();
+    if (!st) return;
+    renderLauncherChild(st.child);
+    const state = st.child?.state || 'stopped';
+    if (state === 'running' && lastChildState !== 'running') {
+      adoptSpawnedChild(st.child);
+      void probeLocal();
+    }
+    lastChildState = state;
+  }, 3000);
+}
+
+btnLauncher.onclick = async () => {
+  btnLauncher.disabled = true;
+  try {
+    if (btnLauncher.dataset.action === 'stop') {
+      const r = await fetch('/launcher/stop', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' });
+      renderLauncherChild((await r.json()).child);
+      void probeLocal();
+      return;
+    }
+    const spec = launcherSpecInput.value.trim();
+    if (!spec) {
+      launcherStateEl.textContent = 'Enter an import spec first (path/to/agent.py::object).';
+      return;
+    }
+    localStorage.setItem(TGT_KEY('spec'), spec);
+    const r = await fetch('/launcher/spawn', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ import_spec: spec }),
+    });
+    const data = await r.json();
+    if (!r.ok) {
+      launcherStateEl.textContent = data.error || `Spawn failed (${r.status}).`;
+      return;
+    }
+    renderLauncherChild(data.child);
+    adoptSpawnedChild(data.child);
+    lastChildState = data.child?.state || null;
+  } catch (err) {
+    launcherStateEl.textContent = String(err?.message || err);
+  } finally {
+    btnLauncher.disabled = false;
+  }
+};
+
+function onTargetChanged() {
+  probeSeq += 1; // cancel in-flight probes for the previous target
+  if (targetMode() === 'local') {
+    void probeLocal();
+  } else {
+    applyMeta(null);
+    if (connVisual !== 'live' && connVisual !== 'connecting') {
+      setConn('ended', 'Ready', 'Fill in the workforce details, then press Start.');
+    }
+  }
+}
+
+async function initStandalone() {
+  // Standalone layout mirrors the right panel: TARGET (panel header), then --- AGENT.
+  document.getElementById('agent-panel-title').hidden = true;
+  targetSection.hidden = false;
+  targetSection.classList.add('panel-section--top');
+  document.getElementById('target-heading').className = 'panel-title';
+  const agentSection = document.getElementById('agent-section');
+  agentSection.classList.remove('panel-section--top'); // restore the section rule
+  document.getElementById('agent-section-title').hidden = false;
+  targetModeSelect.value = localStorage.getItem(TGT_KEY('mode')) || 'local';
+  if (!targetModeSelect.value) targetModeSelect.value = 'local';
+  localUrlInput.value = localStorage.getItem(TGT_KEY('local-url')) || '';
+  pf.api.value = localStorage.getItem(TGT_KEY('pf-api')) || '';
+  pf.org.value = localStorage.getItem(TGT_KEY('pf-org')) || '';
+  pf.project.value = localStorage.getItem(TGT_KEY('pf-project')) || '';
+  pf.workforce.value = localStorage.getItem(TGT_KEY('pf-workforce')) || '';
+  pf.rev.value = localStorage.getItem(TGT_KEY('pf-rev')) || '';
+  pf.token.value = localStorage.getItem(TGT_KEY('pf-token')) || '';
+  pf.endpoint.value = localStorage.getItem(TGT_KEY('pf-endpoint')) || 'deployed';
+  syncTargetVisibility();
+
+  targetModeSelect.onchange = () => {
+    localStorage.setItem(TGT_KEY('mode'), targetModeSelect.value);
+    syncTargetVisibility();
+    onTargetChanged();
+  };
+  localUrlInput.onchange = () => {
+    localStorage.setItem(TGT_KEY('local-url'), localUrlInput.value.trim());
+    void probeLocal();
+  };
+  for (const [key, el] of Object.entries(pf)) {
+    el.onchange = () => {
+      localStorage.setItem(TGT_KEY(`pf-${key}`), el.value);
+      if (key === 'endpoint') syncTransportForTarget();
+    };
+  }
+
+  const st = await fetchLauncherStatus();
+  if (st) {
+    launcherBox.hidden = false;
+    launcherSpecInput.value = localStorage.getItem(TGT_KEY('spec')) || st.launcher?.default_import_spec || '';
+    renderLauncherChild(st.child);
+    lastChildState = st.child?.state || null;
+    if (st.child?.state === 'running') adoptSpawnedChild(st.child);
+    startLauncherPolling();
+  }
+  onTargetChanged();
+}
+
+applyMeta(EMBEDDED ? META : null);
 setSessionButton('start');
-setConn('connecting', 'Getting ready', 'Microphone and server connection…');
 cardEl.classList.add('card--inactive');
-// Auto-start on load — no idle play click. Start remains after Stop for a new session.
-void startSession();
+if (EMBEDDED) {
+  setConn('connecting', 'Getting ready', 'Microphone and server connection…');
+  // Auto-start on load — no idle play click. Start remains after Stop for a new session.
+  void startSession();
+} else {
+  setConn('ended', 'Ready', 'Pick a target, then press Start.');
+  void initStandalone();
+}
 </script>
 </body>
 </html>

--- a/python/timbal/server/voice.html
+++ b/python/timbal/server/voice.html
@@ -923,11 +923,14 @@ fillerMax.onchange = () => localStorage.setItem(FILLER_MAX_STORAGE_KEY, fillerMa
 
 const transportSelect = document.getElementById('transport-select');
 const TRANSPORT_STORAGE_KEY = 'timbal-voice-transport';
-transportSelect.value = new URLSearchParams(location.search).get('transport')
-  || localStorage.getItem(TRANSPORT_STORAGE_KEY) || 'webrtc';
+const transportFromUrl = new URLSearchParams(location.search).get('transport');
+transportSelect.value = transportFromUrl || localStorage.getItem(TRANSPORT_STORAGE_KEY) || 'webrtc';
 if (![...transportSelect.options].some((o) => o.value === transportSelect.value && !o.disabled)) {
   transportSelect.value = 'webrtc';
 }
+// Only the *default* WebRTC silently falls back to WS when the server lacks
+// the voice extra (501) — an explicit user/URL choice surfaces the error.
+let transportExplicit = !!(transportFromUrl || localStorage.getItem(TRANSPORT_STORAGE_KEY));
 function syncNsForTransport() {
   // WebRTC sends the raw mic track, so the worklet's RNNoise output never
   // reaches the wire — the transport forces browser noise suppression
@@ -940,6 +943,7 @@ function syncNsForTransport() {
 }
 transportSelect.onchange = () => {
   // Applied on the next Start — a live session keeps its transport.
+  transportExplicit = true;
   localStorage.setItem(TRANSPORT_STORAGE_KEY, transportSelect.value);
   syncNsForTransport();
 };
@@ -1090,8 +1094,6 @@ const btnLauncher = document.getElementById('btn-launcher');
 const launcherStateEl = document.getElementById('launcher-state');
 /** True when this page is served by the playground launcher (spawn-on-Start). */
 let launcherAvailable = false;
-/** Spec string the current child was spawned from — a mismatch respawns on Start. */
-let lastSpawnedSpec = null;
 const pf = {
   api: document.getElementById('pf-api'),
   org: document.getElementById('pf-org'),
@@ -1970,8 +1972,20 @@ async function start() {
   }
 
   if (transportSelect.value === 'webrtc') {
-    await startRtc(gen);
-    return;
+    try {
+      await startRtc(gen);
+      return;
+    } catch (err) {
+      if (gen !== startGen) return;
+      if (!err?.rtcUnsupported || transportExplicit) throw err;
+      // Default transport against a server without the voice extra (501):
+      // behave like the old default and connect over WebSocket instead.
+      // Not persisted — RTC is retried first on the next page load.
+      try { pc?.close(); } catch (_) {}
+      pc = null;
+      transportSelect.value = 'ws';
+      syncNsForTransport();
+    }
   }
 
   const isPlatform = targetMode() === 'platform';
@@ -2300,7 +2314,9 @@ async function startRtc(gen) {
         : ' Install it: uv pip install "timbal[voice]".';
     }
     if (isPlatform && resp.status === 404) detail += ' No running deployment for that branch?';
-    throw new Error(detail);
+    const err = new Error(detail);
+    err.rtcUnsupported = resp.status === 501;
+    throw err;
   }
   const answer = await resp.json();
   if (gen !== startGen) return;
@@ -2427,7 +2443,6 @@ btnLauncher.onclick = async () => {
   try {
     const r = await fetch('/launcher/stop', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' });
     renderLauncherChild((await r.json()).child);
-    lastSpawnedSpec = null;
     void probeLocal();
   } catch (err) {
     launcherStateEl.textContent = String(err?.message || err);
@@ -2461,7 +2476,10 @@ async function ensureLocalServer() {
   if (!st) throw new Error('Playground launcher is not reachable — restart `python -m timbal.server.playground`.');
   let child = st.child;
   const alive = child && (child.state === 'running' || child.state === 'starting');
-  if (!alive || spec !== lastSpawnedSpec || (port !== null && child.port !== port)) {
+  // The launcher echoes the raw spec the child was spawned from — compare
+  // against that, not client-side state: a survivor from a previous page load
+  // may be running a different agent than the (persisted) form says.
+  if (!alive || child.requested_import_spec !== spec || (port !== null && child.port !== port)) {
     setConn('connecting', 'Spawning server', `uv run timbal.server — ${spec}`);
     const r = await fetch('/launcher/spawn', {
       method: 'POST',
@@ -2471,7 +2489,6 @@ async function ensureLocalServer() {
     const data = await r.json();
     if (!r.ok) throw new Error(data.error || `Spawn failed (${r.status}).`);
     child = data.child;
-    lastSpawnedSpec = spec;
   }
   renderLauncherChild(child);
 
@@ -2553,12 +2570,9 @@ async function initStandalone() {
     launcherPortInput.onchange = () => localStorage.setItem(TGT_KEY('port'), launcherPortInput.value.trim());
     renderLauncherChild(st.child);
     lastChildState = st.child?.state || null;
-    if (st.child?.state === 'running' || st.child?.state === 'starting') {
-      // Adopt a survivor from a previous page load; assume it matches the form
-      // (the spec is persisted) so Start reuses it instead of respawning.
-      lastSpawnedSpec = launcherSpecInput.value.trim() || null;
-      if (st.child.state === 'running') adoptSpawnedChild(st.child);
-    }
+    // Adopt a running survivor's URL for probing/meta; whether Start reuses it
+    // is decided in ensureLocalServer against the child's own spawned spec.
+    if (st.child?.state === 'running') adoptSpawnedChild(st.child);
     startLauncherPolling();
   }
   onTargetChanged();

--- a/python/timbal/server/voice.html
+++ b/python/timbal/server/voice.html
@@ -875,11 +875,11 @@ const nsSelect = document.getElementById('ns-select');
 const micViz = document.getElementById('mic-viz');
 
 const TD_STORAGE_KEY = 'timbal-voice-turn-detector';
-// Default: Smart Turn + Namo (+ Silero VAD endpointing). Unknown stored values
-// fall back to that too (empty string used to mean "server default", which is
-// the same mode on a voice install).
-tdSelect.value = localStorage.getItem(TD_STORAGE_KEY) || 'local';
-if (![...tdSelect.options].some((o) => o.value === tdSelect.value)) tdSelect.value = 'local';
+// Default '' = server default: Smart Turn + Namo (+ Silero VAD endpointing) on
+// a voice install, lexical without the extra. Pinning 'local' here would skip
+// that server-side degradation (an explicit degraded 'local' is holdless).
+tdSelect.value = localStorage.getItem(TD_STORAGE_KEY) || '';
+if (![...tdSelect.options].some((o) => o.value === tdSelect.value)) tdSelect.value = '';
 tdSelect.onchange = () => {
   // Applied on the next Start (no reload) — modes are fixed per WebSocket hello.
   localStorage.setItem(TD_STORAGE_KEY, tdSelect.value);

--- a/python/timbal/server/voice.html
+++ b/python/timbal/server/voice.html
@@ -111,6 +111,7 @@
     flex-direction: column;
     gap: 0.3rem;
   }
+  .field[hidden] { display: none !important; }
   .field-label {
     font-size: 0.6875rem;
     font-weight: 600;
@@ -628,20 +629,24 @@
           </select>
         </label>
         <div id="target-local" class="target-fields">
-          <label class="field">
-            <span class="field-label">Server URL</span>
-            <input type="text" id="local-url" placeholder="http://localhost:4444" title="A running timbal.server — spawn one below or point at one you started yourself.">
-          </label>
           <div id="launcher-box" class="target-fields" hidden>
             <label class="field">
-              <span class="field-label">Import spec</span>
-              <input type="text" id="launcher-spec" placeholder="path/to/agent.py::agent" title="Runs `uv run python -m timbal.server --import_spec …` from the file's directory (relative paths resolve against the launcher's cwd).">
+              <span class="field-label">Agent</span>
+              <input type="text" id="launcher-spec" placeholder="path/to/agent.py::agent" title="Spawned automatically on Start: runs `uv run python -m timbal.server --import_spec …` from the file's directory (relative paths resolve against the launcher's cwd).">
+            </label>
+            <label class="field">
+              <span class="field-label">Port</span>
+              <input type="text" id="launcher-port" placeholder="auto" inputmode="numeric" title="Port for the spawned server. Leave empty to pick a free one automatically.">
             </label>
             <div class="launcher-row">
-              <button type="button" id="btn-launcher" data-action="spawn">Spawn server</button>
+              <button type="button" id="btn-launcher" hidden>Stop server</button>
               <span id="launcher-state" class="launcher-state"></span>
             </div>
           </div>
+          <label class="field" id="local-url-field">
+            <span class="field-label">Server URL</span>
+            <input type="text" id="local-url" placeholder="http://localhost:4444" title="A timbal.server you started yourself.">
+          </label>
         </div>
         <div id="target-platform" class="target-fields" hidden>
           <label class="field">
@@ -1065,8 +1070,10 @@ function renderModelOptions(preferred, agentDefault) {
 // --- Agent target (standalone mode) ---------------------------------------
 // Embedded pages keep dialing their own origin exactly as before. Standalone
 // pages route everything through one of two targets:
-//   local    — a timbal.server at an arbitrary URL, optionally spawned via
-//              the launcher endpoints on this page's own origin.
+//   local    — a timbal.server on this machine. Served by the playground
+//              launcher, pressing Start spawns it from the agent file path
+//              (optional fixed port); without the launcher (file://), you
+//              point at a server you started yourself by URL.
 //   platform — a deployed workforce through the Timbal platform API. Same
 //              wire protocol; the platform tunnels WS (ticket-authenticated)
 //              and relays RTC signaling (bearer-authenticated).
@@ -1075,10 +1082,16 @@ const targetModeSelect = document.getElementById('target-mode');
 const targetLocalBox = document.getElementById('target-local');
 const targetPlatformBox = document.getElementById('target-platform');
 const localUrlInput = document.getElementById('local-url');
+const localUrlField = document.getElementById('local-url-field');
 const launcherBox = document.getElementById('launcher-box');
 const launcherSpecInput = document.getElementById('launcher-spec');
+const launcherPortInput = document.getElementById('launcher-port');
 const btnLauncher = document.getElementById('btn-launcher');
 const launcherStateEl = document.getElementById('launcher-state');
+/** True when this page is served by the playground launcher (spawn-on-Start). */
+let launcherAvailable = false;
+/** Spec string the current child was spawned from — a mismatch respawns on Start. */
+let lastSpawnedSpec = null;
 const pf = {
   api: document.getElementById('pf-api'),
   org: document.getElementById('pf-org'),
@@ -1935,6 +1948,12 @@ async function start() {
   const gen = startGen;
   // Fail on incomplete platform config before prompting for the microphone.
   if (targetMode() === 'platform') validatePlatform(platformValues());
+  // Local target behind the launcher: spawn (or reuse) the agent server first,
+  // so the WS/RTC dial below lands on a healthy process.
+  if (targetMode() === 'local' && launcherAvailable) {
+    await ensureLocalServer();
+    if (gen !== startGen) return;
+  }
   setConn('connecting', 'Getting ready', 'Microphone and server connection…');
   userEndedSession = false;
   sessionReady = false;
@@ -2316,6 +2335,14 @@ let probeSeq = 0;
 /** Healthcheck + meta fetch against the local target; drives the strip and idle status. */
 async function probeLocal() {
   if (targetMode() !== 'local') return;
+  // Launcher mode with no child yet: nothing to probe — Start spawns it.
+  if (launcherAvailable && lastChildState !== 'running') {
+    applyMeta(null);
+    if (connVisual !== 'live' && connVisual !== 'connecting') {
+      setConn('ended', 'Ready', 'Pick an agent file, then press Start — the server is spawned for you.');
+    }
+    return;
+  }
   const seq = ++probeSeq;
   const base = localBase();
   const idle = () => connVisual !== 'live' && connVisual !== 'connecting';
@@ -2335,14 +2362,18 @@ async function probeLocal() {
   } catch (_) {
     if (seq !== probeSeq) return;
     applyMeta(null);
-    if (idle()) setConn('ended', 'No server', `Nothing answering at ${base}. Spawn one below or start it yourself, then press Start.`);
+    if (idle()) setConn('ended', 'No server', launcherAvailable
+      ? 'The spawned server is not answering — press Start to spawn it again.'
+      : `Nothing answering at ${base}. Start a timbal.server there, then press Start.`);
   }
 }
 
 // --- Launcher client (spawns `uv run python -m timbal.server` children) ----
 // Only reachable when this page is served by `python -m timbal.server.playground`
-// — the launcher endpoints live on the page's own origin. Opened from the
-// filesystem or elsewhere, the status probe fails and the spawn UI stays hidden.
+// — the launcher endpoints live on the page's own origin. Spawning is implicit:
+// pressing Start ensures a child for the agent path in the form (see
+// ensureLocalServer). Opened from the filesystem or elsewhere, the status probe
+// fails and the manual Server URL field is shown instead.
 let lastChildState = null;
 
 async function fetchLauncherStatus() {
@@ -2358,8 +2389,7 @@ async function fetchLauncherStatus() {
 function renderLauncherChild(child) {
   const state = child?.state || 'stopped';
   const stoppable = state === 'running' || state === 'starting';
-  btnLauncher.dataset.action = stoppable ? 'stop' : 'spawn';
-  btnLauncher.textContent = stoppable ? 'Stop server' : 'Spawn server';
+  btnLauncher.hidden = !stoppable; // spawning happens on Start, so the button only stops
   if (state === 'starting') {
     launcherStateEl.textContent = `Starting on port ${child.port}… (first run may pay a uv sync)`;
   } else if (state === 'running') {
@@ -2395,37 +2425,73 @@ function startLauncherPolling() {
 btnLauncher.onclick = async () => {
   btnLauncher.disabled = true;
   try {
-    if (btnLauncher.dataset.action === 'stop') {
-      const r = await fetch('/launcher/stop', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' });
-      renderLauncherChild((await r.json()).child);
-      void probeLocal();
-      return;
-    }
-    const spec = launcherSpecInput.value.trim();
-    if (!spec) {
-      launcherStateEl.textContent = 'Enter an import spec first (path/to/agent.py::object).';
-      return;
-    }
-    localStorage.setItem(TGT_KEY('spec'), spec);
-    const r = await fetch('/launcher/spawn', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ import_spec: spec }),
-    });
-    const data = await r.json();
-    if (!r.ok) {
-      launcherStateEl.textContent = data.error || `Spawn failed (${r.status}).`;
-      return;
-    }
-    renderLauncherChild(data.child);
-    adoptSpawnedChild(data.child);
-    lastChildState = data.child?.state || null;
+    const r = await fetch('/launcher/stop', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' });
+    renderLauncherChild((await r.json()).child);
+    lastSpawnedSpec = null;
+    void probeLocal();
   } catch (err) {
     launcherStateEl.textContent = String(err?.message || err);
   } finally {
     btnLauncher.disabled = false;
   }
 };
+
+/** Optional fixed port for the spawned child, or null for a launcher-picked free one. */
+function launcherPort() {
+  const raw = launcherPortInput.value.trim();
+  if (!raw) return null;
+  const p = parseInt(raw, 10);
+  if (!Number.isFinite(p) || p < 1 || p > 65535) throw new Error(`Invalid port: ${raw}`);
+  return p;
+}
+
+/**
+ * Spawn-on-Start: make sure the launcher child is running the agent currently
+ * in the form (respawning on spec/port changes) and healthy before dialing.
+ * Blocks through the child's `starting` phase — the first run of a project can
+ * pay a `uv sync`, so the deadline is generous.
+ */
+async function ensureLocalServer() {
+  const spec = launcherSpecInput.value.trim();
+  if (!spec) throw new Error('Enter an agent first (path/to/agent.py::object).');
+  const port = launcherPort();
+  localStorage.setItem(TGT_KEY('spec'), spec);
+
+  const st = await fetchLauncherStatus();
+  if (!st) throw new Error('Playground launcher is not reachable — restart `python -m timbal.server.playground`.');
+  let child = st.child;
+  const alive = child && (child.state === 'running' || child.state === 'starting');
+  if (!alive || spec !== lastSpawnedSpec || (port !== null && child.port !== port)) {
+    setConn('connecting', 'Spawning server', `uv run timbal.server — ${spec}`);
+    const r = await fetch('/launcher/spawn', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ import_spec: spec, ...(port !== null ? { port } : {}) }),
+    });
+    const data = await r.json();
+    if (!r.ok) throw new Error(data.error || `Spawn failed (${r.status}).`);
+    child = data.child;
+    lastSpawnedSpec = spec;
+  }
+  renderLauncherChild(child);
+
+  const deadline = Date.now() + 180_000;
+  while (child.state !== 'running') {
+    if (child.state === 'exited') {
+      const lastLog = (child.logs || []).filter(Boolean).slice(-1)[0] || '';
+      throw new Error(`Server exited (code ${child.exit_code}).${lastLog ? ` Last log: ${lastLog}` : ''}`);
+    }
+    if (child.state === 'stopped') throw new Error('Server was stopped before it became ready.');
+    if (Date.now() > deadline) throw new Error('Server did not become healthy in time — check its logs in the launcher terminal.');
+    setConn('connecting', 'Starting server', `Waiting for the agent on port ${child.port}… (first run may pay a uv sync)`);
+    await new Promise((res) => setTimeout(res, 500));
+    child = (await fetchLauncherStatus())?.child || { state: 'stopped' };
+    renderLauncherChild(child);
+  }
+  lastChildState = 'running';
+  adoptSpawnedChild(child);
+  void probeLocal();
+}
 
 function onTargetChanged() {
   probeSeq += 1; // cancel in-flight probes for the previous target
@@ -2478,11 +2544,21 @@ async function initStandalone() {
 
   const st = await fetchLauncherStatus();
   if (st) {
+    launcherAvailable = true;
     launcherBox.hidden = false;
+    localUrlField.hidden = true; // launcher mode: the URL is derived from the spawned child
     launcherSpecInput.value = localStorage.getItem(TGT_KEY('spec')) || st.launcher?.default_import_spec || '';
+    launcherPortInput.value = localStorage.getItem(TGT_KEY('port')) || '';
+    launcherSpecInput.onchange = () => localStorage.setItem(TGT_KEY('spec'), launcherSpecInput.value.trim());
+    launcherPortInput.onchange = () => localStorage.setItem(TGT_KEY('port'), launcherPortInput.value.trim());
     renderLauncherChild(st.child);
     lastChildState = st.child?.state || null;
-    if (st.child?.state === 'running') adoptSpawnedChild(st.child);
+    if (st.child?.state === 'running' || st.child?.state === 'starting') {
+      // Adopt a survivor from a previous page load; assume it matches the form
+      // (the spec is persisted) so Start reuses it instead of respawning.
+      lastSpawnedSpec = launcherSpecInput.value.trim() || null;
+      if (st.child.state === 'running') adoptSpawnedChild(st.child);
+    }
     startLauncherPolling();
   }
   onTargetChanged();

--- a/python/timbal/server/voice.py
+++ b/python/timbal/server/voice.py
@@ -306,6 +306,26 @@ async def voice_page(request: Request) -> HTMLResponse:
     return HTMLResponse(html)
 
 
+@router.get("/meta")
+async def voice_meta(request: Request) -> dict[str, Any]:
+    """Runnable identity + model catalog as JSON.
+
+    Same payload as the blob injected into the served HTML — this endpoint
+    exists for the *standalone* playground (opened from the launcher or the
+    filesystem), which can't get the injection and fetches it cross-origin
+    from whatever local server it's pointed at.
+    """
+    runnable = getattr(request.app.state, "runnable", None)
+    import_spec = os.environ.get("TIMBAL_RUNNABLE", "")
+    meta = (
+        runnable_meta_for_voice_page(runnable, import_spec)
+        if runnable is not None
+        else {"name": "", "kind": "", "import_spec": import_spec}
+    )
+    meta["version"] = timbal_version
+    return meta
+
+
 @router.get("/ambience")
 async def ambience_index() -> dict[str, Any]:
     """Preset catalog for the playground picker."""
@@ -378,22 +398,12 @@ def select_turn_detector_spec(server_spec: Any, client_spec: Any, *, stt_is_flux
     if spec is not None:
         return spec
 
-    # Nothing chosen. The holdless heuristic is the worst of the four on every
-    # backend that endpoints on silence — 65-69% against 96-100% for detectors
-    # that can hold — because Nova and ElevenLabs commit each fragment of a
-    # paused utterance separately, and only a hold puts them back together.
-    #
-    # The warmup path already resolved "local" for this case, so a server with no
-    # `turn_detector` configured was loading Smart Turn, Namo and Silero at
-    # startup and then handing the session a detector that used none of them.
-    #
-    # Without `timbal[voice]`, `local` returns the heuristic decision verbatim
-    # (its punctuation fallback sits behind the audio-EOU branch), so it would buy
-    # nothing; `lexical` holds an unfinished transcript with no extra deps. Asking
-    # the resolver beats probing imports: the degradation rule stays in one place.
+    # Nothing chosen — same rule as ``resolve_turn_detector(None)``: local when
+    # the voice extra is present, lexical otherwise. Never the holdless heuristic.
     from ..voice.turn_detection import resolve_turn_detector
 
-    mode = "local" if getattr(resolve_turn_detector("local"), "audio_eou", None) is not None else "lexical"
+    resolved = resolve_turn_detector(None)
+    mode = "local" if getattr(resolved, "audio_eou", None) is not None else "lexical"
     logger.info("voice_ws_default_turn_detector", using=mode)
     return mode
 
@@ -478,22 +488,22 @@ def build_voice_session(
     # may additionally select a *mode name* (string only — useful for A/B
     # testing detectors from the playground); instances and factories can never
     # come over the wire. When neither picks one, the server chooses by STT
-    # rather than taking ``resolve_turn_detector``'s zero-dep default, because
-    # only here is the STT's endpointing behaviour known.
+    # (Flux → provider; else the resolver default — local / lexical).
     turn_detector = None
     raw_td = select_turn_detector_spec(
         defaults.turn_detector,
         client_config.get("turn_detector"),
         stt_is_flux=stt_is_flux,
     )
-    if raw_td is not None:
-        try:
-            # voice_config is process-wide; VoiceSession clones the resolved
-            # detector so concurrent connections never share buffers/lifecycle.
-            turn_detector = resolve_turn_detector(raw_td)
-        except (TypeError, ValueError) as e:
-            logger.warning("voice_ws_bad_turn_detector", error=str(e))
-    turn_detector_label = type(turn_detector).__name__ if turn_detector is not None else "HeuristicTurnDetector"
+    try:
+        # voice_config is process-wide; VoiceSession clones the resolved
+        # detector so concurrent connections never share buffers/lifecycle.
+        # ``None`` / bad specs fall through to the resolver default (local).
+        turn_detector = resolve_turn_detector(raw_td)
+    except (TypeError, ValueError) as e:
+        logger.warning("voice_ws_bad_turn_detector", error=str(e))
+        turn_detector = resolve_turn_detector(None)
+    turn_detector_label = type(turn_detector).__name__
 
     # Optional bool: force the local VAD endpointing fast path on/off. Default
     # (absent / non-bool) is auto — on when the detector has an audio EOU model

--- a/python/timbal/voice/config.py
+++ b/python/timbal/voice/config.py
@@ -119,9 +119,11 @@ class VoiceConfig(BaseModel):
     encoding: str = "pcm_s16le"
     stt_extra: dict[str, Any] = Field(default_factory=_default_stt_extra)
     tts_extra: dict[str, Any] = Field(default_factory=lambda: {"auto_mode": True})
-    turn_detector: Any = None
+    turn_detector: Any = "local"
     """Mode name, ``TurnDetector`` instance, or zero-arg factory.
-    Clients may only send mode names (see ``select_turn_detector_spec``)."""
+    Default ``"local"`` (Smart Turn + Namo + Silero VAD endpointing when
+    ``timbal[voice]`` is installed). Clients may only send mode names
+    (see ``select_turn_detector_spec``)."""
     vad_endpointing: bool | None = None
     """None → auto: on when the turn detector exposes an audio EOU model."""
     model: str | None = None

--- a/python/timbal/voice/config.py
+++ b/python/timbal/voice/config.py
@@ -119,10 +119,12 @@ class VoiceConfig(BaseModel):
     encoding: str = "pcm_s16le"
     stt_extra: dict[str, Any] = Field(default_factory=_default_stt_extra)
     tts_extra: dict[str, Any] = Field(default_factory=lambda: {"auto_mode": True})
-    turn_detector: Any = "local"
+    turn_detector: Any = None
     """Mode name, ``TurnDetector`` instance, or zero-arg factory.
-    Default ``"local"`` (Smart Turn + Namo + Silero VAD endpointing when
-    ``timbal[voice]`` is installed). Clients may only send mode names
+    ``None`` (unset) resolves to ``"local"`` — Smart Turn + Namo + Silero VAD
+    endpointing — when ``timbal[voice]`` is installed, and degrades to
+    ``"lexical"`` without it (an explicit ``"local"`` pin would skip that
+    degradation and behave holdless). Clients may only send mode names
     (see ``select_turn_detector_spec``)."""
     vad_endpointing: bool | None = None
     """None → auto: on when the turn detector exposes an audio EOU model."""

--- a/python/timbal/voice/turn_detection.py
+++ b/python/timbal/voice/turn_detection.py
@@ -13,20 +13,15 @@ without session changes.
 
 **Modes** (see :func:`resolve_turn_detector`):
 
-* ``heuristic`` (resolver default) — :class:`HeuristicTurnDetector`, no extra deps
+* ``local`` (resolver default) — :class:`LocalAudioTurnDetector` + Smart Turn /
+  Namo when ``timbal[voice]`` is installed; falls back to ``lexical`` without
+  the extra (never the holdless heuristic)
 * ``provider`` — :class:`ProviderTurnDetector`, trust STT/realtime endpointing
-* ``local`` — :class:`LocalAudioTurnDetector` + injectable :class:`AudioEouModel`
 * ``lexical`` — :class:`LexicalTurnDetector`, optional zero-dep text overlay
+* ``heuristic`` — :class:`HeuristicTurnDetector`, no holds (opt-in only)
 
-``heuristic`` is the resolver's default only because it is the one mode that
-needs no extras and makes no assumption about the STT. It is *not* the best
-choice: it cannot hold, so on any STT that endpoints on silence it splits a
-paused utterance into several turns (``benchmarks/voice`` measures 65-69% on
-Nova and ElevenLabs against 96-100% for the holding modes). Pick by STT —
-``provider`` for Deepgram Flux, ``local`` (or ``lexical`` without the
-``timbal[voice]`` extra) for everything else. :mod:`timbal.server.voice` does
-this for you; direct :class:`~timbal.voice.session.VoiceSession` users should
-pass ``turn_detector=`` explicitly.
+Pick by STT when overriding: ``provider`` for Deepgram Flux (the server forces
+this automatically), ``local`` for everything else.
 
 Provider-native paths (OpenAI ``semantic_vad``, ElevenLabs Scribe VAD commits,
 Deepgram Flux, Gemini Live) map to ``provider`` or a future realtime session
@@ -1307,25 +1302,44 @@ _TEXT_EOU_UNSET: Any = object()
 _DEFAULT_TEXT_EOU: TextEouPredictor | Any = _TEXT_EOU_UNSET
 
 
+def _default_turn_detector() -> TurnDetector:
+    """Smart Turn + Namo when ``timbal[voice]`` is present, else lexical.
+
+    ``local`` without an audio EOU model collapses to the holdless heuristic
+    decision path, so without the extra we pick ``lexical`` (can HOLD, no deps)
+    rather than a degraded ``local``.
+    """
+    local = LocalAudioTurnDetector(
+        audio_eou=_default_audio_eou(),
+        fallback_text_eou=_default_text_eou(),
+    )
+    if getattr(local, "audio_eou", None) is not None:
+        return local
+    return LexicalTurnDetector(text_eou=_default_text_eou())
+
+
 def resolve_turn_detector(spec: Any = None) -> TurnDetector:
     """Build a :class:`TurnDetector` from a name, instance, factory, or ``None``.
 
-    Accepted names: ``heuristic`` (default), ``provider``, ``local``, ``lexical``,
+    Accepted names: ``local`` (default), ``provider``, ``lexical``, ``heuristic``,
     ``raw`` (debug: no silence/noise/echo filtering at all).
-    ``local`` auto-loads Smart Turn (audio) + Namo (text) when the
-    ``timbal[voice]`` extra is installed (heuristic / punctuation degradation
-    otherwise). Instances are returned unchanged — callers that reuse one spec
-    across concurrent sessions (server ``voice_config``) must
-    :meth:`~TurnDetector.clone` per session, or pass a zero-arg factory
-    callable instead.
+    ``None`` / ``""`` / ``"default"`` resolve to :func:`_default_turn_detector`
+    (Smart Turn + Namo when ``timbal[voice]`` is installed, else lexical).
+    ``local`` auto-loads Smart Turn (audio) + Namo (text) when the extra is
+    installed (heuristic / punctuation degradation otherwise). Instances are
+    returned unchanged — callers that reuse one spec across concurrent sessions
+    (server ``voice_config``) must :meth:`~TurnDetector.clone` per session, or
+    pass a zero-arg factory callable instead.
     """
     if spec is None:
-        return HeuristicTurnDetector()
+        return _default_turn_detector()
     if isinstance(spec, TurnDetector):
         return spec
     if isinstance(spec, str):
         key = spec.strip().lower()
-        if key in ("", "heuristic", "default"):
+        if key in ("", "default"):
+            return _default_turn_detector()
+        if key == "heuristic":
             return HeuristicTurnDetector()
         if key in ("provider", "stt"):
             return ProviderTurnDetector()
@@ -1340,7 +1354,7 @@ def resolve_turn_detector(spec: Any = None) -> TurnDetector:
             return RawTurnDetector()
         raise ValueError(
             f"Unknown turn_detector {spec!r}; expected one of "
-            "'heuristic', 'provider', 'local', 'lexical', 'raw', a TurnDetector "
+            "'local', 'provider', 'lexical', 'heuristic', 'raw', a TurnDetector "
             "instance, or a zero-arg factory returning one"
         )
     if callable(spec):


### PR DESCRIPTION
…cal defaults

voice.html now opens without a server underneath: a stdlib-only launcher (`python -m timbal.server.playground`) serves it raw and spawns/stops `uv run python -m timbal.server` children on demand. The page detects standalone mode (meta placeholder intact) and adds a Target panel — a local timbal.server by URL/spawn, or a deployed workforce through the platform (single-use ticket WS auth, bearer-authenticated RTC signaling, voice/preview variant). New GET /voice/meta exposes runnable identity + model catalog for cross-origin pickup; embedded GET /voice is unchanged.

Defaults change too: resolve_turn_detector(None) now returns Smart Turn + Namo (lexical without timbal[voice]) instead of the holdless heuristic, VoiceConfig.turn_detector defaults to "local", and the playground dials WebRTC first. Session-mechanics tests pin "heuristic" explicitly since they script STT text with no real mic audio.