### PR TITLE
fix(tool): avoid chaining CredentialNotAvailable into unrelated proxy…

### DIFF
--- a/python/tests/platform/test_tool_proxy.py
+++ b/python/tests/platform/test_tool_proxy.py
@@ -380,6 +380,73 @@ async def test_tool_proxy_other_4xx_surfaces_platform_error():
 
 
 @pytest.mark.asyncio
+async def test_tool_proxy_failure_traceback_not_chained_to_credential_error():
+    """A proxy failure unrelated to credentials must not carry the earlier
+    CredentialNotAvailable as implicit exception context — it makes the trace
+    traceback read as an auth problem when the real error is downstream."""
+    run_context = RunContext(platform_config=_platform_config(), tracing_provider=None)
+    set_run_context(run_context)
+
+    async def _handler(url: str) -> dict:
+        from timbal.tools._creds import resolve_api_key
+
+        await resolve_api_key(
+            provider_name="Firecrawl",
+            env_var="FIRECRAWL_API_KEY",
+            integration=None,
+            api_key=None,
+        )
+        return {"url": url}
+
+    tool = Tool(name="firecrawl_scrape", handler=_handler, tracing_provider=None)
+
+    with patch(
+        "timbal.core.tool.execute_tool_proxy",
+        new_callable=AsyncMock,
+        side_effect=PlatformError("bad request", status_code=400),
+    ):
+        result = await tool(url="https://example.com").collect()
+
+    assert result.status.code == "error"
+    assert result.error is not None
+    assert result.error["type"] == "PlatformError"
+    assert "CredentialNotAvailable" not in result.error["traceback"]
+    assert "credentials not found" not in result.error["traceback"]
+
+
+@pytest.mark.asyncio
+async def test_tool_proxy_failure_exception_context_is_clean():
+    """Direct check on the raised exception: __context__ must not be the
+    credential error that triggered the proxy fallback."""
+    run_context = RunContext(platform_config=_platform_config(), tracing_provider=None)
+    set_run_context(run_context)
+
+    from timbal.errors import CredentialNotAvailable
+
+    async def _handler(url: str) -> dict:  # noqa: ARG001
+        raise CredentialNotAvailable("Firecrawl", env_vars=["FIRECRAWL_API_KEY"])
+
+    tool = Tool(name="firecrawl_scrape", handler=_handler, tracing_provider=None)
+    validated_input = {"url": "https://example.com"}
+
+    with patch(
+        "timbal.core.tool.execute_tool_proxy",
+        new_callable=AsyncMock,
+        side_effect=PlatformError("bad request", status_code=400),
+    ):
+        with pytest.raises(PlatformError) as exc_info:
+            async for _ in tool._execute_handler(validated_input, run_context, None):
+                pass
+
+    chain = []
+    exc = exc_info.value
+    while exc is not None:
+        chain.append(type(exc).__name__)
+        exc = exc.__context__
+    assert "CredentialNotAvailable" not in chain
+
+
+@pytest.mark.asyncio
 async def test_tool_collect_passes_run_call_id_in_proxy_headers():
     run_context = RunContext(platform_config=_platform_config(), tracing_provider=None)
     set_run_context(run_context)

--- a/python/timbal/core/tool.py
+++ b/python/timbal/core/tool.py
@@ -142,27 +142,37 @@ class Tool(Runnable):
         ``ToolProxyUnavailable`` so the user fixes platform setup rather than
         local provider credentials.
         """
+        cred_error: CredentialNotAvailable | None = None
         try:
             async for event, final_output, collector in super()._execute_handler(
                 validated_input, run_context, span, event_queue
             ):
                 yield (event, final_output, collector)
-        except CredentialNotAvailable as cred_error:
-            try:
-                output = await execute_tool_proxy(self.name, validated_input)
-            except ToolProxyUnavailable:
-                if run_context.platform_config is None:
-                    # Local run without platform config — fall back to credential error.
-                    raise cred_error from None
-                raise
-            except PlatformError as proxy_error:
-                # 403 is what the platform returns when no proxy is available for this
-                # tool (no service-account credentials configured). 404/501 are kept as
-                # fallbacks. In all these cases, surface the actionable credential error.
-                if proxy_error.status_code in (403, 404, 501):
-                    raise cred_error from None
-                raise
-            yield (None, output, None)
+        except CredentialNotAvailable as e:
+            # Capture and fall through instead of calling the proxy here: anything
+            # raised inside this except block would implicitly chain the credential
+            # error as __context__, making unrelated proxy failures read as auth
+            # problems in tracebacks.
+            cred_error = e
+
+        if cred_error is None:
+            return
+
+        try:
+            output = await execute_tool_proxy(self.name, validated_input)
+        except ToolProxyUnavailable:
+            if run_context.platform_config is None:
+                # Local run without platform config — fall back to credential error.
+                raise cred_error from None
+            raise
+        except PlatformError as proxy_error:
+            # 403 is what the platform returns when no proxy is available for this
+            # tool (no service-account credentials configured). 404/501 are kept as
+            # fallbacks. In all these cases, surface the actionable credential error.
+            if proxy_error.status_code in (403, 404, 501):
+                raise cred_error from None
+            raise
+        yield (None, output, None)
 
     @override
     def nest(self, parent_path: str) -> None:


### PR DESCRIPTION
… failures

Move the execute_tool_proxy() fallback out of the except block's dynamic scope so downstream proxy errors no longer pick up the credential error as implicit __context__, which made trace tracebacks read as auth problems. The 403/404/501 raise-cred_error-from-None branches are unchanged. Adds regression tests asserting the traceback and exception context stay clean.