### PR TITLE
feat(playground): enable WebRTC on platform voice preview

### DIFF
--- a/python/timbal/server/voice.html
+++ b/python/timbal/server/voice.html
@@ -2217,13 +2217,24 @@ function handleServerMessage(msg) {
 
 async function startRtc(gen) {
   const isPlatform = targetMode() === 'platform';
-  const isPreview = isPlatform && platformValues().endpoint === 'preview';
+  // One snapshot for the whole dial: the ICE-gathering wait below yields for
+  // seconds, and form edits during it must not mix endpoint/rev/token between
+  // reads — changes apply on the next Start.
+  const pv = isPlatform ? platformValues() : null;
+  if (pv) validatePlatform(pv);
+  const isPreview = !!pv && pv.endpoint === 'preview';
   setConn('connecting', 'Connecting', isPreview
     ? 'Negotiating WebRTC against the branch worktree (first call after a source edit pays a uv sync — up to ~2 min)…'
     : isPlatform
       ? 'Negotiating WebRTC through the platform (box spawn can take up to ~30 s)…'
       : 'Negotiating WebRTC with the server…');
-  pc = new RTCPeerConnection();
+  // Platform answers are relay-only — the relay only accepts traffic from
+  // addresses it saw in the offer. Without STUN the browser offers private
+  // LAN addresses, connectivity checks die ~15 s after a "successful" answer,
+  // and nothing surfaces an error. STUN only; no TURN credentials on our side.
+  pc = new RTCPeerConnection({
+    iceServers: [{ urls: 'stun:turn.timbal.ai:3478' }],
+  });
   const conn = pc;
 
   // Raw mic track (browser AEC/NS applied via getUserMedia constraints). The
@@ -2291,13 +2302,11 @@ async function startRtc(gen) {
   if (targetMode() === 'local') {
     rtcUrl = localBase() + '/voice/rtc';
   } else if (isPlatform) {
-    const v = platformValues();
-    validatePlatform(v);
     // Same signaling contract on both endpoints — preview just sources the
     // branch worktree instead of a deployment (POST + offer selects RTC there).
     const path = isPreview ? 'voice/preview' : 'voice/rtc';
-    rtcUrl = `${platformBase(v)}/${path}?rev=${encodeURIComponent(v.rev)}`;
-    rtcHeaders.Authorization = `Bearer ${v.token}`;
+    rtcUrl = `${platformBase(pv)}/${path}?rev=${encodeURIComponent(pv.rev)}`;
+    rtcHeaders.Authorization = `Bearer ${pv.token}`;
   }
   const resp = await fetch(rtcUrl, {
     method: 'POST',

--- a/python/timbal/server/voice.html
+++ b/python/timbal/server/voice.html
@@ -675,7 +675,7 @@
           </label>
           <label class="field">
             <span class="field-label">Endpoint</span>
-            <select id="pf-endpoint" title="Deployed dials the running deployment for the branch. Preview runs the branch worktree instead (WS only; first connect after a source change pays uv sync).">
+            <select id="pf-endpoint" title="Deployed dials the running deployment for the branch. Preview runs the branch worktree instead — edit the agent, call it immediately (first connect after a source change pays a uv sync; needs timbal >= 2.3.2 on the branch for WebRTC).">
               <option value="deployed">Deployed</option>
               <option value="preview">Preview (branch worktree)</option>
             </select>
@@ -2217,12 +2217,12 @@ function handleServerMessage(msg) {
 
 async function startRtc(gen) {
   const isPlatform = targetMode() === 'platform';
-  if (isPlatform && platformValues().endpoint === 'preview') {
-    throw new Error('WebRTC is not available on voice/preview — switch the transport to WebSocket.');
-  }
-  setConn('connecting', 'Connecting', isPlatform
-    ? 'Negotiating WebRTC through the platform (box spawn can take up to ~30 s)…'
-    : 'Negotiating WebRTC with the server…');
+  const isPreview = isPlatform && platformValues().endpoint === 'preview';
+  setConn('connecting', 'Connecting', isPreview
+    ? 'Negotiating WebRTC against the branch worktree (first call after a source edit pays a uv sync — up to ~2 min)…'
+    : isPlatform
+      ? 'Negotiating WebRTC through the platform (box spawn can take up to ~30 s)…'
+      : 'Negotiating WebRTC with the server…');
   pc = new RTCPeerConnection();
   const conn = pc;
 
@@ -2293,7 +2293,10 @@ async function startRtc(gen) {
   } else if (isPlatform) {
     const v = platformValues();
     validatePlatform(v);
-    rtcUrl = `${platformBase(v)}/voice/rtc?rev=${encodeURIComponent(v.rev)}`;
+    // Same signaling contract on both endpoints — preview just sources the
+    // branch worktree instead of a deployment (POST + offer selects RTC there).
+    const path = isPreview ? 'voice/preview' : 'voice/rtc';
+    rtcUrl = `${platformBase(v)}/${path}?rev=${encodeURIComponent(v.rev)}`;
     rtcHeaders.Authorization = `Bearer ${v.token}`;
   }
   const resp = await fetch(rtcUrl, {
@@ -2309,11 +2312,15 @@ async function startRtc(gen) {
     let detail = `Server answered ${resp.status}.`;
     try { detail = (await resp.json()).error || detail; } catch (_) {}
     if (resp.status === 501) {
-      detail += isPlatform
-        ? ' The deployed timbal lacks the voice extra (needs timbal[voice] >= 2.3.2).'
-        : ' Install it: uv pip install "timbal[voice]".';
+      detail += isPreview
+        ? ' The branch pins a timbal without RTC preview support — bump it to timbal >= 2.3.2.'
+        : isPlatform
+          ? ' The deployed timbal lacks the voice extra (needs timbal[voice] >= 2.3.2).'
+          : ' Install it: uv pip install "timbal[voice]".';
     }
-    if (isPlatform && resp.status === 404) detail += ' No running deployment for that branch?';
+    if (isPlatform && resp.status === 404) {
+      detail += isPreview ? ' Check org/project/workforce and the branch (rev).' : ' No running deployment for that branch?';
+    }
     const err = new Error(detail);
     err.rtcUnsupported = resp.status === 501;
     throw err;
@@ -2330,11 +2337,10 @@ async function startRtc(gen) {
 // --- Standalone bootstrap --------------------------------------------------
 
 function syncTransportForTarget() {
-  // Preview tunnels WebSocket only — there is no RTC preview today.
-  const preview = !EMBEDDED && targetModeSelect.value === 'platform' && pf.endpoint.value === 'preview';
+  // Both transports work on every target now (preview gained RTC signaling:
+  // POST + SDP offer on the same voice/preview URL) — nothing to disable.
   const rtcOpt = [...transportSelect.options].find((o) => o.value === 'webrtc');
-  if (rtcOpt) rtcOpt.disabled = preview;
-  if (preview && transportSelect.value === 'webrtc') transportSelect.value = 'ws';
+  if (rtcOpt) rtcOpt.disabled = false;
   syncNsForTransport();
 }
 


### PR DESCRIPTION
The platform's voice/preview endpoint now accepts RTC signaling (POST + SDP offer on the same URL, bearer auth), so stop disabling the WebRTC transport for Preview and route the offer there. Preview-specific status/error copy: first call after a source edit pays a uv sync (~2 min), 501 means the branch pins timbal < 2.3.2, and 404 no longer suggests a missing deployment.