### PR TITLE
feat(voice): answer phone calls — Twilio + Telnyx media stream bridges

### DIFF
--- a/python/tests/server/test_voice_telephony.py
+++ b/python/tests/server/test_voice_telephony.py
@@ -427,6 +427,15 @@ class TestTelnyxWebhook:
         assert ok.status_code == 200
         assert bad.status_code == 403
 
+    def test_missing_cryptography_fails_closed(self, monkeypatch) -> None:
+        """Key set + cryptography unimportable must reject, not bypass auth."""
+        import sys
+
+        from timbal.server.telephony import _telnyx_signature_ok
+
+        monkeypatch.setitem(sys.modules, "cryptography.exceptions", None)
+        assert _telnyx_signature_ok(b"body", "123", base64.b64encode(b"\x00" * 64).decode(), "notakey") is False
+
 
 class TestUlawWire:
     def test_media_payload_is_valid_ulaw(self, monkeypatch, tmp_path) -> None:

--- a/python/tests/server/test_voice_telephony.py
+++ b/python/tests/server/test_voice_telephony.py
@@ -1,0 +1,451 @@
+"""End-to-end tests for the telephony routes (Twilio + Telnyx).
+
+Mocks ElevenLabs STT/TTS at the module boundary (like ``test_voice_ws``) so
+the full media-WS bridge — start-frame handshake, μ-law decode/encode,
+resampling, mark bookkeeping — is exercised through a real Starlette
+TestClient WebSocket speaking each provider's dialect.
+"""
+
+# ruff: noqa: ARG002
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import hmac
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from timbal.server.http import create_app
+from timbal.voice import (
+    AudioInputConfig,
+    AudioOutputConfig,
+    SpeechToText,
+    TextToSpeech,
+    TranscriptEvent,
+)
+from timbal.voice.telephony import ulaw_decode
+
+from .voice_env import VOICE_ENV_KEYS
+
+# ---------------------------------------------------------------------------
+# Mocks (constructor-compatible with the ElevenLabs classes)
+# ---------------------------------------------------------------------------
+
+
+def _make_stt_class(script: list[TranscriptEvent] | None = None):
+    """STT that replays *script* on connect(), then ends the event stream."""
+    _script = list(script or [])
+
+    class _STT(SpeechToText):
+        pushed: list[bytes] = []
+
+        def __init__(self, api_key=None):
+            self._queue: asyncio.Queue[TranscriptEvent | None] = asyncio.Queue()
+
+        async def connect(self, config: AudioInputConfig) -> None:
+            for ev in _script:
+                await self._queue.put(ev)
+            await self._queue.put(None)
+
+        async def push_audio(self, chunk: bytes) -> None:
+            type(self).pushed.append(chunk)
+
+        async def commit(self) -> None:
+            pass
+
+        async def events(self) -> AsyncIterator[TranscriptEvent]:
+            while True:
+                item = await self._queue.get()
+                if item is None:
+                    break
+                if item.text:
+                    yield item
+
+        async def close(self) -> None:
+            pass
+
+    return _STT
+
+
+def _make_manual_stt_class():
+    """STT whose event stream ends only when the session closes it."""
+
+    class _STT(SpeechToText):
+        pushed: list[bytes] = []
+
+        def __init__(self, api_key=None):
+            self._queue: asyncio.Queue[None] = asyncio.Queue()
+
+        async def connect(self, config: AudioInputConfig) -> None:
+            pass
+
+        async def push_audio(self, chunk: bytes) -> None:
+            type(self).pushed.append(chunk)
+
+        async def commit(self) -> None:
+            pass
+
+        async def events(self) -> AsyncIterator[TranscriptEvent]:
+            while True:
+                if await self._queue.get() is None:
+                    break
+                yield  # pragma: no cover
+
+        async def close(self) -> None:
+            await self._queue.put(None)
+
+    return _STT
+
+
+def _make_tts_class(chunk: bytes, num_chunks: int = 2):
+    class _TTS(TextToSpeech):
+        def __init__(self, api_key=None):
+            pass
+
+        async def connect(self, config: AudioOutputConfig) -> None:
+            pass
+
+        async def synthesize(self, text: str) -> AsyncIterator[bytes]:
+            for _ in range(num_chunks):
+                yield chunk
+
+        async def close(self) -> None:
+            pass
+
+    return _TTS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_agent_module(tmp_path: Path) -> str:
+    mod = tmp_path / "phone_agent.py"
+    mod.write_text(
+        "from timbal import Agent\n"
+        "from timbal.core.test_model import TestModel\n"
+        "agent = Agent(name='phone_test', model=TestModel(responses=['Hi there!']), tools=[])\n"
+    )
+    return f"{mod.resolve()}::agent"
+
+
+def _setup_app(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, stt_cls, tts_cls):
+    monkeypatch.setenv("TIMBAL_RUNNABLE", _write_agent_module(tmp_path))
+    for k in VOICE_ENV_KEYS:
+        monkeypatch.delenv(k, raising=False)
+    monkeypatch.delenv("TWILIO_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("TELNYX_PUBLIC_KEY", raising=False)
+    monkeypatch.setattr("timbal.voice.elevenlabs.ElevenLabsRealtimeSTT", stt_cls)
+    monkeypatch.setattr("timbal.voice.elevenlabs.ElevenLabsStreamTTS", tts_cls)
+    return create_app()
+
+
+def _collect_frames(ws) -> list[dict]:
+    frames: list[dict] = []
+    while True:
+        try:
+            frames.append(ws.receive_json())
+        except Exception:
+            break
+    return frames
+
+
+def _twilio_start_frame(custom: dict | None = None) -> dict:
+    return {
+        "event": "start",
+        "sequenceNumber": "1",
+        "streamSid": "MZ_test_stream",
+        "start": {
+            "accountSid": "AC_test",
+            "callSid": "CA_test_call",
+            "tracks": ["inbound"],
+            "customParameters": {"turn_detector": "heuristic", **(custom or {})},
+            "mediaFormat": {"encoding": "audio/x-mulaw", "sampleRate": 8000, "channels": 1},
+        },
+    }
+
+
+def _telnyx_start_frame() -> dict:
+    return {
+        "event": "start",
+        "sequence_number": "1",
+        "stream_id": "tx-stream-1",
+        "start": {
+            "user_id": "u-1",
+            "call_control_id": "v2:CC_test",
+            "from": "+13120000001",
+            "to": "+13120000002",
+            "custom_parameters": {"turn_detector": "heuristic"},
+            "media_format": {"encoding": "PCMU", "sample_rate": 8000, "channels": 1},
+        },
+    }
+
+
+# 100ms of PCM16 @ 16kHz per TTS chunk → ~800 μ-law bytes downlink per chunk.
+_TTS_CHUNK = b"\x00\x01" * 1600
+
+
+# ---------------------------------------------------------------------------
+# Media WS bridge
+# ---------------------------------------------------------------------------
+
+
+class TestTwilioBridge:
+    def test_turn_produces_media_and_marks(self, monkeypatch, tmp_path) -> None:
+        pytest.importorskip("av")
+        stt_cls = _make_stt_class([TranscriptEvent(type="committed", text="Hello")])
+        app = _setup_app(monkeypatch, tmp_path, stt_cls, _make_tts_class(_TTS_CHUNK))
+
+        with TestClient(app) as client, client.websocket_connect("/voice/twilio/stream") as ws:
+            ws.send_json({"event": "connected", "protocol": "Call", "version": "1.0.0"})
+            ws.send_json(_twilio_start_frame())
+            frames = _collect_frames(ws)
+
+        media = [f for f in frames if f["event"] == "media"]
+        marks = [f for f in frames if f["event"] == "mark"]
+        assert media, f"no media frames in {[f['event'] for f in frames]}"
+        assert all(f["streamSid"] == "MZ_test_stream" for f in media + marks)
+
+        # Two 100ms TTS chunks → ~1600 μ-law bytes total on the wire.
+        total_ulaw = sum(len(base64.b64decode(f["media"]["payload"])) for f in media)
+        assert 1300 <= total_ulaw <= 1900
+
+        # Marks ride cumulative byte counts and pair 1:1 with media frames.
+        assert len(marks) == len(media)
+        names = [int(f["mark"]["name"]) for f in marks]
+        assert names == sorted(names)
+        assert names[-1] == total_ulaw
+
+        # Session teardown may fire a trailing clear (audio still "playing"
+        # when the session ends counts as an interruption) — but no clear may
+        # interrupt the media mid-stream.
+        events = [f["event"] for f in frames]
+        last_media = max(i for i, e in enumerate(events) if e == "media")
+        assert "clear" not in events[:last_media]
+
+    def test_uplink_audio_reaches_stt_resampled(self, monkeypatch, tmp_path) -> None:
+        pytest.importorskip("av")
+        stt_cls = _make_manual_stt_class()
+        app = _setup_app(monkeypatch, tmp_path, stt_cls, _make_tts_class(_TTS_CHUNK))
+
+        # 40ms of μ-law silence @8k → 640 PCM bytes → ~1280 bytes at 16k.
+        payload = base64.b64encode(b"\xff" * 320).decode()
+        with TestClient(app) as client, client.websocket_connect("/voice/twilio/stream") as ws:
+            ws.send_json({"event": "connected"})
+            ws.send_json(_twilio_start_frame())
+            ws.send_json({
+                "event": "media",
+                "streamSid": "MZ_test_stream",
+                "media": {"track": "inbound", "chunk": "1", "timestamp": "5", "payload": payload},
+            })
+            ws.send_json({"event": "stop", "streamSid": "MZ_test_stream", "stop": {}})
+            _collect_frames(ws)
+
+        pushed = b"".join(stt_cls.pushed)
+        assert 1100 <= len(pushed) <= 1300
+        # μ-law 0xFF decodes to digital zero — silence in, silence out.
+        assert set(pushed) == {0}
+
+    def test_outbound_track_media_is_ignored(self, monkeypatch, tmp_path) -> None:
+        pytest.importorskip("av")
+        stt_cls = _make_manual_stt_class()
+        app = _setup_app(monkeypatch, tmp_path, stt_cls, _make_tts_class(_TTS_CHUNK))
+
+        payload = base64.b64encode(b"\xff" * 320).decode()
+        with TestClient(app) as client, client.websocket_connect("/voice/twilio/stream") as ws:
+            ws.send_json(_twilio_start_frame())
+            ws.send_json({
+                "event": "media",
+                "streamSid": "MZ_test_stream",
+                "media": {"track": "outbound", "payload": payload},
+            })
+            ws.send_json({"event": "stop", "streamSid": "MZ_test_stream", "stop": {}})
+            _collect_frames(ws)
+
+        assert stt_cls.pushed == []
+
+    def test_no_start_frame_closes_socket(self, monkeypatch, tmp_path) -> None:
+        stt_cls = _make_stt_class([])
+        app = _setup_app(monkeypatch, tmp_path, stt_cls, _make_tts_class(_TTS_CHUNK))
+
+        with TestClient(app) as client, client.websocket_connect("/voice/twilio/stream") as ws:
+            # A frame that is not a start → handshake keeps scanning; closing
+            # the socket from our side must not hang the handler.
+            ws.send_json({"event": "connected"})
+            ws.close()
+
+    def test_unsupported_encoding_rejected(self, monkeypatch, tmp_path) -> None:
+        stt_cls = _make_stt_class([])
+        app = _setup_app(monkeypatch, tmp_path, stt_cls, _make_tts_class(_TTS_CHUNK))
+
+        frame = _twilio_start_frame()
+        frame["start"]["mediaFormat"]["encoding"] = "audio/l16"
+        with TestClient(app) as client, client.websocket_connect("/voice/twilio/stream") as ws:
+            ws.send_json(frame)
+            frames = _collect_frames(ws)
+        assert frames == []  # closed without any media
+
+
+class TestTelnyxBridge:
+    def test_turn_produces_media_and_marks_in_telnyx_dialect(self, monkeypatch, tmp_path) -> None:
+        pytest.importorskip("av")
+        stt_cls = _make_stt_class([TranscriptEvent(type="committed", text="Hello")])
+        app = _setup_app(monkeypatch, tmp_path, stt_cls, _make_tts_class(_TTS_CHUNK))
+
+        with TestClient(app) as client, client.websocket_connect("/voice/telnyx/stream") as ws:
+            ws.send_json({"event": "connected", "version": "1.0.0"})
+            ws.send_json(_telnyx_start_frame())
+            frames = _collect_frames(ws)
+
+        media = [f for f in frames if f["event"] == "media"]
+        marks = [f for f in frames if f["event"] == "mark"]
+        assert media
+        assert len(marks) == len(media)
+        # Telnyx client frames carry no stream id.
+        assert all("stream_id" not in f and "streamSid" not in f for f in media + marks)
+        # Telnyx requires >=20ms per RTP chunk (160 bytes of μ-law @8k).
+        assert all(len(base64.b64decode(f["media"]["payload"])) >= 160 for f in media)
+
+    def test_uplink_snake_case_media(self, monkeypatch, tmp_path) -> None:
+        pytest.importorskip("av")
+        stt_cls = _make_manual_stt_class()
+        app = _setup_app(monkeypatch, tmp_path, stt_cls, _make_tts_class(_TTS_CHUNK))
+
+        payload = base64.b64encode(b"\xff" * 320).decode()
+        with TestClient(app) as client, client.websocket_connect("/voice/telnyx/stream") as ws:
+            ws.send_json(_telnyx_start_frame())
+            ws.send_json({
+                "event": "media",
+                "sequence_number": "2",
+                "stream_id": "tx-stream-1",
+                "media": {"track": "inbound", "chunk": 1, "timestamp": "5", "payload": payload},
+            })
+            ws.send_json({"event": "stop", "sequence_number": "3", "stream_id": "tx-stream-1", "stop": {}})
+            _collect_frames(ws)
+
+        assert len(b"".join(stt_cls.pushed)) > 0
+
+
+# ---------------------------------------------------------------------------
+# Webhooks
+# ---------------------------------------------------------------------------
+
+
+def _twilio_signature(url: str, params: dict[str, str], token: str) -> str:
+    payload = url + "".join(k + v for k, v in sorted(params.items()))
+    return base64.b64encode(hmac.new(token.encode(), payload.encode(), hashlib.sha1).digest()).decode()
+
+
+class TestTwilioWebhook:
+    def test_returns_twiml_pointing_at_stream_ws(self, monkeypatch, tmp_path) -> None:
+        app = _setup_app(monkeypatch, tmp_path, _make_stt_class([]), _make_tts_class(_TTS_CHUNK))
+        with TestClient(app) as client:
+            r = client.post(
+                "/voice/twilio/incoming",
+                data={"CallSid": "CA123", "From": "+15550001111", "To": "+15550002222"},
+            )
+        assert r.status_code == 200
+        assert r.headers["content-type"].startswith("application/xml")
+        assert "<Connect><Stream url=" in r.text
+        assert "ws://testserver/voice/twilio/stream" in r.text
+        # Caller metadata tunnels through custom parameters.
+        assert '<Parameter name="from" value="+15550001111" />' in r.text
+        assert '<Parameter name="call_sid" value="CA123" />' in r.text
+
+    def test_https_proxy_yields_wss_url(self, monkeypatch, tmp_path) -> None:
+        app = _setup_app(monkeypatch, tmp_path, _make_stt_class([]), _make_tts_class(_TTS_CHUNK))
+        with TestClient(app) as client:
+            r = client.post(
+                "/voice/twilio/incoming",
+                data={"CallSid": "CA123"},
+                headers={"x-forwarded-proto": "https", "x-forwarded-host": "phone.example.com"},
+            )
+        assert "wss://phone.example.com/voice/twilio/stream" in r.text
+
+    def test_signature_enforced_when_token_set(self, monkeypatch, tmp_path) -> None:
+        app = _setup_app(monkeypatch, tmp_path, _make_stt_class([]), _make_tts_class(_TTS_CHUNK))
+        monkeypatch.setenv("TWILIO_AUTH_TOKEN", "secret-token")
+        params = {"CallSid": "CA123", "From": "+15550001111"}
+        good = _twilio_signature("http://testserver/voice/twilio/incoming", params, "secret-token")
+
+        with TestClient(app) as client:
+            ok = client.post("/voice/twilio/incoming", data=params, headers={"X-Twilio-Signature": good})
+            bad = client.post("/voice/twilio/incoming", data=params, headers={"X-Twilio-Signature": "nope"})
+            missing = client.post("/voice/twilio/incoming", data=params)
+        assert ok.status_code == 200
+        assert bad.status_code == 403
+        assert missing.status_code == 403
+
+
+class TestTelnyxWebhook:
+    def test_returns_texml_with_rtp_mode(self, monkeypatch, tmp_path) -> None:
+        app = _setup_app(monkeypatch, tmp_path, _make_stt_class([]), _make_tts_class(_TTS_CHUNK))
+        with TestClient(app) as client:
+            r = client.post("/voice/telnyx/incoming", data={"CallSid": "CC123"})
+        assert r.status_code == 200
+        assert "ws://testserver/voice/telnyx/stream" in r.text
+        assert 'bidirectionalMode="rtp"' in r.text
+        assert 'bidirectionalCodec="PCMU"' in r.text
+
+    def test_ed25519_signature_enforced_when_key_set(self, monkeypatch, tmp_path) -> None:
+        crypto = pytest.importorskip("cryptography.hazmat.primitives.asymmetric.ed25519")
+        from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+        priv = crypto.Ed25519PrivateKey.generate()
+        pub_b64 = base64.b64encode(priv.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)).decode()
+
+        app = _setup_app(monkeypatch, tmp_path, _make_stt_class([]), _make_tts_class(_TTS_CHUNK))
+        monkeypatch.setenv("TELNYX_PUBLIC_KEY", pub_b64)
+
+        body = b"CallSid=CC123&From=%2B13120000001"
+        timestamp = "1700000000"
+        signature = base64.b64encode(priv.sign(f"{timestamp}|".encode() + body)).decode()
+
+        with TestClient(app) as client:
+            ok = client.post(
+                "/voice/telnyx/incoming",
+                content=body,
+                headers={
+                    "content-type": "application/x-www-form-urlencoded",
+                    "telnyx-signature-ed25519": signature,
+                    "telnyx-timestamp": timestamp,
+                },
+            )
+            bad = client.post(
+                "/voice/telnyx/incoming",
+                content=body,
+                headers={
+                    "content-type": "application/x-www-form-urlencoded",
+                    "telnyx-signature-ed25519": base64.b64encode(b"\x00" * 64).decode(),
+                    "telnyx-timestamp": timestamp,
+                },
+            )
+        assert ok.status_code == 200
+        assert bad.status_code == 403
+
+
+class TestUlawWire:
+    def test_media_payload_is_valid_ulaw(self, monkeypatch, tmp_path) -> None:
+        """The downlink payload must decode to real PCM (sanity vs base64 PCM)."""
+        pytest.importorskip("av")
+        stt_cls = _make_stt_class([TranscriptEvent(type="committed", text="Hello")])
+        # Loud constant tone so μ-law bytes are far from the 0xFF silence code.
+        loud = (16_000).to_bytes(2, "little", signed=True) * 1600
+        app = _setup_app(monkeypatch, tmp_path, stt_cls, _make_tts_class(loud))
+
+        with TestClient(app) as client, client.websocket_connect("/voice/twilio/stream") as ws:
+            ws.send_json(_twilio_start_frame())
+            frames = _collect_frames(ws)
+
+        media = [f for f in frames if f["event"] == "media"]
+        assert media
+        ulaw = base64.b64decode(media[0]["media"]["payload"])
+        pcm = ulaw_decode(ulaw)
+        values = [int.from_bytes(pcm[i : i + 2], "little", signed=True) for i in range(0, len(pcm), 2)]
+        # Resampler ramps in, but the steady-state must sit near 16000.
+        steady = values[len(values) // 2 :]
+        assert sum(steady) / len(steady) > 10_000

--- a/python/tests/voice/test_telephony.py
+++ b/python/tests/voice/test_telephony.py
@@ -1,0 +1,109 @@
+"""Unit tests for the telephony primitives (G.711 μ-law, resampler, tracker)."""
+
+from __future__ import annotations
+
+import pytest
+from timbal.voice.telephony import (
+    TELEPHONY_SAMPLE_RATE,
+    ULAW_SILENCE,
+    PcmResampler,
+    TelephonyPlaybackTracker,
+    ulaw_decode,
+    ulaw_encode,
+)
+
+
+def _pcm(samples: list[int]) -> bytes:
+    out = bytearray()
+    for s in samples:
+        out += int(s).to_bytes(2, "little", signed=True)
+    return bytes(out)
+
+
+def _samples(pcm: bytes) -> list[int]:
+    return [int.from_bytes(pcm[i : i + 2], "little", signed=True) for i in range(0, len(pcm), 2)]
+
+
+class TestUlawCodec:
+    def test_silence_is_0xff(self) -> None:
+        assert ulaw_encode(_pcm([0])) == ULAW_SILENCE
+        assert ulaw_decode(ULAW_SILENCE) == _pcm([0])
+
+    def test_round_trip_within_quantization_error(self) -> None:
+        values = [-32768, -32635, -10000, -1000, -137, -1, 0, 1, 137, 1000, 10000, 32635, 32767]
+        decoded = _samples(ulaw_decode(ulaw_encode(_pcm(values))))
+        for original, got in zip(values, decoded, strict=True):
+            clipped = max(-32635, min(32635, original))
+            # μ-law is logarithmic: error grows with amplitude (~4% of value).
+            tolerance = max(33, abs(clipped) * 0.04)
+            assert abs(got - clipped) <= tolerance, f"{original} -> {got}"
+
+    def test_sign_symmetry(self) -> None:
+        for v in (1, 100, 5000, 30000):
+            pos = _samples(ulaw_decode(ulaw_encode(_pcm([v]))))[0]
+            neg = _samples(ulaw_decode(ulaw_encode(_pcm([-v]))))[0]
+            assert neg == -pos
+
+    def test_decode_covers_all_bytes(self) -> None:
+        pcm = ulaw_decode(bytes(range(256)))
+        assert len(pcm) == 512
+        values = _samples(pcm)
+        assert min(values) < -30000
+        assert max(values) > 30000
+
+    def test_encode_drops_trailing_odd_byte(self) -> None:
+        assert ulaw_encode(b"\x00\x00\x01") == ULAW_SILENCE
+
+
+class TestPcmResampler:
+    def test_downsample_halves_length(self) -> None:
+        pytest.importorskip("av")
+        resampler = PcmResampler(16_000, TELEPHONY_SAMPLE_RATE)
+        out = b""
+        # 100ms per chunk; multiple chunks so filter delay amortizes.
+        for _ in range(5):
+            out += resampler.process(b"\x00\x01" * 1600)
+        # 500ms in → ~250ms out (4000 samples) minus a little filter delay.
+        assert 3600 * 2 <= len(out) <= 4000 * 2
+
+    def test_upsample_doubles_length(self) -> None:
+        pytest.importorskip("av")
+        resampler = PcmResampler(TELEPHONY_SAMPLE_RATE, 16_000)
+        out = b""
+        for _ in range(5):
+            out += resampler.process(b"\x00\x01" * 800)
+        assert 7200 * 2 <= len(out) <= 8000 * 2
+
+    def test_empty_chunk_is_noop(self) -> None:
+        pytest.importorskip("av")
+        resampler = PcmResampler(TELEPHONY_SAMPLE_RATE, 16_000)
+        assert resampler.process(b"") == b""
+
+
+class TestTelephonyPlaybackTracker:
+    def test_interruption_fires_clear_and_freezes_axis(self) -> None:
+        now = [0.0]
+        cleared: list[int] = []
+        tracker = TelephonyPlaybackTracker(32_000, on_clear=lambda: cleared.append(1))
+        tracker._clock = lambda: now[0]  # deterministic time
+
+        tracker.on_audio_emitted(32_000)  # 1s of audio scheduled
+        now[0] = 0.25
+        tracker.on_interrupted()
+        assert cleared == [1]
+        frozen = tracker.played_bytes
+        assert frozen == 8_000  # 250ms worth
+        now[0] = 10.0
+        assert tracker.played_bytes == frozen  # axis frozen after clear
+
+    def test_mark_acks_bound_the_estimate(self) -> None:
+        now = [0.0]
+        tracker = TelephonyPlaybackTracker(32_000, on_clear=lambda: None)
+        tracker._clock = lambda: now[0]
+
+        tracker.on_audio_emitted(32_000)
+        now[0] = 0.5
+        # Provider says only 100ms actually played: ack caps the estimate.
+        tracker.on_playback_ack(100.0)
+        assert tracker.played_bytes == 3_200
+        assert tracker.ack_received

--- a/python/tests/voice/test_telephony.py
+++ b/python/tests/voice/test_telephony.py
@@ -79,6 +79,26 @@ class TestPcmResampler:
         resampler = PcmResampler(TELEPHONY_SAMPLE_RATE, 16_000)
         assert resampler.process(b"") == b""
 
+    def test_reset_drops_filter_tail(self) -> None:
+        """After a barge-in reset, no residue of the old audio may leak out."""
+        pytest.importorskip("av")
+        resampler = PcmResampler(16_000, TELEPHONY_SAMPLE_RATE)
+        loud = (16_000).to_bytes(2, "little", signed=True) * 1600
+        silence = b"\x00\x00" * 1600
+
+        resampler.process(loud)
+        resampler.reset()
+        out = _samples(resampler.process(silence))
+        assert out
+        assert max(abs(v) for v in out) == 0
+
+        # Control: without a reset the FIR delay line does leak the tail —
+        # if this stops failing, the reset (and its call site) is dead code.
+        leaky = PcmResampler(16_000, TELEPHONY_SAMPLE_RATE)
+        leaky.process(loud)
+        leaked = _samples(leaky.process(silence))
+        assert max(abs(v) for v in leaked) > 1_000
+
 
 class TestTelephonyPlaybackTracker:
     def test_interruption_fires_clear_and_freezes_axis(self) -> None:

--- a/python/timbal/server/README.md
+++ b/python/timbal/server/README.md
@@ -214,6 +214,30 @@ The server answers with the TTS audio track on the same m-line. Client teardown 
 | `TIMBAL_TURN_USERNAME` / `TIMBAL_TURN_PASSWORD` | TURN credentials. |
 | `TIMBAL_VOICE_RTC_FORCE_RELAY` | `1` → relay-only ICE: allocate on the TURN server above, skip STUN, and strip host/srflx candidates from the answer SDP. For servers on private subnets (serverless boxes) where every non-relay candidate is unreachable dead weight that slows the browser's ICE convergence. Requires `TIMBAL_TURN_URL` — without it (or if the TURN allocation yields no relay candidate) the server logs an error and answers with all candidates instead of an unconnectable SDP. |
 
+## Telephony: `/voice/twilio` and `/voice/telnyx`
+
+Answer real phone calls with the same voice session. Twilio and Telnyx stream call audio (G.711 μ-law, 8kHz mono) over a WebSocket they open toward the server; a shared bridge decodes/resamples into the session and sends TTS back the same way. Requires **`timbal[voice]`** (av for resampling).
+
+Routes per provider:
+
+- `POST /voice/twilio/incoming` / `POST /voice/telnyx/incoming` — the phone number's voice webhook. Answers with TwiML/TeXML that connects the call to the media WebSocket below (URL derived from `X-Forwarded-Proto`/`Host`, so it works behind a TLS proxy or an ngrok tunnel).
+- `WS /voice/twilio/stream` / `WS /voice/telnyx/stream` — the bidirectional media stream.
+
+**Provider setup:**
+
+- **Twilio:** point the number's *A call comes in* webhook (HTTP POST) at `https://<host>/voice/twilio/incoming`. Set `TWILIO_AUTH_TOKEN` so webhook signatures (`X-Twilio-Signature`, HMAC-SHA1) are enforced — without it requests are accepted with a warning.
+- **Telnyx:** create a TeXML application whose voice webhook is `https://<host>/voice/telnyx/incoming` and assign the number to it. Set `TELNYX_PUBLIC_KEY` (portal → API keys → public key) to enforce Ed25519 webhook signatures. The returned TeXML pins `bidirectionalMode="rtp"` and PCMU both ways.
+
+**Bridge semantics:**
+
+- Caller audio: μ-law 8kHz → PCM16 → resampled to the session rate (default 16kHz). No client `sample_rate` config applies; the line format is fixed by the carrier.
+- TTS audio: resampled to 8kHz, μ-law encoded, sent as `media` frames batched to ≥20ms (Telnyx's RTP minimum). A `mark` frame carrying the cumulative byte count follows each media frame; its echo is the playback ack, so barge-in truncation (`heard_text`, memory) works exactly like the browser transports.
+- Barge-in sends the provider's `clear` message, dropping their buffered audio immediately. Marks echoed *by* the clear (audio that never played) are ignored.
+- Custom `<Parameter>` values on the stream may override allowlisted session config (`turn_detector`, `stt_provider`, `stt_model`, `tts_model`, `model`, `language`, `voice`) — the webhook's TwiML already forwards `from`/`to`/`call_sid` so recordings are call-addressable.
+- DTMF frames are logged and otherwise ignored (no keypad actions yet). Outbound calls are not implemented yet either — these routes cover inbound.
+
+Single-session mode applies: a phone call counts as the process's one session.
+
 ## Single-session lifetime (serverless voice boxes)
 
 `TIMBAL_VOICE_SINGLE_SESSION=1` makes the server process serve **exactly one voice session and then exit 0** — for deployments that spawn one process per call and reap the box on process exit (the platform cannot see a WebRTC call: media flows browser ↔ TURN ↔ box, so the process must own its lifetime). Applies to both transports; whichever session arrives first (WS or RTC) owns the process.

--- a/python/timbal/server/http.py
+++ b/python/timbal/server/http.py
@@ -88,10 +88,12 @@ def create_app() -> FastAPI:
     )
 
     from .rtc import router as rtc_router
+    from .telephony import router as telephony_router
     from .voice import router as voice_router
 
     app.include_router(voice_router)
     app.include_router(rtc_router)
+    app.include_router(telephony_router)
 
     @app.get("/healthcheck")
     async def healthcheck() -> Response:

--- a/python/timbal/server/telephony.py
+++ b/python/timbal/server/telephony.py
@@ -216,8 +216,15 @@ def _telnyx_signature_ok(body: bytes, timestamp: str, signature_b64: str, public
         from cryptography.exceptions import InvalidSignature
         from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
     except ImportError:
-        logger.warning("telnyx_signature_skipped", hint="Ed25519 verification requires the cryptography package")
-        return True
+        # Fail closed: the operator explicitly asked for verification by
+        # setting TELNYX_PUBLIC_KEY — accepting unverified webhooks here
+        # would turn a missing dependency into an auth bypass. (cryptography
+        # ships with timbal[voice] via aiortc, so this is a broken install.)
+        logger.error(
+            "telnyx_signature_unverifiable",
+            hint="TELNYX_PUBLIC_KEY is set but the cryptography package is missing; rejecting webhook",
+        )
+        return False
     try:
         key = Ed25519PublicKey.from_public_bytes(base64.b64decode(public_key_b64))
         key.verify(base64.b64decode(signature_b64), f"{timestamp}|".encode() + body)

--- a/python/timbal/server/telephony.py
+++ b/python/timbal/server/telephony.py
@@ -1,0 +1,535 @@
+"""Telephony routes — phone calls bridged into voice sessions.
+
+Providers (Twilio, Telnyx) answer a call, then open a WebSocket to this server
+and stream the caller's audio as base64 G.711 μ-law at 8kHz inside JSON
+frames. The bridge decodes/resamples into a regular :class:`VoiceSession` and
+sends TTS audio back the same way — barge-in maps to the provider's ``clear``
+message, playback tracking to ``mark`` echoes.
+
+Routes (per provider ``{p}`` in ``twilio`` | ``telnyx``):
+
+- ``POST /voice/{p}/incoming`` — the number's voice webhook. Returns
+  TwiML/TeXML that connects the call to the media WebSocket below.
+- ``WS /voice/{p}/stream`` — the bidirectional media stream.
+
+The two providers speak near-identical protocols with different spellings
+(Twilio camelCase / ``streamSid``; Telnyx snake_case / ``stream_id``), so one
+handler runs both via a small dialect table.
+
+Signature validation: set ``TWILIO_AUTH_TOKEN`` (HMAC-SHA1 of the webhook URL
++ params) and/or ``TELNYX_PUBLIC_KEY`` (Ed25519 over ``timestamp|body``) to
+enforce webhook authenticity; without them webhooks are accepted with a
+warning (dev mode).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import os
+import time
+from contextlib import aclosing
+from typing import Any
+from urllib.parse import parse_qsl
+from xml.sax.saxutils import quoteattr
+
+import structlog
+from fastapi import APIRouter, HTTPException, Request, Response, WebSocket, WebSocketDisconnect
+
+from ..voice.config import VoiceConfig
+
+logger = structlog.get_logger("timbal.server.telephony")
+
+router = APIRouter(prefix="/voice", tags=["telephony"])
+
+# Custom <Parameter> names a webhook may pass through to the session config.
+# Same trust level as the browser hello, but telephony parameters are set by
+# whoever controls the TwiML/TeXML — still allowlist to names, never callables.
+_CONFIG_PARAM_KEYS = ("turn_detector", "stt_provider", "stt_model", "tts_model", "model", "language", "voice")
+
+_ULAW_ENCODINGS = {"audio/x-mulaw", "pcmu"}
+
+# Telnyx rejects RTP media chunks under 20ms; Twilio takes any size. Batch
+# the downlink to >=20ms for both (fewer frames is also just cheaper).
+_MIN_MEDIA_BYTES = 160  # 20ms of mulaw @ 8kHz
+
+
+# ---------------------------------------------------------------------------
+# Provider dialects
+# ---------------------------------------------------------------------------
+
+
+class _TwilioDialect:
+    """Twilio Media Streams: camelCase frames keyed by ``streamSid``."""
+
+    name = "twilio"
+
+    def stream_id(self, frame: dict) -> str | None:
+        return frame.get("streamSid")
+
+    def start_info(self, frame: dict) -> dict[str, Any]:
+        start = frame.get("start") or {}
+        media_format = start.get("mediaFormat") or {}
+        custom = start.get("customParameters") or {}
+        return {
+            "call_id": start.get("callSid"),
+            # Twilio's start frame has no From/To; our TwiML forwards them
+            # as custom parameters (see twilio_incoming).
+            "from": custom.get("from"),
+            "to": custom.get("to"),
+            "custom": custom,
+            "encoding": media_format.get("encoding"),
+            "sample_rate": media_format.get("sampleRate"),
+        }
+
+    def media_bytes(self, frame: dict) -> bytes | None:
+        media = frame.get("media") or {}
+        track = media.get("track")
+        if track not in (None, "inbound"):
+            return None
+        payload = media.get("payload")
+        return base64.b64decode(payload) if payload else None
+
+    def mark_name(self, frame: dict) -> str | None:
+        return (frame.get("mark") or {}).get("name")
+
+    def dtmf_digit(self, frame: dict) -> str | None:
+        return (frame.get("dtmf") or {}).get("digit")
+
+    def media_frame(self, stream_id: str, payload_b64: str) -> dict:
+        return {"event": "media", "streamSid": stream_id, "media": {"payload": payload_b64}}
+
+    def mark_frame(self, stream_id: str, name: str) -> dict:
+        return {"event": "mark", "streamSid": stream_id, "mark": {"name": name}}
+
+    def clear_frame(self, stream_id: str) -> dict:
+        return {"event": "clear", "streamSid": stream_id}
+
+
+class _TelnyxDialect:
+    """Telnyx bidirectional streaming: snake_case frames keyed by ``stream_id``.
+
+    Client → Telnyx frames carry no stream id (one stream per socket).
+    """
+
+    name = "telnyx"
+
+    def stream_id(self, frame: dict) -> str | None:
+        return frame.get("stream_id")
+
+    def start_info(self, frame: dict) -> dict[str, Any]:
+        start = frame.get("start") or {}
+        media_format = start.get("media_format") or {}
+        return {
+            "call_id": start.get("call_control_id"),
+            "from": start.get("from"),
+            "to": start.get("to"),
+            "custom": start.get("custom_parameters") or {},
+            "encoding": media_format.get("encoding"),
+            "sample_rate": media_format.get("sample_rate"),
+        }
+
+    def media_bytes(self, frame: dict) -> bytes | None:
+        media = frame.get("media") or {}
+        track = media.get("track")
+        if track not in (None, "inbound"):
+            return None
+        payload = media.get("payload")
+        return base64.b64decode(payload) if payload else None
+
+    def mark_name(self, frame: dict) -> str | None:
+        return (frame.get("mark") or {}).get("name")
+
+    def dtmf_digit(self, frame: dict) -> str | None:
+        dtmf = frame.get("dtmf") or frame.get("payload") or {}
+        return dtmf.get("digit") if isinstance(dtmf, dict) else None
+
+    def media_frame(self, stream_id: str, payload_b64: str) -> dict:  # noqa: ARG002
+        return {"event": "media", "media": {"payload": payload_b64}}
+
+    def mark_frame(self, stream_id: str, name: str) -> dict:  # noqa: ARG002
+        return {"event": "mark", "mark": {"name": name}}
+
+    def clear_frame(self, stream_id: str) -> dict:  # noqa: ARG002
+        return {"event": "clear"}
+
+
+_TWILIO = _TwilioDialect()
+_TELNYX = _TelnyxDialect()
+
+
+# ---------------------------------------------------------------------------
+# Webhooks (call answer → connect the media stream)
+# ---------------------------------------------------------------------------
+
+
+def _external_base(request: Request) -> tuple[str, str]:
+    """(scheme, host) as the outside world sees this server (proxy-aware)."""
+    proto = request.headers.get("x-forwarded-proto") or request.url.scheme
+    host = request.headers.get("x-forwarded-host") or request.headers.get("host") or request.url.netloc
+    return proto, host
+
+
+def _external_url(request: Request) -> str:
+    proto, host = _external_base(request)
+    url = f"{proto}://{host}{request.url.path}"
+    if request.url.query:
+        url += f"?{request.url.query}"
+    return url
+
+
+def _stream_ws_url(request: Request, path: str) -> str:
+    proto, host = _external_base(request)
+    ws_proto = "wss" if proto == "https" else "ws"
+    return f"{ws_proto}://{host}{path}"
+
+
+def _stream_xml(ws_url: str, params: dict[str, str], *, telnyx: bool) -> str:
+    """TwiML/TeXML that answers the call into the bidirectional media WS."""
+    attrs = f"url={quoteattr(ws_url)}"
+    if telnyx:
+        # Default TeXML mode is mp3 playback; RTP is the raw-audio mode. Pin
+        # PCMU both ways so the bridge never has to sniff codecs.
+        attrs += ' bidirectionalMode="rtp" codec="PCMU" bidirectionalCodec="PCMU"'
+    children = "".join(
+        f"<Parameter name={quoteattr(k)} value={quoteattr(v)} />" for k, v in params.items() if v
+    )
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        f"<Response><Connect><Stream {attrs}>{children}</Stream></Connect></Response>"
+    )
+
+
+def _twilio_signature_ok(url: str, params: dict[str, str], signature: str, auth_token: str) -> bool:
+    """Twilio request validation: base64(HMAC-SHA1(token, url + sorted params))."""
+    payload = url + "".join(k + params[k] for k in sorted(params))
+    digest = hmac.new(auth_token.encode(), payload.encode(), hashlib.sha1).digest()
+    return hmac.compare_digest(base64.b64encode(digest).decode(), signature)
+
+
+def _telnyx_signature_ok(body: bytes, timestamp: str, signature_b64: str, public_key_b64: str) -> bool:
+    """Telnyx webhook validation: Ed25519 over ``{timestamp}|{raw body}``."""
+    try:
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+    except ImportError:
+        logger.warning("telnyx_signature_skipped", hint="Ed25519 verification requires the cryptography package")
+        return True
+    try:
+        key = Ed25519PublicKey.from_public_bytes(base64.b64decode(public_key_b64))
+        key.verify(base64.b64decode(signature_b64), f"{timestamp}|".encode() + body)
+        return True
+    except (InvalidSignature, ValueError):
+        return False
+
+
+@router.post("/twilio/incoming")
+async def twilio_incoming(request: Request) -> Response:
+    body = await request.body()
+    params = dict(parse_qsl(body.decode("utf-8", "replace"), keep_blank_values=True))
+    auth_token = os.environ.get("TWILIO_AUTH_TOKEN")
+    if auth_token:
+        signature = request.headers.get("x-twilio-signature", "")
+        if not _twilio_signature_ok(_external_url(request), params, signature, auth_token):
+            logger.warning("twilio_webhook_rejected", reason="bad signature")
+            raise HTTPException(status_code=403, detail="Invalid Twilio signature")
+    else:
+        logger.warning("twilio_webhook_unverified", hint="set TWILIO_AUTH_TOKEN to verify webhook signatures")
+    logger.info("twilio_incoming_call", call_sid=params.get("CallSid"), from_=params.get("From"), to=params.get("To"))
+    xml = _stream_xml(
+        _stream_ws_url(request, "/voice/twilio/stream"),
+        # Twilio's WS start frame carries no caller metadata; tunnel it.
+        {"call_sid": params.get("CallSid", ""), "from": params.get("From", ""), "to": params.get("To", "")},
+        telnyx=False,
+    )
+    return Response(content=xml, media_type="application/xml")
+
+
+@router.post("/telnyx/incoming")
+async def telnyx_incoming(request: Request) -> Response:
+    body = await request.body()
+    public_key = os.environ.get("TELNYX_PUBLIC_KEY")
+    if public_key:
+        signature = request.headers.get("telnyx-signature-ed25519", "")
+        timestamp = request.headers.get("telnyx-timestamp", "")
+        if not _telnyx_signature_ok(body, timestamp, signature, public_key):
+            logger.warning("telnyx_webhook_rejected", reason="bad signature")
+            raise HTTPException(status_code=403, detail="Invalid Telnyx signature")
+    else:
+        logger.warning("telnyx_webhook_unverified", hint="set TELNYX_PUBLIC_KEY to verify webhook signatures")
+    params = dict(parse_qsl(body.decode("utf-8", "replace"), keep_blank_values=True))
+    logger.info("telnyx_incoming_call", call_sid=params.get("CallSid"), from_=params.get("From"), to=params.get("To"))
+    xml = _stream_xml(_stream_ws_url(request, "/voice/telnyx/stream"), {}, telnyx=True)
+    return Response(content=xml, media_type="application/xml")
+
+
+# ---------------------------------------------------------------------------
+# Media WebSocket bridge
+# ---------------------------------------------------------------------------
+
+
+@router.websocket("/twilio/stream")
+async def twilio_stream(ws: WebSocket) -> None:
+    await _media_ws(ws, _TWILIO)
+
+
+@router.websocket("/telnyx/stream")
+async def telnyx_stream(ws: WebSocket) -> None:
+    await _media_ws(ws, _TELNYX)
+
+
+async def _media_ws(ws: WebSocket, dialect: Any) -> None:
+    from ..core.agent import Agent
+
+    await ws.accept()
+    logger.info("telephony_ws_connected", provider=dialect.name)
+
+    runnable = ws.app.state.runnable
+    if not isinstance(runnable, Agent):
+        logger.error("telephony_ws_rejected", reason="runnable is not an Agent", type=type(runnable).__name__)
+        await ws.close(code=1008, reason="Voice requires an Agent runnable")
+        return
+
+    guard = getattr(ws.app.state, "single_session_guard", None)
+    if guard is None:
+        await _serve_media_ws(ws, runnable, dialect)
+        return
+
+    if not guard.claim():
+        logger.info("telephony_ws_rejected", reason="single-session server already served its session")
+        await ws.close(code=1008, reason="Single-session server: a voice session was already served")
+        return
+    guard.mark_connected()
+    try:
+        await _serve_media_ws(ws, runnable, dialect)
+    finally:
+        await guard.finish()
+
+
+async def _safe_close(ws: WebSocket, code: int, reason: str) -> None:
+    try:
+        await ws.close(code=code, reason=reason)
+    except Exception:
+        # Already disconnected — the close was only best-effort courtesy.
+        pass
+
+
+async def _serve_media_ws(ws: WebSocket, runnable: Any, dialect: Any) -> None:
+    """One phone call: start frame → session → μ-law media both ways, until stop."""
+    try:
+        from ..voice import AudioOutput
+        from ..voice.telephony import (
+            TELEPHONY_SAMPLE_RATE,
+            ULAW_SILENCE,
+            PcmResampler,
+            TelephonyPlaybackTracker,
+            ulaw_decode,
+            ulaw_encode,
+        )
+    except ImportError as e:
+        logger.error("telephony_unavailable", error=str(e), hint="telephony requires the timbal[voice] extra")
+        await _safe_close(ws, 1011, "telephony requires timbal[voice]")
+        return
+
+    from .voice import build_voice_session, merge_client_voice_overrides
+
+    # -- Handshake: providers send `connected` then `start`; media only after.
+    start_frame: dict | None = None
+    deadline = time.monotonic() + 10.0
+    try:
+        while (remaining := deadline - time.monotonic()) > 0:
+            raw = await asyncio.wait_for(ws.receive_text(), timeout=remaining)
+            try:
+                frame = json.loads(raw)
+            except ValueError:
+                continue
+            if isinstance(frame, dict) and frame.get("event") == "start":
+                start_frame = frame
+                break
+    except (TimeoutError, WebSocketDisconnect, RuntimeError):
+        pass
+    if start_frame is None:
+        logger.warning("telephony_no_start_frame", provider=dialect.name)
+        await _safe_close(ws, 1002, "expected a start frame")
+        return
+
+    stream_id = dialect.stream_id(start_frame) or ""
+    info = dialect.start_info(start_frame)
+    encoding = (info.get("encoding") or "audio/x-mulaw").lower()
+    line_rate = int(info.get("sample_rate") or TELEPHONY_SAMPLE_RATE)
+    if encoding not in _ULAW_ENCODINGS:
+        # v1 speaks G.711 μ-law only; both webhooks pin it, so this means a
+        # stream started outside our TwiML/TeXML with another codec.
+        logger.error("telephony_unsupported_encoding", provider=dialect.name, encoding=encoding)
+        await _safe_close(ws, 1003, f"unsupported media encoding: {encoding}")
+        return
+    logger.info(
+        "telephony_call_started",
+        provider=dialect.name,
+        call_id=info.get("call_id"),
+        from_=info.get("from"),
+        to=info.get("to"),
+        line_rate=line_rate,
+    )
+
+    custom = info.get("custom") or {}
+    client_config = {k: v for k, v in custom.items() if k in _CONFIG_PARAM_KEYS and isinstance(v, str) and v}
+
+    defaults: VoiceConfig = getattr(ws.app.state, "voice_config", None) or VoiceConfig()
+    session_rate = int(merge_client_voice_overrides(defaults, client_config).sample_rate)
+
+    audio_queue: asyncio.Queue[bytes] = asyncio.Queue()
+    send_lock = asyncio.Lock()
+
+    async def _send_frame(frame: dict) -> None:
+        try:
+            async with send_lock:
+                await ws.send_json(frame)
+        except Exception as e:
+            logger.debug("telephony_send_skipped", provider=dialect.name, error=str(e))
+
+    # -- Playback tracking: cumulative μ-law bytes sent ride as mark names;
+    # a mark echo means everything before it has played (8 bytes/ms @ 8kHz).
+    # After a clear, providers echo all outstanding marks for *unplayed*
+    # audio — those must not count as acks.
+    pending_marks: set[str] = set()
+    ignored_marks: set[str] = set()
+    clear_tasks: set[asyncio.Task] = set()
+    out_ulaw = bytearray()  # downlink batch buffer (see _MIN_MEDIA_BYTES)
+
+    def _on_clear() -> None:
+        # Called by the session (same loop) at barge-in, before it resumes
+        # listening — schedule the provider-side buffer drop right away.
+        ignored_marks.update(pending_marks)
+        pending_marks.clear()
+        out_ulaw.clear()
+        task = asyncio.get_running_loop().create_task(_send_frame(dialect.clear_frame(stream_id)))
+        clear_tasks.add(task)
+        task.add_done_callback(clear_tasks.discard)
+
+    tracker = TelephonyPlaybackTracker(bytes_per_second=session_rate * 2, on_clear=_on_clear)
+    session, meta = build_voice_session(runnable, defaults, client_config, playback_tracker=tracker)
+    meta = {
+        "transport": dialect.name,
+        "call_id": info.get("call_id"),
+        "from": info.get("from"),
+        "to": info.get("to"),
+        **meta,
+    }
+    session.recording_meta = meta
+
+    up_resampler = PcmResampler(line_rate, session_rate) if line_rate != session_rate else None
+    down_resampler = PcmResampler(session_rate, TELEPHONY_SAMPLE_RATE) if session_rate != TELEPHONY_SAMPLE_RATE else None
+
+    sent_ulaw_bytes = 0
+
+    async def _send_media(payload: bytes) -> None:
+        nonlocal sent_ulaw_bytes
+        await _send_frame(dialect.media_frame(stream_id, base64.b64encode(payload).decode("ascii")))
+        sent_ulaw_bytes += len(payload)
+        name = str(sent_ulaw_bytes)
+        pending_marks.add(name)
+        await _send_frame(dialect.mark_frame(stream_id, name))
+
+    async def _push_downlink(pcm: bytes) -> None:
+        data = down_resampler.process(pcm) if down_resampler else pcm
+        out_ulaw.extend(ulaw_encode(data))
+        if len(out_ulaw) >= _MIN_MEDIA_BYTES:
+            payload = bytes(out_ulaw)
+            out_ulaw.clear()
+            await _send_media(payload)
+
+    async def _flush_downlink() -> None:
+        if not out_ulaw:
+            return
+        # Pad short tails to the provider minimum with μ-law silence.
+        payload = bytes(out_ulaw).ljust(_MIN_MEDIA_BYTES, ULAW_SILENCE)
+        out_ulaw.clear()
+        await _send_media(payload)
+
+    async def _recv_loop() -> None:
+        """Provider frames → PCM into the session; mark echoes → playback acks."""
+        try:
+            while True:
+                msg = await ws.receive()
+                if msg.get("type") == "websocket.disconnect":
+                    break
+                raw = msg.get("text")
+                if not raw:
+                    continue
+                try:
+                    frame = json.loads(raw)
+                except ValueError:
+                    continue
+                event = frame.get("event")
+                if event == "media":
+                    payload = dialect.media_bytes(frame)
+                    if payload:
+                        pcm = ulaw_decode(payload)
+                        if up_resampler:
+                            pcm = up_resampler.process(pcm)
+                        if pcm:
+                            await audio_queue.put(pcm)
+                elif event == "mark":
+                    name = dialect.mark_name(frame)
+                    if not name:
+                        continue
+                    if name in ignored_marks:
+                        ignored_marks.discard(name)
+                        continue
+                    pending_marks.discard(name)
+                    try:
+                        played_ms = int(name) / (TELEPHONY_SAMPLE_RATE / 1000)
+                    except ValueError:
+                        continue
+                    session.playback.on_playback_ack(played_ms)
+                elif event == "stop":
+                    logger.info("telephony_call_stopped", provider=dialect.name, call_id=info.get("call_id"))
+                    break
+                elif event == "dtmf":
+                    logger.info("telephony_dtmf", provider=dialect.name, digit=dialect.dtmf_digit(frame))
+                elif event == "error":
+                    logger.warning("telephony_provider_error", provider=dialect.name, detail=str(frame)[:300])
+        except WebSocketDisconnect:
+            pass
+        except Exception as e:
+            logger.warning("telephony_recv_error", provider=dialect.name, error=str(e))
+        finally:
+            await audio_queue.put(b"")
+            # Caller hung up (or the stream stopped): end the session now
+            # instead of waiting for the STT silence timeout.
+            await session.close()
+
+    async def _phone_stream():
+        while True:
+            chunk = await audio_queue.get()
+            if not chunk:
+                break
+            yield chunk
+
+    recv_task = asyncio.create_task(_recv_loop())
+    try:
+        async with aclosing(session.run(_phone_stream())) as event_iter:
+            async for event in event_iter:
+                if isinstance(event, AudioOutput):
+                    await _push_downlink(event.data)
+                else:
+                    # Any non-audio event marks a pause in synthesis: flush the
+                    # sub-minimum tail so turn endings aren't clipped.
+                    await _flush_downlink()
+    finally:
+        if not recv_task.done():
+            recv_task.cancel()
+        await asyncio.gather(recv_task, *clear_tasks, return_exceptions=True)
+        try:
+            await session.close()
+        except Exception as e:
+            logger.debug("telephony_session_close_suppressed", error=str(e))
+        try:
+            await ws.close()
+        except Exception:
+            pass
+        logger.info("telephony_ws_disconnected", provider=dialect.name)

--- a/python/timbal/server/telephony.py
+++ b/python/timbal/server/telephony.py
@@ -406,6 +406,10 @@ async def _serve_media_ws(ws: WebSocket, runnable: Any, dialect: Any) -> None:
         ignored_marks.update(pending_marks)
         pending_marks.clear()
         out_ulaw.clear()
+        if down_resampler is not None:
+            # The FIR delay line still holds a tail of the interrupted reply;
+            # without a reset it would leak into the next turn's audio.
+            down_resampler.reset()
         task = asyncio.get_running_loop().create_task(_send_frame(dialect.clear_frame(stream_id)))
         clear_tasks.add(task)
         task.add_done_callback(clear_tasks.discard)

--- a/python/timbal/server/telephony.py
+++ b/python/timbal/server/telephony.py
@@ -457,7 +457,7 @@ async def _serve_media_ws(ws: WebSocket, runnable: Any, dialect: Any) -> None:
         if not out_ulaw:
             return
         # Pad short tails to the provider minimum with μ-law silence.
-        payload = bytes(out_ulaw).ljust(_MIN_MEDIA_BYTES, ULAW_SILENCE)
+        payload = bytes(out_ulaw) + ULAW_SILENCE * max(0, _MIN_MEDIA_BYTES - len(out_ulaw))
         out_ulaw.clear()
         await _send_media(payload)
 

--- a/python/timbal/server/telephony.py
+++ b/python/timbal/server/telephony.py
@@ -327,7 +327,7 @@ async def _safe_close(ws: WebSocket, code: int, reason: str) -> None:
 async def _serve_media_ws(ws: WebSocket, runnable: Any, dialect: Any) -> None:
     """One phone call: start frame → session → μ-law media both ways, until stop."""
     try:
-        from ..voice import AudioOutput
+        from ..voice import AgentTextDone, AudioOutput, FillerSpoken, SessionEnded, TurnMetricsEvent
         from ..voice.telephony import (
             TELEPHONY_SAMPLE_RATE,
             ULAW_SILENCE,
@@ -521,15 +521,20 @@ async def _serve_media_ws(ws: WebSocket, runnable: Any, dialect: Any) -> None:
                 break
             yield chunk
 
+    # Events that follow *completed* speech (turn reply spoken, filler spoken,
+    # turn wrapped up, session over) — the only safe points to flush the
+    # sub-minimum downlink tail. Flushing on every non-audio event would pad
+    # mid-utterance (AgentTextDelta interleaves with AudioOutput while TTS
+    # streams), stitching audible silence gaps into continuous speech.
+    flush_events = (AgentTextDone, FillerSpoken, TurnMetricsEvent, SessionEnded)
+
     recv_task = asyncio.create_task(_recv_loop())
     try:
         async with aclosing(session.run(_phone_stream())) as event_iter:
             async for event in event_iter:
                 if isinstance(event, AudioOutput):
                     await _push_downlink(event.data)
-                else:
-                    # Any non-audio event marks a pause in synthesis: flush the
-                    # sub-minimum tail so turn endings aren't clipped.
+                elif isinstance(event, flush_events):
                     await _flush_downlink()
     finally:
         if not recv_task.done():

--- a/python/timbal/voice/telephony.py
+++ b/python/timbal/voice/telephony.py
@@ -112,8 +112,19 @@ class PcmResampler:
         if src_rate <= 0 or dst_rate <= 0:
             raise ValueError("sample rates must be positive")
         self._src_rate = src_rate
+        self._dst_rate = dst_rate
         self._audio_frame_cls = AudioFrame
+        self._resampler_cls = AudioResampler
         self._resampler = AudioResampler(format="s16", layout="mono", rate=dst_rate)
+        self._pts = 0
+
+    def reset(self) -> None:
+        """Drop filter state — audio still in the delay line is discarded.
+
+        Call after a barge-in throws away queued output: without this, the
+        FIR tail of the interrupted reply leaks into the next turn's audio.
+        """
+        self._resampler = self._resampler_cls(format="s16", layout="mono", rate=self._dst_rate)
         self._pts = 0
 
     def process(self, pcm: bytes) -> bytes:

--- a/python/timbal/voice/telephony.py
+++ b/python/timbal/voice/telephony.py
@@ -1,0 +1,150 @@
+"""Provider-agnostic telephony primitives.
+
+Phone carriers deliver audio as G.711 μ-law mono at 8kHz over provider media
+WebSockets (Twilio Media Streams, Telnyx bidirectional streaming). This module
+holds everything the server bridge needs that is *not* provider dialect:
+
+- G.711 μ-law encode/decode (pure Python, table-driven)
+- ``PcmResampler`` — stateful 8kHz ↔ session-rate PCM16 resampling (via av)
+- ``TelephonyPlaybackTracker`` — mark-based playback tracking that also fires
+  a ``clear`` callback on barge-in so the provider drops its buffered audio
+
+The provider dialects (frame shapes, webhook formats, signatures) live in
+``timbal.server.telephony``.
+"""
+
+from __future__ import annotations
+
+import fractions
+from array import array
+from collections.abc import Callable
+
+from .playback import BufferedPlaybackTracker
+
+TELEPHONY_SAMPLE_RATE = 8_000
+"""G.711 carrier audio: 8kHz mono, one μ-law byte per sample (8 bytes/ms)."""
+
+_BIAS = 0x84
+_CLIP = 32_635
+
+# exponent = position of the highest set bit of (magnitude >> 7), i.e. the
+# G.711 segment number. Classic Sun/CCITT exp_lut.
+_EXP_LUT = bytes(max(0, i.bit_length() - 1) for i in range(256))
+
+
+def _encode_sample(sample: int) -> int:
+    """Encode one signed 16-bit sample to a μ-law byte (G.711)."""
+    sign = 0x80 if sample < 0 else 0x00
+    if sample < 0:
+        sample = -sample
+    if sample > _CLIP:
+        sample = _CLIP
+    sample += _BIAS
+    exponent = _EXP_LUT[(sample >> 7) & 0xFF]
+    mantissa = (sample >> (exponent + 3)) & 0x0F
+    return ~(sign | (exponent << 4) | mantissa) & 0xFF
+
+
+def _build_decode_table() -> array:
+    table = array("h", bytes(512))
+    for b in range(256):
+        u = ~b & 0xFF
+        sign = u & 0x80
+        exponent = (u >> 4) & 0x07
+        mantissa = u & 0x0F
+        magnitude = (((mantissa << 3) + _BIAS) << exponent) - _BIAS
+        table[b] = -magnitude if sign else magnitude
+    return table
+
+
+_DECODE_TABLE = _build_decode_table()
+_ENCODE_TABLE: bytes | None = None
+
+
+def _encode_table() -> bytes:
+    # 64KB, built once on first downlink use (a few ms), keyed by the
+    # sample's unsigned 16-bit representation.
+    global _ENCODE_TABLE
+    if _ENCODE_TABLE is None:
+        table = bytearray(65_536)
+        for s in range(-32_768, 32_768):
+            table[s & 0xFFFF] = _encode_sample(s)
+        _ENCODE_TABLE = bytes(table)
+    return _ENCODE_TABLE
+
+
+def ulaw_decode(data: bytes) -> bytes:
+    """μ-law bytes → PCM16 little-endian mono (same sample count)."""
+    out = array("h", bytes(2 * len(data)))
+    dec = _DECODE_TABLE
+    for i, b in enumerate(data):
+        out[i] = dec[b]
+    return out.tobytes()
+
+
+def ulaw_encode(pcm: bytes) -> bytes:
+    """PCM16 little-endian mono → μ-law bytes (drops a trailing odd byte)."""
+    table = _encode_table()
+    samples = memoryview(pcm[: len(pcm) & ~1]).cast("h")
+    return bytes(table[s & 0xFFFF] for s in samples)
+
+
+ULAW_SILENCE = b"\xff"
+"""μ-law encoding of a zero sample — used to pad sub-minimum media chunks."""
+
+
+class PcmResampler:
+    """Stateful PCM16 mono resampler between two fixed rates.
+
+    Thin wrapper over ``av.AudioResampler`` (ships with ``timbal[voice]``)
+    that speaks raw bytes instead of frames. One instance per direction per
+    call — the underlying FIR filter carries state across chunks.
+    """
+
+    def __init__(self, src_rate: int, dst_rate: int) -> None:
+        try:
+            from av import AudioFrame, AudioResampler
+        except ImportError as e:  # pragma: no cover — exercised only without the extra
+            raise ImportError(
+                "Telephony audio bridging requires the timbal[voice] extra: "
+                "uv pip install 'timbal[voice]'"
+            ) from e
+        if src_rate <= 0 or dst_rate <= 0:
+            raise ValueError("sample rates must be positive")
+        self._src_rate = src_rate
+        self._audio_frame_cls = AudioFrame
+        self._resampler = AudioResampler(format="s16", layout="mono", rate=dst_rate)
+        self._pts = 0
+
+    def process(self, pcm: bytes) -> bytes:
+        """Resample a chunk. May return b"" or a different length (filter delay)."""
+        samples = len(pcm) // 2
+        if samples <= 0:
+            return b""
+        frame = self._audio_frame_cls(format="s16", layout="mono", samples=samples)
+        frame.planes[0].update(pcm[: samples * 2])
+        frame.sample_rate = self._src_rate
+        frame.pts = self._pts
+        frame.time_base = fractions.Fraction(1, self._src_rate)
+        self._pts += samples
+        # Plane buffers are alignment-padded; only samples*2 bytes are audio.
+        return b"".join(bytes(out.planes[0])[: out.samples * 2] for out in self._resampler.resample(frame))
+
+
+class TelephonyPlaybackTracker(BufferedPlaybackTracker):
+    """Buffered tracker whose acks come from provider ``mark`` echoes.
+
+    The provider buffers our media messages and plays them at line rate; we
+    send a ``mark`` after each media message and treat its echo as a playback
+    ack. On barge-in the session calls :meth:`on_interrupted` — beyond
+    freezing the played axis, the provider must also drop its buffered audio,
+    so the bridge's ``clear``-sender fires here.
+    """
+
+    def __init__(self, bytes_per_second: int, on_clear: Callable[[], None]) -> None:
+        super().__init__(bytes_per_second)
+        self._on_clear = on_clear
+
+    def on_interrupted(self) -> None:
+        super().on_interrupted()
+        self._on_clear()


### PR DESCRIPTION
Inbound telephony for voice agents (plan T1+T3). Providers answer the call and stream G.711 mulaw @8kHz over a WebSocket they open to us:

- voice/telephony.py: pure-Python G.711 codec (audioop is gone in 3.13), av-backed 8k<->session-rate resampler, and a playback tracker that treats provider mark echoes as acks and fires the provider `clear` on barge-in
- server/telephony.py: POST /voice/{twilio,telnyx}/incoming webhooks (TwiML/TeXML into the media WS, proxy-aware URLs, HMAC-SHA1 / Ed25519 signature validation) and WS /voice/{p}/stream — one bridge handler over a two-entry dialect table (camelCase/streamSid vs snake_case/stream_id)

Marks echoed by a clear are ignored so unplayed audio never counts as heard; downlink batches to >=20ms (Telnyx RTP minimum); Twilio caller metadata tunnels through <Parameter> since its start frame has no From/To; single-session guard applies to calls.