### PR TITLE
surface voice_config in Agent.get_config and fail loudly on codegen n…

### DIFF
--- a/python/tests/codegen/test_add_mcp.py
+++ b/python/tests/codegen/test_add_mcp.py
@@ -70,6 +70,20 @@ class TestAddStdioServer:
         assert server.transport == "stdio"
         assert server.args == ["-y", "@modelcontextprotocol/server-filesystem", "."]
 
+    def test_annotated_entry_point(self, workspace):
+        """add-mcp appends to the tools list of an annotated agent assignment."""
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent: Agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[])
+        """)
+        output = _run(ws, "--name", "fs", "--command", "npx")
+        assert "tools=[fs]" in output
+        ns = _exec_agent(output)
+        server = ns["agent"].tools[0]
+        assert server.name == "fs"
+        assert server.transport == "stdio"
+
     def test_transport_inferred_from_command(self, workspace):
         ws = workspace(AGENT_SOURCE)
         output = _run(ws, "--name", "fs", "--command", "npx")

--- a/python/tests/codegen/test_add_step.py
+++ b/python/tests/codegen/test_add_step.py
@@ -63,6 +63,45 @@ class TestAgentStep:
         assert 'name="agent_a"' in norm
         assert "workflow.step(agent_a)" in output
 
+    def test_annotated_workflow_entry_point(self, workspace):
+        """The new step variable must precede the .step() call on an annotated workflow."""
+        ws = workspace("""\
+        from timbal import Workflow
+
+        workflow: Workflow = Workflow(name="my_workflow")
+        """)
+        output = _run_dry(ws, "--type", "Agent", "--config", '{"name": "agent_a", "model": "openai/gpt-4o-mini"}')
+        assert "workflow.step(agent_a)" in output
+        assert output.index("agent_a = Agent") < output.index("workflow.step(agent_a)")
+        exec(output, {})  # no NameError → definition order is valid
+
+    def test_annotated_step_variable_idempotent_readd(self, workspace):
+        """Re-adding a step whose variable is annotated updates it in place."""
+        ws = workspace("""\
+        from timbal import Agent, Workflow
+
+        agent_a: Agent = Agent(name="agent_a", model="openai/gpt-4o-mini")
+
+        workflow = Workflow(name="my_workflow")
+        workflow.step(agent_a)
+        """)
+        output = _run_dry(ws, "--type", "Agent", "--config", '{"name": "agent_a", "model": "openai/gpt-4o"}')
+        assert output.count("workflow.step(agent_a)") == 1
+        assert output.count("Agent(") <= 2  # annotation + constructor, no duplicate assignment
+        assert 'model="openai/gpt-4o"' in output
+
+    def test_missing_entry_point_fails_loudly(self, workspace):
+        """A wrong fqn must not emit a dangling workflow.step(...) call."""
+        ws = workspace("""\
+        from timbal import Workflow
+
+        wf = Workflow(name="my_workflow")
+        """)
+        stderr = _run_dry_expect_error(
+            ws, "--type", "Agent", "--config", '{"name": "agent_a", "model": "openai/gpt-4o-mini"}'
+        )
+        assert "Entry point variable 'workflow' not found" in stderr
+
     def test_rejects_agent_without_name(self, workspace):
         """Agent steps must have a name."""
         ws = workspace("""\

--- a/python/tests/codegen/test_add_tool.py
+++ b/python/tests/codegen/test_add_tool.py
@@ -63,6 +63,18 @@ class TestFrameworkTool:
         ns = _exec_agent(output)
         assert "web_search" in [t.name for t in ns["agent"].tools]
 
+    def test_annotated_entry_point(self, workspace):
+        """add-tool appends to the tools list of an annotated agent assignment."""
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent: Agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[])
+        """)
+        output = _run_dry(ws, "--type", "WebSearch")
+        assert "tools=[web_search]" in output
+        ns = _exec_agent(output)
+        assert "web_search" in [t.name for t in ns["agent"].tools]
+
     def test_idempotent(self, workspace):
         """Re-adding an existing variable-style tool doesn't duplicate it."""
         ws = workspace("""\

--- a/python/tests/codegen/test_get_flow.py
+++ b/python/tests/codegen/test_get_flow.py
@@ -1,3 +1,4 @@
+import json
 import textwrap
 from pathlib import Path
 
@@ -143,6 +144,72 @@ class TestAgentNode:
         """)
         config = _single_node(_flow(ws))["data"]["config"]
         assert config["system_prompt"]["value"] is None
+
+    def test_voice_config_dict(self, workspace):
+        """voice_config set in the source round-trips through get-flow."""
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent = Agent(
+            name="a",
+            model="openai/gpt-4o-mini",
+            max_tokens=128,
+            voice_config={"voice": "CURRENT_VOICE", "tts_extra": {"auto_mode": True}},
+        )
+        """)
+        config = _single_node(_flow(ws))["data"]["config"]
+        assert config["voice_config"]["value"] == {
+            "voice": "CURRENT_VOICE",
+            "tts_extra": {"auto_mode": True},
+        }
+
+    def test_voice_config_absent(self, workspace):
+        """Agents without voice_config still expose the key with a None value."""
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini", max_tokens=128)
+        """)
+        config = _single_node(_flow(ws))["data"]["config"]
+        assert "voice_config" in config
+        assert config["voice_config"]["value"] is None
+
+    def test_voice_config_callable(self, workspace):
+        """A callable voice_config is rendered as an opaque placeholder."""
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        def make_voice_config():
+            return {"voice": "CURRENT_VOICE"}
+
+        agent = Agent(
+            name="a",
+            model="openai/gpt-4o-mini",
+            max_tokens=128,
+            voice_config=make_voice_config,
+        )
+        """)
+        config = _single_node(_flow(ws))["data"]["config"]
+        assert config["voice_config"]["value"] == "<make_voice_config>"
+
+    def test_voice_config_instance(self, workspace):
+        """A VoiceConfig instance is dumped to a JSON-safe dict."""
+        ws = workspace("""\
+        from timbal.core import Agent
+        from timbal.voice.config import VoiceConfig
+
+        agent = Agent(
+            name="a",
+            model="openai/gpt-4o-mini",
+            max_tokens=128,
+            voice_config=VoiceConfig(voice="my-voice"),
+        )
+        """)
+        config = _single_node(_flow(ws))["data"]["config"]
+        value = config["voice_config"]["value"]
+        assert isinstance(value, dict)
+        assert value["voice"] == "my-voice"
+        json.dumps(value)  # must stay JSON-serialisable
 
     def test_has_params_and_return(self, workspace):
         ws = workspace("""\

--- a/python/tests/codegen/test_get_flow.py
+++ b/python/tests/codegen/test_get_flow.py
@@ -191,6 +191,10 @@ class TestAgentNode:
         """)
         config = _single_node(_flow(ws))["data"]["config"]
         assert config["voice_config"]["value"] == "<make_voice_config>"
+        # Schema must advertise the callable variant (mirrors system_prompt).
+        any_of_types = [v.get("type") for v in config["voice_config"]["anyOf"]]
+        assert "callable" in any_of_types
+        assert "object" in any_of_types
 
     def test_voice_config_instance(self, workspace):
         """A VoiceConfig instance is dumped to a JSON-safe dict."""

--- a/python/tests/codegen/test_remove_edge.py
+++ b/python/tests/codegen/test_remove_edge.py
@@ -55,6 +55,23 @@ class TestRemoveOrderingEdge:
         assert '"agent_a"' not in normalized.split("depends_on")[1] if "depends_on" in normalized else True
 
 
+class TestIdempotency:
+    def test_remove_absent_edge_is_noop_success(self, wf_workspace):
+        """Removing an edge that is already gone succeeds without changes."""
+        ws = wf_workspace("""\
+        from timbal import Agent, Workflow
+
+        agent_a = Agent(name="agent_a", model="openai/gpt-4o-mini")
+        agent_b = Agent(name="agent_b", model="openai/gpt-4o-mini")
+
+        workflow = Workflow(name="wf")
+        workflow.step(agent_a)
+        workflow.step(agent_b)
+        """)
+        output = _run(ws, source="agent_a", target="agent_b")
+        assert "workflow.step(agent_b)" in output
+
+
 class TestRemoveDataFlowEdge:
     def test_remove_param_lambda(self, wf_workspace):
         ws = wf_workspace("""\

--- a/python/tests/codegen/test_remove_step.py
+++ b/python/tests/codegen/test_remove_step.py
@@ -59,6 +59,33 @@ class TestRemoveAgentStep:
         # Variable and import should be cleaned up by remove_unused_code
         assert "agent_a = Agent" not in output
 
+    def test_missing_entry_point_fails_loudly(self, workspace):
+        """A wrong fqn must not phantom-succeed via allow_noop."""
+        ws = workspace("""\
+        from timbal import Agent, Workflow
+
+        agent_a = Agent(name="agent_a", model="openai/gpt-4o-mini")
+
+        wf = Workflow(name="my_workflow")
+        wf.step(agent_a)
+        """)
+        stderr = _run_dry_expect_error(ws, "agent_a")
+        assert "Entry point variable 'workflow' not found" in stderr
+
+    def test_aliased_workflow_with_step_calls_works(self, workspace):
+        """An alias entry point whose .step() calls use the fqn name still works."""
+        ws = workspace("""\
+        from timbal import Agent, Workflow
+
+        agent_a = Agent(name="agent_a", model="openai/gpt-4o-mini")
+
+        _wf = Workflow(name="my_workflow")
+        workflow = _wf
+        workflow.step(agent_a)
+        """)
+        output = _run_dry(ws, "agent_a")
+        assert "workflow.step(agent_a)" not in output
+
     def test_removes_one_keeps_other(self, workspace):
         """Remove one step but keep the other intact."""
         ws = workspace("""\

--- a/python/tests/codegen/test_remove_tool.py
+++ b/python/tests/codegen/test_remove_tool.py
@@ -32,6 +32,15 @@ def _run_dry(workspace_path: Path, tool_name: str) -> str:
     return result.stdout
 
 
+def _run_dry_fail(workspace_path: Path, tool_name: str) -> subprocess.CompletedProcess:
+    """Run codegen remove-tool with --dry-run and return the raw result."""
+    return subprocess.run(
+        codegen_cmd("--path", str(workspace_path), "--dry-run", "remove-tool", "--name", tool_name),
+        capture_output=True,
+        text=True,
+    )
+
+
 def _exec_agent(code: str) -> dict:
     """Exec the generated code and return its globals."""
     ns = {}
@@ -360,3 +369,39 @@ class TestRemoveToolStep:
         )
         assert result.returncode != 0
         assert "--step requires a Workflow" in result.stderr
+
+
+class TestEntryPointValidation:
+    def test_aliased_entry_point_fails_loudly(self, workspace):
+        """An alias entry point (agent = _agent) must not phantom-succeed via allow_noop."""
+        ws = workspace("""\
+        from timbal.core import Agent
+        from timbal.tools import WebSearch
+
+        _agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[WebSearch()])
+        agent = _agent
+        """)
+        result = _run_dry_fail(ws, "web_search")
+        assert result.returncode != 0
+        assert "Entry point variable 'agent' not found" in result.stderr
+
+    def test_unknown_step_fails_loudly(self, wf_workspace):
+        """Removing from a nonexistent step is an error, not an idempotent no-op."""
+        ws = wf_workspace("""\
+        from timbal import Agent, Workflow
+        from timbal.tools import WebSearch
+
+        agent_a = Agent(name="agent_a", model="openai/gpt-4o-mini", tools=[WebSearch()])
+
+        workflow = Workflow(name="workflow")
+        workflow.step(agent_a)
+        """)
+        result = subprocess.run(
+            codegen_cmd("--path", str(ws), "--dry-run",
+                "remove-tool", "--name", "web_search", "--step", "nope",
+            ),
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "Workflow step 'nope' not found" in result.stderr

--- a/python/tests/codegen/test_remove_tool.py
+++ b/python/tests/codegen/test_remove_tool.py
@@ -52,6 +52,18 @@ class TestRemoveFrameworkTool:
         ns = _exec_agent(output)
         assert len(ns["agent"].tools) == 0
 
+    def test_annotated_entry_point(self, workspace):
+        """remove-tool prunes the tools list of an annotated agent assignment."""
+        ws = workspace("""\
+        from timbal.core import Agent
+        from timbal.tools import WebSearch
+
+        agent: Agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[WebSearch()])
+        """)
+        output = _run_dry(ws, "web_search")
+        ns = _exec_agent(output)
+        assert len(ns["agent"].tools) == 0
+
     def test_removes_one_keeps_others(self, workspace):
         """Remove WebSearch but keep other tools intact."""
         ws = workspace("""\

--- a/python/tests/codegen/test_set_config.py
+++ b/python/tests/codegen/test_set_config.py
@@ -485,6 +485,95 @@ class TestToolNameAndDescription:
 
 
 # ---------------------------------------------------------------------------
+# Entry point shapes (annotated / aliased / factory assignments)
+# ---------------------------------------------------------------------------
+
+
+class TestEntryPointShapes:
+    def test_annotated_assignment(self, workspace):
+        """``agent: Agent = Agent(...)`` is transformed like a plain assignment."""
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent: Agent = Agent(name="a", model="openai/gpt-4o-mini")
+        """)
+        config = json.dumps({"voice_config": {"voice": "NEW_VOICE"}})
+        output = _run_dry(ws, "--config", config)
+        ns = _exec_agent(output)
+        assert ns["agent"].voice_config == {"voice": "NEW_VOICE"}
+
+    def test_annotated_assignment_set_model(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent: Agent = Agent(name="a", model="openai/gpt-4o-mini")
+        """)
+        config = json.dumps({"model": "openai/gpt-4o"})
+        output = _run_dry(ws, "--config", config)
+        ns = _exec_agent(output)
+        assert ns["agent"].model == "openai/gpt-4o"
+
+    def test_aliased_assignment_fails_loudly(self, workspace):
+        """``agent = _agent`` cannot be transformed — must exit non-zero, not silently no-op."""
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        _agent = Agent(name="a", model="openai/gpt-4o-mini")
+        agent = _agent
+        """)
+        config = json.dumps({"voice_config": {"voice": "NEW_VOICE"}})
+        result = _run_dry_fail(ws, "--config", config)
+        assert result.returncode != 0
+        assert "produced no changes" in result.stderr
+
+    def test_factory_call_fails_loudly(self, workspace):
+        """``agent = build()`` must error instead of appending kwargs to build()."""
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        def build():
+            return Agent(name="a", model="openai/gpt-4o-mini")
+
+        agent = build()
+        """)
+        config = json.dumps({"voice_config": {"voice": "NEW_VOICE"}})
+        result = _run_dry_fail(ws, "--config", config)
+        assert result.returncode != 0
+        assert "factory" in result.stderr
+
+    def test_noop_same_value_is_idempotent_success(self, workspace):
+        """Setting a field to its current value is a success: the transformer
+        matched the entry point, the source was already in the desired state."""
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent = Agent(name="a", model="openai/gpt-4o-mini")
+        """)
+        config = json.dumps({"model": "openai/gpt-4o-mini"})
+        output = _run_dry(ws, "--config", config)
+        ns = _exec_agent(output)
+        assert ns["agent"].model == "openai/gpt-4o-mini"
+
+    def test_write_mode_noop_leaves_file_untouched(self, workspace):
+        """A failed no-op without --dry-run must not rewrite the source file."""
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        _agent = Agent(name="a", model="openai/gpt-4o-mini")
+        agent = _agent
+        """)
+        original = (ws / "agent.py").read_text()
+        config = json.dumps({"voice_config": {"voice": "NEW_VOICE"}})
+        result = subprocess.run(
+            codegen_cmd("--path", str(ws), "set-config", "--config", config),
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert (ws / "agent.py").read_text() == original
+
+
+# ---------------------------------------------------------------------------
 # Workflow step config
 # ---------------------------------------------------------------------------
 

--- a/python/tests/codegen/test_set_config.py
+++ b/python/tests/codegen/test_set_config.py
@@ -695,6 +695,19 @@ class TestStepConstructorConfig:
         output = _run_dry_wf(ws, "--name", "agent_a", "--config", '{"model": "openai/gpt-4o"}')
         assert 'model="openai/gpt-4o"' in output
 
+    def test_annotated_step_variable(self, wf_workspace):
+        """Update constructor config on an annotated step variable."""
+        ws = wf_workspace("""\
+        from timbal import Agent, Workflow
+
+        agent_a: Agent = Agent(name="agent_a", model="openai/gpt-4o-mini")
+
+        workflow = Workflow(name="my_workflow")
+        workflow.step(agent_a)
+        """)
+        output = _run_dry_wf(ws, "--name", "agent_a", "--config", '{"model": "openai/gpt-4o"}')
+        assert 'model="openai/gpt-4o"' in output
+
     def test_rename_step_updates_depends_on(self, wf_workspace):
         """Renaming a step via set-config updates depends_on references."""
         ws = wf_workspace("""\

--- a/python/tests/codegen/test_set_config.py
+++ b/python/tests/codegen/test_set_config.py
@@ -541,6 +541,75 @@ class TestEntryPointShapes:
         assert result.returncode != 0
         assert "factory" in result.stderr
 
+    def test_imported_factory_call_fails_loudly(self, workspace):
+        """An imported factory must also error, not get kwargs injected."""
+        ws = workspace("""\
+        from helpers import build
+
+        agent = build()
+        """)
+        config = json.dumps({"voice_config": {"voice": "NEW_VOICE"}})
+        result = _run_dry_fail(ws, "--config", config)
+        assert result.returncode != 0
+        assert "factory" in result.stderr
+
+    def test_aliased_agent_import_still_works(self, workspace):
+        """``from timbal.core import Agent as A`` is recognized as a constructor."""
+        ws = workspace("""\
+        from timbal.core import Agent as A
+
+        agent = A(name="a", model="openai/gpt-4o-mini")
+        """)
+        config = json.dumps({"model": "openai/gpt-4o"})
+        output = _run_dry(ws, "--config", config)
+        ns = _exec_agent(output)
+        assert ns["agent"].model == "openai/gpt-4o"
+
+    def test_module_qualified_constructor_works(self, workspace):
+        """``timbal.Agent(...)`` is recognized as a constructor."""
+        ws = workspace("""\
+        import timbal
+
+        agent = timbal.Agent(name="a", model="openai/gpt-4o-mini")
+        """)
+        config = json.dumps({"model": "openai/gpt-4o"})
+        output = _run_dry(ws, "--config", config)
+        ns = _exec_agent(output)
+        assert ns["agent"].model == "openai/gpt-4o"
+
+    def test_annotated_assignment_tool_config(self, workspace):
+        """Tool-level set-config works when the agent uses an annotated assignment."""
+        ws = workspace("""\
+        from timbal.core import Agent
+        from timbal.core.tool import Tool
+
+        def my_func():
+            return "hello"
+
+        my_tool = Tool(handler=my_func, name="my_tool")
+
+        agent: Agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[my_tool])
+        """)
+        config = json.dumps({"description": "Does something useful"})
+        output = _run_dry(ws, "--name", "my_tool", "--config", config)
+        ns = _exec_agent(output)
+        assert ns["my_tool"].description == "Does something useful"
+
+    def test_annotated_assignment_inline_tool_migration(self, workspace):
+        """Inline tool migration inserts the variable before an annotated entry point."""
+        ws = workspace("""\
+        from timbal.core import Agent
+        from timbal.tools import WebSearch
+
+        agent: Agent = Agent(name="a", model="openai/gpt-4o-mini", tools=[WebSearch()])
+        """)
+        config = json.dumps({"allowed_domains": ["example.com"]})
+        output = _run_dry(ws, "--name", "web_search", "--config", config)
+        # exec fails with NameError if the variable lands after the entry point.
+        ns = _exec_agent(output)
+        tool = next(t for t in ns["agent"].tools if t.name == "web_search")
+        assert tool.allowed_domains == ["example.com"]
+
     def test_noop_same_value_is_idempotent_success(self, workspace):
         """Setting a field to its current value is a success: the transformer
         matched the entry point, the source was already in the desired state."""

--- a/python/tests/codegen/test_set_param.py
+++ b/python/tests/codegen/test_set_param.py
@@ -362,6 +362,19 @@ class TestValueParam:
         output = _run(ws, target="agent_b", name="prompt", param_type="value", source=None, key=None, value="null")
         assert "prompt=" not in output
 
+    def test_set_same_value_is_idempotent_success(self, wf_workspace):
+        """Setting a param to its current value succeeds without changes."""
+        ws = wf_workspace("""\
+        from timbal import Agent, Workflow
+
+        agent_a = Agent(name="agent_a", model="openai/gpt-4o-mini")
+
+        workflow = Workflow(name="wf")
+        workflow.step(agent_a, prompt="Hello world")
+        """)
+        output = _run(ws, target="agent_a", name="prompt", param_type="value", source=None, key=None, value='"Hello world"')
+        assert 'prompt="Hello world"' in output
+
     def test_update_existing_value_param(self, wf_workspace):
         ws = wf_workspace("""\
         from timbal import Agent, Workflow

--- a/python/tests/codegen/test_set_position.py
+++ b/python/tests/codegen/test_set_position.py
@@ -169,6 +169,20 @@ class TestWorkflowStepPosition:
         ns = _exec_agent(output)
         assert ns["agent_a"].metadata["position"] == {"x": 150.0, "y": 250.0}
 
+    def test_annotated_step_variable(self, wf_workspace):
+        """Set position on an annotated step variable."""
+        ws = wf_workspace("""\
+        from timbal import Agent, Workflow
+
+        agent_a: Agent = Agent(name="agent_a", model="openai/gpt-4o-mini")
+
+        workflow = Workflow(name="my_workflow")
+        workflow.step(agent_a)
+        """)
+        output = _run_dry(ws, "--name", "agent_a", "--x", "150", "--y", "250")
+        ns = _exec_agent(output)
+        assert ns["agent_a"].metadata["position"] == {"x": 150.0, "y": 250.0}
+
     def test_set_step_position_preserves_metadata(self, wf_workspace):
         ws = wf_workspace("""\
         from timbal import Agent, Workflow

--- a/python/tests/codegen/test_set_position.py
+++ b/python/tests/codegen/test_set_position.py
@@ -91,6 +91,21 @@ class TestAgentPosition:
         ns = _exec_agent(output)
         assert ns["agent"].metadata["position"] == {"x": 300.0, "y": 400.0}
 
+    def test_same_position_is_idempotent_success(self, workspace):
+        """Setting the current coordinates again succeeds without changes."""
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent = Agent(
+            name="a",
+            model="openai/gpt-4o-mini",
+            metadata={"position": {"x": 10.0, "y": 20.0}},
+        )
+        """)
+        output = _run_dry(ws, "--x", "10", "--y", "20")
+        ns = _exec_agent(output)
+        assert ns["agent"].metadata["position"] == {"x": 10.0, "y": 20.0}
+
     def test_preserves_other_kwargs(self, workspace):
         ws = workspace("""\
         from timbal.core import Agent

--- a/python/tests/codegen/test_set_position.py
+++ b/python/tests/codegen/test_set_position.py
@@ -91,6 +91,17 @@ class TestAgentPosition:
         ns = _exec_agent(output)
         assert ns["agent"].metadata["position"] == {"x": 300.0, "y": 400.0}
 
+    def test_annotated_entry_point(self, workspace):
+        """set-position works on an annotated agent assignment."""
+        ws = workspace("""\
+        from timbal.core import Agent
+
+        agent: Agent = Agent(name="a", model="openai/gpt-4o-mini")
+        """)
+        output = _run_dry(ws, "--x", "100", "--y", "200")
+        ns = _exec_agent(output)
+        assert ns["agent"].metadata["position"] == {"x": 100.0, "y": 200.0}
+
     def test_same_position_is_idempotent_success(self, workspace):
         """Setting the current coordinates again succeeds without changes."""
         ws = workspace("""\

--- a/python/tests/evals/test_utils.py
+++ b/python/tests/evals/test_utils.py
@@ -79,6 +79,12 @@ class TestDiscoverEvalFiles:
         b = touch(tmp_path / "more_evals" / "deep" / "b_eval.yaml")
         assert discover_eval_files(tmp_path) == sorted([a, b])
 
+    def test_skips_evalconf(self, tmp_path):
+        """evalconf.yaml matches the eval* glob but is the shared config, not a suite."""
+        touch(tmp_path / "evalconf.yaml", "runnable: ../agent.py::agent\n")
+        eval_file = touch(tmp_path / "eval_smoke.yaml")
+        assert discover_eval_files(tmp_path) == [eval_file]
+
 
 class TestParseEvalFileRunnableResolution:
     def test_runnable_relative_to_eval_file_dir(self, tmp_path):

--- a/python/timbal/codegen/cst_utils.py
+++ b/python/timbal/codegen/cst_utils.py
@@ -260,6 +260,29 @@ def collect_step_names(
     return var_to_name
 
 
+def has_step_expr(tree: cst.Module, entry_point: str) -> bool:
+    """True when a standalone ``<entry_point>.step(...)`` statement exists.
+
+    Used to validate workflow entry points that ``collect_assignments`` cannot
+    see (e.g. an alias like ``workflow = _wf`` whose steps are registered via
+    ``workflow.step(...)`` statements).
+    """
+    for stmt in tree.body:
+        if not isinstance(stmt, cst.SimpleStatementLine):
+            continue
+        for item in stmt.body:
+            if (
+                isinstance(item, cst.Expr)
+                and isinstance(item.value, cst.Call)
+                and isinstance(item.value.func, cst.Attribute)
+                and isinstance(item.value.func.value, cst.Name)
+                and item.value.func.value.value == entry_point
+                and item.value.func.attr.value == "step"
+            ):
+                return True
+    return False
+
+
 def collect_chained_step_names(
     tree: cst.Module,
     entry_point: str,
@@ -277,14 +300,19 @@ def collect_chained_step_names(
         if not isinstance(stmt, cst.SimpleStatementLine):
             continue
         for item in stmt.body:
-            if not isinstance(item, cst.Assign):
+            if isinstance(item, cst.Assign):
+                if not any(
+                    isinstance(t.target, cst.Name) and t.target.value == entry_point
+                    for t in item.targets
+                ):
+                    continue
+                node = item.value
+            elif isinstance(item, cst.AnnAssign):
+                if not (isinstance(item.target, cst.Name) and item.target.value == entry_point):
+                    continue
+                node = item.value
+            else:
                 continue
-            if not any(
-                isinstance(t.target, cst.Name) and t.target.value == entry_point
-                for t in item.targets
-            ):
-                continue
-            node = item.value
             while isinstance(node, cst.Call) and isinstance(node.func, cst.Attribute):
                 if node.func.attr.value == "step" and node.args:
                     first_arg = node.args[0].value
@@ -421,7 +449,10 @@ class _BareFunctionWrapper(cst.CSTTransformer):
             f'{self.step_name} = Tool(name="{self.step_name}", handler={self.step_name}_fn)\n'
         )
 
-        # Insert before the entry-point assignment.
+        # Insert before the entry-point assignment (plain or annotated). Also
+        # stop at the first standalone ``.step()`` statement so aliased entry
+        # points (not visible as assignments) still get the Tool defined
+        # before its first reference.
         insert_idx = len(body)
         for i, stmt in enumerate(body):
             if isinstance(stmt, cst.SimpleStatementLine):
@@ -430,6 +461,17 @@ class _BareFunctionWrapper(cst.CSTTransformer):
                         for t in item_node.targets:
                             if isinstance(t.target, cst.Name) and t.target.value == self.entry_point:
                                 insert_idx = min(insert_idx, i)
+                    elif isinstance(item_node, cst.AnnAssign):
+                        if isinstance(item_node.target, cst.Name) and item_node.target.value == self.entry_point:
+                            insert_idx = min(insert_idx, i)
+                    elif (
+                        isinstance(item_node, cst.Expr)
+                        and isinstance(item_node.value, cst.Call)
+                        and isinstance(item_node.value.func, cst.Attribute)
+                        and isinstance(item_node.value.func.value, cst.Name)
+                        and item_node.value.func.value.value == self.entry_point
+                    ):
+                        insert_idx = min(insert_idx, i)
         body.insert(insert_idx, cst.parse_statement(assignment_code))
 
         return updated_node.with_changes(body=body)

--- a/python/timbal/codegen/cst_utils.py
+++ b/python/timbal/codegen/cst_utils.py
@@ -16,14 +16,47 @@ def _root_constructor_name(value: cst.BaseExpression) -> str | None:
     """Return the root constructor's class name for an assignment value.
 
     Walks down chained method calls (e.g. ``Workflow(...).step(...).step(...)``)
-    to find the root constructor.
+    to find the root constructor. Module-qualified constructors
+    (e.g. ``timbal.Agent(...)``) resolve to the attribute name.
     """
     call = value
-    while isinstance(call, cst.Call) and isinstance(call.func, cst.Attribute):
+    # Chained method calls have a Call as the attribute base; module access
+    # (``timbal.Agent``) has a Name/Attribute base and must not be walked.
+    while (
+        isinstance(call, cst.Call)
+        and isinstance(call.func, cst.Attribute)
+        and isinstance(call.func.value, cst.Call)
+    ):
         call = call.func.value
-    if isinstance(call, cst.Call) and isinstance(call.func, cst.Name):
-        return call.func.value
+    if isinstance(call, cst.Call):
+        if isinstance(call.func, cst.Name):
+            return call.func.value
+        if isinstance(call.func, cst.Attribute):
+            return call.func.attr.value
     return None
+
+
+def _collect_entry_point_aliases(tree: cst.Module) -> dict[str, str]:
+    """Map local import aliases to canonical entry point class names.
+
+    Covers ``from timbal import Agent as A`` so aliased constructors are
+    recognized like the canonical names.
+    """
+    aliases: dict[str, str] = {}
+    for stmt in tree.body:
+        if isinstance(stmt, cst.SimpleStatementLine):
+            for item in stmt.body:
+                if isinstance(item, cst.ImportFrom) and not isinstance(item.names, cst.ImportStar):
+                    for alias in item.names:
+                        if (
+                            isinstance(alias, cst.ImportAlias)
+                            and isinstance(alias.name, cst.Name)
+                            and alias.name.value in ENTRY_POINT_TYPES
+                            and alias.asname is not None
+                            and isinstance(alias.asname.name, cst.Name)
+                        ):
+                            aliases[alias.asname.name.value] = alias.name.value
+    return aliases
 
 
 def resolve_entry_point_type(tree: cst.Module, entry_point: str) -> str | None:
@@ -31,17 +64,25 @@ def resolve_entry_point_type(tree: cst.Module, entry_point: str) -> str | None:
 
     Inspects top-level assignments (plain and annotated, e.g.
     ``agent: Agent = Agent(...)``) to find `entry_point = ClassName(...)` and
-    returns the class name if it's a known entry point type. Returns None if
-    not found.
+    returns the class name if it's a known entry point type. Import aliases
+    (``Agent as A``) and module-qualified constructors (``timbal.Agent(...)``)
+    are canonicalized. Returns None if not found.
     """
+    aliases = _collect_entry_point_aliases(tree)
+
+    def _canonical(value: cst.BaseExpression) -> str | None:
+        cls_name = _root_constructor_name(value)
+        cls_name = aliases.get(cls_name, cls_name)
+        return cls_name if cls_name in ENTRY_POINT_TYPES else None
+
     for stmt in tree.body:
         if isinstance(stmt, cst.SimpleStatementLine):
             for item in stmt.body:
                 if isinstance(item, cst.Assign):
                     for target in item.targets:
                         if isinstance(target.target, cst.Name) and target.target.value == entry_point:
-                            cls_name = _root_constructor_name(item.value)
-                            if cls_name in ENTRY_POINT_TYPES:
+                            cls_name = _canonical(item.value)
+                            if cls_name is not None:
                                 return cls_name
                 elif isinstance(item, cst.AnnAssign):
                     if (
@@ -49,8 +90,8 @@ def resolve_entry_point_type(tree: cst.Module, entry_point: str) -> str | None:
                         and item.target.value == entry_point
                         and item.value is not None
                     ):
-                        cls_name = _root_constructor_name(item.value)
-                        if cls_name in ENTRY_POINT_TYPES:
+                        cls_name = _canonical(item.value)
+                        if cls_name is not None:
                             return cls_name
     return None
 

--- a/python/timbal/codegen/cst_utils.py
+++ b/python/timbal/codegen/cst_utils.py
@@ -12,11 +12,27 @@ if TYPE_CHECKING:
 ENTRY_POINT_TYPES = {"Agent", "Workflow"}
 
 
+def _root_constructor_name(value: cst.BaseExpression) -> str | None:
+    """Return the root constructor's class name for an assignment value.
+
+    Walks down chained method calls (e.g. ``Workflow(...).step(...).step(...)``)
+    to find the root constructor.
+    """
+    call = value
+    while isinstance(call, cst.Call) and isinstance(call.func, cst.Attribute):
+        call = call.func.value
+    if isinstance(call, cst.Call) and isinstance(call.func, cst.Name):
+        return call.func.value
+    return None
+
+
 def resolve_entry_point_type(tree: cst.Module, entry_point: str) -> str | None:
     """Return the constructor class name ('Agent' or 'Workflow') for the entry point variable.
 
-    Inspects top-level assignments to find `entry_point = ClassName(...)` and returns
-    the class name if it's a known entry point type. Returns None if not found.
+    Inspects top-level assignments (plain and annotated, e.g.
+    ``agent: Agent = Agent(...)``) to find `entry_point = ClassName(...)` and
+    returns the class name if it's a known entry point type. Returns None if
+    not found.
     """
     for stmt in tree.body:
         if isinstance(stmt, cst.SimpleStatementLine):
@@ -24,15 +40,18 @@ def resolve_entry_point_type(tree: cst.Module, entry_point: str) -> str | None:
                 if isinstance(item, cst.Assign):
                     for target in item.targets:
                         if isinstance(target.target, cst.Name) and target.target.value == entry_point:
-                            # Walk down chained method calls (e.g. Workflow(...).step(...).step(...))
-                            # to find the root constructor.
-                            call = item.value
-                            while isinstance(call, cst.Call) and isinstance(call.func, cst.Attribute):
-                                call = call.func.value
-                            if isinstance(call, cst.Call) and isinstance(call.func, cst.Name):
-                                cls_name = call.func.value
-                                if cls_name in ENTRY_POINT_TYPES:
-                                    return cls_name
+                            cls_name = _root_constructor_name(item.value)
+                            if cls_name in ENTRY_POINT_TYPES:
+                                return cls_name
+                elif isinstance(item, cst.AnnAssign):
+                    if (
+                        isinstance(item.target, cst.Name)
+                        and item.target.value == entry_point
+                        and item.value is not None
+                    ):
+                        cls_name = _root_constructor_name(item.value)
+                        if cls_name in ENTRY_POINT_TYPES:
+                            return cls_name
     return None
 
 
@@ -141,7 +160,11 @@ def build_cst_value(value: object) -> cst.BaseExpression:
 
 
 def collect_assignments(tree: cst.Module) -> dict[str, cst.Call]:
-    """Build a map of variable_name -> Call node for all top-level assignments."""
+    """Build a map of variable_name -> Call node for all top-level assignments.
+
+    Covers plain assignments (``x = Call(...)``) and annotated assignments
+    (``x: T = Call(...)``).
+    """
     result = {}
     for stmt in tree.body:
         if isinstance(stmt, cst.SimpleStatementLine):
@@ -150,6 +173,12 @@ def collect_assignments(tree: cst.Module) -> dict[str, cst.Call]:
                     for target in item.targets:
                         if isinstance(target.target, cst.Name):
                             result[target.target.value] = item.value
+                elif (
+                    isinstance(item, cst.AnnAssign)
+                    and isinstance(item.target, cst.Name)
+                    and isinstance(item.value, cst.Call)
+                ):
+                    result[item.target.value] = item.value
     return result
 
 

--- a/python/timbal/codegen/transformers/__init__.py
+++ b/python/timbal/codegen/transformers/__init__.py
@@ -307,4 +307,26 @@ def apply_operation(workspace_path: str | Path, operation: str, **kwargs) -> str
     if getattr(transformer, "needs_reorder", False):
         code = reorder_step_calls(code, spec.target)
 
-    return format_code(code, spec.path)
+    formatted = format_code(code, spec.path)
+
+    # Every transformer operation is a mutation, so identical output is
+    # suspicious — it usually means the transformer never matched its target
+    # (e.g. an aliased entry point like ``agent = _agent``). Fail loudly
+    # instead of reporting a phantom success, except when:
+    # - the transformer has intentional no-op semantics (``allow_noop = True``,
+    #   e.g. add-edge deduplication, removing an already-absent tool), or
+    # - the transformer affirmatively found its target (``matched = True``),
+    #   in which case an unchanged file just means the source was already in
+    #   the desired state (idempotent save).
+    if (
+        formatted == source
+        and not getattr(transformer, "allow_noop", False)
+        and getattr(transformer, "matched", None) is not True
+    ):
+        raise ValueError(
+            f"{operation.replace('_', '-')} produced no changes to {spec.path.name}. "
+            f"The source may use a shape the transformer does not recognize "
+            f"(e.g. an aliased entry point assignment)."
+        )
+
+    return formatted

--- a/python/timbal/codegen/transformers/__init__.py
+++ b/python/timbal/codegen/transformers/__init__.py
@@ -78,6 +78,9 @@ class _Remover(cst.CSTTransformer):
                 for target in item.targets:
                     if isinstance(target.target, cst.Name) and target.target.value in self._unused_vars:
                         return cst.RemovalSentinel.REMOVE
+            elif isinstance(item, cst.AnnAssign):
+                if isinstance(item.target, cst.Name) and item.target.value in self._unused_vars:
+                    return cst.RemovalSentinel.REMOVE
         return updated_node
 
 
@@ -102,6 +105,9 @@ def remove_unused_code(code: str, protected: set[str]) -> str:
                         for target in item.targets:
                             if isinstance(target.target, cst.Name):
                                 var_defs.add(target.target.value)
+                    elif isinstance(item, cst.AnnAssign):
+                        if isinstance(item.target, cst.Name):
+                            var_defs.add(item.target.value)
 
         candidates = (var_defs | func_defs) - protected
         if not candidates:
@@ -116,19 +122,26 @@ def remove_unused_code(code: str, protected: set[str]) -> str:
         for stmt in tree.body:
             if isinstance(stmt, cst.SimpleStatementLine):
                 for item in stmt.body:
+                    assigned_names: list[str] = []
                     if isinstance(item, cst.Assign):
-                        for target in item.targets:
-                            if isinstance(target.target, cst.Name) and target.target.value in candidates:
-                                name = target.target.value
-                                # Count Name nodes in the assignment value + target itself.
-                                count = 0
-                                stack = list(stmt.children)
-                                while stack:
-                                    child = stack.pop()
-                                    if isinstance(child, cst.Name) and child.value == name:
-                                        count += 1
-                                    stack.extend(child.children)
-                                var_self_counts[name] = var_self_counts.get(name, 0) + count
+                        assigned_names = [
+                            t.target.value
+                            for t in item.targets
+                            if isinstance(t.target, cst.Name) and t.target.value in candidates
+                        ]
+                    elif isinstance(item, cst.AnnAssign):
+                        if isinstance(item.target, cst.Name) and item.target.value in candidates:
+                            assigned_names = [item.target.value]
+                    for name in assigned_names:
+                        # Count Name nodes in the assignment value + target itself.
+                        count = 0
+                        stack = list(stmt.children)
+                        while stack:
+                            child = stack.pop()
+                            if isinstance(child, cst.Name) and child.value == name:
+                                count += 1
+                            stack.extend(child.children)
+                        var_self_counts[name] = var_self_counts.get(name, 0) + count
 
         def_weight: dict[str, int] = {}
         for name in candidates:

--- a/python/timbal/codegen/transformers/add_edge.py
+++ b/python/timbal/codegen/transformers/add_edge.py
@@ -63,6 +63,9 @@ class EdgeAdder(cst.CSTTransformer):
     """Add an ordering or conditional edge between two workflow steps."""
 
     needs_reorder = True
+    # Adding an edge that already exists deduplicates to an unchanged file —
+    # that is a legitimate success, not a silent failure.
+    allow_noop = True
 
     def __init__(
         self,

--- a/python/timbal/codegen/transformers/add_mcp.py
+++ b/python/timbal/codegen/transformers/add_mcp.py
@@ -360,6 +360,26 @@ class MCPAdder(cst.CSTTransformer):
                         raise _name_collision_error(runtime_name)
         return updated_node
 
+    def leave_AnnAssign(self, original_node: cst.AnnAssign, updated_node: cst.AnnAssign) -> cst.AnnAssign:  # noqa: ARG002
+        """Handle annotated assignments, e.g. ``agent: Agent = Agent(...)``."""
+        if not isinstance(updated_node.target, cst.Name) or not isinstance(updated_node.value, cst.Call):
+            return updated_node
+        target_name = updated_node.target.value
+
+        if target_name == self.target:
+            return updated_node.with_changes(value=self._add_to_tools(updated_node.value))
+
+        for var_name, runtime_name, kwargs in self.servers:
+            mcp_id = _mcp_server_id(updated_node.value, target_name)
+            if mcp_id == runtime_name or (_is_mcp_call(updated_node.value) and target_name == var_name):
+                self._updated.add(runtime_name)
+                call_code, _ = _server_call_code(kwargs)
+                return updated_node.with_changes(value=cst.parse_expression(call_code))
+            resolved = resolve_runnable_name(updated_node.value)
+            if resolved == runtime_name and not _is_mcp_call(updated_node.value):
+                raise _name_collision_error(runtime_name)
+        return updated_node
+
     def leave_Module(self, original_node: cst.Module, updated_node: cst.Module) -> cst.Module:
         imports_to_add: list[cst.BaseStatement] = []
         stmts_to_add: list[cst.BaseStatement] = []
@@ -402,6 +422,16 @@ class MCPAdder(cst.CSTTransformer):
                             for t in item.targets:
                                 if isinstance(t.target, cst.Name) and t.target.value == self.target:
                                     insert_idx = min(insert_idx, i)
+                        elif (
+                            isinstance(item, cst.AnnAssign)
+                            and isinstance(item.target, cst.Name)
+                            and isinstance(item.value, cst.Call)
+                        ):
+                            if (
+                                resolve_runnable_name(item.value) in runtime_names
+                                or item.target.value == self.target
+                            ):
+                                insert_idx = min(insert_idx, i)
             for stmt in reversed(stmts_to_add):
                 body.insert(insert_idx, stmt)
 

--- a/python/timbal/codegen/transformers/add_mcp.py
+++ b/python/timbal/codegen/transformers/add_mcp.py
@@ -320,6 +320,10 @@ def _name_collision_error(runtime_name: str) -> ValueError:
 
 
 class MCPAdder(cst.CSTTransformer):
+    # Re-adding an identical server is an idempotent success (same-named
+    # assignment replaced in place, file unchanged), not a silent failure.
+    allow_noop = True
+
     def __init__(self, assignments: dict[str, cst.Call], *, target: str, servers: list[tuple[str, dict]]):
         self.assignments = assignments
         self.target = target

--- a/python/timbal/codegen/transformers/add_step.py
+++ b/python/timbal/codegen/transformers/add_step.py
@@ -294,6 +294,9 @@ class StepAdder(cst.CSTTransformer):
     # A re-added step's .step() call is appended last; if existing steps depend
     # on it, topologically re-sort so dependencies precede their dependents.
     needs_reorder = True
+    # Re-adding an identical step is an idempotent success (existing assignment
+    # and .step() call updated in place), not a silent failure.
+    allow_noop = True
 
     def __init__(
         self,

--- a/python/timbal/codegen/transformers/add_step.py
+++ b/python/timbal/codegen/transformers/add_step.py
@@ -7,6 +7,7 @@ from ..cst_utils import (
     build_cst_value,
     collect_assignments,
     has_import,
+    has_step_expr,
     resolve_entry_point_type,
     resolve_runnable_name,
 )
@@ -77,15 +78,21 @@ def _count_workflow_steps(tree: cst.Module, entry_point: str) -> int:
                     and call.func.attr.value == "step"
                 ):
                     count += 1
-            # Chained: workflow = Workflow().step().step()
+            # Chained: workflow = Workflow().step().step() (plain or annotated)
+            chained_value = None
             if isinstance(item, cst.Assign):
                 for t in item.targets:
                     if isinstance(t.target, cst.Name) and t.target.value == entry_point:
-                        node = item.value
-                        while isinstance(node, cst.Call) and isinstance(node.func, cst.Attribute):
-                            if node.func.attr.value == "step":
-                                count += 1
-                            node = node.func.value
+                        chained_value = item.value
+            elif isinstance(item, cst.AnnAssign):
+                if isinstance(item.target, cst.Name) and item.target.value == entry_point:
+                    chained_value = item.value
+            if chained_value is not None:
+                node = chained_value
+                while isinstance(node, cst.Call) and isinstance(node.func, cst.Attribute):
+                    if node.func.attr.value == "step":
+                        count += 1
+                    node = node.func.value
     return count
 
 
@@ -188,6 +195,17 @@ def run(entry_point: str, args: argparse.Namespace, *, tree: cst.Module | None =
             raise ValueError(f"add-step requires a Workflow entry point, but '{entry_point}' is a {ep_type}.")
 
     assignments = collect_assignments(tree) if tree else {}
+
+    # The entry point must resolve to a constructor assignment (plain or
+    # annotated) or already have standalone .step() statements (covers aliases
+    # like ``workflow = _wf``). Otherwise the emitted ``<entry>.step(...)``
+    # would reference an undefined or wrong name.
+    if tree is not None and entry_point not in assignments and not has_step_expr(tree, entry_point):
+        raise ValueError(
+            f"Entry point variable '{entry_point}' not found in source. "
+            "Ensure timbal.yaml fqn matches the Agent/Workflow variable name."
+        )
+
     step_type = args.step_type
     config = parse_json_arg(args.config, "--config") if args.config else {}
 
@@ -362,6 +380,19 @@ class StepAdder(cst.CSTTransformer):
                     )
         return updated_node
 
+    def leave_AnnAssign(self, original_node: cst.AnnAssign, updated_node: cst.AnnAssign) -> cst.AnnAssign:  # noqa: ARG002
+        """Handle annotated step variables, e.g. ``agent_a: Agent = Agent(...)``."""
+        if (
+            not isinstance(updated_node.target, cst.Name)
+            or updated_node.target.value == self.entry_point
+            or not isinstance(updated_node.value, cst.Call)
+        ):
+            return updated_node
+        if resolve_runnable_name(updated_node.value) == self.runtime_name:
+            self._assignment_updated = True
+            return updated_node.with_changes(value=self._build_assignment_call())
+        return updated_node
+
     # -- ExpressionStatement: update existing .step() call -----------------
 
     def leave_Expr(self, original_node: cst.Expr, updated_node: cst.Expr) -> cst.Expr:
@@ -433,7 +464,10 @@ class StepAdder(cst.CSTTransformer):
             for stmt in reversed(imports_to_add):
                 body.insert(import_insert_idx, stmt)
 
-        # Insert definitions/assignments before the entry point.
+        # Insert definitions/assignments before the entry point (plain or
+        # annotated assignment), or before its first standalone .step() call
+        # (aliased entry points), so the new step variable precedes the
+        # ``.step()`` statement that references it.
         if stmts_to_add:
             insert_idx = len(body)
             for i, stmt in enumerate(body):
@@ -443,6 +477,12 @@ class StepAdder(cst.CSTTransformer):
                             for t in item.targets:
                                 if isinstance(t.target, cst.Name) and t.target.value == self.entry_point:
                                     insert_idx = min(insert_idx, i)
+                        elif isinstance(item, cst.AnnAssign):
+                            if isinstance(item.target, cst.Name) and item.target.value == self.entry_point:
+                                insert_idx = min(insert_idx, i)
+                        elif isinstance(item, cst.Expr) and isinstance(item.value, cst.Call):
+                            if self._is_step_call(item.value):
+                                insert_idx = min(insert_idx, i)
             for stmt in reversed(stmts_to_add):
                 body.insert(insert_idx, stmt)
 
@@ -465,6 +505,9 @@ class StepAdder(cst.CSTTransformer):
                             for t in item.targets:
                                 if isinstance(t.target, cst.Name) and t.target.value == self.entry_point:
                                     entry_point_idx = i + 1
+                        if isinstance(item, cst.AnnAssign):
+                            if isinstance(item.target, cst.Name) and item.target.value == self.entry_point:
+                                entry_point_idx = i + 1
 
             insert_at = step_insert_idx if step_insert_idx is not None else entry_point_idx
             if insert_at is not None:

--- a/python/timbal/codegen/transformers/add_tool.py
+++ b/python/timbal/codegen/transformers/add_tool.py
@@ -161,6 +161,10 @@ def run(entry_point: str, args: argparse.Namespace, *, tree: cst.Module | None =
 
 
 class ToolAdder(cst.CSTTransformer):
+    # Re-adding an existing tool is an idempotent success (no duplicate entry,
+    # file unchanged), not a silent failure.
+    allow_noop = True
+
     def __init__(
         self,
         entry_point: str,

--- a/python/timbal/codegen/transformers/add_tool.py
+++ b/python/timbal/codegen/transformers/add_tool.py
@@ -231,6 +231,21 @@ class ToolAdder(cst.CSTTransformer):
                     )
         return updated_node
 
+    def leave_AnnAssign(self, original_node: cst.AnnAssign, updated_node: cst.AnnAssign) -> cst.AnnAssign:  # noqa: ARG002
+        """Handle annotated assignments, e.g. ``agent: Agent = Agent(...)``."""
+        if not isinstance(updated_node.target, cst.Name) or not isinstance(updated_node.value, cst.Call):
+            return updated_node
+        target_name = updated_node.target.value
+
+        if target_name == self.target:
+            return updated_node.with_changes(value=self._add_to_tools(updated_node.value))
+
+        resolved = resolve_runnable_name(updated_node.value)
+        if resolved == self.runtime_name:
+            self._assignment_updated = True
+            return updated_node.with_changes(value=self._merge_config_into_call(updated_node.value))
+        return updated_node
+
     # -- Module: add imports, function defs, and variable assignments -------
 
     def leave_Module(self, original_node: cst.Module, updated_node: cst.Module) -> cst.Module:
@@ -277,8 +292,9 @@ class ToolAdder(cst.CSTTransformer):
             for stmt in reversed(imports_to_add):
                 body.insert(import_insert_idx, stmt)
 
-        # Insert statements before the earliest relevant assignment:
-        # either a tool wrapper assignment or the target (entry point / step).
+        # Insert statements before the earliest relevant assignment (plain or
+        # annotated): either a tool wrapper assignment or the target
+        # (entry point / step).
         if stmts_to_add:
             insert_idx = len(body)
             for i, stmt in enumerate(body):
@@ -291,6 +307,14 @@ class ToolAdder(cst.CSTTransformer):
                             for t in item.targets:
                                 if isinstance(t.target, cst.Name) and t.target.value == self.target:
                                     insert_idx = min(insert_idx, i)
+                        elif (
+                            isinstance(item, cst.AnnAssign)
+                            and isinstance(item.target, cst.Name)
+                            and isinstance(item.value, cst.Call)
+                        ):
+                            resolved = resolve_runnable_name(item.value)
+                            if resolved == self.runtime_name or item.target.value == self.target:
+                                insert_idx = min(insert_idx, i)
             for stmt in reversed(stmts_to_add):
                 body.insert(insert_idx, stmt)
 

--- a/python/timbal/codegen/transformers/remove_edge.py
+++ b/python/timbal/codegen/transformers/remove_edge.py
@@ -49,6 +49,9 @@ def run(entry_point: str, args: argparse.Namespace, *, tree: cst.Module | None =
 class EdgeRemover(cst.CSTTransformer):
     """Remove an edge between two workflow steps by modifying the target's .step() call."""
 
+    # Removing an edge that is already absent is an idempotent success.
+    allow_noop = True
+
     def __init__(
         self,
         entry_point: str,

--- a/python/timbal/codegen/transformers/remove_step.py
+++ b/python/timbal/codegen/transformers/remove_step.py
@@ -2,7 +2,12 @@ import argparse
 
 import libcst as cst
 
-from ..cst_utils import collect_assignments, resolve_entry_point_type, resolve_runnable_name
+from ..cst_utils import (
+    collect_assignments,
+    has_step_expr,
+    resolve_entry_point_type,
+    resolve_runnable_name,
+)
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:
@@ -20,6 +25,17 @@ def run(entry_point: str, args: argparse.Namespace, *, tree: cst.Module | None =
             raise ValueError(f"remove-step requires a Workflow entry point, but '{entry_point}' is a {ep_type}.")
 
     assignments = collect_assignments(tree) if tree else {}
+
+    # The entry point must resolve to a constructor assignment (plain or
+    # annotated) or have standalone .step() statements (covers aliases like
+    # ``workflow = _wf``). Otherwise ``allow_noop`` would turn a wrong fqn
+    # into a phantom success while the step stays in place.
+    if tree is not None and entry_point not in assignments and not has_step_expr(tree, entry_point):
+        raise ValueError(
+            f"Entry point variable '{entry_point}' not found in source. "
+            "Ensure timbal.yaml fqn matches the Agent/Workflow variable name."
+        )
+
     return StepRemover(entry_point, args.name, assignments)
 
 

--- a/python/timbal/codegen/transformers/remove_step.py
+++ b/python/timbal/codegen/transformers/remove_step.py
@@ -24,6 +24,9 @@ def run(entry_point: str, args: argparse.Namespace, *, tree: cst.Module | None =
 
 
 class StepRemover(cst.CSTTransformer):
+    # Removing a step that is already absent is an idempotent success.
+    allow_noop = True
+
     def __init__(self, entry_point: str, step_name: str, assignments: dict[str, cst.Call]):
         self.entry_point = entry_point
         self.step_name = step_name

--- a/python/timbal/codegen/transformers/remove_tool.py
+++ b/python/timbal/codegen/transformers/remove_tool.py
@@ -52,6 +52,18 @@ class ToolRemover(cst.CSTTransformer):
                     )
         return updated_node
 
+    def leave_AnnAssign(self, original_node: cst.AnnAssign, updated_node: cst.AnnAssign) -> cst.AnnAssign:  # noqa: ARG002
+        """Handle annotated assignments, e.g. ``agent: Agent = Agent(...)``."""
+        if (
+            isinstance(updated_node.target, cst.Name)
+            and updated_node.target.value == self.entry_point
+            and isinstance(updated_node.value, cst.Call)
+        ):
+            return updated_node.with_changes(
+                value=self._remove_from_tools(updated_node.value),
+            )
+        return updated_node
+
     def _remove_from_tools(self, call: cst.Call) -> cst.Call:
         for i, arg in enumerate(call.args):
             if isinstance(arg.keyword, cst.Name) and arg.keyword.value == "tools":

--- a/python/timbal/codegen/transformers/remove_tool.py
+++ b/python/timbal/codegen/transformers/remove_tool.py
@@ -2,7 +2,13 @@ import argparse
 
 import libcst as cst
 
-from ..cst_utils import collect_assignments, resolve_entry_point_type, resolve_runnable_name
+from ..cst_utils import (
+    collect_assignments,
+    collect_step_names,
+    is_bare_function_step,
+    resolve_entry_point_type,
+    resolve_runnable_name,
+)
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:
@@ -31,6 +37,29 @@ def run(entry_point: str, args: argparse.Namespace, *, tree: cst.Module | None =
 
     target = step if step else entry_point
     assignments = collect_assignments(tree) if tree else {}
+
+    # Validate the target resolves to a constructor assignment (mirrors
+    # add-tool). Without this, an aliased entry point like ``agent = _agent``
+    # would ride ``allow_noop`` to a phantom success: the transformer never
+    # matches anything, the file is unchanged, and the tool stays in place.
+    if tree is not None:
+        if step:
+            step_names = collect_step_names(tree, entry_point, assignments)
+            if (
+                step not in step_names
+                and step not in assignments
+                and not is_bare_function_step(tree, entry_point, step, assignments)
+            ):
+                raise ValueError(
+                    f"Workflow step '{step}' not found. "
+                    "Use the step variable name from .step(...), not the runtime name."
+                )
+        elif entry_point not in assignments:
+            raise ValueError(
+                f"Entry point variable '{entry_point}' not found in source. "
+                "Ensure timbal.yaml fqn matches the Agent/Workflow variable name."
+            )
+
     return ToolRemover(target, args.name, assignments)
 
 

--- a/python/timbal/codegen/transformers/remove_tool.py
+++ b/python/timbal/codegen/transformers/remove_tool.py
@@ -35,6 +35,9 @@ def run(entry_point: str, args: argparse.Namespace, *, tree: cst.Module | None =
 
 
 class ToolRemover(cst.CSTTransformer):
+    # Removing a tool that is already absent is an idempotent success.
+    allow_noop = True
+
     def __init__(self, entry_point: str, tool_name: str, assignments: dict[str, cst.Call]):
         self.entry_point = entry_point
         self.tool_name = tool_name

--- a/python/timbal/codegen/transformers/set_config.py
+++ b/python/timbal/codegen/transformers/set_config.py
@@ -90,7 +90,7 @@ def run(entry_point: str, args: argparse.Namespace, *, tree: cst.Module | None =
 
     if args.name and args.name != entry_point:
         assignments = collect_assignments(tree) if tree else {}
-        tool_class = _resolve_tool_class(tree, entry_point, args.name, assignments)
+        tool_class = _resolve_tool_class(entry_point, args.name, assignments)
         if tool_class is None:
             raise ValueError(f"Tool '{args.name}' not found in agent tools list.")
         validate_tool_config(tool_class, config)
@@ -107,37 +107,49 @@ def run(entry_point: str, args: argparse.Namespace, *, tree: cst.Module | None =
             f"Valid fields: {', '.join(sorted(AGENT_FIELDS))}."
         )
 
-    # ``agent = build()`` — a factory call, not a constructor. Appending config
-    # kwargs to ``build()`` would corrupt the module, so fail loudly instead.
+    # ``ep_type is None`` with a call on the RHS: the entry point may be a
+    # factory call like ``agent = build()`` (local or imported) — appending
+    # config kwargs to that call would corrupt the module, so fail loudly.
+    # Constructors can't be told apart from factories statically for imports,
+    # so use PEP 8 naming: CapWords callees (``Tool``, ``WebSearch``, custom
+    # runnables) are treated as constructors, everything else as a factory.
+    # (Aliased imports like ``Agent as A`` and module-qualified ``timbal.Agent``
+    # are canonicalized by resolve_entry_point_type and never land here.)
     if tree is not None and ep_type is None:
         ep_call = collect_assignments(tree).get(entry_point)
-        if ep_call is not None and isinstance(ep_call.func, cst.Name):
-            func_name = ep_call.func.value
-            is_local_func = any(
+        if ep_call is not None:
+            if isinstance(ep_call.func, cst.Name):
+                func_name = ep_call.func.value
+            elif isinstance(ep_call.func, cst.Attribute):
+                func_name = ep_call.func.attr.value
+            else:
+                func_name = None
+            is_local_func = func_name is not None and any(
                 isinstance(stmt, cst.FunctionDef) and stmt.name.value == func_name for stmt in tree.body
             )
-            if is_local_func:
+            looks_like_function = func_name is None or not func_name[:1].isupper()
+            if is_local_func or looks_like_function:
                 raise ValueError(
-                    f"Entry point '{entry_point}' is built by calling the local function '{func_name}()'. "
-                    f"set-config cannot modify a factory-built agent; construct the Agent directly "
-                    f"in the '{entry_point}' assignment."
+                    f"Entry point '{entry_point}' is built by calling '{func_name or '<expression>'}()', "
+                    f"which looks like a factory function, not an Agent(...) constructor. set-config "
+                    f"cannot modify a factory-built agent; construct the Agent directly in the "
+                    f"'{entry_point}' assignment."
                 )
 
     return AgentConfigSetter(entry_point, config)
 
 
 def _resolve_tool_class(
-    tree: cst.Module, entry_point: str, tool_name: str, assignments: dict[str, cst.Call]
+    entry_point: str, tool_name: str, assignments: dict[str, cst.Call]
 ) -> str | None:
-    """Find the framework class name for a tool in the agent's tools list."""
-    for stmt in tree.body:
-        if isinstance(stmt, cst.SimpleStatementLine):
-            for item in stmt.body:
-                if isinstance(item, cst.Assign):
-                    for target in item.targets:
-                        if isinstance(target.target, cst.Name) and target.target.value == entry_point:
-                            if isinstance(item.value, cst.Call):
-                                return _find_tool_class(item.value, tool_name, assignments)
+    """Find the framework class name for a tool in the agent's tools list.
+
+    ``assignments`` covers both plain and annotated entry point assignments
+    (see ``collect_assignments``).
+    """
+    call = assignments.get(entry_point)
+    if call is not None:
+        return _find_tool_class(call, tool_name, assignments)
     return None
 
 
@@ -283,6 +295,30 @@ class ToolConfigSetter(cst.CSTTransformer):
                     )
         return updated_node
 
+    def leave_AnnAssign(self, original_node: cst.AnnAssign, updated_node: cst.AnnAssign) -> cst.AnnAssign:  # noqa: ARG002
+        """Handle annotated assignments, e.g. ``agent: Agent = Agent(..., tools=[...])``."""
+        if not isinstance(updated_node.target, cst.Name) or not isinstance(updated_node.value, cst.Call):
+            return updated_node
+        target_name = updated_node.target.value
+
+        # Entry point — check for inline tools to migrate.
+        if target_name == self.entry_point:
+            new_call = self._migrate_inline(updated_node.value)
+            if new_call is not updated_node.value:
+                self.matched = True
+                return updated_node.with_changes(value=new_call)
+            return updated_node
+
+        # Variable assignment — update config kwargs.
+        resolved = resolve_runnable_name(updated_node.value)
+        if resolved == self.tool_name:
+            self.matched = True
+            self._var_updated = True
+            return updated_node.with_changes(
+                value=self._build_configured_call(updated_node.value),
+            )
+        return updated_node
+
     def leave_Module(self, original_node: cst.Module, updated_node: cst.Module) -> cst.Module:
         if not self._needs_migration:
             return updated_node
@@ -299,7 +335,7 @@ class ToolConfigSetter(cst.CSTTransformer):
 
         body = list(updated_node.body)
 
-        # Insert before the entry point assignment.
+        # Insert before the entry point assignment (plain or annotated).
         insert_idx = len(body)
         for i, stmt in enumerate(body):
             if isinstance(stmt, cst.SimpleStatementLine):
@@ -308,6 +344,9 @@ class ToolConfigSetter(cst.CSTTransformer):
                         for t in item.targets:
                             if isinstance(t.target, cst.Name) and t.target.value == self.entry_point:
                                 insert_idx = min(insert_idx, i)
+                    elif isinstance(item, cst.AnnAssign):
+                        if isinstance(item.target, cst.Name) and item.target.value == self.entry_point:
+                            insert_idx = min(insert_idx, i)
 
         for stmt in reversed(stmts_to_add):
             body.insert(insert_idx, stmt)

--- a/python/timbal/codegen/transformers/set_config.py
+++ b/python/timbal/codegen/transformers/set_config.py
@@ -106,6 +106,23 @@ def run(entry_point: str, args: argparse.Namespace, *, tree: cst.Module | None =
             f"Unknown agent config field(s): {', '.join(sorted(unknown))}. "
             f"Valid fields: {', '.join(sorted(AGENT_FIELDS))}."
         )
+
+    # ``agent = build()`` — a factory call, not a constructor. Appending config
+    # kwargs to ``build()`` would corrupt the module, so fail loudly instead.
+    if tree is not None and ep_type is None:
+        ep_call = collect_assignments(tree).get(entry_point)
+        if ep_call is not None and isinstance(ep_call.func, cst.Name):
+            func_name = ep_call.func.value
+            is_local_func = any(
+                isinstance(stmt, cst.FunctionDef) and stmt.name.value == func_name for stmt in tree.body
+            )
+            if is_local_func:
+                raise ValueError(
+                    f"Entry point '{entry_point}' is built by calling the local function '{func_name}()'. "
+                    f"set-config cannot modify a factory-built agent; construct the Agent directly "
+                    f"in the '{entry_point}' assignment."
+                )
+
     return AgentConfigSetter(entry_point, config)
 
 
@@ -173,13 +190,30 @@ class AgentConfigSetter(cst.CSTTransformer):
     def __init__(self, entry_point: str, config: dict):
         self.entry_point = entry_point
         self.config = config
+        # True once the entry point constructor was found and updated. An
+        # unchanged file with matched=True is an idempotent save (success);
+        # matched=False means the source shape was never recognized (failure).
+        self.matched = False
 
     def leave_Assign(self, original_node: cst.Assign, updated_node: cst.Assign) -> cst.Assign:
         for target in updated_node.targets:
             if isinstance(target.target, cst.Name) and target.target.value == self.entry_point:
                 if isinstance(updated_node.value, cst.Call):
+                    self.matched = True
                     new_call = self._update_agent_kwargs(updated_node.value)
                     return updated_node.with_changes(value=new_call)
+        return updated_node
+
+    def leave_AnnAssign(self, original_node: cst.AnnAssign, updated_node: cst.AnnAssign) -> cst.AnnAssign:  # noqa: ARG002
+        """Handle annotated assignments, e.g. ``agent: Agent = Agent(...)``."""
+        if (
+            isinstance(updated_node.target, cst.Name)
+            and updated_node.target.value == self.entry_point
+            and isinstance(updated_node.value, cst.Call)
+        ):
+            self.matched = True
+            new_call = self._update_agent_kwargs(updated_node.value)
+            return updated_node.with_changes(value=new_call)
         return updated_node
 
     def _update_agent_kwargs(self, call: cst.Call) -> cst.Call:
@@ -220,6 +254,7 @@ class ToolConfigSetter(cst.CSTTransformer):
         self.assignments = assignments
         self.tool_class = tool_class  # e.g. "WebSearch"
         self.var_name = var_name  # e.g. "web_search"
+        self.matched = False  # target tool found — unchanged file means idempotent save
         self._var_updated = False
         self._needs_migration = False
         self._inline_call: cst.Call | None = None  # original inline call args for migration
@@ -234,12 +269,14 @@ class ToolConfigSetter(cst.CSTTransformer):
             if target_name == self.entry_point and isinstance(updated_node.value, cst.Call):
                 new_call = self._migrate_inline(updated_node.value)
                 if new_call is not updated_node.value:
+                    self.matched = True
                     return updated_node.with_changes(value=new_call)
 
             # Variable assignment — update config kwargs.
             if target_name != self.entry_point and isinstance(updated_node.value, cst.Call):
                 resolved = resolve_runnable_name(updated_node.value)
                 if resolved == self.tool_name:
+                    self.matched = True
                     self._var_updated = True
                     return updated_node.with_changes(
                         value=self._build_configured_call(updated_node.value),
@@ -328,6 +365,7 @@ class StepConstructorConfigSetter(cst.CSTTransformer):
         self.step_name = step_name
         self.config = config
         self.assignments = assignments
+        self.matched = False  # target step found — unchanged file means idempotent save
         # When renaming, track the old→new runtime name for reference updates.
         self._new_runtime_name: str | None = config.get("name")
         # Context tracking for string replacement (mirrors Renamer).
@@ -346,6 +384,7 @@ class StepConstructorConfigSetter(cst.CSTTransformer):
             if isinstance(updated_node.value, cst.Call):
                 resolved = resolve_runnable_name(updated_node.value)
                 if resolved == self.step_name:
+                    self.matched = True
                     args = [
                         a for a in updated_node.value.args
                         if not (isinstance(a.keyword, cst.Name) and a.keyword.value in self.config)

--- a/python/timbal/codegen/transformers/set_config.py
+++ b/python/timbal/codegen/transformers/set_config.py
@@ -424,17 +424,36 @@ class StepConstructorConfigSetter(cst.CSTTransformer):
                 resolved = resolve_runnable_name(updated_node.value)
                 if resolved == self.step_name:
                     self.matched = True
-                    args = [
-                        a for a in updated_node.value.args
-                        if not (isinstance(a.keyword, cst.Name) and a.keyword.value in self.config)
-                    ]
-                    for key, value in self.config.items():
-                        if value is not None:
-                            args.append(cst.Arg(keyword=cst.Name(key), value=build_cst_value(value)))
                     return updated_node.with_changes(
-                        value=updated_node.value.with_changes(args=args),
+                        value=self._merge_config_into_call(updated_node.value),
                     )
         return updated_node
+
+    def leave_AnnAssign(self, original_node: cst.AnnAssign, updated_node: cst.AnnAssign) -> cst.AnnAssign:  # noqa: ARG002
+        """Handle annotated step variables, e.g. ``agent_a: Agent = Agent(...)``."""
+        if (
+            not isinstance(updated_node.target, cst.Name)
+            or updated_node.target.value == self.entry_point
+            or not isinstance(updated_node.value, cst.Call)
+        ):
+            return updated_node
+        if resolve_runnable_name(updated_node.value) == self.step_name:
+            self.matched = True
+            return updated_node.with_changes(
+                value=self._merge_config_into_call(updated_node.value),
+            )
+        return updated_node
+
+    def _merge_config_into_call(self, call: cst.Call) -> cst.Call:
+        """Drop overridden kwargs and append the new config values."""
+        args = [
+            a for a in call.args
+            if not (isinstance(a.keyword, cst.Name) and a.keyword.value in self.config)
+        ]
+        for key, value in self.config.items():
+            if value is not None:
+                args.append(cst.Arg(keyword=cst.Name(key), value=build_cst_value(value)))
+        return call.with_changes(args=args)
 
     # -- Context tracking for depends_on / step_span string replacement --------
 

--- a/python/timbal/codegen/transformers/set_param.py
+++ b/python/timbal/codegen/transformers/set_param.py
@@ -197,6 +197,9 @@ class ParamSetter(cst.CSTTransformer):
         self.assignments = assignments or {}
         self.step_names = step_names or {}
         self.needs_reorder = param_type == "map"
+        # True once the target .step() call was found — an unchanged file is
+        # then an idempotent save (param already set to this value).
+        self.matched = False
 
     def _is_step_call(self, call: cst.Call) -> bool:
         return (
@@ -242,6 +245,7 @@ class ParamSetter(cst.CSTTransformer):
         if not self._is_step_call(call) or not self._matches_target(call):
             return updated_node
 
+        self.matched = True
         step_call_code = self._build_step_call_code(call)
         parsed = cst.parse_module(step_call_code + "\n")
         for stmt in parsed.body:

--- a/python/timbal/codegen/transformers/set_position.py
+++ b/python/timbal/codegen/transformers/set_position.py
@@ -134,6 +134,18 @@ class ConstructorPositionSetter(cst.CSTTransformer):
                     return updated_node.with_changes(value=updated_node.value.with_changes(args=new_args))
         return updated_node
 
+    def leave_AnnAssign(self, original_node: cst.AnnAssign, updated_node: cst.AnnAssign) -> cst.AnnAssign:  # noqa: ARG002
+        """Handle annotated assignments, e.g. ``agent: Agent = Agent(...)``."""
+        if (
+            isinstance(updated_node.target, cst.Name)
+            and updated_node.target.value == self.entry_point
+            and isinstance(updated_node.value, cst.Call)
+        ):
+            self.matched = True
+            new_args = _merge_position_into_metadata(list(updated_node.value.args), self.position)
+            return updated_node.with_changes(value=updated_node.value.with_changes(args=new_args))
+        return updated_node
+
 
 class StepPositionSetter(cst.CSTTransformer):
     """Set position metadata on a workflow step's constructor variable."""

--- a/python/timbal/codegen/transformers/set_position.py
+++ b/python/timbal/codegen/transformers/set_position.py
@@ -173,3 +173,19 @@ class StepPositionSetter(cst.CSTTransformer):
                         value=updated_node.value.with_changes(args=new_args),
                     )
         return updated_node
+
+    def leave_AnnAssign(self, original_node: cst.AnnAssign, updated_node: cst.AnnAssign) -> cst.AnnAssign:  # noqa: ARG002
+        """Handle annotated step variables, e.g. ``agent_a: Agent = Agent(...)``."""
+        if (
+            not isinstance(updated_node.target, cst.Name)
+            or updated_node.target.value == self.entry_point
+            or not isinstance(updated_node.value, cst.Call)
+        ):
+            return updated_node
+        if resolve_runnable_name(updated_node.value) == self.step_name:
+            self.matched = True
+            new_args = _merge_position_into_metadata(list(updated_node.value.args), self.position)
+            return updated_node.with_changes(
+                value=updated_node.value.with_changes(args=new_args),
+            )
+        return updated_node

--- a/python/timbal/codegen/transformers/set_position.py
+++ b/python/timbal/codegen/transformers/set_position.py
@@ -121,11 +121,15 @@ class ConstructorPositionSetter(cst.CSTTransformer):
     def __init__(self, entry_point: str, position: dict):
         self.entry_point = entry_point
         self.position = position
+        # True once the constructor was found — an unchanged file is then an
+        # idempotent save (position already set to these coordinates).
+        self.matched = False
 
     def leave_Assign(self, original_node: cst.Assign, updated_node: cst.Assign) -> cst.Assign:
         for target in updated_node.targets:
             if isinstance(target.target, cst.Name) and target.target.value == self.entry_point:
                 if isinstance(updated_node.value, cst.Call):
+                    self.matched = True
                     new_args = _merge_position_into_metadata(list(updated_node.value.args), self.position)
                     return updated_node.with_changes(value=updated_node.value.with_changes(args=new_args))
         return updated_node
@@ -139,6 +143,7 @@ class StepPositionSetter(cst.CSTTransformer):
         self.step_name = step_name
         self.position = position
         self.assignments = assignments
+        self.matched = False  # target step found — unchanged file means idempotent save
 
     def leave_Assign(self, original_node: cst.Assign, updated_node: cst.Assign) -> cst.Assign:
         for target in updated_node.targets:
@@ -150,6 +155,7 @@ class StepPositionSetter(cst.CSTTransformer):
             if isinstance(updated_node.value, cst.Call):
                 resolved = resolve_runnable_name(updated_node.value)
                 if resolved == self.step_name:
+                    self.matched = True
                     new_args = _merge_position_into_metadata(list(updated_node.value.args), self.position)
                     return updated_node.with_changes(
                         value=updated_node.value.with_changes(args=new_args),

--- a/python/timbal/core/agent.py
+++ b/python/timbal/core/agent.py
@@ -388,6 +388,26 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
             "value": _extract_fallbacks(self.model),
         }
 
+        # ``voice_config`` is not a declared field — it rides ``extra="allow"``
+        # and the voice server reads it via ``getattr`` (merge_voice_config).
+        # Surface it here so get-flow round-trips what set-config writes. It
+        # may be a dict, a zero-arg callable, or a VoiceConfig instance.
+        vc = getattr(self, "voice_config", None)
+        if vc is not None and not isinstance(vc, dict):
+            if callable(vc):
+                vc = f"<{getattr(vc, '__name__', 'callable')}>"
+            elif isinstance(vc, BaseModel):
+                vc = vc.model_dump(exclude_none=True)
+            else:
+                vc = str(vc)
+        if isinstance(vc, dict):
+            vc = self._coerce_to_json_safe(vc)
+        config["voice_config"] = {
+            "anyOf": [{"type": "object"}, {"type": "null"}],
+            "default": None,
+            "value": vc,
+        }
+
         return {**super().get_config(), **config}
 
     @override

--- a/python/timbal/core/agent.py
+++ b/python/timbal/core/agent.py
@@ -402,8 +402,11 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
                 vc = str(vc)
         if isinstance(vc, dict):
             vc = self._coerce_to_json_safe(vc)
+        # "callable" mirrors how system_prompt advertises non-serialisable
+        # variants (see _partial_schema) — the value is then a "<fn_name>"
+        # placeholder string rather than an object.
         config["voice_config"] = {
-            "anyOf": [{"type": "object"}, {"type": "null"}],
+            "anyOf": [{"type": "object"}, {"type": "callable"}, {"type": "null"}],
             "default": None,
             "value": vc,
         }

--- a/python/timbal/evals/utils.py
+++ b/python/timbal/evals/utils.py
@@ -278,7 +278,8 @@ def discover_eval_files(path: Path) -> list[Path]:
         current = Path(dirpath)
         dirnames[:] = [d for d in dirnames if not _is_ignored_dir(current / d)]
         for filename in filenames:
-            if not filename.endswith(".yaml"):
+            # evalconf.yaml is the shared config file, not an eval suite.
+            if not filename.endswith(".yaml") or filename == CONFIG_FILENAME:
                 continue
             stem = filename[: -len(".yaml")]
             if filename.startswith("eval") or stem.endswith("eval"):


### PR DESCRIPTION
…o-ops

voice_config rode extra="allow" and was write-only: set-config saved it but get-flow never returned it, so Studio fell back to stale values on every refresh. Agent.get_config now emits it JSON-safely (dict passthrough, callable as "<name>", VoiceConfig dumped).

Also fixes the write-side silent failures:
- annotated assignments (agent: Agent = Agent(...)) are now transformed (AnnAssign support in cst_utils + AgentConfigSetter)
- factory entry points (agent = build()) error instead of corrupting the call
- unmatched shapes (agent = _agent) exit non-zero instead of phantom-saving; transformers report matched=True so idempotent saves still succeed, and idempotent ops (re-add tool/mcp, remove absent tool/step, dup edge) opt out via allow_noop