### PR TITLE
feat(codegen): extract-tool and add-library-tool ops for the org tool…

### DIFF
--- a/docs/agents/index.mdx
+++ b/docs/agents/index.mdx
@@ -28,7 +28,7 @@ The sidebar follows a **basics → platform → production** path. You can jump 
 
 1. **[Tools](/agents/tools)** — give the agent capabilities (the core primitive)
 2. **[Structured output](/agents/structured-output)** — constrain what comes back
-3. **[Memory](/agents/memory)** → **[Memory compaction](/agents/memory-compaction)** — multi-turn context, then keeping it within the window
+3. **[Memory](/agents/memory)** → **[Memory compaction](/agents/memory-compaction)** — multi-turn context, then keeping oversized tool results and history within the window
 4. **[Skills](/agents/skills)** — domain packages (knowledge + tools) once the agent loop makes sense
 5. **[Dynamic agents](/agents/dynamic)** — runtime prompts and tool sets
 6. **[Background tasks](/agents/background-tasks)** · **[Commands](/agents/commands)** — utilities (async tools, slash shortcuts)

--- a/docs/agents/memory-compaction.mdx
+++ b/docs/agents/memory-compaction.mdx
@@ -1,15 +1,145 @@
 ---
 title: "Memory Compaction"
-description: "Keep agent memory within context window limits using built-in compaction strategies"
+description: "Keep agent memory within context window limits with tool result offloading and built-in compaction strategies"
 ---
 
-<Warning>
-Memory compaction is in **beta**. The API may change in future releases.
-</Warning>
+As conversations grow longer, the accumulated message history can exceed a model's context window. Timbal keeps memory bounded with two complementary layers, both configured on the agent and applied without changing how you call it:
 
-As conversations grow longer, the accumulated message history can exceed a model's context window. Memory compaction lets you define strategies that automatically trim or condense that history before each agent call, keeping token usage under control without changing how you call the agent.
+1. **[Tool result offloading](#tool-result-offloading)** — oversized tool results are moved out of the window *the moment they are produced*, losslessly: the payload goes to a store, and the model keeps a preview plus a handle it can page back on demand.
+2. **[Compaction strategies](#how-compaction-works)** — when context utilization crosses a threshold, the history already inside the window is trimmed or condensed (drop old tool results, keep the last N turns, summarize with an LLM).
 
-## How It Works
+Most long-running agents want both: offloading prevents the bloat at the source; compaction handles everything else.
+
+## Tool Result Offloading
+
+A single tool call can return hundreds of kilobytes — a big file read, a verbose log, a large API response. Because tool results persist in conversation memory, an oversized result is re-sent on **every subsequent LLM call**, paying its token cost for the rest of the run.
+
+Tool result offloading intercepts a result when it is produced. If it exceeds a size threshold, the full payload is persisted to an offload store and the model sees a short placeholder instead:
+
+```python
+from timbal import Agent
+
+agent = Agent(
+    name="my_agent",
+    model="openai/gpt-4o-mini",
+    tools=[search_docs, run_query],
+    tool_result_limit=20_000,  # offload results over 20,000 chars
+)
+```
+
+Results under the threshold pass through untouched. Oversized ones are replaced with a placeholder like:
+
+```text
+[Tool result offloaded: 184,203 chars from 'search_docs'. The full content was saved and
+can be read with read_tool_result(handle="06a7.../t1") — page with offset/limit or filter
+with pattern.]
+Shape: {"results": list[92], "total": int}
+Preview (first 1,000 of 184,203 chars):
+...
+```
+
+The reduction happens **once**, before the result ever enters memory, the serialized trace, or a provider request:
+
+- **Lossless** — unlike truncation or summarization, the full payload stays retrievable. The model decides whether it needs line 500 of that output.
+- **Prompt-cache friendly** — history stays append-only. The oversized payload never occupies a cached prefix that would later be rewritten (rewriting old messages invalidates provider prompt caches from that point on).
+- **Persistent** — the placeholder is what gets traced and what seeds the next turn's memory. The reduction is never recomputed per request.
+
+### Configuration
+
+`tool_result_limit` accepts an int (threshold shorthand) or a `ToolResultLimit`:
+
+```python
+from timbal.core import LocalOffloadStore, Spill, ToolResultLimit, Truncate
+
+agent = Agent(
+    name="my_agent",
+    model="openai/gpt-4o-mini",
+    tool_result_limit=ToolResultLimit(
+        threshold=20_000,                  # chars of text content (default 20,000)
+        action=Spill(preview_chars=1_000), # what to do when the threshold is reached
+        store=LocalOffloadStore(),         # where spilled payloads live
+    ),
+)
+```
+
+**`Spill`** (default) — persist the full payload, keep a preview + handle inline. Lossless. If the store write fails, `fallback` (default `Truncate()`) applies so an oversized result never slips through:
+
+```python
+Spill(preview_chars=1_000, fallback=Truncate(max_chars=2_000))
+```
+
+**`Truncate`** — clamp to a character budget. Lossy, zero-cost, no store needed:
+
+```python
+Truncate(strategy="head")       # keep the start — headers, schemas
+Truncate(strategy="tail")       # keep the end — build/test output where errors land last
+Truncate(strategy="head_tail")  # keep both ends, elide the middle (default)
+```
+
+### Per-tool overrides
+
+`Tool(result_limit=...)` overrides the agent default. `None` exempts a tool entirely:
+
+```python
+from timbal.core import Tool, ToolResultLimit, Truncate
+
+agent = Agent(
+    name="my_agent",
+    model="openai/gpt-4o-mini",
+    tool_result_limit=20_000,  # agent-wide default: spill over 20k
+    tools=[
+        Tool(name="run_tests", handler=run_tests,
+             result_limit=ToolResultLimit(threshold=8_000, action=Truncate(strategy="tail"))),
+        Tool(name="load_policy", handler=load_policy, result_limit=None),  # never reduced
+    ],
+)
+```
+
+Some results are never reduced, regardless of configuration:
+
+- **Error results** — the model needs the full error to recover.
+- **Pinned tools** (`pin_result=True`) — durable context like [skill](/agents/skills) documentation. See [Pinned results](#pinned-results).
+- **`read_tool_result`'s own output** — it is bounded by construction.
+
+### Reading content back
+
+When offloading is active, the agent auto-registers a `read_tool_result` tool:
+
+```python
+read_tool_result(handle, offset=0, limit=200, pattern=None)
+```
+
+- Line-numbered paging via `offset`/`limit` (hard-capped at 500 lines / 50,000 chars per call, so a read can never blow the window back up).
+- `pattern` filters to lines containing a **literal substring** (not a regex).
+- Unknown or expired handles return a clean tool error the model can react to.
+
+The model uses it on its own — the placeholder tells it how.
+
+### The offload store
+
+Spilled payloads go through a narrow protocol, so the backend is swappable:
+
+```python
+class OffloadStore(Protocol):
+    async def write(self, key: str, data: bytes) -> str:  # returns a handle
+    async def read(self, handle: str) -> bytes:
+```
+
+The default `LocalOffloadStore` writes one file per result under `~/.timbal/offload/` (owner-only permissions; reads are hardened against path traversal and symlink escapes). Handles are store-relative keys, not absolute paths, so a different backend can resolve the same handle in another process.
+
+Payloads are kept **forever by default** — deleting on run end would break a resumed or chained session that still holds handles. Bound disk usage with opt-in age-based pruning:
+
+```python
+from datetime import timedelta
+from timbal.core import LocalOffloadStore, ToolResultLimit
+
+store = LocalOffloadStore(cleanup_after=timedelta(days=7))
+agent = Agent(..., tool_result_limit=ToolResultLimit(store=store))
+```
+
+Pruning runs off the hot path and never fails a run.
+
+## How Compaction Works
 
 Compaction is triggered automatically when context-window utilization exceeds `memory_compaction_ratio` (default `0.75`, i.e. 75%), at two points:
 
@@ -31,6 +161,8 @@ agent = Agent(
 ```
 
 Set `memory_compaction_ratio=0.0` to always compact, or `1.0` to effectively disable auto-triggering.
+
+Offloading and compaction compose cleanly: offloaded placeholders are small, so they push utilization down and compaction triggers later or never; `compact_tool_results` keeps offloaded placeholders intact by default so their handles stay dereferenceable; and `summarize` writes its canonical record to the same store, readable back through the same `read_tool_result` tool.
 
 ## Built-in Strategies
 
@@ -85,8 +217,10 @@ agent = Agent(
 **`replacement` controls what happens to compacted tool results:**
 
 - `None` (default) — drop tool results and their corresponding `tool_use` entries entirely. Assistant messages that become empty are also dropped.
-- `str` — replace each result with a template string. Supported placeholders: `{tool_name}`, `{call_id}`, `{result_length}`.
+- `str` — replace each result with a template string. Supported placeholders: `{tool_name}`, `{call_id}`, `{result_length}`, and `{handle}` (the offload handle when the result was [offloaded](#tool-result-offloading), empty otherwise).
 - `callable(tool_name, call_id, result_text) -> str` — call a function per result and use the return value as the replacement.
+
+**`keep_offloaded`** (default `True`) — results already [offloaded at production time](#tool-result-offloading) are kept intact: they are small placeholders whose handle keeps the full payload reachable. Set `False` to compact them like any other result.
 
 ```python
 # Drop all tool results
@@ -127,6 +261,23 @@ agent = Agent(
 Use a smaller, cheaper model for summarization to reduce cost. For example, `model="openai/gpt-5.4-nano"` works well for summarization tasks.
 </Tip>
 
+The summary message is **sectioned**, and everything except the LLM summary itself is assembled mechanically — never paraphrased by the summarizer:
+
+- **Verbatim User Messages** — the user's own words from the summarized region, carried forward verbatim across passes (`preserve_user_messages=True`, default). Summaries that drop or mischaracterize user instructions are the most damaging compaction failure, so the user's words are never trusted to the LLM. Budgeted by `max_verbatim_chars` (default 10,000; oldest entries dropped first).
+- **Compacted Transcripts** — when an offload store is available, the full untruncated text of every summarized region is persisted and its handle listed, readable via `read_tool_result` (`canonical_record=True`, default). Summarization becomes recoverable instead of destructive. The store is shared automatically from the agent's [`tool_result_limit`](#tool-result-offloading), or passed explicitly via `store=`.
+- **Note** — conservative continuation guidance: the model is told to verify intent against the user's verbatim words rather than acting on the summary alone.
+- **Rehydrated Context** — output of an optional `rehydrate=` callable (sync or async, returning `str`, `list[str]`, or `None`), re-run on **every** compaction pass. Use it to re-inject working state that must survive summarization — the active plan, recently edited files:
+
+```python
+from pathlib import Path
+from timbal.core.memory_compaction import summarize
+
+memory_compaction=summarize(
+    threshold=20,
+    rehydrate=lambda: Path("PLAN.md").read_text(),
+)
+```
+
 ## Pinned results
 
 Some tool results are durable context the model must keep referencing — for example loaded
@@ -134,7 +285,7 @@ Some tool results are durable context the model must keep referencing — for ex
 preserves them verbatim (and never orphans their paired tool call), regardless of `keep_last_n`,
 turn windows, or drop/replacement mode. For `keep_last_n_messages` / `keep_last_n_turns` the
 effective behavior is "last N **plus** pinned"; for `summarize`, pinned results are kept verbatim
-and never fed to the summarizer (like system messages).
+and never fed to the summarizer (like system messages). Offloading skips pinned results too.
 
 You opt a tool in declaratively with `pin_result=True`:
 
@@ -187,5 +338,18 @@ When compaction fires, the agent span records a `compaction` key in its metadata
 - `utilization` — the context window fraction that triggered the most recent pass (`null` when `memory_compaction_ratio=0.0`).
 - `steps` — one entry per compactor with message counts before and after (for the most recent pass).
 - `passes` — how many times compaction fired on this span (turn start plus each mid-loop pass).
+
+Every offload is recorded separately, in an `offload` key:
+
+```json
+{
+  "offload": [
+    { "tool": "search_docs", "call_id": "t1", "original_chars": 184203,
+      "action": "spill", "handle": "06a7.../t1" }
+  ]
+}
+```
+
+`action` is `"spill"`, `"truncate"`, or `"truncate_fallback"` (a spill that degraded because the store was unavailable). The handle also persists on the tool result itself (`ToolResultContent.offload_handle`), surviving trace serialization and reload.
 
 This data is visible in the Timbal platform trace viewer alongside the other span metadata.

--- a/docs/agents/memory.mdx
+++ b/docs/agents/memory.mdx
@@ -29,7 +29,7 @@ Memory storage depends on your deployment environment:
 
 ## Nested Agent Memory
 
-When agents call other agents, memory flows seamlessly between them. Child agents automatically receive conversation context from their parent, enabling sophisticated multi-agent workflows while maintaining conversation continuity.
+When an agent is used as a tool of another agent, the **child gets an isolated context** — it does not inherit the parent's conversation history. The parent only sees what the child returns as its tool result. That keeps specialist agents focused and prevents parent history from bloating every nested call.
 
 ```python
 from timbal import Agent
@@ -37,7 +37,7 @@ from timbal import Agent
 billing_agent = Agent(
     name="billing_agent",
     model="anthropic/claude-haiku-4-5",
-    # Receives full conversation history from parent when used as a tool
+    # Fresh context per call — only the tool prompt from the parent, not the full chat
 )
 
 support_agent = Agent(
@@ -46,6 +46,8 @@ support_agent = Agent(
     tools=[billing_agent],  # add more specialist agents as needed
 )
 ```
+
+To hand the child specific context, put it in the tool call (the parent's prompt / args). To share state across turns of the *parent*, use the parent's own memory via `parent_id` session chaining — see [Rewind](#rewind) and [Tracing](/core-concepts/tracing).
 
 ## Configuration
 
@@ -104,10 +106,11 @@ This creates branching conversations:
 Each branch maintains independent memory from the branching point. Learn more about the underlying mechanisms in [Context](/core-concepts/context).
 </Note>
 
-## Memory Compaction
+## Keeping memory within the context window
 
-For long-running conversations, memory can grow large enough to exceed the model's context window. Timbal provides built-in **memory compaction** strategies — such as keeping only the last N turns, truncating tool results, or summarizing older messages with an LLM — that fire automatically when context utilization crosses a configurable threshold.
+For long-running conversations, memory can grow large enough to exceed the model's context window. Timbal has two complementary layers:
 
-<Note>
-Memory compaction is a beta feature. See [Memory Compaction](/agents/memory-compaction) for the full reference.
-</Note>
+1. **[Tool result offloading](/agents/memory-compaction#tool-result-offloading)** — oversized tool results are spilled to a store *when produced*, so they never dominate every later LLM call. Lossless; the model pages content back via `read_tool_result`.
+2. **[Memory compaction](/agents/memory-compaction)** — strategies (keep last N turns, shrink old tool results, LLM summarize) that fire when context utilization crosses `memory_compaction_ratio` (default 75%).
+
+Most long-running agents want both: offloading prevents the bloat at the source; compaction handles everything else. See [Memory Compaction](/agents/memory-compaction) for the full reference.

--- a/docs/agents/skills.mdx
+++ b/docs/agents/skills.mdx
@@ -43,7 +43,7 @@ skills/
 This lazy-loading approach keeps the agent's context efficient while ensuring specialized knowledge is available when needed.
 
 <Note>
-**Skills and memory compaction.** A skill's documentation reaches the model as the result of the `read_skill` tool call. Those results are **pinned**, so [memory compaction](/agents/memory-compaction) never drops or truncates them — the guidance stays available for as long as the skill is active, even on long runs where the rest of the history is compacted. This keeps an agent's tools and the instructions for using them from drifting apart.
+**Skills, compaction, and offloading.** A skill's documentation reaches the model as the result of the `read_skill` tool call. Those results are **pinned**, so [memory compaction](/agents/memory-compaction) never drops or truncates them, and [tool result offloading](/agents/memory-compaction#tool-result-offloading) never spills them — the guidance stays available for as long as the skill is active, even on long runs where the rest of the history is compacted. This keeps an agent's tools and the instructions for using them from drifting apart.
 </Note>
 
 

--- a/docs/agents/tools.mdx
+++ b/docs/agents/tools.mdx
@@ -197,6 +197,39 @@ travel_agent = Agent(
 **Automatic Nesting:** When an agent is used as a tool within another agent (as shown above), it's automatically nested for proper tracing and context management. However, if you use an agent inside a `pre_hook` or `post_hook`, you must manually call `.nest()`. See [Using Agents in Hooks](/core-concepts/context#using-agents-in-hooks) for details.
 </Note>
 
+### Pinning results against compaction
+
+Some tool results are durable context the model must keep referencing (loaded policy docs, skill guidance). Opt in with `pin_result=True` — [memory compaction](/agents/memory-compaction) never drops or truncates those results, and [tool result offloading](/agents/memory-compaction#tool-result-offloading) skips them too:
+
+```python
+Tool(
+    handler=load_policy,
+    pin_result=True,  # survive compaction for the life of the conversation
+)
+```
+
+The built-in `read_skill` tool sets this automatically. See [Pinned results](/agents/memory-compaction#pinned-results).
+
+### Limiting oversized results
+
+When a tool can return huge payloads, set a per-tool size limit. Results over the threshold are spilled to a store (or truncated) **once, when produced**, before they enter memory:
+
+```python
+from timbal.core import ToolResultLimit, Truncate
+
+Tool(
+    handler=run_tests,
+    result_limit=ToolResultLimit(threshold=8_000, action=Truncate(strategy="tail")),
+)
+
+Tool(
+    handler=load_policy,
+    result_limit=None,  # exempt — never reduced
+)
+```
+
+An agent-wide default is `Agent(tool_result_limit=...)`. Precedence: `Tool.result_limit` > agent default. See [Tool Result Offloading](/agents/memory-compaction#tool-result-offloading).
+
 ## Commands
 
 Register a `command` on any tool, agent, or workflow to let users invoke it directly with a `/` prefix — bypassing the LLM for that turn:
@@ -262,5 +295,6 @@ See [Dynamic Agents](/agents/dynamic#dynamic-tools) for implementation details a
 - **Tool Sets**: Dynamic tool resolution
 - **MCP Servers**: Any Model Context Protocol server as a tool source — see [MCP Servers](/agents/mcp)
 - **Commands**: Slash-command shortcuts for direct tool invocation — see [Commands](/agents/commands)
+- **Result limits & pinning**: Keep oversized or durable tool output under control — see [Memory Compaction](/agents/memory-compaction)
 
 For more advanced patterns, see [Dynamic Agents](/agents/dynamic) and explore the built-in tools in the Timbal library.

--- a/docs/core-concepts/context.mdx
+++ b/docs/core-concepts/context.mdx
@@ -176,7 +176,7 @@ agent = Agent(
 )
 ```
 
-The `.nest()` method updates the agent's path hierarchy, ensuring proper tracing structure (e.g., `agent.agent_is_company` instead of just `agent_is_company`), correct context propagation, and accurate memory resolution for nested agent calls.
+The `.nest()` method updates the agent's path hierarchy, ensuring proper tracing structure (e.g., `agent.agent_is_company` instead of just `agent_is_company`) and correct span nesting under the parent. Nested agents still run with **isolated memory** — they do not inherit the parent's conversation history (see [Nested Agent Memory](/agents/memory#nested-agent-memory)).
 
 ## Early Exit with bail()
 

--- a/docs/human-in-the-loop/resuming.mdx
+++ b/docs/human-in-the-loop/resuming.mdx
@@ -90,6 +90,8 @@ Timbal loads the parent trace (input messages, pending gates/suspensions, prior 
 
 If the agent has `memory_compaction` configured, a resume turn is treated like a continuation of the paused turn, not a fresh one. The loaded memory ends with the gated/suspended `tool_use` that has **no `tool_result` yet** — that trailing block is exactly what Timbal re-executes to settle the pause without re-calling the model.
 
+[Tool result offloading](/agents/memory-compaction#tool-result-offloading) applies on resume the same way it does on a fresh turn: when the gated tool finally runs after approval, an oversized result is reduced once before it enters memory.
+
 Compaction is structure-aware about this:
 
 - The pending `tool_use` is **never** compacted away. (A naive pass would treat it as an orphaned tool call, strip it, and force the model to re-plan — which is nondeterministic and would silently drop the human's decision.)

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -45,7 +45,7 @@ Both share the same interface and emit the same event stream, so you can compose
 
 <Columns cols={3}>
   <Card title="Memory" icon="database" href="/agents/memory">
-    Persistent context with built-in compaction for long conversations.
+    Persistent context with tool-result offloading and compaction for long conversations.
   </Card>
   <Card title="Model Routing" icon="arrow-progress" href="/models/overview">
     One interface across every provider, with fallback chains for failover.

--- a/python/tests/codegen/test_library.py
+++ b/python/tests/codegen/test_library.py
@@ -1,0 +1,436 @@
+"""Org tool library ops: extract-tool and add-library-tool."""
+
+import json
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from timbal.codegen.library import extract_tool
+
+from .conftest import codegen_cmd
+
+TIMBAL_YAML = 'fqn: "agent.py::agent"\n'
+
+PRODUCER_SOURCE = """\
+import os
+
+import httpx
+from timbal.core import Agent, Tool
+
+API_BASE = "https://api.example.com"
+TIMEOUT = 10
+
+
+def _auth_headers() -> dict:
+    return {"Authorization": f"Bearer {os.getenv('EXAMPLE_API_KEY')}"}
+
+
+def search_products(query: str, limit: int = 5) -> str:
+    \"\"\"Search the product catalog.
+
+    Longer docs here.
+    \"\"\"
+    resp = httpx.get(
+        f"{API_BASE}/search",
+        params={"q": query, "limit": limit},
+        headers=_auth_headers(),
+        timeout=TIMEOUT,
+    )
+    return resp.text
+
+
+def get_datetime() -> str:
+    from datetime import datetime
+
+    return datetime.now().isoformat()
+
+
+search_tool = Tool(handler=search_products, description="Product catalog search.")
+
+agent = Agent(
+    name="agent",
+    model="openai/gpt-5.2",
+    tools=[search_tool, get_datetime],
+)
+"""
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    """Write a source file + timbal.yaml (+ optional pyproject) and return the dir."""
+
+    def _write(source: str, pyproject: str | None = None, subdir: str | None = None) -> Path:
+        ws = tmp_path / subdir if subdir else tmp_path
+        ws.mkdir(parents=True, exist_ok=True)
+        (ws / "agent.py").write_text(textwrap.dedent(source))
+        (ws / "timbal.yaml").write_text(TIMBAL_YAML)
+        if pyproject is not None:
+            (ws / "pyproject.toml").write_text(textwrap.dedent(pyproject))
+        return ws
+
+    return _write
+
+
+def _run_cli(*cli_args: str, expect_failure: bool = False) -> subprocess.CompletedProcess:
+    result = subprocess.run(codegen_cmd(*cli_args), capture_output=True, text=True)
+    if expect_failure:
+        assert result.returncode != 0, f"expected failure, got:\n{result.stdout}"
+    else:
+        assert result.returncode == 0, f"codegen failed:\n{result.stderr}"
+    return result
+
+
+class TestExtractClosure:
+    def test_wrapper_tool_closure(self, workspace):
+        """The closure has the handler, helpers, constants, and imports — nothing else."""
+        ws = workspace(
+            PRODUCER_SOURCE,
+            pyproject="""\
+            [project]
+            name = "demo"
+            dependencies = ["timbal[all]", "httpx>=0.27"]
+            """,
+        )
+        manifest = extract_tool(ws, "search_products")
+
+        assert manifest["name"] == "search_products"
+        assert manifest["binding"] == "search_tool"
+        source = manifest["source"]
+        assert "def search_products" in source
+        assert "def _auth_headers" in source
+        assert "API_BASE" in source
+        assert "TIMEOUT" in source
+        assert "import httpx" in source
+        # Unrelated definitions and the agent must not leak in.
+        assert "get_datetime" not in source
+        assert "Agent(" not in source
+
+        # The module must be importable and expose the binding.
+        ns: dict = {}
+        exec(compile(source, "<tool>", "exec"), ns)
+        assert ns["search_tool"].name == "search_products"
+
+    def test_manifest_metadata(self, workspace):
+        ws = workspace(
+            PRODUCER_SOURCE,
+            pyproject="""\
+            [project]
+            name = "demo"
+            dependencies = ["timbal[all]", "httpx>=0.27"]
+            """,
+        )
+        manifest = extract_tool(ws, "search_products")
+
+        assert manifest["description"] == "Product catalog search."
+        assert manifest["requirements"] == ["httpx>=0.27"]
+        assert manifest["env_vars"] == ["EXAMPLE_API_KEY"]
+        assert [p["name"] for p in manifest["params"]] == ["query", "limit"]
+        assert manifest["params"][0]["annotation"] == "str"
+        assert manifest["params"][1]["default"] == "5"
+
+    def test_requirements_fall_back_to_import_name(self, workspace):
+        """Imports missing from pyproject still show up, dist-mapped."""
+        ws = workspace("""\
+        import yaml
+        from timbal.core import Agent, Tool
+
+
+        def load(doc: str) -> str:
+            return str(yaml.safe_load(doc))
+
+
+        load_tool = Tool(handler=load)
+        agent = Agent(name="a", model="openai/gpt-5.2", tools=[load_tool])
+        """)
+        manifest = extract_tool(ws, "load")
+        assert manifest["requirements"] == ["pyyaml"]
+
+    def test_bare_function_tool(self, workspace):
+        ws = workspace(PRODUCER_SOURCE)
+        manifest = extract_tool(ws, "get_datetime")
+        assert manifest["binding"] == "get_datetime"
+        assert "def get_datetime" in manifest["source"]
+        assert "search_products" not in manifest["source"]
+        # Docstring absent → description falls back to None.
+        assert manifest["description"] is None
+
+    def test_inline_tool_call_synthesizes_binding(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent, Tool
+
+
+        def shout(text: str) -> str:
+            return text.upper()
+
+
+        agent = Agent(name="a", model="openai/gpt-5.2", tools=[Tool(handler=shout)])
+        """)
+        manifest = extract_tool(ws, "shout")
+        assert manifest["binding"] == "shout_tool"
+        assert "shout_tool = Tool(handler=shout)" in manifest["source"]
+        ns: dict = {}
+        exec(compile(manifest["source"], "<tool>", "exec"), ns)
+        assert ns["shout_tool"].name == "shout"
+
+    def test_integration_annotation_detected(self, workspace):
+        ws = workspace("""\
+        from typing import Annotated
+
+        from timbal.core import Agent, Tool
+        from timbal.platform.integrations import Integration
+
+
+        def send(to: str, integration: Annotated[str, Integration("gmail")] | None = None) -> str:
+            return to
+
+
+        send_tool = Tool(handler=send)
+        agent = Agent(name="a", model="openai/gpt-5.2", tools=[send_tool])
+        """)
+        manifest = extract_tool(ws, "send")
+        assert manifest["integrations"] == ["gmail"]
+
+
+class TestExtractRejections:
+    def test_framework_tool_rejected(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent
+        from timbal.tools import WebSearch
+
+        web_search = WebSearch()
+        agent = Agent(name="a", model="openai/gpt-5.2", tools=[web_search])
+        """)
+        with pytest.raises(ValueError, match="Only custom tools"):
+            extract_tool(ws, "web_search")
+
+    def test_entry_point_reference_rejected(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent, Tool
+
+
+        def ask_self(q: str) -> str:
+            return str(agent)
+
+
+        ask_tool = Tool(handler=ask_self)
+        agent = Agent(name="a", model="openai/gpt-5.2", tools=[ask_tool])
+        """)
+        with pytest.raises(ValueError, match="entry point"):
+            extract_tool(ws, "ask_self")
+
+    def test_local_module_import_rejected(self, workspace):
+        ws = workspace("""\
+        import helpers
+        from timbal.core import Agent, Tool
+
+
+        def run(q: str) -> str:
+            return helpers.go(q)
+
+
+        run_tool = Tool(handler=run)
+        agent = Agent(name="a", model="openai/gpt-5.2", tools=[run_tool])
+        """)
+        (ws / "helpers.py").write_text("def go(q):\n    return q\n")
+        with pytest.raises(ValueError, match="local module 'helpers'"):
+            extract_tool(ws, "run")
+
+    def test_unknown_tool_lists_available(self, workspace):
+        ws = workspace(PRODUCER_SOURCE)
+        with pytest.raises(ValueError, match="Available tools"):
+            extract_tool(ws, "nope")
+
+    def test_loop_bound_dependency_rejected(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent, Tool
+
+        for _prefix in ["a", "b"]:
+            PREFIX = _prefix
+
+
+        def tag(text: str) -> str:
+            return PREFIX + text
+
+
+        tag_tool = Tool(handler=tag)
+        agent = Agent(name="a", model="openai/gpt-5.2", tools=[tag_tool])
+        """)
+        with pytest.raises(ValueError, match="unsupported statements"):
+            extract_tool(ws, "tag")
+
+
+class TestAddLibraryTool:
+    LIB_MODULE = """\
+    from timbal.core import Tool
+
+
+    def shout(text: str) -> str:
+        \"\"\"Uppercase the text.\"\"\"
+        return text.upper()
+
+
+    shout_tool = Tool(handler=shout)
+    """
+
+    CONSUMER = """\
+    from timbal.core import Agent
+
+    agent = Agent(name="agent", model="openai/gpt-5.2", tools=[])
+    """
+
+    def _write_lib(self, tmp_path: Path) -> Path:
+        lib = tmp_path / "lib_module.py"
+        lib.write_text(textwrap.dedent(self.LIB_MODULE))
+        return lib
+
+    def test_vendors_wires_and_stamps_provenance(self, workspace, tmp_path):
+        ws = workspace(self.CONSUMER, subdir="consumer")
+        lib = self._write_lib(tmp_path)
+        result = _run_cli(
+            "--path", str(ws), "add-library-tool",
+            "--tool", "shout", "--source", f"@{lib}", "--provenance", "shout@abc1234",
+        )
+        info = json.loads(result.stdout)
+        assert info["binding"] == "shout_tool"
+        assert info["name"] == "shout"
+
+        vendored = (ws / "tools" / "shout.py").read_text()
+        assert vendored.startswith("# timbal-tool: shout@abc1234\n")
+        agent_src = (ws / "agent.py").read_text()
+        assert "from tools.shout import shout_tool" in agent_src
+        assert "tools=[shout_tool]" in agent_src
+
+    def test_idempotent_re_add(self, workspace, tmp_path):
+        ws = workspace(self.CONSUMER, subdir="consumer")
+        lib = self._write_lib(tmp_path)
+        for _ in range(2):
+            _run_cli(
+                "--path", str(ws), "add-library-tool",
+                "--tool", "shout", "--source", f"@{lib}", "--provenance", "shout@abc1234",
+            )
+        agent_src = (ws / "agent.py").read_text()
+        assert agent_src.count("shout_tool") == 2  # one import + one tools entry
+
+    def test_dry_run_writes_nothing(self, workspace, tmp_path):
+        ws = workspace(self.CONSUMER, subdir="consumer")
+        lib = self._write_lib(tmp_path)
+        original = (ws / "agent.py").read_text()
+        result = _run_cli(
+            "--path", str(ws), "--dry-run", "add-library-tool",
+            "--tool", "shout", "--source", f"@{lib}",
+        )
+        assert "shout_tool" in result.stdout
+        assert (ws / "agent.py").read_text() == original
+        assert not (ws / "tools").exists()
+
+    def test_runtime_name_conflict_rejected(self, workspace, tmp_path):
+        ws = workspace("""\
+        from timbal.core import Agent
+
+
+        def shout(text: str) -> str:
+            return text
+
+
+        agent = Agent(name="agent", model="openai/gpt-5.2", tools=[shout])
+        """, subdir="consumer")
+        lib = self._write_lib(tmp_path)
+        result = _run_cli(
+            "--path", str(ws), "add-library-tool",
+            "--tool", "org_shout", "--source", f"@{lib}",
+            expect_failure=True,
+        )
+        assert "already exists" in result.stderr
+
+    def test_symbol_collision_gets_aliased_import(self, workspace, tmp_path):
+        ws = workspace("""\
+        from timbal.core import Agent
+
+
+        def shout_tool(text: str) -> str:
+            return text
+
+
+        agent = Agent(name="agent", model="openai/gpt-5.2", tools=[])
+        """, subdir="consumer")
+        lib = self._write_lib(tmp_path)
+        result = _run_cli(
+            "--path", str(ws), "add-library-tool",
+            "--tool", "org_shout", "--source", f"@{lib}",
+        )
+        info = json.loads(result.stdout)
+        assert info["local_name"] == "org_shout"
+        agent_src = (ws / "agent.py").read_text()
+        assert "from tools.org_shout import shout_tool as org_shout" in agent_src
+        assert "tools=[org_shout]" in agent_src
+
+    def test_bare_function_module_binding_inferred(self, workspace, tmp_path):
+        ws = workspace(self.CONSUMER, subdir="consumer")
+        lib = tmp_path / "bare.py"
+        lib.write_text("def stamp() -> str:\n    return 'now'\n")
+        result = _run_cli(
+            "--path", str(ws), "add-library-tool",
+            "--tool", "stamp", "--source", f"@{lib}",
+        )
+        info = json.loads(result.stdout)
+        assert info["binding"] == "stamp"
+        assert "from tools.stamp import stamp" in (ws / "agent.py").read_text()
+
+
+class TestRoundTrip:
+    def test_extract_then_add_produces_working_agent(self, workspace, tmp_path):
+        producer = workspace("""\
+        from timbal.core import Agent, Tool
+
+        SUFFIX = "!"
+
+
+        def _decorate(text: str) -> str:
+            return text + SUFFIX
+
+
+        def shout(text: str) -> str:
+            \"\"\"Uppercase and decorate.\"\"\"
+            return _decorate(text.upper())
+
+
+        shout_tool = Tool(handler=shout)
+        agent = Agent(name="agent", model="openai/gpt-5.2", tools=[shout_tool])
+        """, subdir="producer")
+        manifest = extract_tool(producer, "shout")
+
+        lib = tmp_path / "lib.py"
+        lib.write_text(manifest["source"])
+
+        consumer = workspace("""\
+        from timbal.core import Agent
+
+        agent = Agent(name="agent", model="openai/gpt-5.2", tools=[])
+        """, subdir="consumer")
+        _run_cli(
+            "--path", str(consumer), "add-library-tool",
+            "--tool", "shout", "--source", f"@{lib}",
+            "--binding", manifest["binding"],
+            "--provenance", "shout@1234abc",
+        )
+
+        # Load the consumer agent with the member dir on sys.path (mirrors
+        # how ImportSpec.load runs it) and check the tool is live.
+        import subprocess as sp
+        import sys
+
+        code = (
+            "import sys; sys.path.insert(0, sys.argv[1])\n"
+            "import agent\n"
+            "tool = next(t for t in agent.agent.tools if t.name == 'shout')\n"
+            "import asyncio\n"
+            "print(asyncio.run(tool(text='hey').collect()).output)\n"
+        )
+        result = sp.run(
+            [sys.executable, "-c", code, str(consumer)],
+            capture_output=True, text=True, cwd=str(consumer),
+        )
+        assert result.returncode == 0, result.stderr
+        assert "HEY!" in result.stdout

--- a/python/tests/codegen/test_library.py
+++ b/python/tests/codegen/test_library.py
@@ -1,12 +1,14 @@
 """Org tool library ops: extract-tool and add-library-tool."""
 
 import json
+import re
 import subprocess
 import textwrap
 from pathlib import Path
 
+import libcst as cst
 import pytest
-from timbal.codegen.library import extract_tool
+from timbal.codegen.library import _find_import_alias, extract_tool
 
 from .conftest import codegen_cmd
 
@@ -729,6 +731,58 @@ class TestAddLibraryTool:
         agent_src = (ws / "agent.py").read_text()
         assert "from tools.org_shout import shout_tool as org_shout" in agent_src
         assert "tools=[org_shout]" in agent_src
+
+    def test_unrelated_import_from_same_module_does_not_steal_binding(self, workspace, tmp_path):
+        """Existing ``from tools.x import HELPER`` must not become this tool's local_name.
+
+        Before the fix, any import from the vendor module made add-library-tool
+        reuse the first symbol and skip importing the real binding — wiring the
+        wrong name into tools=[] while exiting successfully.
+        """
+        lib_src = textwrap.dedent("""\
+        from timbal.core import Tool
+
+        HELPER = "shared"
+
+
+        def shout(text: str) -> str:
+            return text.upper()
+
+
+        shout_tool = Tool(handler=shout)
+        """)
+        lib = tmp_path / "lib_module.py"
+        lib.write_text(lib_src)
+
+        ws = workspace("""\
+        from timbal.core import Agent
+        from tools.shout import HELPER
+
+
+        agent = Agent(name="agent", model="openai/gpt-5.2", tools=[HELPER])
+        """, subdir="consumer")
+        # Same bytes as --source so re-vendor is a no-op (not a fork conflict).
+        (ws / "tools").mkdir()
+        (ws / "tools" / "shout.py").write_text(lib_src)
+
+        result = _run_cli(
+            "--path", str(ws), "add-library-tool",
+            "--tool", "shout", "--source", f"@{lib}",
+        )
+        info = json.loads(result.stdout)
+        assert info["local_name"] == "shout_tool"
+        agent_src = (ws / "agent.py").read_text()
+        # May be a new line or merged into the existing from-import.
+        assert re.search(r"from tools\.shout import .*\bshout_tool\b", agent_src)
+        assert "tools=[HELPER, shout_tool]" in agent_src
+
+    def test_find_import_alias_matches_binding_not_first_symbol(self):
+        tree = cst.parse_module(textwrap.dedent("""\
+        from tools.shout import HELPER, shout_tool as shout
+        """))
+        assert _find_import_alias(tree, "tools.shout", "shout_tool") == "shout"
+        assert _find_import_alias(tree, "tools.shout", "HELPER") == "HELPER"
+        assert _find_import_alias(tree, "tools.shout", "missing") is None
 
     def test_bare_function_module_binding_inferred(self, workspace, tmp_path):
         ws = workspace(self.CONSUMER, subdir="consumer")

--- a/python/tests/codegen/test_library.py
+++ b/python/tests/codegen/test_library.py
@@ -6,7 +6,6 @@ import textwrap
 from pathlib import Path
 
 import pytest
-
 from timbal.codegen.library import extract_tool
 
 from .conftest import codegen_cmd
@@ -260,6 +259,371 @@ class TestExtractRejections:
         with pytest.raises(ValueError, match="unsupported statements"):
             extract_tool(ws, "tag")
 
+    def test_aug_assign_dependency_rejected(self, workspace):
+        """A top-level AugAssign must fail loudly — silently extracting only the
+        initial assignment would emit a module with the wrong value."""
+        ws = workspace("""\
+        from timbal.core import Agent, Tool
+
+        RETRIES = 1
+        RETRIES += 2
+
+
+        def fetch(url: str) -> str:
+            return f"{url}?retries={RETRIES}"
+
+
+        fetch_tool = Tool(handler=fetch)
+        agent = Agent(name="a", model="openai/gpt-5.2", tools=[fetch_tool])
+        """)
+        with pytest.raises(ValueError, match="unsupported top-level statement"):
+            extract_tool(ws, "fetch")
+
+    def test_lambda_handler_rejected(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent, Tool
+
+        agent = Agent(
+            name="a",
+            model="openai/gpt-5.2",
+            tools=[Tool(name="shouty", handler=lambda text: text.upper())],
+        )
+        """)
+        with pytest.raises(ValueError, match="non-portable handler"):
+            extract_tool(ws, "shouty")
+
+
+def _exec_tool(manifest: dict):
+    """Exec the extracted module and return the bound tool object."""
+    ns: dict = {}
+    exec(compile(manifest["source"], "<tool>", "exec"), ns)  # noqa: S102
+    return ns[manifest["binding"]]
+
+
+class TestExtractAdversarial:
+    """Complex closures designed to break the dependency analysis. Every accepted
+    extraction must also execute; every unsupported shape must fail loudly."""
+
+    def test_deep_transitive_chain(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent, Tool
+
+        BASE = 10
+
+
+        def _level3(x: int) -> int:
+            return x + BASE
+
+
+        def _level2(x: int) -> int:
+            return _level3(x) * 2
+
+
+        def _level1(x: int) -> int:
+            return _level2(x) + 1
+
+
+        def compute(x: int) -> int:
+            \"\"\"Compute.\"\"\"
+            return _level1(x)
+
+
+        compute_tool = Tool(handler=compute)
+        agent = Agent(name="a", model="openai/gpt-5.2", tools=[compute_tool])
+        """)
+        manifest = extract_tool(ws, "compute")
+        for name in ("_level1", "_level2", "_level3", "BASE"):
+            assert name in manifest["source"]
+        tool = _exec_tool(manifest)
+        assert tool.name == "compute"
+
+    def test_diamond_dependency_included_once(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent, Tool
+
+
+        def _shared(x: str) -> str:
+            return x.strip()
+
+
+        def _left(x: str) -> str:
+            return _shared(x).upper()
+
+
+        def _right(x: str) -> str:
+            return _shared(x).lower()
+
+
+        def both(x: str) -> str:
+            return _left(x) + _right(x)
+
+
+        both_tool = Tool(handler=both)
+        agent = Agent(name="a", model="openai/gpt-5.2", tools=[both_tool])
+        """)
+        manifest = extract_tool(ws, "both")
+        assert manifest["source"].count("def _shared") == 1
+        _exec_tool(manifest)
+
+    def test_mutual_recursion(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent, Tool
+
+
+        def _is_even(n: int) -> bool:
+            return True if n == 0 else _is_odd(n - 1)
+
+
+        def _is_odd(n: int) -> bool:
+            return False if n == 0 else _is_even(n - 1)
+
+
+        def parity(n: int) -> str:
+            return "even" if _is_even(n) else "odd"
+
+
+        parity_tool = Tool(handler=parity)
+        agent = Agent(name="a", model="openai/gpt-5.2", tools=[parity_tool])
+        """)
+        manifest = extract_tool(ws, "parity")
+        assert "_is_even" in manifest["source"] and "_is_odd" in manifest["source"]
+        _exec_tool(manifest)
+
+    def test_class_hierarchy_with_method_globals(self, workspace):
+        """Handler → class → base class → constant referenced inside a method."""
+        ws = workspace("""\
+        import json
+
+        from timbal.core import Agent, Tool
+
+        RETRIES = 3
+
+
+        class BaseClient:
+            def encode(self, payload: dict) -> str:
+                return json.dumps({"retries": RETRIES, **payload})
+
+
+        class Client(BaseClient):
+            def fetch(self, q: str) -> str:
+                return self.encode({"q": q})
+
+
+        def query(q: str) -> str:
+            return Client().fetch(q)
+
+
+        query_tool = Tool(handler=query)
+        agent = Agent(name="a", model="openai/gpt-5.2", tools=[query_tool])
+        """)
+        manifest = extract_tool(ws, "query")
+        for name in ("class BaseClient", "class Client", "RETRIES", "import json"):
+            assert name in manifest["source"]
+        _exec_tool(manifest)
+
+    def test_decorator_factory_with_global_arg(self, workspace):
+        ws = workspace("""\
+        import functools
+
+        from timbal.core import Agent, Tool
+
+        TIMES = 2
+
+
+        def repeat(n: int):
+            def deco(fn):
+                @functools.wraps(fn)
+                def inner(*a, **k):
+                    out = None
+                    for _ in range(n):
+                        out = fn(*a, **k)
+                    return out
+                return inner
+            return deco
+
+
+        @repeat(TIMES)
+        def stamp(x: str) -> str:
+            \"\"\"Stamp.\"\"\"
+            return x + "!"
+
+
+        stamp_tool = Tool(handler=stamp)
+        agent = Agent(name="a", model="openai/gpt-5.2", tools=[stamp_tool])
+        """)
+        manifest = extract_tool(ws, "stamp")
+        for name in ("def repeat", "TIMES", "import functools"):
+            assert name in manifest["source"]
+        _exec_tool(manifest)
+
+    def test_default_arg_and_comprehension_dependencies(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent, Tool
+
+        RAW = ["a", "b"]
+        UPPER = [x.upper() for x in RAW]
+        DEFAULT_SEP = ", "
+
+
+        def join(items: str, sep: str = DEFAULT_SEP) -> str:
+            return sep.join(UPPER) + items
+
+
+        join_tool = Tool(handler=join)
+        agent = Agent(name="a", model="openai/gpt-5.2", tools=[join_tool])
+        """)
+        manifest = extract_tool(ws, "join")
+        for name in ("RAW", "UPPER", "DEFAULT_SEP"):
+            assert name in manifest["source"]
+        _exec_tool(manifest)
+
+    def test_local_shadowing_excludes_global(self, workspace):
+        """A local variable shadowing a global must not pull the global in."""
+        ws = workspace("""\
+        from timbal.core import Agent, Tool
+
+        SECRET = "do not leak"
+
+
+        def echo(x: str) -> str:
+            SECRET = "local"
+            return SECRET + x
+
+
+        echo_tool = Tool(handler=echo)
+        agent = Agent(name="a", model="openai/gpt-5.2", tools=[echo_tool])
+        """)
+        manifest = extract_tool(ws, "echo")
+        assert "do not leak" not in manifest["source"]
+        _exec_tool(manifest)
+
+    def test_global_keyword_mutation(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent, Tool
+
+        COUNT = 0
+
+
+        def bump(x: str) -> str:
+            global COUNT
+            COUNT += 1
+            return f"{x}:{COUNT}"
+
+
+        bump_tool = Tool(handler=bump)
+        agent = Agent(name="a", model="openai/gpt-5.2", tools=[bump_tool])
+        """)
+        manifest = extract_tool(ws, "bump")
+        assert "COUNT = 0" in manifest["source"]
+        _exec_tool(manifest)
+
+    def test_quoted_annotation_pulls_class(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent, Tool
+
+
+        class Payload:
+            pass
+
+
+        def handle(x: "Payload") -> str:
+            return str(x)
+
+
+        handle_tool = Tool(handler=handle)
+        agent = Agent(name="a", model="openai/gpt-5.2", tools=[handle_tool])
+        """)
+        manifest = extract_tool(ws, "handle")
+        assert "class Payload" in manifest["source"]
+        _exec_tool(manifest)
+
+    def test_future_annotations_forward_ref(self, workspace):
+        """`from __future__ import annotations` makes forward refs legal; the
+        extracted module must carry both the future import and the late class."""
+        ws = workspace("""\
+        from __future__ import annotations
+
+        from timbal.core import Agent, Tool
+
+
+        def handle(x: Late | None = None) -> str:
+            return str(x)
+
+
+        class Late:
+            pass
+
+
+        handle_tool = Tool(handler=handle)
+        agent = Agent(name="a", model="openai/gpt-5.2", tools=[handle_tool])
+        """)
+        manifest = extract_tool(ws, "handle")
+        assert "from __future__ import annotations" in manifest["source"]
+        assert "class Late" in manifest["source"]
+        _exec_tool(manifest)
+
+    def test_try_except_import_rejected(self, workspace):
+        """The common ujson/json fallback binds inside a Try block — loud rejection."""
+        ws = workspace("""\
+        from timbal.core import Agent, Tool
+
+        try:
+            import ujson as j
+        except ImportError:
+            import json as j
+
+
+        def dump(x: str) -> str:
+            return j.dumps(x)
+
+
+        dump_tool = Tool(handler=dump)
+        agent = Agent(name="a", model="openai/gpt-5.2", tools=[dump_tool])
+        """)
+        with pytest.raises(ValueError, match="unsupported statements"):
+            extract_tool(ws, "dump")
+
+    def test_module_level_walrus_rejected(self, workspace):
+        ws = workspace("""\
+        from timbal.core import Agent, Tool
+
+        (N := 5)
+
+
+        def add(x: int) -> int:
+            return x + N
+
+
+        add_tool = Tool(handler=add)
+        agent = Agent(name="a", model="openai/gpt-5.2", tools=[add_tool])
+        """)
+        with pytest.raises(ValueError, match="unsupported statements"):
+            extract_tool(ws, "add")
+
+    def test_conditional_definition_rejected(self, workspace):
+        ws = workspace("""\
+        import os
+
+        from timbal.core import Agent, Tool
+
+        if os.getenv("FAST"):
+            def mode() -> str:
+                return "fast"
+        else:
+            def mode() -> str:
+                return "slow"
+
+
+        def report(x: str) -> str:
+            return x + mode()
+
+
+        report_tool = Tool(handler=report)
+        agent = Agent(name="a", model="openai/gpt-5.2", tools=[report_tool])
+        """)
+        with pytest.raises(ValueError, match="unsupported statements"):
+            extract_tool(ws, "report")
+
 
 class TestAddLibraryTool:
     LIB_MODULE = """\
@@ -377,6 +741,113 @@ class TestAddLibraryTool:
         info = json.loads(result.stdout)
         assert info["binding"] == "stamp"
         assert "from tools.stamp import stamp" in (ws / "agent.py").read_text()
+
+    def test_forked_vendor_file_not_overwritten(self, workspace, tmp_path):
+        """A locally edited vendored module (a fork) must never be silently destroyed."""
+        ws = workspace(self.CONSUMER, subdir="consumer")
+        lib = self._write_lib(tmp_path)
+        _run_cli(
+            "--path", str(ws), "add-library-tool",
+            "--tool", "shout", "--source", f"@{lib}", "--provenance", "shout@abc1234",
+        )
+        vendor_path = ws / "tools" / "shout.py"
+        forked = vendor_path.read_text() + "\n# local fix\n"
+        vendor_path.write_text(forked)
+
+        result = _run_cli(
+            "--path", str(ws), "add-library-tool",
+            "--tool", "shout", "--source", f"@{lib}", "--provenance", "shout@abc1234",
+            expect_failure=True,
+        )
+        assert "--force" in result.stderr
+        assert vendor_path.read_text() == forked, "the fork must survive the rejected re-add"
+
+    def test_force_overwrites_forked_vendor_file(self, workspace, tmp_path):
+        ws = workspace(self.CONSUMER, subdir="consumer")
+        lib = self._write_lib(tmp_path)
+        _run_cli(
+            "--path", str(ws), "add-library-tool",
+            "--tool", "shout", "--source", f"@{lib}", "--provenance", "shout@abc1234",
+        )
+        vendor_path = ws / "tools" / "shout.py"
+        vendor_path.write_text(vendor_path.read_text() + "\n# local fix\n")
+
+        _run_cli(
+            "--path", str(ws), "add-library-tool",
+            "--tool", "shout", "--source", f"@{lib}", "--provenance", "shout@def5678", "--force",
+        )
+        content = vendor_path.read_text()
+        assert "# local fix" not in content
+        assert content.startswith("# timbal-tool: shout@def5678\n")
+
+
+class TestWorkflowStep:
+    """--step routes both ops at a Workflow step's agent instead of the entry point."""
+
+    WORKFLOW_YAML = 'fqn: "workflow.py::workflow"\n'
+
+    PRODUCER_WF = """\
+    from timbal import Agent, Workflow
+    from timbal.core import Tool
+
+    GREETING = "hello"
+
+
+    def greet(name: str) -> str:
+        \"\"\"Greet someone.\"\"\"
+        return f"{GREETING} {name}"
+
+
+    greet_tool = Tool(handler=greet)
+    agent_a = Agent(name="agent_a", model="openai/gpt-5.2", tools=[greet_tool])
+
+    workflow = Workflow(name="workflow")
+    workflow.step(agent_a)
+    """
+
+    @pytest.fixture
+    def wf_workspace(self, tmp_path):
+        def _write(source: str, subdir: str) -> Path:
+            ws = tmp_path / subdir
+            ws.mkdir(parents=True, exist_ok=True)
+            (ws / "workflow.py").write_text(textwrap.dedent(source))
+            (ws / "timbal.yaml").write_text(self.WORKFLOW_YAML)
+            return ws
+
+        return _write
+
+    def test_extract_from_step(self, wf_workspace):
+        ws = wf_workspace(self.PRODUCER_WF, subdir="producer")
+        manifest = extract_tool(ws, "greet", step="agent_a")
+        assert manifest["binding"] == "greet_tool"
+        assert "def greet" in manifest["source"]
+        assert "GREETING" in manifest["source"]
+        assert "Workflow" not in manifest["source"]
+
+    def test_extract_without_step_rejected_on_workflow(self, wf_workspace):
+        ws = wf_workspace(self.PRODUCER_WF, subdir="producer")
+        with pytest.raises(ValueError, match="Agent entry point"):
+            extract_tool(ws, "greet")
+
+    def test_add_library_tool_to_step(self, wf_workspace, tmp_path):
+        ws = wf_workspace("""\
+        from timbal import Agent, Workflow
+
+        agent_a = Agent(name="agent_a", model="openai/gpt-5.2", tools=[])
+
+        workflow = Workflow(name="workflow")
+        workflow.step(agent_a)
+        """, subdir="consumer")
+        lib = tmp_path / "lib_module.py"
+        lib.write_text(textwrap.dedent(TestAddLibraryTool.LIB_MODULE))
+        _run_cli(
+            "--path", str(ws), "add-library-tool",
+            "--tool", "shout", "--source", f"@{lib}", "--step", "agent_a",
+        )
+        src = (ws / "workflow.py").read_text()
+        assert "from tools.shout import shout_tool" in src
+        assert "tools=[shout_tool]" in src
+        assert (ws / "tools" / "shout.py").exists()
 
 
 class TestRoundTrip:

--- a/python/timbal/codegen/README.md
+++ b/python/timbal/codegen/README.md
@@ -584,6 +584,63 @@ uv run python scripts/generate_models.py
 
 ---
 
+### `extract-tool` — Extract a custom tool as a portable module
+
+```bash
+python -m timbal.codegen extract-tool --tool search_products
+python -m timbal.codegen extract-tool --tool search_products --step agent_a
+```
+
+Locates the tool in the entry point's (or step's) `tools=[...]` list, computes
+its dependency closure via scope analysis — the handler function, every
+top-level helper/constant/class it transitively references, and the imports
+they use — and prints a JSON manifest to stdout:
+
+```json
+{
+  "name": "search_products",
+  "binding": "search_tool",
+  "description": "Product catalog search.",
+  "source": "<self-contained python module>",
+  "params": [{ "name": "query", "annotation": "str", "default": null }],
+  "requirements": ["httpx>=0.27"],
+  "integrations": [],
+  "env_vars": ["EXAMPLE_API_KEY"]
+}
+```
+
+- `binding` is the importable symbol (the `Tool(...)` assignment variable, the
+  bare function name, or a synthesized `<name>_tool` for inline calls).
+- `requirements` maps the closure's non-stdlib imports to specs from the
+  member's `pyproject.toml` (falling back to dist-mapped import names).
+- Only custom tools extract (`Tool(...)` wrappers or bare functions). Fails
+  loudly on framework tools, references to the entry point, relative or
+  local-module imports, and names bound by unsupported statement shapes.
+
+### `add-library-tool` — Vendor an org library tool into the workspace
+
+```bash
+python -m timbal.codegen add-library-tool \
+  --tool search_products \
+  --source @/tmp/tool_module.py \
+  --provenance search_products@abc1234
+```
+
+Writes the module to `tools/<module>.py` under the member dir (prefixed with a
+`# timbal-tool: <name>@<rev>` provenance header when `--provenance` is given),
+adds the import, and appends the binding to the entry point's (or `--step`'s)
+`tools=[...]` list. Prints a JSON summary
+(`{"vendored", "binding", "local_name", "name", "module"}`).
+
+- `--binding` overrides the importable symbol; otherwise inferred from the
+  source (last `Tool(...)` assignment, else last function).
+- A *different* tool already answering to the same runtime name is rejected;
+  a symbol-name collision gets an aliased import
+  (`from tools.x import y as z`) automatically.
+- Idempotent — re-adding an existing library tool doesn't duplicate.
+
+---
+
 ### `get-flow` — Print the execution graph
 
 ```bash

--- a/python/timbal/codegen/README.md
+++ b/python/timbal/codegen/README.md
@@ -638,6 +638,9 @@ adds the import, and appends the binding to the entry point's (or `--step`'s)
   a symbol-name collision gets an aliased import
   (`from tools.x import y as z`) automatically.
 - Idempotent — re-adding an existing library tool doesn't duplicate.
+- An existing `tools/<module>.py` with **different content** (a local fork, or a
+  vendored copy from another revision) is never silently overwritten — the op
+  fails unless `--force` is passed.
 
 ---
 

--- a/python/timbal/codegen/__main__.py
+++ b/python/timbal/codegen/__main__.py
@@ -133,6 +133,11 @@ def main() -> None:
     add_library_tool_parser.add_argument(
         "--step", default=None, help="Target step name within a Workflow."
     )
+    add_library_tool_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing vendored module whose content differs (a local fork or another revision).",
+    )
 
     test_parser = subparsers.add_parser("test", help="Execute a single test run of the workspace entry point.")
     test_parser.add_argument(
@@ -319,10 +324,14 @@ def main() -> None:
         from timbal.codegen.library import run_add_library_tool
 
         try:
-            run_add_library_tool(workspace_path, args)
+            result = run_add_library_tool(workspace_path, args)
         except (FileNotFoundError, ValueError) as e:
             print(f"error: {e}", file=sys.stderr)
             sys.exit(1)
+        if result.get("dry_run"):
+            print(result["source"])
+        else:
+            print(json.dumps(result))
         return
 
     if operation == "test":

--- a/python/timbal/codegen/__main__.py
+++ b/python/timbal/codegen/__main__.py
@@ -95,6 +95,45 @@ def main() -> None:
     # Test run operation
     from timbal.codegen.cli_utils import arg_input
 
+    # Org tool library operations
+    extract_tool_parser = subparsers.add_parser(
+        "extract-tool",
+        help="Extract a custom tool as a portable module + manifest (JSON to stdout).",
+    )
+    extract_tool_parser.add_argument(
+        "--tool", required=True, help="Runtime name (or variable name) of the tool to extract."
+    )
+    extract_tool_parser.add_argument(
+        "--step", default=None, help="Workflow step whose tools list contains the tool."
+    )
+
+    add_library_tool_parser = subparsers.add_parser(
+        "add-library-tool",
+        help="Vendor an org library tool module into the workspace and wire it into the tools list.",
+    )
+    add_library_tool_parser.add_argument(
+        "--tool", required=True, help="Library tool name (also used for the vendored module filename)."
+    )
+    add_library_tool_parser.add_argument(
+        "--source",
+        required=True,
+        type=arg_input,
+        help="Library tool module source. Use '@path' to read from file or '-' to read from stdin.",
+    )
+    add_library_tool_parser.add_argument(
+        "--binding",
+        default=None,
+        help="Importable symbol exported by the module. Inferred from the source when omitted.",
+    )
+    add_library_tool_parser.add_argument(
+        "--provenance",
+        default=None,
+        help="Provenance marker '<name>@<rev>' written as a '# timbal-tool:' header in the vendored file.",
+    )
+    add_library_tool_parser.add_argument(
+        "--step", default=None, help="Target step name within a Workflow."
+    )
+
     test_parser = subparsers.add_parser("test", help="Execute a single test run of the workspace entry point.")
     test_parser.add_argument(
         "--input",
@@ -263,6 +302,27 @@ def main() -> None:
             print(json.dumps(flow, indent=2))
         else:
             print(format_compact(flow))
+        return
+
+    if operation == "extract-tool":
+        from timbal.codegen.library import extract_tool
+
+        try:
+            result = extract_tool(workspace_path, args.tool, step=args.step)
+        except (FileNotFoundError, ValueError) as e:
+            print(f"error: {e}", file=sys.stderr)
+            sys.exit(1)
+        print(json.dumps(result, indent=2))
+        return
+
+    if operation == "add-library-tool":
+        from timbal.codegen.library import run_add_library_tool
+
+        try:
+            run_add_library_tool(workspace_path, args)
+        except (FileNotFoundError, ValueError) as e:
+            print(f"error: {e}", file=sys.stderr)
+            sys.exit(1)
         return
 
     if operation == "test":

--- a/python/timbal/codegen/library.py
+++ b/python/timbal/codegen/library.py
@@ -1,0 +1,776 @@
+"""Org tool library operations.
+
+Two operations live here (dispatched from ``__main__`` like the other
+read-only/special ops, not via the transformer table):
+
+- ``extract-tool``: pull a custom tool out of a workspace member's source as a
+  self-contained, portable module + manifest (JSON to stdout). The dependency
+  closure is computed with libcst scope analysis: the handler function, every
+  top-level helper/constant/class it transitively references, and the imports
+  they use.
+- ``add-library-tool``: vendor a library tool module into a workspace member
+  (``tools/<module>.py`` with a provenance header) and wire it into the
+  entry point's ``tools=[...]`` list.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import libcst as cst
+from libcst.metadata import Assignment, GlobalScope, MetadataWrapper, ScopeProvider
+
+from timbal.codegen import parse_fqn
+
+from .cst_utils import (
+    insert_imports,
+    resolve_runnable_name,
+    validate_tools_target,
+)
+from .format import format_code
+
+PROVENANCE_PREFIX = "# timbal-tool:"
+PROVENANCE_RE = re.compile(r"^# timbal-tool: (?P<name>\S+)@(?P<rev>\S+)\s*$")
+
+VENDOR_DIR = "tools"
+
+# Import name -> PyPI distribution name, for the common mismatches.
+_IMPORT_TO_DIST = {
+    "yaml": "pyyaml",
+    "dotenv": "python-dotenv",
+    "PIL": "pillow",
+    "cv2": "opencv-python",
+    "bs4": "beautifulsoup4",
+    "sklearn": "scikit-learn",
+    "dateutil": "python-dateutil",
+}
+
+
+# ---------------------------------------------------------------------------
+# Small CST helpers
+# ---------------------------------------------------------------------------
+
+
+def _walk(node: cst.CSTNode):
+    """Yield every descendant of *node* (including itself)."""
+    stack = [node]
+    while stack:
+        current = stack.pop()
+        yield current
+        stack.extend(current.children)
+
+
+def _get_kwarg(call: cst.Call, name: str) -> cst.BaseExpression | None:
+    for arg in call.args:
+        if isinstance(arg.keyword, cst.Name) and arg.keyword.value == name:
+            return arg.value
+    return None
+
+
+def _string_value(node: cst.BaseExpression | None) -> str | None:
+    if isinstance(node, (cst.SimpleString, cst.ConcatenatedString)):
+        return node.evaluated_value
+    return None
+
+
+def _constructor_name(call: cst.Call) -> str | None:
+    if isinstance(call.func, cst.Name):
+        return call.func.value
+    if isinstance(call.func, cst.Attribute):
+        return call.func.attr.value
+    return None
+
+
+def _bound_names(stmt: cst.BaseStatement) -> set[str]:
+    """Top-level names bound by a module-level statement."""
+    names: set[str] = set()
+    if isinstance(stmt, (cst.FunctionDef, cst.ClassDef)):
+        names.add(stmt.name.value)
+        return names
+    if not isinstance(stmt, cst.SimpleStatementLine):
+        return names
+    for item in stmt.body:
+        if isinstance(item, cst.Assign):
+            for target in item.targets:
+                if isinstance(target.target, cst.Name):
+                    names.add(target.target.value)
+                elif isinstance(target.target, (cst.Tuple, cst.List)):
+                    for el in target.target.elements:
+                        if isinstance(el.value, cst.Name):
+                            names.add(el.value.value)
+        elif isinstance(item, cst.AnnAssign):
+            if isinstance(item.target, cst.Name):
+                names.add(item.target.value)
+        elif isinstance(item, cst.Import):
+            for alias in item.names:
+                if alias.asname is not None and isinstance(alias.asname.name, cst.Name):
+                    names.add(alias.asname.name.value)
+                else:
+                    # ``import a.b`` binds ``a``.
+                    node = alias.name
+                    while isinstance(node, cst.Attribute):
+                        node = node.value
+                    if isinstance(node, cst.Name):
+                        names.add(node.value)
+        elif isinstance(item, cst.ImportFrom) and not isinstance(item.names, cst.ImportStar):
+            for alias in item.names:
+                if alias.asname is not None and isinstance(alias.asname.name, cst.Name):
+                    names.add(alias.asname.name.value)
+                elif isinstance(alias.name, cst.Name):
+                    names.add(alias.name.value)
+    return names
+
+
+def _is_import_stmt(stmt: cst.BaseStatement) -> bool:
+    return isinstance(stmt, cst.SimpleStatementLine) and all(
+        isinstance(item, (cst.Import, cst.ImportFrom)) for item in stmt.body
+    )
+
+
+def _import_top_level_modules(stmt: cst.BaseStatement) -> list[tuple[str, bool]]:
+    """Return ``(top_level_module, is_relative)`` pairs for an import statement."""
+    result: list[tuple[str, bool]] = []
+    if not isinstance(stmt, cst.SimpleStatementLine):
+        return result
+    for item in stmt.body:
+        if isinstance(item, cst.Import):
+            for alias in item.names:
+                node = alias.name
+                while isinstance(node, cst.Attribute):
+                    node = node.value
+                if isinstance(node, cst.Name):
+                    result.append((node.value, False))
+        elif isinstance(item, cst.ImportFrom):
+            if item.relative:
+                result.append(("", True))
+                continue
+            node = item.module
+            while isinstance(node, cst.Attribute):
+                node = node.value
+            if isinstance(node, cst.Name):
+                result.append((node.value, False))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# extract-tool
+# ---------------------------------------------------------------------------
+
+
+def _stdlib_modules() -> frozenset[str]:
+    return frozenset(sys.stdlib_module_names)
+
+
+def _requirements_for_imports(workspace_path: Path, modules: set[str]) -> list[str]:
+    """Best-effort mapping of imported top-level modules to dependency specs.
+
+    Looks each module up in the member's pyproject dependencies; falls back to
+    the (dist-mapped) import name when no spec matches.
+    """
+    import tomllib
+
+    deps: list[str] = []
+    pyproject = workspace_path / "pyproject.toml"
+    if pyproject.exists():
+        try:
+            data = tomllib.loads(pyproject.read_text())
+            deps = data.get("project", {}).get("dependencies", []) or []
+        except tomllib.TOMLDecodeError:
+            deps = []
+
+    def _norm(name: str) -> str:
+        return re.sub(r"[-_.]+", "-", name).lower()
+
+    spec_by_name: dict[str, str] = {}
+    for spec in deps:
+        m = re.match(r"\s*([A-Za-z0-9._-]+)", spec)
+        if m:
+            spec_by_name[_norm(m.group(1))] = spec.strip()
+
+    requirements: list[str] = []
+    for module in sorted(modules):
+        dist = _IMPORT_TO_DIST.get(module, module)
+        spec = spec_by_name.get(_norm(dist))
+        requirements.append(spec if spec is not None else dist)
+    return requirements
+
+
+def _scan_integrations(stmts: list[cst.BaseStatement]) -> list[str]:
+    found: set[str] = set()
+    for stmt in stmts:
+        for node in _walk(stmt):
+            if (
+                isinstance(node, cst.Call)
+                and isinstance(node.func, cst.Name)
+                and node.func.value == "Integration"
+                and node.args
+            ):
+                value = _string_value(node.args[0].value)
+                if value is not None:
+                    found.add(value)
+    return sorted(found)
+
+
+def _scan_env_vars(stmts: list[cst.BaseStatement]) -> list[str]:
+    found: set[str] = set()
+
+    def _is_os_environ(node: cst.BaseExpression) -> bool:
+        return (
+            isinstance(node, cst.Attribute)
+            and isinstance(node.value, cst.Name)
+            and node.value.value == "os"
+            and node.attr.value == "environ"
+        )
+
+    for stmt in stmts:
+        for node in _walk(stmt):
+            if isinstance(node, cst.Call):
+                func = node.func
+                # os.getenv("X") / os.environ.get("X")
+                if isinstance(func, cst.Attribute) and node.args:
+                    if (
+                        isinstance(func.value, cst.Name)
+                        and func.value.value == "os"
+                        and func.attr.value == "getenv"
+                    ) or (_is_os_environ(func.value) and func.attr.value == "get"):
+                        value = _string_value(node.args[0].value)
+                        if value is not None:
+                            found.add(value)
+            elif isinstance(node, cst.Subscript) and _is_os_environ(node.value):
+                # os.environ["X"]
+                for el in node.slice:
+                    if isinstance(el.slice, cst.Index):
+                        value = _string_value(el.slice.value)
+                        if value is not None:
+                            found.add(value)
+    return sorted(found)
+
+
+def _extract_params(func: cst.FunctionDef, module: cst.Module) -> list[dict]:
+    params: list[dict] = []
+    all_params = [
+        *func.params.posonly_params,
+        *func.params.params,
+        *func.params.kwonly_params,
+    ]
+    for p in all_params:
+        entry: dict = {"name": p.name.value}
+        entry["annotation"] = (
+            module.code_for_node(p.annotation.annotation).strip() if p.annotation is not None else None
+        )
+        entry["default"] = module.code_for_node(p.default).strip() if p.default is not None else None
+        params.append(entry)
+    return params
+
+
+def _docstring_summary(func: cst.FunctionDef) -> str | None:
+    doc = func.get_docstring()
+    if not doc:
+        return None
+    # First paragraph only.
+    return doc.strip().split("\n\n")[0].strip()
+
+
+def extract_tool(workspace_path: str | Path, tool_ref: str, step: str | None = None) -> dict:
+    """Extract *tool_ref* from the workspace entry point as a portable module.
+
+    Returns a manifest dict with the self-contained ``source`` plus inferred
+    metadata (params, requirements, integrations, env vars).
+
+    Raises ``ValueError`` for framework tools and non-portable closures
+    (references to the entry point, relative/local-module imports, or names
+    bound by unsupported statement shapes).
+    """
+    workspace_path = Path(workspace_path)
+    spec = parse_fqn(workspace_path)
+    if not spec.path.exists():
+        raise FileNotFoundError(f"source file not found: {spec.path}")
+
+    source = spec.path.read_text()
+    try:
+        tree = cst.parse_module(source)
+    except cst.ParserSyntaxError as e:
+        raise ValueError(f"Cannot parse {spec.path}: {e}") from e
+
+    entry_point = spec.target
+    target, assignments = validate_tools_target(tree, entry_point, step, operation="extract-tool")
+
+    target_call = assignments.get(target)
+    if target_call is None:
+        raise ValueError(f"Could not find the constructor call for '{target}'.")
+    tools_val = _get_kwarg(target_call, "tools")
+    if not isinstance(tools_val, cst.List) or not tools_val.elements:
+        raise ValueError(f"'{target}' has no tools list to extract from.")
+
+    # -- Locate the tool element ------------------------------------------
+    element: cst.BaseExpression | None = None
+    runtime_name: str | None = None
+    for el in tools_val.elements:
+        resolved = resolve_runnable_name(el.value, assignments)
+        if resolved == tool_ref or (isinstance(el.value, cst.Name) and el.value.value == tool_ref):
+            element = el.value
+            runtime_name = resolved if resolved is not None else tool_ref
+            break
+    if element is None:
+        available = sorted(
+            {n for el in tools_val.elements if (n := resolve_runnable_name(el.value, assignments)) is not None}
+        )
+        raise ValueError(
+            f"Tool '{tool_ref}' not found in '{target}' tools list. "
+            f"Available tools: {', '.join(available) if available else '(none)'}."
+        )
+
+    # -- Classify the element and pick the binding + seed names ------------
+    func_defs = {stmt.name.value: stmt for stmt in tree.body if isinstance(stmt, cst.FunctionDef)}
+
+    binding: str
+    tool_call: cst.Call | None = None  # the Tool(...) wrapper call, when present
+    synthesized_binding_code: str | None = None
+    seed_names: set[str] = set()
+    inline_element: cst.Call | None = None
+
+    if isinstance(element, cst.Name):
+        var_name = element.value
+        if var_name in assignments:
+            ctor_call = assignments[var_name]
+            ctor = _constructor_name(ctor_call)
+            if ctor != "Tool":
+                raise ValueError(
+                    f"Tool '{tool_ref}' is a {ctor or 'non-Tool'} instance. "
+                    "Only custom tools (Tool(...) wrappers or bare functions) can be extracted."
+                )
+            binding = var_name
+            tool_call = ctor_call
+            seed_names = {var_name}
+        elif var_name in func_defs:
+            binding = var_name
+            seed_names = {var_name}
+        else:
+            raise ValueError(
+                f"Tool '{tool_ref}' resolves to '{var_name}', which is neither a top-level "
+                "assignment nor a top-level function definition."
+            )
+    elif isinstance(element, cst.Call):
+        ctor = _constructor_name(element)
+        if ctor != "Tool":
+            raise ValueError(
+                f"Tool '{tool_ref}' is an inline {ctor or 'non-Tool'} call. "
+                "Only custom tools (Tool(...) wrappers or bare functions) can be extracted."
+            )
+        inline_element = element
+        safe = re.sub(r"\W+", "_", runtime_name or tool_ref).strip("_").lower() or "tool"
+        binding = f"{safe}_tool"
+        tool_call = element
+        synthesized_binding_code = f"{binding} = {tree.code_for_node(element)}\n"
+    else:
+        raise ValueError(f"Unsupported tools list element for '{tool_ref}'.")
+
+    handler_name: str | None = None
+    if tool_call is not None:
+        handler_val = _get_kwarg(tool_call, "handler")
+        if not isinstance(handler_val, cst.Name):
+            raise ValueError(
+                f"Tool '{tool_ref}' has a non-portable handler (expected a plain function "
+                "reference, e.g. handler=my_func)."
+            )
+        handler_name = handler_val.value
+    else:
+        handler_name = binding
+
+    # -- Scope analysis: statement-level dependency graph ------------------
+    wrapper = MetadataWrapper(tree, unsafe_skip_copy=True)
+    scopes = wrapper.resolve(ScopeProvider)
+    all_scopes = {s for s in scopes.values() if s is not None}
+    global_scope = next((s for s in all_scopes if isinstance(s, GlobalScope)), None)
+    if global_scope is None:
+        raise ValueError("Could not resolve the module's global scope.")
+
+    body = list(tree.body)
+    stmt_of_node: dict[int, int] = {}
+    for i, stmt in enumerate(body):
+        for node in _walk(stmt):
+            stmt_of_node[id(node)] = i
+
+    name_def_stmts: dict[str, set[int]] = {}
+    for i, stmt in enumerate(body):
+        for name in _bound_names(stmt):
+            name_def_stmts.setdefault(name, set()).add(i)
+
+    # stmt index -> global names it references.
+    stmt_deps: dict[int, set[str]] = {}
+    inline_ids: set[int] = {id(n) for n in _walk(inline_element)} if inline_element is not None else set()
+    inline_deps: set[str] = set()
+    for scope in all_scopes:
+        for access in scope.accesses:
+            for referent in access.referents:
+                if not isinstance(referent, Assignment):
+                    continue  # builtins etc.
+                if referent.scope is not global_scope:
+                    continue
+                stmt_idx = stmt_of_node.get(id(access.node))
+                if stmt_idx is not None:
+                    stmt_deps.setdefault(stmt_idx, set()).add(referent.name)
+                if id(access.node) in inline_ids:
+                    inline_deps.add(referent.name)
+
+    if inline_element is not None:
+        seed_names = inline_deps
+
+    # -- BFS the closure ----------------------------------------------------
+    needed_names: set[str] = set()
+    included_stmts: set[int] = set()
+    queue = list(seed_names)
+    while queue:
+        name = queue.pop()
+        if name in needed_names:
+            continue
+        needed_names.add(name)
+        for stmt_idx in name_def_stmts.get(name, set()):
+            if stmt_idx in included_stmts:
+                continue
+            included_stmts.add(stmt_idx)
+            for dep in stmt_deps.get(stmt_idx, set()):
+                if dep not in needed_names:
+                    queue.append(dep)
+
+    # -- Portability validation --------------------------------------------
+    if entry_point in needed_names or target in needed_names:
+        raise ValueError(
+            f"Tool '{tool_ref}' references '{entry_point if entry_point in needed_names else target}' "
+            "(the entry point) and cannot be extracted as a standalone module."
+        )
+
+    unresolved = {n for n in needed_names if n not in name_def_stmts}
+    # Names without a top-level binding are fine only when they resolve to
+    # builtins or scoped locals; anything the BFS queued came from a global
+    # referent, so leftovers here indicate an unsupported binding shape.
+    if unresolved - set(dir(__import__("builtins"))):
+        raise ValueError(
+            f"Tool '{tool_ref}' references names bound by unsupported statements "
+            f"(e.g. loops, with-blocks, or conditionals): {', '.join(sorted(unresolved))}."
+        )
+
+    ordered = sorted(included_stmts)
+    local_stems = {p.stem for p in workspace_path.glob("*.py")} | {
+        p.name for p in workspace_path.iterdir() if p.is_dir() and not p.name.startswith(".")
+    }
+    for i in ordered:
+        stmt = body[i]
+        if isinstance(stmt, (cst.FunctionDef, cst.ClassDef)):
+            continue
+        if not isinstance(stmt, cst.SimpleStatementLine) or not all(
+            isinstance(item, (cst.Assign, cst.AnnAssign, cst.Import, cst.ImportFrom)) for item in stmt.body
+        ):
+            snippet = tree.code_for_node(stmt).strip().split("\n")[0]
+            raise ValueError(
+                f"Tool '{tool_ref}' depends on an unsupported top-level statement: '{snippet}'. "
+                "Only imports, assignments, functions, and classes can be extracted."
+            )
+        for module_name, is_relative in _import_top_level_modules(stmt):
+            if is_relative:
+                raise ValueError(
+                    f"Tool '{tool_ref}' uses a relative import, which cannot be extracted."
+                )
+            if module_name in local_stems:
+                raise ValueError(
+                    f"Tool '{tool_ref}' imports the local module '{module_name}'. "
+                    "Extraction only supports single-module closures; inline the helper first."
+                )
+
+    # -- Emit the portable module -------------------------------------------
+    import_stmts = [i for i in ordered if _is_import_stmt(body[i])]
+    other_stmts = [i for i in ordered if i not in set(import_stmts)]
+    parts: list[str] = []
+    for i in import_stmts:
+        parts.append(tree.code_for_node(body[i]).strip("\n"))
+    if import_stmts:
+        parts.append("")
+    for i in other_stmts:
+        parts.append(tree.code_for_node(body[i]).strip("\n"))
+        parts.append("")
+    if synthesized_binding_code is not None:
+        parts.append(synthesized_binding_code.strip("\n"))
+        parts.append("")
+    module_code = "\n".join(parts).strip("\n") + "\n"
+    formatted = format_code(module_code, spec.path.with_name("tool.py"))
+
+    # -- Manifest metadata ----------------------------------------------------
+    emitted_stmts = [body[i] for i in ordered]
+    handler_def = func_defs.get(handler_name) if handler_name else None
+
+    description: str | None = None
+    if tool_call is not None:
+        description = _string_value(_get_kwarg(tool_call, "description"))
+    if description is None and handler_def is not None:
+        description = _docstring_summary(handler_def)
+
+    stdlib = _stdlib_modules()
+    external_modules: set[str] = set()
+    for i in import_stmts:
+        for module_name, is_relative in _import_top_level_modules(body[i]):
+            if not is_relative and module_name and module_name not in stdlib and module_name != "timbal":
+                external_modules.add(module_name)
+
+    return {
+        "name": runtime_name,
+        "binding": binding,
+        "description": description,
+        "source": formatted,
+        "params": _extract_params(handler_def, tree) if handler_def is not None else [],
+        "requirements": _requirements_for_imports(workspace_path, external_modules),
+        "integrations": _scan_integrations(emitted_stmts),
+        "env_vars": _scan_env_vars(emitted_stmts),
+    }
+
+
+# ---------------------------------------------------------------------------
+# add-library-tool
+# ---------------------------------------------------------------------------
+
+
+def _infer_binding(source_tree: cst.Module) -> tuple[str, str]:
+    """Infer ``(binding, runtime_name)`` from a library tool module.
+
+    Prefers the last top-level ``x = Tool(...)`` assignment; falls back to the
+    last top-level function definition (bare-function tools). The runtime name
+    is what the tool answers to inside an agent: the Tool's ``name=`` kwarg,
+    else the handler function's name, else the binding itself.
+    """
+    binding: str | None = None
+    tool_call: cst.Call | None = None
+    last_func: str | None = None
+    for stmt in source_tree.body:
+        if isinstance(stmt, cst.FunctionDef):
+            last_func = stmt.name.value
+        elif isinstance(stmt, cst.SimpleStatementLine):
+            for item in stmt.body:
+                if isinstance(item, cst.Assign) and isinstance(item.value, cst.Call):
+                    if _constructor_name(item.value) == "Tool":
+                        for t in item.targets:
+                            if isinstance(t.target, cst.Name):
+                                binding = t.target.value
+                                tool_call = item.value
+    if binding is not None:
+        runtime_name = _string_value(_get_kwarg(tool_call, "name"))
+        if runtime_name is None:
+            handler_val = _get_kwarg(tool_call, "handler")
+            runtime_name = handler_val.value if isinstance(handler_val, cst.Name) else binding
+        return binding, runtime_name
+    if last_func is not None:
+        return last_func, last_func
+    raise ValueError("Could not infer the tool binding from the module (no Tool assignment or function found).")
+
+
+def _find_import_alias(tree: cst.Module, module: str) -> str | None:
+    """Return the local name bound by an existing ``from <module> import ...``."""
+    for stmt in tree.body:
+        if not isinstance(stmt, cst.SimpleStatementLine):
+            continue
+        for item in stmt.body:
+            if not isinstance(item, cst.ImportFrom) or isinstance(item.names, cst.ImportStar):
+                continue
+            parts: list[str] = []
+            node = item.module
+            while isinstance(node, cst.Attribute):
+                parts.append(node.attr.value)
+                node = node.value
+            if isinstance(node, cst.Name):
+                parts.append(node.value)
+            if ".".join(reversed(parts)) != module:
+                continue
+            for alias in item.names:
+                if alias.asname is not None and isinstance(alias.asname.name, cst.Name):
+                    return alias.asname.name.value
+                if isinstance(alias.name, cst.Name):
+                    return alias.name.value
+    return None
+
+
+class LibraryToolAdder(cst.CSTTransformer):
+    """Add the library import and append the local name to tools=[...]."""
+
+    # Re-adding is an idempotent success.
+    allow_noop = True
+
+    def __init__(
+        self,
+        target: str,
+        assignments: dict[str, cst.Call],
+        *,
+        local_name: str,
+        binding: str,
+        import_module: str,
+    ) -> None:
+        self.target = target
+        self.assignments = assignments
+        self.local_name = local_name
+        self.binding = binding
+        self.import_module = import_module
+
+    def _add_to_tools(self, call: cst.Call) -> cst.Call:
+        new_ref = cst.Name(self.local_name)
+        for i, arg in enumerate(call.args):
+            if isinstance(arg.keyword, cst.Name) and arg.keyword.value == "tools":
+                if isinstance(arg.value, cst.List):
+                    for el in arg.value.elements:
+                        if isinstance(el.value, cst.Name) and el.value.value == self.local_name:
+                            return call  # already present
+                    new_list = arg.value.with_changes(
+                        elements=[*arg.value.elements, cst.Element(value=new_ref)],
+                    )
+                    new_args = [*call.args[:i], arg.with_changes(value=new_list), *call.args[i + 1 :]]
+                    return call.with_changes(args=new_args)
+        new_arg = cst.Arg(keyword=cst.Name("tools"), value=cst.List(elements=[cst.Element(value=new_ref)]))
+        return call.with_changes(args=[*call.args, new_arg])
+
+    def leave_Assign(self, original_node: cst.Assign, updated_node: cst.Assign) -> cst.Assign:  # noqa: ARG002
+        for target in updated_node.targets:
+            if (
+                isinstance(target.target, cst.Name)
+                and target.target.value == self.target
+                and isinstance(updated_node.value, cst.Call)
+            ):
+                return updated_node.with_changes(value=self._add_to_tools(updated_node.value))
+        return updated_node
+
+    def leave_AnnAssign(self, original_node: cst.AnnAssign, updated_node: cst.AnnAssign) -> cst.AnnAssign:  # noqa: ARG002
+        if (
+            isinstance(updated_node.target, cst.Name)
+            and updated_node.target.value == self.target
+            and isinstance(updated_node.value, cst.Call)
+        ):
+            return updated_node.with_changes(value=self._add_to_tools(updated_node.value))
+        return updated_node
+
+    def leave_Module(self, original_node: cst.Module, updated_node: cst.Module) -> cst.Module:
+        if _find_import_alias(original_node, self.import_module) is not None:
+            return updated_node
+        if self.local_name != self.binding:
+            import_stmt = f"from {self.import_module} import {self.binding} as {self.local_name}\n"
+        else:
+            import_stmt = f"from {self.import_module} import {self.binding}\n"
+        body = list(updated_node.body)
+        insert_imports(body, [cst.parse_statement(import_stmt)])
+        return updated_node.with_changes(body=body)
+
+
+def vendor_module_name(tool_name: str) -> str:
+    """Sanitize a library tool name into a valid python module name."""
+    module_name = re.sub(r"\W+", "_", tool_name).strip("_").lower() or "tool"
+    if not module_name.isidentifier():
+        module_name = f"_{module_name}"
+    return module_name
+
+
+def run_add_library_tool(workspace_path: str | Path, args: argparse.Namespace) -> None:
+    """Vendor a library tool module and wire it into the entry point.
+
+    Writes ``tools/<module>.py`` (with a provenance header when provided) and
+    updates the entry point source. With ``--dry-run``, prints the updated
+    entry point source and writes nothing.
+    """
+    workspace_path = Path(workspace_path)
+    spec = parse_fqn(workspace_path)
+    if not spec.path.exists():
+        raise FileNotFoundError(f"source file not found: {spec.path}")
+
+    module_source: str = args.source
+    try:
+        source_tree = cst.parse_module(module_source)
+    except cst.ParserSyntaxError as e:
+        raise ValueError(f"--source is not valid python: {e}") from e
+
+    inferred_binding, runtime_name = _infer_binding(source_tree)
+    binding = args.binding or inferred_binding
+    tool_name = args.tool
+    module_name = vendor_module_name(tool_name)
+    import_module = f"{VENDOR_DIR}.{module_name}"
+
+    source = spec.path.read_text()
+    try:
+        tree = cst.parse_module(source)
+    except cst.ParserSyntaxError as e:
+        raise ValueError(f"Cannot parse {spec.path}: {e}") from e
+
+    step = getattr(args, "step", None)
+    target, assignments = validate_tools_target(tree, spec.target, step, operation="add-library-tool")
+
+    # Resolve the local name for the imported binding. An existing import of
+    # the vendor module wins (idempotent re-add); otherwise a collision with
+    # any top-level name gets an aliased import.
+    existing_alias = _find_import_alias(tree, import_module)
+    if existing_alias is not None:
+        local_name = existing_alias
+    else:
+        bound_names: set[str] = set()
+        for stmt in tree.body:
+            bound_names |= _bound_names(stmt)
+        if binding in bound_names:
+            local_name = module_name if module_name != binding else f"{binding}_lib"
+            if local_name in bound_names:
+                raise ValueError(
+                    f"Cannot import library tool '{tool_name}': both '{binding}' and the "
+                    f"fallback alias '{local_name}' already exist in {spec.path.name}. "
+                    "Rename the local symbol first."
+                )
+        else:
+            local_name = binding
+
+    # Runtime tool names must be unique within the agent. A different tool
+    # already answering to this name is a hard conflict, not something to
+    # silently shadow.
+    target_call = assignments.get(target)
+    if target_call is not None:
+        tools_val = _get_kwarg(target_call, "tools")
+        if isinstance(tools_val, cst.List):
+            for el in tools_val.elements:
+                if isinstance(el.value, cst.Name) and el.value.value == local_name:
+                    continue  # our own reference — idempotent
+                if resolve_runnable_name(el.value, assignments) == runtime_name:
+                    raise ValueError(
+                        f"A different tool named '{runtime_name}' already exists in '{target}'. "
+                        "Remove or rename it before adding this library tool."
+                    )
+
+    transformer = LibraryToolAdder(
+        target,
+        assignments,
+        local_name=local_name,
+        binding=binding,
+        import_module=import_module,
+    )
+    new_tree = tree.visit(transformer)
+    formatted = format_code(new_tree.code, spec.path)
+
+    header = ""
+    if getattr(args, "provenance", None):
+        header = (
+            f"{PROVENANCE_PREFIX} {args.provenance}\n"
+            "# Vendored from the org tool library. Edits make this a fork and stop updates.\n\n"
+        )
+    vendor_content = header + module_source.strip("\n") + "\n"
+
+    if getattr(args, "dry_run", False):
+        print(formatted)
+        return
+
+    vendor_path = workspace_path / VENDOR_DIR / f"{module_name}.py"
+    vendor_path.parent.mkdir(parents=True, exist_ok=True)
+    vendor_path.write_text(vendor_content)
+    spec.path.write_text(formatted)
+
+    print(
+        json.dumps(
+            {
+                "vendored": str(vendor_path.relative_to(workspace_path)),
+                "binding": binding,
+                "local_name": local_name,
+                "name": runtime_name,
+                "module": import_module,
+            }
+        )
+    )

--- a/python/timbal/codegen/library.py
+++ b/python/timbal/codegen/library.py
@@ -16,7 +16,6 @@ read-only/special ops, not via the transformer table):
 from __future__ import annotations
 
 import argparse
-import json
 import re
 import sys
 from pathlib import Path
@@ -103,6 +102,14 @@ def _bound_names(stmt: cst.BaseStatement) -> set[str]:
                         if isinstance(el.value, cst.Name):
                             names.add(el.value.value)
         elif isinstance(item, cst.AnnAssign):
+            if isinstance(item.target, cst.Name):
+                names.add(item.target.value)
+        elif isinstance(item, cst.AugAssign):
+            # An AugAssign both reads and rebinds the name. Registering it as a
+            # binding pulls the statement into the extraction closure, where the
+            # statement-shape validation rejects it loudly — without this, the
+            # closure would keep only the initial `X = ...` and silently emit a
+            # module with the wrong value.
             if isinstance(item.target, cst.Name):
                 names.add(item.target.value)
         elif isinstance(item, cst.Import):
@@ -404,18 +411,36 @@ def extract_tool(workspace_path: str | Path, tool_ref: str, step: str | None = N
     stmt_deps: dict[int, set[str]] = {}
     inline_ids: set[int] = {id(n) for n in _walk(inline_element)} if inline_element is not None else set()
     inline_deps: set[str] = set()
+
+    def _record_dep(access_node: cst.CSTNode, name: str) -> None:
+        stmt_idx = stmt_of_node.get(id(access_node))
+        if stmt_idx is not None:
+            stmt_deps.setdefault(stmt_idx, set()).add(name)
+        if id(access_node) in inline_ids:
+            inline_deps.add(name)
+
     for scope in all_scopes:
         for access in scope.accesses:
+            has_assignment_referent = False
             for referent in access.referents:
                 if not isinstance(referent, Assignment):
                     continue  # builtins etc.
+                has_assignment_referent = True
                 if referent.scope is not global_scope:
                     continue
-                stmt_idx = stmt_of_node.get(id(access.node))
-                if stmt_idx is not None:
-                    stmt_deps.setdefault(stmt_idx, set()).add(referent.name)
-                if id(access.node) in inline_ids:
-                    inline_deps.add(referent.name)
+                _record_dep(access.node, referent.name)
+            # Forward references get no referent link from the scope analysis:
+            # an annotation under `from __future__ import annotations` (or a
+            # quoted one) may legally name a class defined *later* in the
+            # module. Fall back to the bare name when it is bound at the top
+            # level. Locally shadowed names are unaffected — their access has
+            # an Assignment referent (the local one) and never reaches this.
+            if (
+                not has_assignment_referent
+                and isinstance(access.node, cst.Name)
+                and access.node.value in name_def_stmts
+            ):
+                _record_dep(access.node, access.node.value)
 
     if inline_element is not None:
         seed_names = inline_deps
@@ -485,9 +510,30 @@ def extract_tool(workspace_path: str | Path, tool_ref: str, step: str | None = N
     import_stmts = [i for i in ordered if _is_import_stmt(body[i])]
     other_stmts = [i for i in ordered if i not in set(import_stmts)]
     parts: list[str] = []
+    # `from __future__ import ...` changes annotation semantics module-wide
+    # (annotations become lazy strings) but binds a name nothing ever accesses,
+    # so the closure never picks it up. Dropping it would make the extracted
+    # module evaluate annotations eagerly at def time — breaking forward
+    # references that were legal in the producer. Always carry it.
+    future_import = next(
+        (
+            i
+            for i, stmt in enumerate(body)
+            if isinstance(stmt, cst.SimpleStatementLine)
+            and any(
+                isinstance(item, cst.ImportFrom)
+                and isinstance(item.module, cst.Name)
+                and item.module.value == "__future__"
+                for item in stmt.body
+            )
+        ),
+        None,
+    )
+    if future_import is not None and future_import not in import_stmts:
+        parts.append(tree.code_for_node(body[future_import]).strip("\n"))
     for i in import_stmts:
         parts.append(tree.code_for_node(body[i]).strip("\n"))
-    if import_stmts:
+    if import_stmts or future_import is not None:
         parts.append("")
     for i in other_stmts:
         parts.append(tree.code_for_node(body[i]).strip("\n"))
@@ -666,12 +712,17 @@ def vendor_module_name(tool_name: str) -> str:
     return module_name
 
 
-def run_add_library_tool(workspace_path: str | Path, args: argparse.Namespace) -> None:
+def run_add_library_tool(workspace_path: str | Path, args: argparse.Namespace) -> dict:
     """Vendor a library tool module and wire it into the entry point.
 
     Writes ``tools/<module>.py`` (with a provenance header when provided) and
-    updates the entry point source. With ``--dry-run``, prints the updated
-    entry point source and writes nothing.
+    updates the entry point source. Returns a summary dict for ``__main__`` to
+    print; with ``--dry-run`` the dict carries the updated entry point source
+    and nothing is written.
+
+    An existing vendored file whose content differs is a local fork (or a
+    different library revision): overwriting would silently destroy edits, so
+    it is rejected unless ``--force`` is passed.
     """
     workspace_path = Path(workspace_path)
     spec = parse_fqn(workspace_path)
@@ -755,22 +806,27 @@ def run_add_library_tool(workspace_path: str | Path, args: argparse.Namespace) -
     vendor_content = header + module_source.strip("\n") + "\n"
 
     if getattr(args, "dry_run", False):
-        print(formatted)
-        return
+        return {"dry_run": True, "source": formatted}
 
     vendor_path = workspace_path / VENDOR_DIR / f"{module_name}.py"
+    if (
+        vendor_path.exists()
+        and vendor_path.read_text() != vendor_content
+        and not getattr(args, "force", False)
+    ):
+        raise ValueError(
+            f"'{vendor_path.relative_to(workspace_path)}' already exists with different content — "
+            "it was edited locally (a fork) or vendored from another revision. "
+            "Pass --force to overwrite it."
+        )
     vendor_path.parent.mkdir(parents=True, exist_ok=True)
     vendor_path.write_text(vendor_content)
     spec.path.write_text(formatted)
 
-    print(
-        json.dumps(
-            {
-                "vendored": str(vendor_path.relative_to(workspace_path)),
-                "binding": binding,
-                "local_name": local_name,
-                "name": runtime_name,
-                "module": import_module,
-            }
-        )
-    )
+    return {
+        "vendored": str(vendor_path.relative_to(workspace_path)),
+        "binding": binding,
+        "local_name": local_name,
+        "name": runtime_name,
+        "module": import_module,
+    }

--- a/python/timbal/codegen/library.py
+++ b/python/timbal/codegen/library.py
@@ -611,8 +611,13 @@ def _infer_binding(source_tree: cst.Module) -> tuple[str, str]:
     raise ValueError("Could not infer the tool binding from the module (no Tool assignment or function found).")
 
 
-def _find_import_alias(tree: cst.Module, module: str) -> str | None:
-    """Return the local name bound by an existing ``from <module> import ...``."""
+def _find_import_alias(tree: cst.Module, module: str, binding: str) -> str | None:
+    """Return the local name for *binding* if already imported from *module*.
+
+    Only matches the specific imported symbol (``from tools.x import binding`` or
+    ``from tools.x import binding as local``). An import of a *different* name
+    from the same module — e.g. a helper — is not treated as this tool's import.
+    """
     for stmt in tree.body:
         if not isinstance(stmt, cst.SimpleStatementLine):
             continue
@@ -629,10 +634,11 @@ def _find_import_alias(tree: cst.Module, module: str) -> str | None:
             if ".".join(reversed(parts)) != module:
                 continue
             for alias in item.names:
+                if not isinstance(alias.name, cst.Name) or alias.name.value != binding:
+                    continue
                 if alias.asname is not None and isinstance(alias.asname.name, cst.Name):
                     return alias.asname.name.value
-                if isinstance(alias.name, cst.Name):
-                    return alias.name.value
+                return binding
     return None
 
 
@@ -693,7 +699,7 @@ class LibraryToolAdder(cst.CSTTransformer):
         return updated_node
 
     def leave_Module(self, original_node: cst.Module, updated_node: cst.Module) -> cst.Module:
-        if _find_import_alias(original_node, self.import_module) is not None:
+        if _find_import_alias(original_node, self.import_module, self.binding) is not None:
             return updated_node
         if self.local_name != self.binding:
             import_stmt = f"from {self.import_module} import {self.binding} as {self.local_name}\n"
@@ -751,9 +757,12 @@ def run_add_library_tool(workspace_path: str | Path, args: argparse.Namespace) -
     target, assignments = validate_tools_target(tree, spec.target, step, operation="add-library-tool")
 
     # Resolve the local name for the imported binding. An existing import of
-    # the vendor module wins (idempotent re-add); otherwise a collision with
-    # any top-level name gets an aliased import.
-    existing_alias = _find_import_alias(tree, import_module)
+    # *this* binding from the vendor module wins (idempotent re-add); otherwise
+    # a collision with any top-level name gets an aliased import. A different
+    # symbol already imported from the same module (e.g. a helper) is ignored —
+    # treating it as this tool's local name would wire the wrong name into tools
+    # and skip adding the real import.
+    existing_alias = _find_import_alias(tree, import_module, binding)
     if existing_alias is not None:
         local_name = existing_alias
     else:


### PR DESCRIPTION
… library

extract-tool pulls a custom tool out of a workspace member as a portable module: scope-analysis dependency closure (handler, helpers, constants, imports) plus an inferred manifest (params, requirements from pyproject, Integration annotations, env vars). Custom tools only; fails loudly on entry-point references, relative/local-module imports, and unsupported binding shapes.

add-library-tool vendors a library module into tools/<module>.py with a "# timbal-tool: <name>@<rev>" provenance header and wires the import + tools=[...] entry. Runtime-name conflicts are rejected; symbol collisions get an aliased import; re-adds are idempotent.

Both dispatch from __main__ like the other read-only/special ops, keeping the lazy-libcst transformer table untouched.