### PR TITLE
feat(workflow): while_ do-while step loops

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,15 +128,16 @@ workflow = (
 result = await workflow.collect(url="https://...")
 ```
 
-**`.step(runnable, depends_on=None, when=None, **kwargs)`**
+**`.step(runnable, depends_on=None, when=None, while_=None, **kwargs)`**
 - `runnable` — function, dict, or `Runnable`
 - `depends_on` — explicit list of step names to wait for
 - `when` — parameterless callable returning bool; step is skipped if False
+- `while_` — int (>= 1, run exactly N times) or parameterless callable evaluated after each iteration (do-while: always runs at least once). Each iteration gets its own span; `step_span()` returns the latest. Params resolve ONCE before iteration 1 — the step owns its cursor state. No built-in cap for callable conditions. Pausing mid-loop (approval/suspend) restarts the loop from iteration 1 on resume, and one approval resolution covers every iteration (approval id derives from the fixed input).
 - `**kwargs` — param overrides; can be plain values or callables for runtime resolution
 - Returns `self` for chaining
 
 **Dependency resolution (automatic):**
-The framework inspects `when` and `**kwargs` callables for `step_span()` calls and automatically adds those steps as dependencies. No need to specify `depends_on` when using `get_run_context().step_span()`.
+The framework inspects `when`/`while_` and `**kwargs` callables for `step_span()` calls and automatically adds those steps as dependencies (a `while_` self-reference is ignored — not a cycle). No need to specify `depends_on` when using `get_run_context().step_span()`.
 
 **Concurrent execution:** Independent steps run in parallel via asyncio. DAG cycle detection runs after each `.step()`.
 

--- a/docs/workflows/control-flow.mdx
+++ b/docs/workflows/control-flow.mdx
@@ -172,6 +172,40 @@ workflow = (
 **Key Point**: `step_span("name", default=None)` returns `None` if the step was skipped, allowing you to handle optional dependencies gracefully. Without `default=None`, accessing a skipped step would raise an error.
 </Note>
 
+## Loops
+
+Use `while_` to repeat a step. It accepts an int (run exactly N times) or a parameterless callable evaluated after each iteration (do-while — the step always runs at least once):
+
+```python
+def fetch_page() -> dict:
+    # The step owns its cursor state (module global, closure, or reading
+    # its own previous span) — params are NOT re-resolved per iteration.
+    span = get_run_context().step_span("fetch_page", default=None)
+    cursor = span.output["next_cursor"] if span else None
+    return api.fetch(cursor=cursor)
+
+workflow = (
+    Workflow(name="paginate")
+    .step(fetch_page,
+        while_=lambda: get_run_context().step_span("fetch_page").output["next_cursor"] is not None)
+    .step(summarize,
+        pages=lambda: get_run_context().step_span("fetch_page").output)
+)
+```
+
+Each iteration produces its own span. `step_span("name")` returns the **latest** one — both inside the `while_` condition and in downstream steps. `Trace.get_path()` returns all iterations.
+
+A `while_` condition that reads its own step's span does not create a dependency edge (the loop is not a cycle in the DAG). Conditions reading *other* steps' spans create dependencies as usual. `while_` combines with `when`: if `when` returns `False`, the step (and the whole loop) is skipped.
+
+<Warning>
+Things to keep in mind with `while_`:
+
+- **Params resolve once**, before the first iteration. Lambdas are not re-evaluated per iteration — a looping step must own its cursor/accumulator state (e.g. by reading its own previous span, as above).
+- **No built-in iteration cap** for callable conditions. A condition that never returns falsy loops forever; prefer an int count or make the condition provably terminating.
+- **Pausing mid-loop restarts the loop.** If the step hits an approval gate or calls `suspend()`, loop progress is not persisted — on resume the loop restarts from iteration 1, re-running side effects of completed iterations. Also, because approval ids derive from `(path, input)` and the input is fixed across iterations, a single approval covers every iteration in the same resume run. Avoid combining `while_` with approval-gated or suspending steps unless that behavior is acceptable.
+- An error in any iteration stops the loop and fails the step (and the workflow).
+</Warning>
+
 ## Explicit Dependencies
 
 Use `depends_on` when you need ordering without a data dependency:
@@ -192,3 +226,4 @@ workflow = (
 - Access sibling step data via `step_span()`, custom variables via `current_span()`
 - Lambda parameters **automatically create dependencies** — even if the referenced step hasn't executed yet
 - Use `depends_on` for explicit ordering without data dependency
+- Use `while_` (int count or callable, do-while) to repeat a step; `step_span()` returns the latest iteration

--- a/python/tests/codegen/test_get_flow.py
+++ b/python/tests/codegen/test_get_flow.py
@@ -1272,6 +1272,81 @@ class TestEdgeKinds:
 
 
 # ---------------------------------------------------------------------------
+# while_ loops
+# ---------------------------------------------------------------------------
+
+
+class TestWhileFlow:
+    def test_while_count_on_node(self, workspace):
+        ws = workspace(
+            """\
+        from timbal.core import Workflow, Tool
+
+        def tick() -> int:
+            return 1
+
+        agent = Workflow(name="wf")
+        agent.step(Tool(handler=tick), while_=3)
+        """,
+            fqn='fqn: "agent.py::agent"\n',
+        )
+        flow = _flow(ws)
+        node = flow["nodes"][0]
+        assert node["data"]["while"] == {"count": 3}
+        out = format_compact(flow)
+        assert "while: count=3" in out
+
+    def test_while_callable_on_node_and_edge_kind(self, workspace):
+        """A while_ condition reading another step's span produces a 'while'
+        edge and an expr on the node; the self-reference produces neither."""
+        ws = workspace(
+            """\
+        from timbal.core import Workflow, Tool
+        from timbal.state import get_run_context
+
+        def seed() -> int:
+            return 3
+
+        def tick() -> int:
+            return 1
+
+        agent = Workflow(name="wf")
+        agent.step(Tool(handler=seed))
+        agent.step(
+            Tool(handler=tick),
+            while_=lambda: get_run_context().step_span("tick").output
+            < get_run_context().step_span("seed").output,
+        )
+        """,
+            fqn='fqn: "agent.py::agent"\n',
+        )
+        flow = _flow(ws)
+        edge = _edge(flow, "seed", "tick")
+        assert edge is not None and edge["kind"] == "while"
+        assert _edge(flow, "tick", "tick") is None
+        tick_node = [n for n in flow["nodes"] if n["id"] == "wf.tick"][0]
+        assert "expr" in tick_node["data"]["while"]
+        assert "while:" in format_compact(flow)
+
+    def test_no_while_no_marker(self, workspace):
+        ws = workspace(
+            """\
+        from timbal.core import Workflow, Tool
+
+        def tick() -> int:
+            return 1
+
+        agent = Workflow(name="wf")
+        agent.step(Tool(handler=tick))
+        """,
+            fqn='fqn: "agent.py::agent"\n',
+        )
+        flow = _flow(ws)
+        assert "while" not in flow["nodes"][0]["data"]
+        assert "while:" not in format_compact(flow)
+
+
+# ---------------------------------------------------------------------------
 # Error handling
 # ---------------------------------------------------------------------------
 

--- a/python/tests/core/test_workflow.py
+++ b/python/tests/core/test_workflow.py
@@ -456,6 +456,156 @@ class TestControlFlow:
         assert result.output == "aggregated"
 
 
+class TestWhileLoop:
+    """Do-while step loops: while_=int / callable, span-per-iteration, last-wins step_span."""
+
+    async def test_while_count_runs_exactly_n_times(self):
+        counter = {"n": 0}
+
+        def tick() -> dict:
+            counter["n"] += 1
+            return {"n": counter["n"]}
+
+        def take_last() -> int:
+            return get_run_context().step_span("tick").output["n"]
+
+        wf = (
+            Workflow(name="while_count_wf")
+            .step(tick, while_=3)
+            .step(take_last)
+        )
+        result = await wf().collect()
+        spans = get_run_context()._trace.get_path("while_count_wf.tick")
+        assert len(spans) == 3
+        assert [s.output["n"] for s in spans] == [1, 2, 3]
+        assert result.output == 3
+
+    async def test_while_callable_do_while_runs_at_least_once(self):
+        """Condition would be False if checked before the first run — still runs once."""
+        counter = {"n": 0}
+
+        def once() -> dict:
+            counter["n"] += 1
+            return {"n": counter["n"], "again": False}
+
+        wf = Workflow(name="while_once_wf").step(
+            once,
+            while_=lambda: get_run_context().step_span("once").output["again"],
+        )
+        await wf().collect()
+        spans = get_run_context()._trace.get_path("while_once_wf.once")
+        assert len(spans) == 1
+        assert spans[0].output == {"n": 1, "again": False}
+
+    async def test_while_callable_stops_after_two(self):
+        counter = {"n": 0}
+
+        def tick() -> dict:
+            counter["n"] += 1
+            return {"n": counter["n"], "again": counter["n"] < 2}
+
+        wf = Workflow(name="while_two_wf").step(
+            tick,
+            while_=lambda: get_run_context().step_span("tick").output["again"],
+        )
+        await wf().collect()
+        spans = get_run_context()._trace.get_path("while_two_wf.tick")
+        assert len(spans) == 2
+        assert spans[-1].output == {"n": 2, "again": False}
+
+    async def test_when_false_skips_while(self):
+        counter = {"n": 0}
+
+        def tick() -> int:
+            counter["n"] += 1
+            return counter["n"]
+
+        wf = Workflow(name="when_while_wf").step(tick, when=lambda: False, while_=3)
+        await wf().collect()
+        assert get_run_context()._trace.get_path("when_while_wf.tick") == []
+        assert counter["n"] == 0
+
+    async def test_error_on_second_iteration_stops_loop(self):
+        """Error mid-loop marks the step FAILED, stops further iterations, fails the workflow."""
+        counter = {"n": 0}
+
+        def flaky() -> int:
+            counter["n"] += 1
+            if counter["n"] >= 2:
+                raise ValueError("boom")
+            return counter["n"]
+
+        wf = Workflow(name="while_err_wf").step(flaky, while_=3)
+        result = await wf().collect()
+        assert result.status.code == "error"
+        assert counter["n"] == 2  # did not continue to iteration 3
+        spans = get_run_context()._trace.get_path("while_err_wf.flaky")
+        assert len(spans) == 2
+        assert spans[0].output == 1
+        assert spans[1].error is not None
+
+    async def test_step_span_returns_latest_iteration(self):
+        counter = {"n": 0}
+        seen_in_condition: list[int] = []
+
+        def tick() -> dict:
+            counter["n"] += 1
+            return {"n": counter["n"], "again": counter["n"] < 3}
+
+        def cond() -> bool:
+            n = get_run_context().step_span("tick").output["n"]
+            seen_in_condition.append(n)
+            return get_run_context().step_span("tick").output["again"]
+
+        def take_last() -> int:
+            return get_run_context().step_span("tick").output["n"]
+
+        wf = (
+            Workflow(name="while_latest_wf")
+            .step(tick, while_=cond)
+            .step(take_last)
+        )
+        result = await wf().collect()
+        assert seen_in_condition == [1, 2, 3]
+        assert result.output == 3
+
+    async def test_non_looping_step_span_unchanged(self):
+        """Single-span steps still resolve via step_span (last-wins == first-wins)."""
+
+        def produce() -> str:
+            return "only"
+
+        def consume() -> str:
+            return get_run_context().step_span("produce").output
+
+        wf = (
+            Workflow(name="no_while_wf")
+            .step(produce)
+            .step(consume)
+        )
+        result = await wf().collect()
+        assert result.output == "only"
+        assert len(get_run_context()._trace.get_path("no_while_wf.produce")) == 1
+
+    def test_while_invalid_type_raises(self):
+        with pytest.raises(ValueError, match="while_ must be"):
+            Workflow(name="bad_while").step(step1_handler, while_="nope")  # type: ignore[arg-type]
+
+    async def test_while_self_ref_does_not_create_cycle(self):
+        """while_ reading its own step_span must not register a self-edge."""
+
+        def tick() -> dict:
+            return {"again": False}
+
+        wf = Workflow(name="while_self_wf").step(
+            tick,
+            while_=lambda: get_run_context().step_span("tick").output["again"],
+        )
+        assert "tick" not in wf._steps["tick"].previous_steps
+        await wf().collect()
+        assert len(get_run_context()._trace.get_path("while_self_wf.tick")) == 1
+
+
 class TestParameterAndNesting:
     def test_params_model_validation(self, simple_workflow):
         """Test that params_model validates input correctly."""

--- a/python/tests/core/test_workflow.py
+++ b/python/tests/core/test_workflow.py
@@ -591,6 +591,19 @@ class TestWhileLoop:
         with pytest.raises(ValueError, match="while_ must be"):
             Workflow(name="bad_while").step(step1_handler, while_="nope")  # type: ignore[arg-type]
 
+    def test_while_bool_raises(self):
+        """bool is an int subclass — True would silently mean count=1, not 'loop forever'."""
+        with pytest.raises(ValueError, match="got a bool"):
+            Workflow(name="bad_while_bool").step(step1_handler, while_=True)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="got a bool"):
+            Workflow(name="bad_while_bool2").step(step1_handler, while_=False)  # type: ignore[arg-type]
+
+    def test_while_count_below_one_raises(self):
+        with pytest.raises(ValueError, match="while_ count must be >= 1"):
+            Workflow(name="bad_while_zero").step(step1_handler, while_=0)
+        with pytest.raises(ValueError, match="while_ count must be >= 1"):
+            Workflow(name="bad_while_neg").step(step1_handler, while_=-2)
+
     async def test_while_self_ref_does_not_create_cycle(self):
         """while_ reading its own step_span must not register a self-edge."""
 
@@ -604,6 +617,85 @@ class TestWhileLoop:
         assert "tick" not in wf._steps["tick"].previous_steps
         await wf().collect()
         assert len(get_run_context()._trace.get_path("while_self_wf.tick")) == 1
+
+
+class TestWhileLoopHITL:
+    """Pin the documented while_ + HITL semantics.
+
+    These behaviors are deliberate scope decisions, documented on
+    ``Workflow.step()`` and in docs/workflows/control-flow.mdx. If either
+    test fails after a behavior change (e.g. loop-progress persistence or
+    per-iteration approval ids), update the docs alongside the fix.
+    """
+
+    async def test_single_approval_covers_all_iterations(self):
+        """approval_id derives from (path, input); input is fixed across
+        iterations, so ONE resolution auto-approves every iteration of the
+        loop in the same resume run."""
+        from timbal.types.events import ApprovalEvent
+
+        calls: list[int] = []
+        counter = {"n": 0}
+
+        def deploy() -> int:
+            counter["n"] += 1
+            calls.append(counter["n"])
+            return counter["n"]
+
+        step = Tool(name="deploy", handler=deploy, requires_approval=True)
+        wf = Workflow(name="while_approval_wf").step(step, while_=3)
+
+        events = [e async for e in wf()]
+        approval = next(e for e in events if isinstance(e, ApprovalEvent))
+        first = next(e for e in reversed(events) if isinstance(e, OutputEvent))
+        assert first.status.reason == "approval_required"
+        assert calls == [], "gate fires before iteration 1 — no handler ran"
+        approvals = [e for e in events if isinstance(e, ApprovalEvent)]
+        assert len(approvals) == 1, "only iteration 1's gate fires before the pause"
+
+        resumed = await wf(resume={approval.approval_id: True}).collect()
+        assert resumed.status.code == "success"
+        assert calls == [1, 2, 3], (
+            "the single resolution must cover iterations 2 and 3 too "
+            "(same approval_id — path and input are fixed across iterations)"
+        )
+
+    async def test_suspend_mid_loop_restarts_from_iteration_one(self):
+        """Loop progress is not persisted across a pause: a suspend() on
+        iteration 2 pauses the run, and on resume the loop restarts from
+        iteration 1 — side effects of completed iterations run again."""
+        from timbal.state import suspend
+        from timbal.types.events import InteractionEvent
+
+        calls: list[int] = []
+        counter = {"n": 0}
+
+        def tick() -> int:
+            counter["n"] += 1
+            calls.append(counter["n"])
+            if counter["n"] == 2:
+                return suspend({"question": "continue?"}, kind="ask_user")
+            return counter["n"]
+
+        wf = Workflow(name="while_suspend_wf").step(tick, while_=3)
+
+        events = [e async for e in wf()]
+        interaction = next(e for e in events if isinstance(e, InteractionEvent))
+        first = next(e for e in reversed(events) if isinstance(e, OutputEvent))
+        assert first.status.reason == "input_required"
+        assert calls == [1, 2], "iteration 1 completed; iteration 2 suspended"
+
+        resumed = await wf(
+            parent_id=first.run_id,
+            resume={interaction.interaction_id: "go"},
+        ).collect()
+        assert resumed.status.code == "success"
+        # The resumed run restarts the loop and runs the full count of THREE
+        # fresh iterations (counter 3, 4, 5) — iteration 1's side effect is
+        # re-executed. Continuation from the pause point would have produced
+        # [1, 2, 3, 4] instead. The handler no longer suspends (counter != 2),
+        # so the supplied resume value is never consumed.
+        assert calls == [1, 2, 3, 4, 5]
 
 
 class TestParameterAndNesting:

--- a/python/timbal/codegen/flow.py
+++ b/python/timbal/codegen/flow.py
@@ -39,6 +39,20 @@ def _get_when_source(step: Any) -> str | None:
     return _get_callable_source(step.when["callable"])
 
 
+def _get_while_info(step: Any) -> dict[str, Any] | None:
+    """Describe a step's while_ loop config for JSON output.
+
+    Returns ``{"count": N}`` for count loops, ``{"expr": "<source>"}`` for
+    callable conditions, or None when the step doesn't loop.
+    """
+    while_ = getattr(step, "while_", None)
+    if not while_:
+        return None
+    if "count" in while_:
+        return {"count": while_["count"]}
+    return {"expr": _get_callable_source(while_["callable"]) or "<callable>"}
+
+
 def _extract_key_from_lambda(fn: Any, source_step: str) -> str | None:
     """Extract the dot-notation key path from a runtime lambda's source.
 
@@ -208,9 +222,9 @@ def _edge_kind(kinds: set[str] | None) -> str:
 
     A dependency can arise from several sources at once (e.g. an explicit
     ``depends_on`` that also reads the step's output via a param map). Precedence
-    is ``ordering > when > param`` so explicit sequencing is never masked by
-    param wiring. Unknown/missing (e.g. edges from a direct ``_link``) default to
-    ``ordering`` — the safe choice, since ordering edges are never reduced away.
+    is ``ordering > when > while > param`` so explicit sequencing is never masked
+    by param wiring. Unknown/missing (e.g. edges from a direct ``_link``) default
+    to ``ordering`` — the safe choice, since ordering edges are never reduced away.
     """
     if not kinds:
         return "ordering"
@@ -218,6 +232,8 @@ def _edge_kind(kinds: set[str] | None) -> str:
         return "ordering"
     if "when" in kinds:
         return "when"
+    if "while" in kinds:
+        return "while"
     return "param"
 
 
@@ -253,7 +269,11 @@ def get_flow(workspace_path: str | Path) -> dict[str, Any]:
 
     if isinstance(runnable, Workflow):
         for step in runnable._steps.values():
-            nodes.append(_build_node(step, include_tools=isinstance(step, Agent)))
+            node = _build_node(step, include_tools=isinstance(step, Agent))
+            while_info = _get_while_info(step)
+            if while_info is not None:
+                node["data"]["while"] = while_info
+            nodes.append(node)
 
         for _step_name, step in runnable._steps.items():
             when_source = _get_when_source(step) if step.when else None
@@ -407,6 +427,13 @@ def _fmt_node_lines(node: dict, indent: str) -> list[str]:
     elif ntype == "workflow":
         lines.append(f"{indent}workflow  {name}")
 
+    while_info = node["data"].get("while")
+    if while_info:
+        if "count" in while_info:
+            lines.append(f"{indent}  while: count={while_info['count']}")
+        else:
+            lines.append(f"{indent}  while: {while_info.get('expr', '<callable>')}")
+
     return lines
 
 
@@ -420,9 +447,10 @@ def _reduce_param_edges(edges: list[dict]) -> list[dict]:
     first step.
 
     Only edges whose single ``kind`` is ``param`` are eligible for removal —
-    explicit ordering (``depends_on`` / hooks) and ``when`` edges are always
-    kept so user-added structure never silently disappears from the compact
-    view. The full edge set (including these) is retained in the JSON output.
+    explicit ordering (``depends_on`` / hooks), ``when``, and ``while`` edges
+    are always kept so user-added structure never silently disappears from the
+    compact view. The full edge set (including these) is retained in the JSON
+    output.
     """
     adj: dict[str, list[str]] = defaultdict(list)
     for e in edges:

--- a/python/timbal/core/runnable.py
+++ b/python/timbal/core/runnable.py
@@ -349,9 +349,11 @@ class Runnable(ABC, BaseModel):
     next_steps: Any = Field(default=None, exclude=True)
     """Names of steps that depend on this step (set by Workflow.step)."""
     previous_steps_kinds: Any = Field(default=None, exclude=True)
-    """Per-source edge kinds ('ordering' | 'when' | 'param') for introspection."""
+    """Per-source edge kinds ('ordering' | 'when' | 'while' | 'param') for introspection."""
     when: Any = Field(default=None, exclude=True)
     """Optional {'callable', 'is_coroutine', ...} guard evaluated before the step runs."""
+    while_: Any = Field(default=None, exclude=True)
+    """Optional loop config: {'count': N} or {'callable', 'is_coroutine', ...} (do-while)."""
 
     # NOTE — hot runtime attributes are plain instance attributes assigned in
     # model_post_init, NOT pydantic PrivateAttr declarations. PrivateAttr reads

--- a/python/timbal/core/workflow.py
+++ b/python/timbal/core/workflow.py
@@ -131,9 +131,18 @@ class Workflow(Runnable):
         runnable: RunnableLike,
         depends_on: list[str] | None = None,
         when: Callable[[], bool] | None = None,
+        while_: Callable[[], bool] | int | None = None,
         **kwargs: Any,
     ) -> "Workflow":
-        """Add a step to the workflow with automatic dependency linking."""
+        """Add a step to the workflow with automatic dependency linking.
+
+        ``while_`` (optional) repeats the step after each successful iteration
+        until the condition is false or the count is reached. Semantics are
+        do-while: the step always runs at least once when ``when`` allows it.
+        Each iteration produces its own span; ``step_span(name)`` returns the
+        latest. Self-references in a ``while_`` callable are not treated as
+        graph edges (the step's own span does not exist before iteration 1).
+        """
         if not isinstance(runnable, Runnable):
             if isinstance(runnable, dict):
                 runnable = Tool(**runnable)
@@ -148,11 +157,13 @@ class Workflow(Runnable):
         runnable.previous_steps = set()
         runnable.next_steps = set()
         # Per-source edge kinds: maps a previous step name -> set of kinds
-        # ("ordering" | "when" | "param"). Used by introspection (get_flow) to
-        # distinguish explicit sequencing from param/when-induced dependencies.
-        # Runtime sequencing only ever looks at ``previous_steps``.
+        # ("ordering" | "when" | "while" | "param"). Used by introspection
+        # (get_flow) to distinguish explicit sequencing from param/when/while-
+        # induced dependencies. Runtime sequencing only ever looks at
+        # ``previous_steps``.
         runnable.previous_steps_kinds = {}
         runnable.when = None
+        runnable.while_ = None
 
         # Explicit dependencies
         if depends_on and not isinstance(depends_on, list):
@@ -171,12 +182,27 @@ class Workflow(Runnable):
         # Handler-body step_span() references are data wiring, not explicit ordering.
         param_deps = set(runnable._dependencies)
         when_deps: set[str] = set()
+        while_deps: set[str] = set()
 
         # Optional handler to determine whether to execute the step, and inspect it to automatically link steps
         if when:
             inspect_result = runnable._inspect_callable(when)
             runnable.when = {"callable": when, **inspect_result}
             when_deps.update(inspect_result["dependencies"])
+
+        if isinstance(while_, int):
+            runnable.while_ = {"count": while_}
+        elif callable(while_):
+            inspect_result = runnable._inspect_callable(while_)
+            # Self-references are expected (condition reads this step's latest
+            # output) and must not become a DAG self-edge.
+            deps = set(inspect_result["dependencies"])
+            deps.discard(runnable.name)
+            inspect_result["dependencies"] = list(deps)
+            runnable.while_ = {"callable": while_, **inspect_result}
+            while_deps.update(deps)
+        elif while_ is not None:
+            raise ValueError("while_ must be a callable, an int, or None")
 
         # Use kwargs as default params for the runnable, and inspect callables to automatically link steps
         runnable._prepare_default_params(kwargs)
@@ -188,6 +214,8 @@ class Workflow(Runnable):
             edge_kinds.setdefault(dep, set()).add("ordering")
         for dep in when_deps:
             edge_kinds.setdefault(dep, set()).add("when")
+        for dep in while_deps:
+            edge_kinds.setdefault(dep, set()).add("while")
         for dep in param_deps:
             edge_kinds.setdefault(dep, set()).add("param")
         runnable.previous_steps_kinds = edge_kinds
@@ -284,38 +312,67 @@ class Workflow(Runnable):
                 set_parent_call_id(original_parent_call_id)
 
             status.state = StepState.RUNNING
+            iteration = 0
             try:
-                # Iterate the raw stream: the TimbalCollector wrapper is only
-                # needed at the public API boundary (.collect(), pending-gate
-                # enrichment); a per-event collector layer here is pure overhead.
-                async for event in step._stream(**resolved_input):
-                    yield event
-                    if (
-                        isinstance(event, OutputEvent)
-                        and event.status.code == "cancelled"
-                        and event.status.reason in {"approval_required", "approval_denied", "input_required"}
-                    ):
-                        logger.info(f"Step {step.name} paused ({event.status.reason}).")
-                        status.state = StepState.FAILED
-                        status.signal = PauseRequired(event)
-                        return
-                    if (
-                        isinstance(event, OutputEvent)
-                        and event.status.code == "cancelled"
-                        and event.status.reason == "cancelled"
-                    ):
-                        # A human cancelled this step via Cancel(); terminate the
-                        # whole workflow run rather than continuing other steps.
-                        logger.info(f"Step {step.name} cancelled by user.")
-                        status.state = StepState.FAILED
-                        status.signal = RunCancelled(event.status.message or "Run cancelled by user.")
-                        return
-                    if isinstance(event, OutputEvent) and event.error is not None:
-                        logger.info(f"Step {step.name} completed with error.")
-                        status.state = StepState.FAILED
-                        status.error = event.error
-                        status.done.set()
-                        return
+                # Do-while: always run once, then decide whether to continue.
+                # Each iteration is a full _stream → its own span. Downstream
+                # waits on status.done, which fires after all iterations.
+                # resolved_input is fixed across iterations; the step owns any
+                # cursor/accumulator state itself.
+                while True:
+                    # Iterate the raw stream: the TimbalCollector wrapper is only
+                    # needed at the public API boundary (.collect(), pending-gate
+                    # enrichment); a per-event collector layer here is pure overhead.
+                    async for event in step._stream(**resolved_input):
+                        yield event
+                        if (
+                            isinstance(event, OutputEvent)
+                            and event.status.code == "cancelled"
+                            and event.status.reason
+                            in {"approval_required", "approval_denied", "input_required"}
+                        ):
+                            logger.info(f"Step {step.name} paused ({event.status.reason}).")
+                            status.state = StepState.FAILED
+                            status.signal = PauseRequired(event)
+                            return
+                        if (
+                            isinstance(event, OutputEvent)
+                            and event.status.code == "cancelled"
+                            and event.status.reason == "cancelled"
+                        ):
+                            # A human cancelled this step via Cancel(); terminate the
+                            # whole workflow run rather than continuing other steps.
+                            logger.info(f"Step {step.name} cancelled by user.")
+                            status.state = StepState.FAILED
+                            status.signal = RunCancelled(
+                                event.status.message or "Run cancelled by user."
+                            )
+                            return
+                        if isinstance(event, OutputEvent) and event.error is not None:
+                            logger.info(f"Step {step.name} completed with error.")
+                            status.state = StepState.FAILED
+                            status.error = event.error
+                            status.done.set()
+                            return
+
+                    iteration += 1
+
+                    if not step.while_:
+                        break
+                    if "count" in step.while_:
+                        if iteration >= step.while_["count"]:
+                            break
+                    else:
+                        set_parent_call_id(workflow_call_id)
+                        try:
+                            should_continue = await step._execute_runtime_callable(
+                                step.while_["callable"], step.while_["is_coroutine"]
+                            )
+                        finally:
+                            set_parent_call_id(original_parent_call_id)
+                        if not should_continue:
+                            break
+
                 status.state = StepState.COMPLETED
             except Exception as e:
                 status.state = StepState.FAILED

--- a/python/timbal/core/workflow.py
+++ b/python/timbal/core/workflow.py
@@ -142,6 +142,26 @@ class Workflow(Runnable):
         Each iteration produces its own span; ``step_span(name)`` returns the
         latest. Self-references in a ``while_`` callable are not treated as
         graph edges (the step's own span does not exist before iteration 1).
+
+        Loop semantics to be aware of:
+
+        - An int count must be >= 1 (bools are rejected). ``while_=1`` is
+          equivalent to no loop.
+        - Step params are resolved ONCE, before the first iteration — lambdas
+          are not re-evaluated per iteration. A step that needs a cursor or
+          accumulator owns that state itself (e.g. reads its own previous
+          output via ``step_span``).
+        - A callable condition has no built-in iteration cap; a condition that
+          never returns falsy loops forever. Prefer an int count or make the
+          condition provably terminating.
+        - Pausing mid-loop (an approval gate or ``suspend()`` inside the step)
+          restarts the loop from iteration 1 on resume: loop progress is not
+          persisted, so side effects of already-completed iterations run
+          again. Additionally, approval ids are derived from ``(path, input)``
+          and the input is fixed across iterations, so a single approval
+          resolution covers EVERY iteration of the loop in the same resume
+          run. Avoid combining ``while_`` with approval-gated or suspending
+          steps unless that is acceptable.
         """
         if not isinstance(runnable, Runnable):
             if isinstance(runnable, dict):
@@ -190,7 +210,13 @@ class Workflow(Runnable):
             runnable.when = {"callable": when, **inspect_result}
             when_deps.update(inspect_result["dependencies"])
 
+        if isinstance(while_, bool):
+            # bool is an int subclass — while_=True would silently mean "run
+            # once" rather than "loop forever". Reject it outright.
+            raise ValueError("while_ must be a callable, an int >= 1, or None (got a bool)")
         if isinstance(while_, int):
+            if while_ < 1:
+                raise ValueError(f"while_ count must be >= 1, got {while_}")
             runnable.while_ = {"count": while_}
         elif callable(while_):
             inspect_result = runnable._inspect_callable(while_)

--- a/python/timbal/state/context.py
+++ b/python/timbal/state/context.py
@@ -347,9 +347,15 @@ class RunContext(BaseModel):
         from . import get_parent_call_id
 
         parent_call_id = get_parent_call_id()
+        # Last-wins: looping steps (while_) produce multiple spans with the same
+        # path; callers (while_ conditions, downstream lambdas) want the latest.
+        # Non-looping steps still produce exactly one span, so behavior is unchanged.
+        result = None
         for span in self._trace.values():
             if span.parent_call_id == parent_call_id and span.path.endswith("." + name):
-                return span
+                result = span
+        if result is not None:
+            return result
 
         if isinstance(default, _NoDefault):
             raise SpanNotFound(name)

--- a/python/timbal/state/context.py
+++ b/python/timbal/state/context.py
@@ -349,13 +349,13 @@ class RunContext(BaseModel):
         parent_call_id = get_parent_call_id()
         # Last-wins: looping steps (while_) produce multiple spans with the same
         # path; callers (while_ conditions, downstream lambdas) want the latest.
-        # Non-looping steps still produce exactly one span, so behavior is unchanged.
-        result = None
-        for span in self._trace.values():
+        # Non-looping steps still produce exactly one span, so behavior is
+        # unchanged. Trace insertion order is chronological, so scanning the
+        # underlying dict in reverse finds the latest match first and keeps the
+        # early exit (this is a hot path for param lambdas / conditions).
+        for span in reversed(self._trace.data.values()):
             if span.parent_call_id == parent_call_id and span.path.endswith("." + name):
-                result = span
-        if result is not None:
-            return result
+                return span
 
         if isinstance(default, _NoDefault):
             raise SpanNotFound(name)


### PR DESCRIPTION
## Summary
- Add `while_` to `Workflow.step()` (`int` count or callable) with do-while semantics: always run once, then continue while the condition holds / until N iterations.
- Each iteration is a full step `_stream` → its own span; `step_span()` last-wins so conditions and downstream lambdas see the latest output.
- Self-references in `while_` callables are stripped from DAG edges (no fake cycles). Orthogonal to `when`.

## Test plan
- [x] `TestWhileLoop` (count, callable do-while, when+while skip, mid-loop error, last-wins step_span, self-ref no cycle)
- [x] Full `python/tests/core/test_workflow.py`
- [x] Full suite with `--all-extras`: **3203 passed** (on combined branch; while_ subset identical)


Made with [Cursor](https://cursor.com)