### PR TITLE
feat(types): Phase-1 Runnable/Agent/OutputEvent generics

### DIFF
--- a/python/timbal/_typing.py
+++ b/python/timbal/_typing.py
@@ -1,0 +1,15 @@
+"""Shared TypeVars for static typing of Runnable / collector / event payloads.
+
+These exist only for the type checker. Runtime behaviour is unchanged — Generic
+bases add ``__class_getitem__`` but no validators or extra fields.
+"""
+
+from typing import Any
+
+from typing_extensions import TypeVar
+
+PayloadT = TypeVar("PayloadT", default=Any)
+"""Payload inside ``OutputEvent.output`` / ``TimbalCollector`` / ``Runnable``."""
+
+CollectT = TypeVar("CollectT")
+"""Result type returned by ``BaseCollector.collect()`` / ``.result()``."""

--- a/python/timbal/collectors/base.py
+++ b/python/timbal/collectors/base.py
@@ -2,13 +2,19 @@ import asyncio
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
 from functools import wraps
-from typing import Any
+from typing import Any, Generic
+
+from .._typing import CollectT
 
 
-class BaseCollector(ABC):
-    """Base abstract class for all event collectors with internal state management."""
-    
-    def __init__(self, async_gen: AsyncGenerator[Any, None], **kwargs: Any): # noqa: ARG002
+class BaseCollector(ABC, Generic[CollectT]):
+    """Base abstract class for all event collectors with internal state management.
+
+    ``CollectT`` is the static type returned by :meth:`collect` / :meth:`result`
+    (e.g. ``OutputEvent[PayloadT] | None`` for ``TimbalCollector``).
+    """
+
+    def __init__(self, async_gen: AsyncGenerator[Any, None], **kwargs: Any):  # noqa: ARG002
         self._async_gen = async_gen
         self._collected = False
 
@@ -65,7 +71,7 @@ class BaseCollector(ABC):
         await self._async_gen.aclose()
         self._collected = True
     
-    async def collect(self) -> Any:
+    async def collect(self) -> CollectT:
         """Collect the final result by consuming the entire stream.
 
         This method consumes all remaining events from the async generator
@@ -99,30 +105,32 @@ class BaseCollector(ABC):
     @classmethod
     def wrap(cls, func):
         """Decorator that wraps async generator return with BaseCollector."""
+
         @wraps(func)
         def wrapper(self, **kwargs) -> cls:
             return cls(async_gen=func(self, **kwargs))
+
         return wrapper
-    
+
     @classmethod
     @abstractmethod
     def can_handle(cls, event: Any) -> bool:
         """Check if this collector can handle the given event type."""
         pass
-    
+
     @abstractmethod
     def process(self, event: Any) -> Any:
         """Process the event and update internal state.
-        
+
         Args:
             event: The event to process
-            
+
         Returns:
             Processed content if available for streaming, None otherwise
         """
         pass
 
     @abstractmethod
-    def result(self) -> Any:
+    def result(self) -> CollectT:
         """Return the final result."""
         pass

--- a/python/timbal/collectors/impl/timbal.py
+++ b/python/timbal/collectors/impl/timbal.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Generic
 
 # `override` was introduced in Python 3.12; use `typing_extensions` for compatibility with older versions
 try:
@@ -8,6 +8,7 @@ except ImportError:
 
 import structlog
 
+from ..._typing import PayloadT
 from ...types.events.approval import ApprovalEvent as TimbalApprovalEvent
 from ...types.events.base import BaseEvent as TimbalBaseEvent
 from ...types.events.delta import DeltaEvent as TimbalDeltaEvent
@@ -21,12 +22,16 @@ logger = structlog.get_logger("timbal.collectors.impl.timbal")
 
 
 @register_collector
-class TimbalCollector(BaseCollector):
-    """Collector for Timbal events."""
+class TimbalCollector(BaseCollector[TimbalOutputEvent[PayloadT] | None], Generic[PayloadT]):
+    """Collector for Timbal events.
+
+    ``PayloadT`` is the static type of the wrapped ``OutputEvent.output``.
+    ``.collect()`` returns ``OutputEvent[PayloadT] | None``.
+    """
 
     def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)
-        self._output_event: TimbalOutputEvent | None = None
+        self._output_event: TimbalOutputEvent[PayloadT] | None = None
         # Capture every approval gate that fires during the stream so callers
         # of .collect() can react to all pending approvals — not just the
         # first one — when concurrent runnables (parallel workflow steps,
@@ -92,7 +97,7 @@ class TimbalCollector(BaseCollector):
             logger.warning("Unknown Timbal event type", event_type=type(event), event=event)
 
     @override
-    def result(self) -> Any:
+    def result(self) -> TimbalOutputEvent[PayloadT] | None:
         """Returns the final OutputEvent enriched with pending gates.
 
         When concurrent runnables pause, the OutputEvent only references the

--- a/python/timbal/core/agent.py
+++ b/python/timbal/core/agent.py
@@ -7,7 +7,7 @@ import traceback
 from collections.abc import AsyncGenerator, Callable, Coroutine
 from functools import cached_property
 from pathlib import Path
-from typing import Any
+from typing import Any, Generic, overload
 
 # `override` was introduced in Python 3.12; use `typing_extensions` for compatibility with older versions
 try:
@@ -28,6 +28,7 @@ from pydantic import (
 )
 from uuid_extensions import uuid7
 
+from .._typing import PayloadT
 from ..errors import InterruptError, PauseRequired, RunCancelled, bail
 from ..state import get_run_context
 from ..types.content import CustomContent, FileContent, TextContent, ToolResultContent, ToolUseContent
@@ -169,8 +170,14 @@ class AgentParams(BaseModel):
         }
 
 
-class Agent(Runnable):
-    """Orchestrates LLM interactions with autonomous tool calling."""
+class Agent(Runnable[PayloadT], Generic[PayloadT]):
+    """Orchestrates LLM interactions with autonomous tool calling.
+
+    ``PayloadT`` is the static type of ``OutputEvent.output``:
+    - default / ``output_model=None`` → ``Message``
+    - ``output_model=MyModel`` → ``MyModel`` (annotate as ``Agent[MyModel]`` or
+      rely on the ``__init__`` overloads below)
+    """
 
     model: SkipValidation[Model | str]
     """LLM model identifier (e.g., 'openai/gpt-4o-mini', 'anthropic/claude-haiku-4-5') or a TestModel for offline testing."""
@@ -211,8 +218,8 @@ class Agent(Runnable):
     See timbal.core.tool_result_offload."""
     temperature: float | None = None
     """Sampling temperature for the LLM response."""
-    output_model: type[BaseModel] | None = None
-    """BaseModel to generate a structured output."""
+    output_model: type[PayloadT] | None = None
+    """BaseModel to generate a structured output. When set, ``OutputEvent.output`` is this type."""
     output_model_context: Any = None
     """Validation context passed to Pydantic's model_validate when validating output_model responses."""
     model_params: dict[str, Any] = {}
@@ -221,6 +228,26 @@ class Agent(Runnable):
     """Custom base URL for the LLM API."""
     api_key: SecretStr | None = None
     """Custom API key for the LLM API."""
+
+    @overload
+    def __init__(
+        self: "Agent[PayloadT]",
+        *,
+        output_model: type[PayloadT],
+        **data: Any,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self: "Agent[Message]",
+        **data: Any,
+    ) -> None: ...
+
+    def __init__(self, **data: Any) -> None:
+        # Thin forwarder so the overloads above can teach the type checker that
+        # ``output_model=MyOut`` → ``Agent[MyOut]`` and otherwise ``Agent[Message]``.
+        # Runtime behaviour is identical to the Pydantic-generated constructor.
+        super().__init__(**data)
 
     def model_post_init(self, __context: Any) -> None:
         """Initialize agent after Pydantic model creation."""

--- a/python/timbal/core/runnable.py
+++ b/python/timbal/core/runnable.py
@@ -12,7 +12,7 @@ import traceback
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator, Callable
 from functools import cached_property
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Generic, Literal
 
 from pydantic import (
     BaseModel,
@@ -23,6 +23,11 @@ from pydantic import (
     field_validator,
     model_serializer,
 )
+
+from .._typing import PayloadT
+
+if TYPE_CHECKING:
+    from ..collectors.impl.timbal import TimbalCollector
 from uuid_extensions import uuid7
 
 from ..collectors import get_collector_registry
@@ -210,8 +215,13 @@ def _approval_id_for(path: str, input_dump: Any) -> str:
     return hashlib.sha256(json.dumps(payload, sort_keys=True, default=str).encode()).hexdigest()[:32]
 
 
-class Runnable(ABC, BaseModel):
+class Runnable(ABC, BaseModel, Generic[PayloadT]):
     """Abstract base class for all runnable components in the Timbal framework.
+
+    ``PayloadT`` is the static type of ``OutputEvent.output`` for this runnable
+    (e.g. ``Message``, a Pydantic ``output_model``, or a tool return type).
+    Calling the runnable returns a ``TimbalCollector[PayloadT]`` whose
+    ``.collect()`` yields ``OutputEvent[PayloadT] | None``.
 
     A Runnable represents an executable unit that can process inputs and produce outputs
     through an async generator interface. Runnables can be nested to form complex
@@ -1434,7 +1444,7 @@ class Runnable(ABC, BaseModel):
         }
         return {"task_id": task_id, "status": "running"}
 
-    def __call__(self, **kwargs: Any) -> Any:
+    def __call__(self, **kwargs: Any) -> "TimbalCollector[PayloadT]":
         """Execute the runnable, returning a TimbalCollector over its event stream.
 
         This is the public entry point. The collector is the API boundary: it

--- a/python/timbal/core/tool.py
+++ b/python/timbal/core/tool.py
@@ -1,7 +1,7 @@
 import inspect
 from collections.abc import Callable
 from functools import cached_property
-from typing import Any, Literal
+from typing import Any, Generic, Literal
 
 # `override` was introduced in Python 3.12; use `typing_extensions` for compatibility with older versions
 try:
@@ -11,6 +11,7 @@ except ImportError:
 
 from pydantic import BaseModel, Field, SkipValidation, computed_field, model_validator
 
+from .._typing import PayloadT
 from ..errors import CredentialNotAvailable, PlatformError, ToolProxyUnavailable
 from ..platform.tool_proxy import execute_tool_proxy
 from ..utils import create_model_from_handler
@@ -18,8 +19,11 @@ from .runnable import Runnable
 from .tool_result_offload import ToolResultLimit
 
 
-class Tool(Runnable):
+class Tool(Runnable[PayloadT], Generic[PayloadT]):
     """A Tool is a Runnable that wraps a callable function or method.
+
+    ``PayloadT`` is the static type of the handler's return value (surfaced on
+    ``OutputEvent.output``). Infer via annotation, e.g. ``Tool[int](...)``.
 
     Tools automatically introspect the handler function to:
     - Generate parameter models from function signatures
@@ -31,7 +35,7 @@ class Tool(Runnable):
     composed into more complex Agents and Workflows.
     """
 
-    handler: SkipValidation[Callable[..., Any]]
+    handler: SkipValidation[Callable[..., PayloadT]]
     """The callable function or method that this tool wraps."""
 
     record_default_request_usage: bool = Field(

--- a/python/timbal/core/workflow.py
+++ b/python/timbal/core/workflow.py
@@ -45,8 +45,11 @@ class StepStatus:
 logger = structlog.get_logger("timbal.core.workflow")
 
 
-class Workflow(Runnable):
-    """Orchestrates execution of multiple steps in a DAG with automatic dependency linking."""
+class Workflow(Runnable[Any]):
+    """Orchestrates execution of multiple steps in a DAG with automatic dependency linking.
+
+    Workflow output typing is ``Any`` for now (``return_model`` is still TODO).
+    """
 
     def model_post_init(self, __context: Any) -> None:
         super().model_post_init(__context)

--- a/python/timbal/types/events/output.py
+++ b/python/timbal/types/events/output.py
@@ -1,17 +1,26 @@
-from typing import Any
+from typing import Any, Generic
 
+from ..._typing import PayloadT
 from ...types.run_status import RunStatus
 from .base import BaseEvent
 
 
-class OutputEvent(BaseEvent):
-    """Event emitted when a step completes with its full output."""
+class OutputEvent(BaseEvent, Generic[PayloadT]):
+    """Event emitted when a step completes with its full output.
+
+    ``PayloadT`` is the static type of :attr:`output` (e.g. ``Message``, a
+    Pydantic ``output_model``, or a tool handler return). Generics are
+    type-checker only — runtime construction is unchanged.
+    """
 
     __slots__ = ("input", "status", "output", "error", "t0", "t1", "usage", "metadata", "_input_dump", "_output_dump")
 
     type = "OUTPUT"
 
     _FIELDS = BaseEvent._FIELDS + ("input", "status", "output", "error", "t0", "t1", "usage", "metadata")
+
+    output: PayloadT
+    """The result of the runnable."""
 
     def __init__(
         self,
@@ -25,7 +34,7 @@ class OutputEvent(BaseEvent):
         parent_run_id: str | None = None,
         parent_call_id: str | None = None,
         input: Any = None,
-        output: Any = None,
+        output: PayloadT | None = None,
         error: Any = None,
         usage: dict[str, int] | None = None,
         metadata: dict[str, Any] | None = None,
@@ -48,8 +57,7 @@ class OutputEvent(BaseEvent):
         """The input arguments passed to the runnable."""
         self.status = status
         """The status summary of the runnable after it completed."""
-        self.output = output
-        """The result of the runnable."""
+        self.output = output  # type: ignore[assignment]
         self.error = error
         """The error that occurred during the runnable."""
         self.t0 = t0

--- a/python/typing_tests/agent_generics.py
+++ b/python/typing_tests/agent_generics.py
@@ -1,0 +1,63 @@
+"""Static typing smoke for Agent / Tool / OutputEvent generics.
+
+Not collected by pytest (outside ``python/tests``). Check with:
+
+    pyright python/typing_tests/agent_generics.py
+"""
+
+from typing import assert_type
+
+from pydantic import BaseModel
+from timbal import Agent, Tool
+from timbal.core.test_model import TestModel
+from timbal.types.events import OutputEvent
+from timbal.types.message import Message
+
+
+class Summary(BaseModel):
+    title: str
+
+
+async def _agent_with_output_model() -> None:
+    agent = Agent(
+        name="typed",
+        model=TestModel(responses=['{"title": "hi"}']),
+        output_model=Summary,
+        tools=[],
+        max_tokens=64,
+    )
+    assert_type(agent, Agent[Summary])
+    result = await agent(prompt="hi").collect()
+    assert_type(result, OutputEvent[Summary] | None)
+    if result is not None:
+        assert_type(result.output, Summary)
+
+
+def _agent_default_message() -> None:
+    agent = Agent(
+        name="plain",
+        model=TestModel(responses=["hello"]),
+        tools=[],
+        max_tokens=64,
+    )
+    assert_type(agent, Agent[Message])
+
+
+def _tool_payload() -> None:
+    tool: Tool[int] = Tool(name="add", handler=lambda x: x + 1)
+    assert_type(tool, Tool[int])
+
+
+def _output_event_payload() -> None:
+    from timbal.types.run_status import RunStatus
+
+    ev: OutputEvent[Summary] = OutputEvent(
+        run_id="r",
+        path="a",
+        call_id="c",
+        status=RunStatus(code="success"),
+        t0=0,
+        t1=1,
+        output=Summary(title="x"),
+    )
+    assert_type(ev.output, Summary)


### PR DESCRIPTION
## Summary
- Add `PayloadT` / `CollectT` and make `OutputEvent`, `BaseCollector`, `TimbalCollector`, `Runnable`, `Agent`, and `Tool` generic.
- Public API stays `await runnable(...).collect()` → **`OutputEvent[PayloadT] | None`**; typed payload is `result.output`.
- `Agent` `__init__` overloads: `output_model=MyModel` → `Agent[MyModel]`, otherwise `Agent[Message]`.
- `Workflow` stays `Runnable[Any]` for now. Smoke file: `python/typing_tests/agent_generics.py`.

**Stacked on** #118 (`feat/while-loop`). Retarget to `main` after that merges, or merge via stack.

## Test plan
- [x] Core agent/tool/workflow/output_model + collectors tests
- [x] `pyright python/typing_tests/agent_generics.py` — 0 errors
- [x] Full suite earlier on combined branch: **3203 passed** (generics is type-only)


Made with [Cursor](https://cursor.com)