### PR TITLE
feat(benchmarks): add Timbal vs Mastra cross-language benchmark suite

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -45,6 +45,11 @@ uv run --with openai-agents --with 'openai>=2.26,<3' python benchmarks/openai_ag
 uv run --with google-adk python benchmarks/google_adk/bench_agent.py --quick
 uv run --with google-adk python benchmarks/google_adk/bench_transfer.py --quick
 uv run --with google-adk python benchmarks/google_adk/bench_callbacks.py --quick
+
+# Mastra benchmarks (TypeScript — needs Node >= 20)
+cd benchmarks/mastra && npm install && cd ../..
+uv run python benchmarks/mastra/bench_agent.py --quick
+uv run python benchmarks/mastra/bench_workflow.py --quick
 ```
 
 No API keys required. All LLM calls are faked by inspecting message history.
@@ -169,6 +174,8 @@ zero provider-specific code in user land.
 | `pydantic/` | Timbal vs PydanticAI/Pydantic Graph + Logfire — agents, graph-style workflows, control flow | WIP |
 | `openai_agents/` | Timbal vs OpenAI Agents SDK - agents, handoffs, agent-as-tool | WIP |
 | `google_adk/` | Timbal vs Google ADK - agents, sub-agent transfer, callbacks | WIP |
+| `mastra/` | Timbal vs Mastra (TypeScript) — cross-language: agents and DAG workflows, each in its native runtime | WIP |
+| `rust/` | Timbal (Python) vs timbal-rs (Rust) — same agent loop, native runtimes | WIP |
 
 **Coming next:** deeper Google ADK orchestration benchmarks.
 

--- a/benchmarks/mastra/README.md
+++ b/benchmarks/mastra/README.md
@@ -151,15 +151,15 @@ tracing built in and always on; compare against Mastra+obs for parity.
 
 | Scenario | Timbal p50 | Mastra p50 | Mastra+obs p50 |
 |----------|-----------:|-----------:|---------------:|
-| Single tool | 271.9 µs | 2.70 ms | 4.53 ms |
-| 3-step chain | 286.0 µs | 4.66 ms | 7.91 ms |
-| Parallel tools | 303.0 µs | 2.76 ms | 4.98 ms |
+| Single tool | 265.2 µs | 2.63 ms | 4.09 ms |
+| 3-step chain | 274.8 µs | 3.74 ms | 6.64 ms |
+| Parallel tools | 278.2 µs | 2.60 ms | 4.65 ms |
 
 | Scenario | Timbal c=10 | Mastra c=10 | Mastra+obs c=10 |
 |----------|------------:|------------:|----------------:|
-| Single tool | 3,828/s | 511/s | 259/s |
-| 3-step chain | 1,845/s | 258/s | 145/s |
-| Parallel tools | 2,252/s | 373/s | 223/s |
+| Single tool | 4,172/s | 512/s | 264/s |
+| 3-step chain | 1,854/s | 284/s | 144/s |
+| Parallel tools | 2,244/s | 374/s | 239/s |
 
 Timbal's agent loop is roughly an order of magnitude faster per run and in
 throughput — despite the V8-vs-CPython runtime handicap running the other way.
@@ -173,15 +173,15 @@ Trivial handlers, no LLM — pure scheduling overhead.
 
 | Scenario | Timbal p50 | Mastra p50 | Mastra+obs p50 |
 |----------|-----------:|-----------:|---------------:|
-| Sequential | 355.0 µs | 94.7 µs | 303.0 µs |
-| Fan-out/in | 486.0 µs | 127.3 µs | 341.4 µs |
-| Diamond | 408.4 µs | 107.1 µs | 276.7 µs |
+| Sequential | 315.1 µs | 95.8 µs | 289.4 µs |
+| Fan-out/in | 467.6 µs | 130.7 µs | 337.9 µs |
+| Diamond | 381.7 µs | 104.9 µs | 289.5 µs |
 
 | Scenario | Timbal c=10 | Mastra c=10 | Mastra+obs c=10 |
 |----------|------------:|------------:|----------------:|
-| Sequential | 3,954/s | 15,770/s | 3,973/s |
-| Fan-out/in | 3,025/s | 9,074/s | 3,183/s |
-| Diamond | 3,557/s | 10,772/s | 3,805/s |
+| Sequential | 4,373/s | 13,091/s | 4,071/s |
+| Fan-out/in | 3,131/s | 9,433/s | 3,440/s |
+| Diamond | 4,039/s | 11,265/s | 4,014/s |
 
 This one cuts the other way and we report it as-is: Mastra's bare workflow
 engine on V8 is ~3x faster than Timbal on trivial DAGs. That advantage is a mix

--- a/benchmarks/mastra/README.md
+++ b/benchmarks/mastra/README.md
@@ -1,0 +1,194 @@
+# Timbal vs Mastra - Benchmarks
+
+Pure framework overhead benchmarks. No real LLM/API calls. Timbal uses `TestModel`;
+Mastra uses the AI SDK's `MockLanguageModelV4` test model.
+
+**This is a cross-language comparison.** Timbal is Python, Mastra is TypeScript.
+Read the methodology section before quoting any number.
+
+**Environment:** Apple Silicon M-series. Timbal on CPython 3.11/asyncio;
+Mastra on Node 22/V8. Raw output from full-mode runs is stored in `results/`.
+
+---
+
+## Methodology: what a cross-language comparison can and cannot say
+
+Every other directory in `benchmarks/` compares two Python frameworks inside one
+process. That is impossible here, so the design is:
+
+- **Each framework runs in its native runtime.** Timbal runs on CPython/asyncio in
+  the benchmark process; Mastra runs on Node/V8 in a subprocess (`bench_*.mjs`).
+  No transpilation, no embedding, no artificial common denominator.
+- **Everything else is held identical:** the same scenarios, the same
+  fake-LLM-that-inspects-message-history trick, the same warmup counts, the same
+  batch sizes, monotonic nanosecond timers on both sides (`time.perf_counter` /
+  `process.hrtime.bigint`), forced GC between batches, one shared pre-built
+  agent/workflow instance (creation excluded from timing).
+
+### What the numbers mean
+
+Latency, burst, and throughput compare **framework + language runtime stacks** —
+the thing you actually deploy. If Mastra is faster at X, part of that is V8's JIT;
+if Timbal is faster at Y, part of that is Timbal's architecture. The numbers do not
+separate the two, and we don't pretend they do. They answer "what overhead do I ship
+with", not "which codebase has better algorithms".
+
+Concretely, expect two systematic runtime effects in Mastra's favor that have
+nothing to do with either framework's design: V8 JIT-compiles hot loops (CPython
+3.12 does not), and V8's allocation/GC path is faster for short-lived objects.
+Timbal's wins happen *despite* that handicap; Mastra's wins should be read with
+it in mind.
+
+### What is explicitly NOT comparable
+
+**Memory.** Python is measured with `tracemalloc` (exact peak of every traced
+allocation); Node reports peak `heapUsed` growth over a batch (post-hoc, GC-timing
+dependent, approximate). These are different instruments measuring different
+things. The tables print both with their method labeled — never compute a
+cross-language ratio from them. Within the Node columns (Mastra vs Mastra+obs)
+the comparison is valid.
+
+**p99 in short runs** — noisy on both sides, shown for completeness.
+
+### Observability
+
+Per the top-level benchmark philosophy, observability is included: nobody ships
+without tracing. Timbal's tracing is built-in and always on. Mastra standalone
+agents have no tracing, so Mastra gets two columns:
+
+- **Mastra** — bare `new Agent(...)` / standalone workflow, no tracing.
+- **Mastra+obs** — registered in a `Mastra` instance with `@mastra/observability`
+  configured; spans are built and processed normally, and the exporter sink is a
+  no-op subclass of `BaseExporter` (the analogue of LangSmith with HTTP mocked).
+
+The honest apples-to-apples column against Timbal is **Mastra+obs**; the bare
+column shows what Mastra costs with tracing off, which Timbal doesn't offer.
+
+---
+
+## Scenarios
+
+Agent loop (`bench_agent.py` + `bench_agent.mjs`) — identical to every other
+framework in `benchmarks/`:
+
+- Single tool call: `LLM -> add -> LLM -> answer`
+- Three-step chain: `LLM -> add -> LLM -> multiply -> LLM -> subtract -> LLM -> answer`
+- Parallel tool calls: `LLM -> [add, multiply, negate] -> LLM -> answer`
+
+Workflow DAG (`bench_workflow.py` + `bench_workflow.mjs`) — Mastra has a
+first-class workflow engine (`createWorkflow` / `.then` / `.parallel`), so this is
+a fair native-primitive comparison, same shapes as the LangGraph benchmark:
+
+- Sequential: `A -> B -> C -> D`
+- Fan-out/in: `A -> [B, C, D] -> E`
+- Diamond: `A -> [B, C] -> D`
+
+Mastra workflow runs include `createRun()` + `start()` — its normal programmatic
+execution path. Timbal runs are `workflow(x=3).collect()`. Construction of the
+workflow/agent object is excluded on both sides.
+
+## Files
+
+| File | What it does |
+|------|--------------|
+| `bench_agent.py` | Orchestrator: runs Timbal in-process, spawns `bench_agent.mjs`, prints combined tables |
+| `bench_agent.mjs` | Mastra agent loop measurements, JSON on stdout |
+| `bench_workflow.py` | Orchestrator for the DAG benchmark |
+| `bench_workflow.mjs` | Mastra workflow measurements, JSON on stdout |
+| `bench_lib.mjs` | Shared Node harness (percentiles, latency/memory/burst/throughput) |
+
+## Setup
+
+Timbal (repo root):
+
+```bash
+uv sync --dev
+```
+
+Mastra side (requires Node >= 20):
+
+```bash
+cd benchmarks/mastra && npm install
+```
+
+## Running
+
+```bash
+# Quick mode — sanity check
+uv run python benchmarks/mastra/bench_agent.py --quick
+uv run python benchmarks/mastra/bench_workflow.py --quick
+
+# Full mode — results worth keeping
+uv run python benchmarks/mastra/bench_agent.py
+uv run python benchmarks/mastra/bench_workflow.py
+```
+
+No API keys required. Useful flags: `--timbal-only` skips the Node side;
+`--mastra-json <file>` reuses a previous Node-side JSON result. To debug the
+Mastra side alone: `node --expose-gc bench_agent.mjs --quick` (JSON on stdout,
+progress on stderr).
+
+---
+
+## Results
+
+Full-mode run, 2026-08-07: Apple Silicon M-series, CPython 3.11, Node v22.18,
+`@mastra/core` 1.57.0, `@mastra/observability` 1.16.5, `ai` 7.0.56.
+Raw outputs:
+
+- `results/bench_agent.txt`
+- `results/bench_workflow.txt`
+
+### Agent loop
+
+Full loop: prompt -> fake LLM -> tool call(s) -> fake LLM -> answer. Timbal has
+tracing built in and always on; compare against Mastra+obs for parity.
+
+| Scenario | Timbal p50 | Mastra p50 | Mastra+obs p50 |
+|----------|-----------:|-----------:|---------------:|
+| Single tool | 260.8 µs | 2.33 ms | 4.19 ms |
+| 3-step chain | 273.0 µs | 3.79 ms | 6.64 ms |
+| Parallel tools | 278.5 µs | 2.39 ms | 4.41 ms |
+
+| Scenario | Timbal c=10 | Mastra c=10 | Mastra+obs c=10 |
+|----------|------------:|------------:|----------------:|
+| Single tool | 4,212/s | 550/s | 278/s |
+| 3-step chain | 1,979/s | 288/s | 155/s |
+| Parallel tools | 2,369/s | 381/s | 237/s |
+
+Timbal's agent loop is roughly an order of magnitude faster per run and in
+throughput — despite the V8-vs-CPython runtime handicap running the other way.
+Mastra's `generate()` path does substantially more per call (message-list
+management, schema conversion, processor pipeline), and enabling observability
+roughly doubles its cost, while Timbal's numbers already include tracing.
+
+### Workflow DAG
+
+Trivial handlers, no LLM — pure scheduling overhead.
+
+| Scenario | Timbal p50 | Mastra p50 | Mastra+obs p50 |
+|----------|-----------:|-----------:|---------------:|
+| Sequential | 338.6 µs | 95.9 µs | 293.1 µs |
+| Fan-out/in | 450.4 µs | 130.6 µs | 330.3 µs |
+| Diamond | 404.2 µs | 104.6 µs | 286.0 µs |
+
+| Scenario | Timbal c=10 | Mastra c=10 | Mastra+obs c=10 |
+|----------|------------:|------------:|----------------:|
+| Sequential | 4,295/s | 15,317/s | 4,174/s |
+| Fan-out/in | 3,233/s | 9,159/s | 3,231/s |
+| Diamond | 3,346/s | 10,996/s | 2,576/s |
+
+This one cuts the other way and we report it as-is: Mastra's bare workflow
+engine on V8 is ~3x faster than Timbal on trivial DAGs. That advantage is a mix
+of a lean run path and V8 JIT-compiling the hot loop — the benchmark cannot and
+does not separate the two. With observability enabled (the production-parity
+column), Mastra lands at rough parity with Timbal on latency and throughput,
+with Timbal keeping tracing on for every number.
+
+### Takeaway
+
+For agent workloads — the workload both frameworks exist for — Timbal's loop is
+~9-24x faster with tracing on both sides. For raw DAG scheduling of trivial
+steps, Mastra without tracing is faster; with tracing it's a wash. As always,
+framework overhead vanishes behind real LLM latency; these numbers measure the
+floor each framework sets, not the ceiling of your app.

--- a/benchmarks/mastra/README.md
+++ b/benchmarks/mastra/README.md
@@ -60,10 +60,11 @@ agents have no tracing, so Mastra gets two columns:
 - **Mastra+obs** — registered in a `Mastra` instance with `@mastra/observability`
   configured; spans are built and processed normally, and the exporter sink is a
   no-op subclass of `BaseExporter` (the analogue of LangSmith with HTTP mocked).
-  Pending observability work is flushed (`Observability.flush()`) after warmup
-  and between measured batches — the same points where the Timbal side clears
-  its in-memory tracing storage — so no side carries deferred work into a timed
-  phase.
+  Pending observability work is flushed (`Observability.flush()`) after warmup,
+  between measured batches, and after every run inside the memory loop — the
+  same points where the Timbal side clears its in-memory tracing storage — so
+  no side carries deferred work into a timed phase or accumulates it into the
+  memory measurement.
 
 The honest apples-to-apples column against Timbal is **Mastra+obs**; the bare
 column shows what Mastra costs with tracing off, which Timbal doesn't offer.
@@ -150,15 +151,15 @@ tracing built in and always on; compare against Mastra+obs for parity.
 
 | Scenario | Timbal p50 | Mastra p50 | Mastra+obs p50 |
 |----------|-----------:|-----------:|---------------:|
-| Single tool | 258.8 µs | 2.28 ms | 4.22 ms |
-| 3-step chain | 273.5 µs | 3.55 ms | 6.48 ms |
-| Parallel tools | 272.4 µs | 2.20 ms | 4.26 ms |
+| Single tool | 271.9 µs | 2.70 ms | 4.53 ms |
+| 3-step chain | 286.0 µs | 4.66 ms | 7.91 ms |
+| Parallel tools | 303.0 µs | 2.76 ms | 4.98 ms |
 
 | Scenario | Timbal c=10 | Mastra c=10 | Mastra+obs c=10 |
 |----------|------------:|------------:|----------------:|
-| Single tool | 4,211/s | 480/s | 278/s |
-| 3-step chain | 1,973/s | 270/s | 161/s |
-| Parallel tools | 2,592/s | 435/s | 239/s |
+| Single tool | 3,828/s | 511/s | 259/s |
+| 3-step chain | 1,845/s | 258/s | 145/s |
+| Parallel tools | 2,252/s | 373/s | 223/s |
 
 Timbal's agent loop is roughly an order of magnitude faster per run and in
 throughput — despite the V8-vs-CPython runtime handicap running the other way.
@@ -172,15 +173,15 @@ Trivial handlers, no LLM — pure scheduling overhead.
 
 | Scenario | Timbal p50 | Mastra p50 | Mastra+obs p50 |
 |----------|-----------:|-----------:|---------------:|
-| Sequential | 332.0 µs | 94.9 µs | 295.3 µs |
-| Fan-out/in | 492.2 µs | 129.3 µs | 334.2 µs |
-| Diamond | 432.4 µs | 105.3 µs | 270.8 µs |
+| Sequential | 355.0 µs | 94.7 µs | 303.0 µs |
+| Fan-out/in | 486.0 µs | 127.3 µs | 341.4 µs |
+| Diamond | 408.4 µs | 107.1 µs | 276.7 µs |
 
 | Scenario | Timbal c=10 | Mastra c=10 | Mastra+obs c=10 |
 |----------|------------:|------------:|----------------:|
-| Sequential | 3,892/s | 15,954/s | 4,214/s |
-| Fan-out/in | 3,000/s | 9,470/s | 3,306/s |
-| Diamond | 3,495/s | 11,184/s | 3,963/s |
+| Sequential | 3,954/s | 15,770/s | 3,973/s |
+| Fan-out/in | 3,025/s | 9,074/s | 3,183/s |
+| Diamond | 3,557/s | 10,772/s | 3,805/s |
 
 This one cuts the other way and we report it as-is: Mastra's bare workflow
 engine on V8 is ~3x faster than Timbal on trivial DAGs. That advantage is a mix

--- a/benchmarks/mastra/README.md
+++ b/benchmarks/mastra/README.md
@@ -60,6 +60,10 @@ agents have no tracing, so Mastra gets two columns:
 - **Mastra+obs** — registered in a `Mastra` instance with `@mastra/observability`
   configured; spans are built and processed normally, and the exporter sink is a
   no-op subclass of `BaseExporter` (the analogue of LangSmith with HTTP mocked).
+  Pending observability work is flushed (`Observability.flush()`) after warmup
+  and between measured batches — the same points where the Timbal side clears
+  its in-memory tracing storage — so no side carries deferred work into a timed
+  phase.
 
 The honest apples-to-apples column against Timbal is **Mastra+obs**; the bare
 column shows what Mastra costs with tracing off, which Timbal doesn't offer.
@@ -146,15 +150,15 @@ tracing built in and always on; compare against Mastra+obs for parity.
 
 | Scenario | Timbal p50 | Mastra p50 | Mastra+obs p50 |
 |----------|-----------:|-----------:|---------------:|
-| Single tool | 260.8 µs | 2.33 ms | 4.19 ms |
-| 3-step chain | 273.0 µs | 3.79 ms | 6.64 ms |
-| Parallel tools | 278.5 µs | 2.39 ms | 4.41 ms |
+| Single tool | 258.8 µs | 2.28 ms | 4.22 ms |
+| 3-step chain | 273.5 µs | 3.55 ms | 6.48 ms |
+| Parallel tools | 272.4 µs | 2.20 ms | 4.26 ms |
 
 | Scenario | Timbal c=10 | Mastra c=10 | Mastra+obs c=10 |
 |----------|------------:|------------:|----------------:|
-| Single tool | 4,212/s | 550/s | 278/s |
-| 3-step chain | 1,979/s | 288/s | 155/s |
-| Parallel tools | 2,369/s | 381/s | 237/s |
+| Single tool | 4,211/s | 480/s | 278/s |
+| 3-step chain | 1,973/s | 270/s | 161/s |
+| Parallel tools | 2,592/s | 435/s | 239/s |
 
 Timbal's agent loop is roughly an order of magnitude faster per run and in
 throughput — despite the V8-vs-CPython runtime handicap running the other way.
@@ -168,15 +172,15 @@ Trivial handlers, no LLM — pure scheduling overhead.
 
 | Scenario | Timbal p50 | Mastra p50 | Mastra+obs p50 |
 |----------|-----------:|-----------:|---------------:|
-| Sequential | 338.6 µs | 95.9 µs | 293.1 µs |
-| Fan-out/in | 450.4 µs | 130.6 µs | 330.3 µs |
-| Diamond | 404.2 µs | 104.6 µs | 286.0 µs |
+| Sequential | 332.0 µs | 94.9 µs | 295.3 µs |
+| Fan-out/in | 492.2 µs | 129.3 µs | 334.2 µs |
+| Diamond | 432.4 µs | 105.3 µs | 270.8 µs |
 
 | Scenario | Timbal c=10 | Mastra c=10 | Mastra+obs c=10 |
 |----------|------------:|------------:|----------------:|
-| Sequential | 4,295/s | 15,317/s | 4,174/s |
-| Fan-out/in | 3,233/s | 9,159/s | 3,231/s |
-| Diamond | 3,346/s | 10,996/s | 2,576/s |
+| Sequential | 3,892/s | 15,954/s | 4,214/s |
+| Fan-out/in | 3,000/s | 9,470/s | 3,306/s |
+| Diamond | 3,495/s | 11,184/s | 3,963/s |
 
 This one cuts the other way and we report it as-is: Mastra's bare workflow
 engine on V8 is ~3x faster than Timbal on trivial DAGs. That advantage is a mix

--- a/benchmarks/mastra/bench_agent.mjs
+++ b/benchmarks/mastra/bench_agent.mjs
@@ -1,0 +1,195 @@
+/**
+ * Mastra side of the agent-loop benchmark. Run by bench_agent.py — do not run
+ * directly unless debugging (JSON goes to stdout, progress to stderr).
+ *
+ * Scenarios (identical to the Timbal side and to every other framework in
+ * benchmarks/):
+ *   1. Single tool call:    LLM → add → LLM → answer
+ *   2. Multi-step (3 tools): LLM → add → LLM → mul → LLM → sub → LLM → answer
+ *   3. Parallel tools:      LLM → [add, mul, neg] concurrent → LLM → answer
+ *
+ * The LLM is a MockLanguageModelV4 (AI SDK test util) that decides its next
+ * response by counting tool results in the message history — no shared counter
+ * state, safe for concurrent runs on a single shared agent.
+ *
+ * Two variants per scenario:
+ *   - bare: plain `new Agent(...)` — no tracing (Mastra's default standalone path)
+ *   - obs:  agent registered in a `Mastra` instance with `@mastra/observability`
+ *           enabled and the exporter mocked (spans built, export dropped) —
+ *           the equivalent of LangGraph+LangSmith-with-HTTP-mocked
+ *
+ * Usage: node --expose-gc bench_agent.mjs [--quick]
+ */
+
+import { Mastra } from '@mastra/core';
+import { Agent } from '@mastra/core/agent';
+import { createTool } from '@mastra/core/tools';
+import { Observability, BaseExporter } from '@mastra/observability';
+import { MockLanguageModelV4 } from 'ai/test';
+import { z } from 'zod';
+
+import { measure, meta, readParams } from './bench_lib.mjs';
+
+const { quick } = readParams();
+
+const N_ITERS = quick ? 20 : 100;
+const N_WARMUP = quick ? 3 : 10;
+const N_MEM = quick ? 20 : 100;
+const N_BURST = { 1: 20, 2: 10, 3: 15 };
+const THROUGHPUT_OPS = quick ? 30 : 200;
+const CONCURRENCY_LEVELS = [1, 10, 50];
+
+// ── Tools ────────────────────────────────────────────────────────────────────
+
+const num = z.number();
+const tools = {
+  add: createTool({
+    id: 'add',
+    description: 'Add two numbers.',
+    inputSchema: z.object({ a: num, b: num }),
+    execute: async ({ a, b }) => a + b,
+  }),
+  multiply: createTool({
+    id: 'multiply',
+    description: 'Multiply two numbers.',
+    inputSchema: z.object({ a: num, b: num }),
+    execute: async ({ a, b }) => a * b,
+  }),
+  subtract: createTool({
+    id: 'subtract',
+    description: 'Subtract b from a.',
+    inputSchema: z.object({ a: num, b: num }),
+    execute: async ({ a, b }) => a - b,
+  }),
+  negate: createTool({
+    id: 'negate',
+    description: 'Negate a number.',
+    inputSchema: z.object({ x: num }),
+    execute: async ({ x }) => -x,
+  }),
+};
+
+const SCENARIO_TOOLS = {
+  1: { add: tools.add },
+  2: { add: tools.add, multiply: tools.multiply, subtract: tools.subtract },
+  3: { add: tools.add, multiply: tools.multiply, negate: tools.negate },
+};
+
+// ── Fake LLM (stateless — step derived from message history) ─────────────────
+
+function countToolResults(prompt) {
+  let n = 0;
+  for (const msg of prompt) {
+    if (msg.role !== 'tool') continue;
+    for (const part of Array.isArray(msg.content) ? msg.content : []) {
+      if (part.type === 'tool-result') n++;
+    }
+  }
+  return n;
+}
+
+const toolCall = (id, name, input) => ({
+  type: 'tool-call',
+  toolCallId: id,
+  toolName: name,
+  input: JSON.stringify(input),
+});
+
+const usage = { inputTokens: 1, outputTokens: 1, totalTokens: 2 };
+const respond = (content, finishReason) => ({ finishReason, usage, content, warnings: [] });
+const answer = (text) => respond([{ type: 'text', text }], 'stop');
+
+function makeModel(scenario) {
+  const handlers = {
+    1: (step) =>
+      step === 0
+        ? respond([toolCall('c1', 'add', { a: 1, b: 2 })], 'tool-calls')
+        : answer('3'),
+    2: (step) => {
+      if (step === 0) return respond([toolCall('c1', 'add', { a: 1, b: 2 })], 'tool-calls');
+      if (step === 1) return respond([toolCall('c2', 'multiply', { a: 3, b: 4 })], 'tool-calls');
+      if (step === 2) return respond([toolCall('c3', 'subtract', { a: 12, b: 3 })], 'tool-calls');
+      return answer('9');
+    },
+    3: (step) =>
+      step === 0
+        ? respond(
+            [
+              toolCall('c1', 'add', { a: 1, b: 2 }),
+              toolCall('c2', 'multiply', { a: 3, b: 4 }),
+              toolCall('c3', 'negate', { x: 5 }),
+            ],
+            'tool-calls',
+          )
+        : answer('done'),
+  };
+  const handler = handlers[scenario];
+  return new MockLanguageModelV4({
+    doGenerate: async (options) => handler(countToolResults(options.prompt)),
+  });
+}
+
+// ── Agent factories ──────────────────────────────────────────────────────────
+
+function makeBareAgent(scenario) {
+  return new Agent({
+    id: 'bench_agent',
+    name: 'bench_agent',
+    instructions: 'You are a calculator. Use the tools.',
+    model: makeModel(scenario),
+    tools: SCENARIO_TOOLS[scenario],
+  });
+}
+
+/** Export mocked at the sink: spans are built and processed, then dropped. */
+class MockedExporter extends BaseExporter {
+  name = 'mocked';
+  async _exportTracingEvent(_event) {}
+  async onLogEvent(_event) {}
+  async onMetricEvent(_event) {}
+}
+
+function makeObsAgent(scenario) {
+  const agent = new Agent({
+    id: 'bench_agent_obs',
+    name: 'bench_agent_obs',
+    instructions: 'You are a calculator. Use the tools.',
+    model: makeModel(scenario),
+    tools: SCENARIO_TOOLS[scenario],
+  });
+  const mastra = new Mastra({
+    agents: { bench_agent_obs: agent },
+    observability: new Observability({
+      configs: { bench: { serviceName: 'bench', exporters: [new MockedExporter()] } },
+    }),
+    logger: false,
+  });
+  return mastra.getAgent('bench_agent_obs');
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+const results = { meta: await meta(), params: { quick, N_ITERS, N_WARMUP, N_MEM, N_BURST, THROUGHPUT_OPS, CONCURRENCY_LEVELS }, scenarios: {} };
+
+for (const scenario of [1, 2, 3]) {
+  console.error(`  scenario ${scenario}`);
+  const common = {
+    iters: N_ITERS,
+    warmup: N_WARMUP,
+    memIters: N_MEM,
+    burstN: N_BURST[scenario],
+    throughputOps: THROUGHPUT_OPS,
+    concurrencyLevels: CONCURRENCY_LEVELS,
+  };
+
+  const bare = makeBareAgent(scenario);
+  const obs = makeObsAgent(scenario);
+
+  results.scenarios[scenario] = {
+    bare: await measure(() => bare.generate('go'), { ...common, label: 'mastra bare' }),
+    obs: await measure(() => obs.generate('go'), { ...common, label: 'mastra+obs' }),
+  };
+}
+
+console.log(JSON.stringify(results));
+process.exit(0);

--- a/benchmarks/mastra/bench_agent.mjs
+++ b/benchmarks/mastra/bench_agent.mjs
@@ -157,14 +157,15 @@ function makeObsAgent(scenario) {
     model: makeModel(scenario),
     tools: SCENARIO_TOOLS[scenario],
   });
+  const observability = new Observability({
+    configs: { bench: { serviceName: 'bench', exporters: [new MockedExporter()] } },
+  });
   const mastra = new Mastra({
     agents: { bench_agent_obs: agent },
-    observability: new Observability({
-      configs: { bench: { serviceName: 'bench', exporters: [new MockedExporter()] } },
-    }),
+    observability,
     logger: false,
   });
-  return mastra.getAgent('bench_agent_obs');
+  return { agent: mastra.getAgent('bench_agent_obs'), observability };
 }
 
 // ── Main ─────────────────────────────────────────────────────────────────────
@@ -183,11 +184,15 @@ for (const scenario of [1, 2, 3]) {
   };
 
   const bare = makeBareAgent(scenario);
-  const obs = makeObsAgent(scenario);
+  const { agent: obs, observability } = makeObsAgent(scenario);
 
   results.scenarios[scenario] = {
     bare: await measure(() => bare.generate('go'), { ...common, label: 'mastra bare' }),
-    obs: await measure(() => obs.generate('go'), { ...common, label: 'mastra+obs' }),
+    obs: await measure(() => obs.generate('go'), {
+      ...common,
+      label: 'mastra+obs',
+      drain: () => observability.flush(),
+    }),
   };
 }
 

--- a/benchmarks/mastra/bench_agent.py
+++ b/benchmarks/mastra/bench_agent.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""
+Timbal vs Mastra — full agent loop benchmark (cross-language).
+
+Three scenarios, identical pipelines on both frameworks:
+  1. Single tool call:   prompt → LLM → tool(add) → LLM → answer
+  2. Multi-step (3 tools): prompt → LLM → add → LLM → mul → LLM → sub → LLM → answer
+  3. Parallel tools:     prompt → LLM → [add, mul, neg] concurrent → LLM → answer
+
+Mastra is a TypeScript framework, so each side runs in its native runtime:
+Timbal on CPython/asyncio (in this process), Mastra on Node/V8 (spawned as a
+subprocess running bench_agent.mjs with the same methodology). Numbers compare
+the full framework+runtime stacks — the thing a user actually deploys — not
+language-neutral algorithm quality. See README.md for what is and isn't
+comparable; memory in particular uses different instruments per runtime
+(tracemalloc vs V8 heap growth) and must not be ratio'd across languages.
+
+All LLMs are faked via message-history inspection. Observability: Timbal
+built-in tracing (always on); Mastra shown both bare and with
+@mastra/observability enabled (export mocked).
+
+Run:
+    uv run python benchmarks/mastra/bench_agent.py
+    uv run python benchmarks/mastra/bench_agent.py --quick
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import warnings
+
+logging.disable(logging.WARNING)
+os.environ.setdefault("TIMBAL_LOG_LEVEL", "CRITICAL")
+warnings.filterwarnings("ignore")
+
+import structlog  # noqa: E402
+
+structlog.configure(wrapper_class=structlog.make_filtering_bound_logger(logging.CRITICAL))
+
+import asyncio  # noqa: E402
+import gc  # noqa: E402
+import json  # noqa: E402
+import shutil  # noqa: E402
+import statistics  # noqa: E402
+import subprocess  # noqa: E402
+import sys  # noqa: E402
+import time  # noqa: E402
+import tracemalloc  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+parser = argparse.ArgumentParser(add_help=False)
+parser.add_argument("--quick", action="store_true")
+parser.add_argument("--timbal-only", action="store_true", help="Skip Mastra, measure Timbal only")
+parser.add_argument("--mastra-json", type=Path, default=None, help="Reuse a previous Mastra JSON result instead of running Node")
+_args, _ = parser.parse_known_args()
+
+N_ITERS = 20 if _args.quick else 100
+N_WARMUP = 3 if _args.quick else 10
+N_BURST = {1: 20, 2: 10, 3: 15}
+N_MEM = 20 if _args.quick else 100
+THROUGHPUT_OPS = 30 if _args.quick else 200
+CONCURRENCY_LEVELS = [1, 10, 50]
+WIDTH = 76
+
+BENCH_DIR = Path(__file__).parent
+
+# ── Display helpers ──────────────────────────────────────────────────────────
+
+RESET = "\033[0m"
+BOLD = "\033[1m"
+CYAN = "\033[36m"
+DIM = "\033[2m"
+
+
+def section(title: str) -> None:
+    print()
+    print(f"{BOLD}{CYAN}{'─' * WIDTH}{RESET}")
+    print(f"{BOLD}{CYAN}  {title}{RESET}")
+    print(f"{BOLD}{CYAN}{'─' * WIDTH}{RESET}")
+
+
+def subsection(title: str) -> None:
+    print(f"\n  {BOLD}{title}{RESET}")
+
+
+def fmt_us(us: float) -> str:
+    if us >= 1_000:
+        return f"{us / 1_000:>8.2f} ms"
+    return f"{us:>8.1f} µs"
+
+
+def pct(samples: list[float], p: float) -> float:
+    idx = min(int(len(samples) * p / 100), len(samples) - 1)
+    return sorted(samples)[idx]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# MASTRA — spawn the Node-side benchmark
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def run_mastra_side(script: str) -> dict | None:
+    if _args.timbal_only:
+        return None
+    if _args.mastra_json:
+        return json.loads(_args.mastra_json.read_text())
+    node = shutil.which("node")
+    if node is None:
+        print(f"{DIM}  node not found on PATH — running Timbal only.{RESET}")
+        return None
+    if not (BENCH_DIR / "node_modules").exists():
+        print(f"{DIM}  benchmarks/mastra/node_modules missing — run `npm install` in benchmarks/mastra first.{RESET}")
+        return None
+    cmd = [node, "--expose-gc", script] + (["--quick"] if _args.quick else [])
+    print(f"{DIM}  running Mastra side: {' '.join(cmd[1:])}…{RESET}")
+    sys.stdout.flush()
+    proc = subprocess.run(cmd, cwd=BENCH_DIR, stdout=subprocess.PIPE, stderr=sys.stderr, text=True, timeout=3600)
+    if proc.returncode != 0:
+        print(f"{DIM}  Mastra side failed (exit {proc.returncode}) — running Timbal only.{RESET}")
+        return None
+    return json.loads(proc.stdout)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TIMBAL — fake LLM agent factory (identical to benchmarks/langchain)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+from timbal import Agent  # noqa: E402
+from timbal.core.test_model import TestModel  # noqa: E402
+from timbal.state.tracing.providers.in_memory import InMemoryTracingProvider  # noqa: E402
+from timbal.types.content import TextContent, ToolResultContent, ToolUseContent  # noqa: E402
+from timbal.types.message import Message  # noqa: E402
+
+
+def _clear_traces():
+    InMemoryTracingProvider._storage.clear()
+
+
+def _count_tool_results(messages) -> int:
+    return sum(
+        1 for m in messages
+        for c in (m.content if hasattr(m, "content") and m.content else [])
+        if isinstance(c, ToolResultContent)
+    )
+
+
+def _make_timbal_agent(scenario: int):
+    def add(a: int, b: int) -> int:
+        """Add two numbers."""
+        return a + b
+
+    def multiply(a: int, b: int) -> int:
+        """Multiply two numbers."""
+        return a * b
+
+    def subtract(a: int, b: int) -> int:
+        """Subtract b from a."""
+        return a - b
+
+    def negate(x: int) -> int:
+        """Negate a number."""
+        return -x
+
+    tools = {1: [add], 2: [add, multiply, subtract], 3: [add, multiply, negate]}[scenario]
+
+    if scenario == 1:
+        def handler(messages):
+            if _count_tool_results(messages) == 0:
+                return Message(role="assistant", content=[ToolUseContent(type="tool_use", id="c1", name="add", input={"a": 1, "b": 2})])
+            return Message(role="assistant", content=[TextContent(type="text", text="3")], stop_reason="end_turn")
+    elif scenario == 2:
+        def handler(messages):
+            step = _count_tool_results(messages)
+            if step == 0:
+                return Message(role="assistant", content=[ToolUseContent(type="tool_use", id="c1", name="add", input={"a": 1, "b": 2})])
+            elif step == 1:
+                return Message(role="assistant", content=[ToolUseContent(type="tool_use", id="c2", name="multiply", input={"a": 3, "b": 4})])
+            elif step == 2:
+                return Message(role="assistant", content=[ToolUseContent(type="tool_use", id="c3", name="subtract", input={"a": 12, "b": 3})])
+            return Message(role="assistant", content=[TextContent(type="text", text="9")], stop_reason="end_turn")
+    else:
+        def handler(messages):
+            if _count_tool_results(messages) == 0:
+                return Message(role="assistant", content=[
+                    ToolUseContent(type="tool_use", id="c1", name="add", input={"a": 1, "b": 2}),
+                    ToolUseContent(type="tool_use", id="c2", name="multiply", input={"a": 3, "b": 4}),
+                    ToolUseContent(type="tool_use", id="c3", name="negate", input={"x": 5}),
+                ])
+            return Message(role="assistant", content=[TextContent(type="text", text="done")], stop_reason="end_turn")
+
+    return Agent(name="bench_agent", model=TestModel(handler=handler), tools=tools)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Timbal measurement (same procedure as the Node side)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def measure_timbal(scenario: int) -> dict:
+    agent = _make_timbal_agent(scenario)
+
+    async def run():
+        await agent(prompt="go").collect()
+
+    # Latency
+    for _ in range(N_WARMUP):
+        await run()
+    _clear_traces()
+    gc.collect()
+    lat = []
+    for _ in range(N_ITERS):
+        t0 = time.perf_counter()
+        await run()
+        lat.append((time.perf_counter() - t0) * 1e6)
+    _clear_traces()
+
+    # Memory
+    for _ in range(N_WARMUP):
+        await run()
+    _clear_traces()
+    gc.collect()
+    tracemalloc.start()
+    for _ in range(N_MEM):
+        await run()
+        _clear_traces()
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    # Burst
+    n_burst = N_BURST[scenario]
+    await asyncio.gather(*[run() for _ in range(5)])
+    _clear_traces()
+    gc.collect()
+    burst: list[float] = []
+
+    async def timed():
+        t0 = time.perf_counter()
+        await run()
+        burst.append((time.perf_counter() - t0) * 1e6)
+
+    await asyncio.gather(*[timed() for _ in range(n_burst)])
+    _clear_traces()
+
+    # Throughput
+    tp = {}
+    for conc in CONCURRENCY_LEVELS:
+        sem = asyncio.Semaphore(conc)
+
+        async def bounded():
+            async with sem:
+                await run()
+
+        gc.collect()
+        t0 = time.perf_counter()
+        await asyncio.gather(*[bounded() for _ in range(THROUGHPUT_OPS)])
+        tp[str(conc)] = THROUGHPUT_OPS / (time.perf_counter() - t0)
+        _clear_traces()
+
+    return {
+        "latency_us": {
+            "mean": statistics.mean(lat),
+            "p50": pct(lat, 50), "p75": pct(lat, 75), "p95": pct(lat, 95), "p99": pct(lat, 99),
+            "max": max(lat),
+        },
+        "mem_per_run_bytes": peak / N_MEM,
+        "burst_us": {
+            "p50": pct(burst, 50), "p75": pct(burst, 75), "p95": pct(burst, 95), "p99": pct(burst, 99),
+            "max": max(burst),
+        },
+        "throughput_ops_s": tp,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Combined output
+# ═══════════════════════════════════════════════════════════════════════════════
+
+SCENARIO_NAMES = {
+    "1": "Single tool call  (LLM → add → LLM → answer)",
+    "2": "Multi-step  (LLM → add → LLM → mul → LLM → sub → LLM → answer)",
+    "3": "Parallel tools  (LLM → [add, mul, neg] → LLM → answer)",
+}
+
+COL_W = 12
+
+
+def print_scenario(key: str, timbal: dict, mastra: dict | None) -> None:
+    section(f"Scenario {key}: {SCENARIO_NAMES[key]}")
+
+    cols = ["Timbal"]
+    frames = [timbal]
+    if mastra:
+        cols += ["Mastra", "Mastra+obs"]
+        frames += [mastra["bare"], mastra["obs"]]
+
+    hdr = f"  {'':>{COL_W}}" + "".join(f"  {c:>{COL_W}}" for c in cols)
+    sep = f"  {'─' * COL_W}" + f"  {'─' * COL_W}" * len(cols)
+
+    subsection(f"Latency  (×{N_ITERS} sequential runs)")
+    print(hdr)
+    print(sep)
+    for label in ["mean", "p50", "p95", "p99"]:
+        vals = [f["latency_us"][label] for f in frames]
+        print(f"  {label:>{COL_W}}" + "".join(f"  {fmt_us(v):>{COL_W}}" for v in vals))
+
+    subsection(f"Memory per run  (×{N_MEM} runs) — different instruments, do not ratio across runtimes")
+    print(f"  {'framework':<{COL_W + 12}}  {'per run':>14}  {'method':<24}")
+    print(f"  {'─' * (COL_W + 12)}  {'─' * 14}  {'─' * 24}")
+    print(f"  {'Timbal':<{COL_W + 12}}  {timbal['mem_per_run_bytes']:>12,.0f} B  {'tracemalloc peak/N':<24}")
+    if mastra:
+        for name, f in [("Mastra", mastra["bare"]), ("Mastra+obs", mastra["obs"])]:
+            print(f"  {name:<{COL_W + 12}}  {f['mem_per_run_bytes']:>12,.0f} B  {'V8 heap growth/N (≈)':<24}")
+
+    n_burst = N_BURST[int(key)]
+    subsection(f"Burst p50/p95  ({n_burst} concurrent runs)")
+    print(hdr)
+    print(sep)
+    for label in ["p50", "p75", "p95", "p99", "max"]:
+        vals = [f["burst_us"][label] for f in frames]
+        print(f"  {label:>{COL_W}}" + "".join(f"  {fmt_us(v):>{COL_W}}" for v in vals))
+
+    subsection(f"Throughput  ({THROUGHPUT_OPS} runs)")
+    print(hdr)
+    print(sep)
+    for conc in CONCURRENCY_LEVELS:
+        vals = [f["throughput_ops_s"][str(conc)] for f in frames]
+        print(f"  {conc:>{COL_W}}" + "".join(f"  {v:>10.0f}/s" for v in vals))
+
+
+async def main() -> None:
+    print()
+    print(f"{BOLD}{'═' * WIDTH}{RESET}")
+    print(f"{BOLD}  Timbal vs Mastra — agent loop benchmark (cross-language){RESET}")
+    print(f"  {N_ITERS} iters · burst {N_BURST} · {N_MEM} mem · {THROUGHPUT_OPS} throughput")
+    print(f"  {DIM}Timbal: CPython {sys.version_info.major}.{sys.version_info.minor}/asyncio, built-in tracing (always on).{RESET}")
+    print(f"  {DIM}Mastra: Node/V8 subprocess, AI SDK MockLanguageModelV4, bare + observability (export mocked).{RESET}")
+    print(f"  {DIM}Same scenarios, same fake-LLM-by-message-inspection, same procedure per side.{RESET}")
+    print(f"  {DIM}Cross-runtime comparison — see README.md for what is and isn't comparable.{RESET}")
+    print(f"{BOLD}{'═' * WIDTH}{RESET}")
+    print()
+
+    mastra = run_mastra_side("bench_agent.mjs")
+    if mastra:
+        m = mastra["meta"]
+        print(f"{DIM}  Mastra side: node {m['node']} · @mastra/core {m['mastra_core']} · @mastra/observability {m['mastra_observability']} · ai {m['ai_sdk']}{RESET}")
+
+    for key in ["1", "2", "3"]:
+        timbal = await measure_timbal(int(key))
+        print_scenario(key, timbal, mastra["scenarios"][key] if mastra else None)
+
+    print()
+    print(f"{DIM}{'─' * WIDTH}")
+    print("  All measurements reuse 1 pre-built agent (creation excluded).")
+    print("  LLMs faked via message inspection on both sides — no network, no API keys.")
+    print("  Each framework runs in its native runtime; numbers include runtime differences.")
+    print("  Memory uses per-runtime instruments (tracemalloc vs V8 heap) — not cross-comparable.")
+    print(f"{'─' * WIDTH}{RESET}")
+    print()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/benchmarks/mastra/bench_lib.mjs
+++ b/benchmarks/mastra/bench_lib.mjs
@@ -72,12 +72,15 @@ export async function memory(fn, iters, warmup, drain) {
   let peak = baseline;
   for (let i = 0; i < iters; i++) {
     await fn();
-    // The Timbal harness clears its tracing storage after every run inside the
-    // memory loop; drain pending observability work at the same point (no GC —
-    // the Python side doesn't collect per run either).
-    if (drain) await drain();
+    // Sample BEFORE draining: tracemalloc's peak is a continuous high-water
+    // mark that includes this run's allocations up to the moment Timbal calls
+    // _clear_traces(), so the heap must be read while buffered observability
+    // work is still resident.
     const cur = process.memoryUsage().heapUsed;
     if (cur > peak) peak = cur;
+    // Then drain, mirroring the per-run _clear_traces() on the Python side
+    // (no GC — the Python side doesn't collect per run either).
+    if (drain) await drain();
   }
   return { peak_growth_bytes: peak - baseline, per_run_bytes: (peak - baseline) / iters };
 }

--- a/benchmarks/mastra/bench_lib.mjs
+++ b/benchmarks/mastra/bench_lib.mjs
@@ -72,6 +72,10 @@ export async function memory(fn, iters, warmup, drain) {
   let peak = baseline;
   for (let i = 0; i < iters; i++) {
     await fn();
+    // The Timbal harness clears its tracing storage after every run inside the
+    // memory loop; drain pending observability work at the same point (no GC —
+    // the Python side doesn't collect per run either).
+    if (drain) await drain();
     const cur = process.memoryUsage().heapUsed;
     if (cur > peak) peak = cur;
   }

--- a/benchmarks/mastra/bench_lib.mjs
+++ b/benchmarks/mastra/bench_lib.mjs
@@ -40,21 +40,34 @@ export function summarize(samples) {
   };
 }
 
-export async function latency(fn, iters, warmup) {
-  for (let i = 0; i < warmup; i++) await fn();
+/**
+ * `drain` is the Node analogue of the Python side's `_clear_traces()`: it is
+ * awaited wherever the Timbal harness resets its in-memory tracing storage
+ * (after warmup and between measured batches), so pending async observability
+ * work (span export through the event bus) never bleeds into a timed phase.
+ * Runners without observability pass no drain.
+ */
+const drainAndGc = async (drain) => {
+  if (drain) await drain();
   globalThis.gc();
+};
+
+export async function latency(fn, iters, warmup, drain) {
+  for (let i = 0; i < warmup; i++) await fn();
+  await drainAndGc(drain);
   const samples = [];
   for (let i = 0; i < iters; i++) {
     const t0 = nowUs();
     await fn();
     samples.push(elapsedUs(t0));
   }
+  await drainAndGc(drain);
   return samples;
 }
 
-export async function memory(fn, iters, warmup) {
+export async function memory(fn, iters, warmup, drain) {
   for (let i = 0; i < warmup; i++) await fn();
-  globalThis.gc();
+  await drainAndGc(drain);
   const baseline = process.memoryUsage().heapUsed;
   let peak = baseline;
   for (let i = 0; i < iters; i++) {
@@ -65,9 +78,9 @@ export async function memory(fn, iters, warmup) {
   return { peak_growth_bytes: peak - baseline, per_run_bytes: (peak - baseline) / iters };
 }
 
-export async function burst(fn, n) {
-  await Promise.all(Array.from({ length: Math.min(5, n) }, () => fn()));
-  globalThis.gc();
+export async function burst(fn, n, warmup, drain) {
+  await Promise.all(Array.from({ length: Math.min(warmup, n) }, () => fn()));
+  await drainAndGc(drain);
   const samples = [];
   const t0 = nowUs();
   await Promise.all(
@@ -78,11 +91,12 @@ export async function burst(fn, n) {
     }),
   );
   const wallMs = elapsedUs(t0) / 1e3;
+  await drainAndGc(drain);
   return { samples, wallMs };
 }
 
-export async function throughput(fn, ops, concurrency) {
-  globalThis.gc();
+export async function throughput(fn, ops, concurrency, drain) {
+  await drainAndGc(drain);
   let next = 0;
   const t0 = nowUs();
   const workers = Array.from({ length: Math.min(concurrency, ops) }, async () => {
@@ -92,24 +106,29 @@ export async function throughput(fn, ops, concurrency) {
     }
   });
   await Promise.all(workers);
-  return ops / (elapsedUs(t0) / 1e6);
+  const elapsed = elapsedUs(t0);
+  if (drain) await drain();
+  return ops / (elapsed / 1e6);
 }
 
 /** Full measurement suite for one runner. Returns a JSON-friendly record. */
-export async function measure(fn, { iters, warmup, memIters, burstN, throughputOps, concurrencyLevels, label }) {
+export async function measure(
+  fn,
+  { iters, warmup, memIters, burstN, burstWarmup = 5, throughputOps, concurrencyLevels, label, drain },
+) {
   console.error(`    [${label}] latency ×${iters}…`);
-  const lat = summarize(await latency(fn, iters, warmup));
+  const lat = summarize(await latency(fn, iters, warmup, drain));
 
   console.error(`    [${label}] memory ×${memIters}…`);
-  const mem = await memory(fn, memIters, warmup);
+  const mem = await memory(fn, memIters, warmup, drain);
 
   console.error(`    [${label}] burst ×${burstN}…`);
-  const b = await burst(fn, burstN);
+  const b = await burst(fn, burstN, burstWarmup, drain);
 
   const tp = {};
   for (const c of concurrencyLevels) {
     console.error(`    [${label}] throughput c=${c}…`);
-    tp[c] = await throughput(fn, throughputOps, c);
+    tp[c] = await throughput(fn, throughputOps, c, drain);
   }
 
   return {

--- a/benchmarks/mastra/bench_lib.mjs
+++ b/benchmarks/mastra/bench_lib.mjs
@@ -1,0 +1,139 @@
+/**
+ * Shared measurement harness for the Mastra side of the Timbal vs Mastra
+ * benchmarks. Mirrors the Python-side methodology:
+ *
+ *   - monotonic ns timer (process.hrtime.bigint ~ time.perf_counter)
+ *   - warmup runs before every measured batch
+ *   - forced GC between batches (requires --expose-gc)
+ *   - latency: sequential runs, percentiles over per-run wall time
+ *   - burst: N concurrent runs, per-run wall time percentiles
+ *   - throughput: worker-pool bounded concurrency, ops/s
+ *   - memory: peak V8 heapUsed growth over a batch / N runs
+ *     (approximate — see NOTES.md; NOT comparable with Python tracemalloc)
+ *
+ * All progress goes to stderr; the caller prints JSON results to stdout.
+ */
+
+if (typeof globalThis.gc !== 'function') {
+  console.error('error: run with node --expose-gc');
+  process.exit(1);
+}
+
+const nowUs = () => process.hrtime.bigint();
+const elapsedUs = (t0) => Number(process.hrtime.bigint() - t0) / 1e3;
+
+export function pct(samples, p) {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const idx = Math.min(Math.floor((sorted.length * p) / 100), sorted.length - 1);
+  return sorted[idx];
+}
+
+export function summarize(samples) {
+  const mean = samples.reduce((a, b) => a + b, 0) / samples.length;
+  return {
+    mean,
+    p50: pct(samples, 50),
+    p75: pct(samples, 75),
+    p95: pct(samples, 95),
+    p99: pct(samples, 99),
+    max: Math.max(...samples),
+  };
+}
+
+export async function latency(fn, iters, warmup) {
+  for (let i = 0; i < warmup; i++) await fn();
+  globalThis.gc();
+  const samples = [];
+  for (let i = 0; i < iters; i++) {
+    const t0 = nowUs();
+    await fn();
+    samples.push(elapsedUs(t0));
+  }
+  return samples;
+}
+
+export async function memory(fn, iters, warmup) {
+  for (let i = 0; i < warmup; i++) await fn();
+  globalThis.gc();
+  const baseline = process.memoryUsage().heapUsed;
+  let peak = baseline;
+  for (let i = 0; i < iters; i++) {
+    await fn();
+    const cur = process.memoryUsage().heapUsed;
+    if (cur > peak) peak = cur;
+  }
+  return { peak_growth_bytes: peak - baseline, per_run_bytes: (peak - baseline) / iters };
+}
+
+export async function burst(fn, n) {
+  await Promise.all(Array.from({ length: Math.min(5, n) }, () => fn()));
+  globalThis.gc();
+  const samples = [];
+  const t0 = nowUs();
+  await Promise.all(
+    Array.from({ length: n }, async () => {
+      const s = nowUs();
+      await fn();
+      samples.push(elapsedUs(s));
+    }),
+  );
+  const wallMs = elapsedUs(t0) / 1e3;
+  return { samples, wallMs };
+}
+
+export async function throughput(fn, ops, concurrency) {
+  globalThis.gc();
+  let next = 0;
+  const t0 = nowUs();
+  const workers = Array.from({ length: Math.min(concurrency, ops) }, async () => {
+    while (next < ops) {
+      next++;
+      await fn();
+    }
+  });
+  await Promise.all(workers);
+  return ops / (elapsedUs(t0) / 1e6);
+}
+
+/** Full measurement suite for one runner. Returns a JSON-friendly record. */
+export async function measure(fn, { iters, warmup, memIters, burstN, throughputOps, concurrencyLevels, label }) {
+  console.error(`    [${label}] latency ×${iters}…`);
+  const lat = summarize(await latency(fn, iters, warmup));
+
+  console.error(`    [${label}] memory ×${memIters}…`);
+  const mem = await memory(fn, memIters, warmup);
+
+  console.error(`    [${label}] burst ×${burstN}…`);
+  const b = await burst(fn, burstN);
+
+  const tp = {};
+  for (const c of concurrencyLevels) {
+    console.error(`    [${label}] throughput c=${c}…`);
+    tp[c] = await throughput(fn, throughputOps, c);
+  }
+
+  return {
+    latency_us: lat,
+    mem_per_run_bytes: mem.per_run_bytes,
+    mem_peak_growth_bytes: mem.peak_growth_bytes,
+    burst_us: summarize(b.samples),
+    burst_wall_ms: b.wallMs,
+    throughput_ops_s: tp,
+  };
+}
+
+export function readParams() {
+  const quick = process.argv.includes('--quick');
+  return { quick };
+}
+
+export async function meta() {
+  const { readFileSync } = await import('node:fs');
+  const read = (p) => JSON.parse(readFileSync(new URL(p, import.meta.url), 'utf8')).version;
+  return {
+    node: process.version,
+    mastra_core: read('./node_modules/@mastra/core/package.json'),
+    mastra_observability: read('./node_modules/@mastra/observability/package.json'),
+    ai_sdk: read('./node_modules/ai/package.json'),
+  };
+}

--- a/benchmarks/mastra/bench_workflow.mjs
+++ b/benchmarks/mastra/bench_workflow.mjs
@@ -1,0 +1,153 @@
+/**
+ * Mastra side of the workflow/DAG benchmark. Run by bench_workflow.py — do not
+ * run directly unless debugging (JSON goes to stdout, progress to stderr).
+ *
+ * Scenarios (identical shapes to benchmarks/langchain/bench_workflow.py):
+ *   1. Sequential:  A → B → C → D
+ *   2. Fan-out/in:  A → [B, C, D] → E
+ *   3. Diamond:     A → [B, C] → D
+ *
+ * Trivial handlers, no LLM — pure DAG scheduling overhead. Workflows are
+ * built once (construction excluded); each run is createRun() + start(),
+ * Mastra's normal programmatic execution path.
+ *
+ * Variants: bare (standalone workflow) and obs (registered in a Mastra
+ * instance with @mastra/observability enabled, exporter mocked).
+ *
+ * Usage: node --expose-gc bench_workflow.mjs [--quick]
+ */
+
+import { Mastra } from '@mastra/core';
+import { createStep, createWorkflow } from '@mastra/core/workflows';
+import { Observability, BaseExporter } from '@mastra/observability';
+import { z } from 'zod';
+
+import { measure, meta, readParams } from './bench_lib.mjs';
+
+const { quick } = readParams();
+
+const N_ITERS = quick ? 50 : 200;
+const N_WARMUP = quick ? 5 : 20;
+const N_MEM = quick ? 50 : 200;
+const N_BURST = quick ? 100 : 500;
+const THROUGHPUT_OPS = quick ? 200 : 1000;
+const CONCURRENCY_LEVELS = [1, 10, 50, 200];
+
+// ── Steps ────────────────────────────────────────────────────────────────────
+
+const io = z.object({ x: z.number() });
+
+const step = (id, fn) =>
+  createStep({
+    id,
+    inputSchema: io,
+    outputSchema: io,
+    execute: async ({ inputData }) => ({ x: fn(inputData.x) }),
+  });
+
+// ── Workflow factories (identical DAG shapes to the Timbal side) ─────────────
+
+function sequential() {
+  // A → B → C → D
+  return createWorkflow({ id: 'sequential', inputSchema: io, outputSchema: io })
+    .then(step('step_a', (x) => x + 1))
+    .then(step('step_b', (x) => x * 2))
+    .then(step('step_c', (x) => x + 10))
+    .then(step('step_d', (x) => x - 3))
+    .commit();
+}
+
+function fanout() {
+  // A → [B, C, D] → E
+  const combine = createStep({
+    id: 'step_e',
+    inputSchema: z.object({
+      branch_b: io,
+      branch_c: io,
+      branch_d: io,
+    }),
+    outputSchema: io,
+    execute: async ({ inputData }) => ({
+      x: inputData.branch_b.x + inputData.branch_c.x + inputData.branch_d.x,
+    }),
+  });
+  return createWorkflow({ id: 'fanout', inputSchema: io, outputSchema: io })
+    .then(step('step_a', (x) => x + 1))
+    .parallel([step('branch_b', (x) => x * 2), step('branch_c', (x) => x * 3), step('branch_d', (x) => x * 4)])
+    .then(combine)
+    .commit();
+}
+
+function diamond() {
+  // A → [B, C] → D
+  const combine = createStep({
+    id: 'combine',
+    inputSchema: z.object({ path_b: io, path_c: io }),
+    outputSchema: io,
+    execute: async ({ inputData }) => ({ x: inputData.path_b.x + inputData.path_c.x }),
+  });
+  return createWorkflow({ id: 'diamond', inputSchema: io, outputSchema: io })
+    .then(step('step_a', (x) => x + 1))
+    .parallel([step('path_b', (x) => x + 10), step('path_c', (x) => x * 5)])
+    .then(combine)
+    .commit();
+}
+
+const FACTORIES = { sequential, fanout, diamond };
+
+// ── Observability variant ────────────────────────────────────────────────────
+
+class MockedExporter extends BaseExporter {
+  name = 'mocked';
+  async _exportTracingEvent(_event) {}
+  async onLogEvent(_event) {}
+  async onMetricEvent(_event) {}
+}
+
+function withObservability(factory, name) {
+  const wf = factory();
+  const mastra = new Mastra({
+    workflows: { [name]: wf },
+    observability: new Observability({
+      configs: { bench: { serviceName: 'bench', exporters: [new MockedExporter()] } },
+    }),
+    logger: false,
+  });
+  return mastra.getWorkflow(name);
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+const runWorkflow = (wf) => async () => {
+  const run = await wf.createRun();
+  const result = await run.start({ inputData: { x: 3 } });
+  if (result.status !== 'success') throw new Error(`workflow run failed: ${result.status}`);
+};
+
+const results = {
+  meta: await meta(),
+  params: { quick, N_ITERS, N_WARMUP, N_MEM, N_BURST, THROUGHPUT_OPS, CONCURRENCY_LEVELS },
+  scenarios: {},
+};
+
+const common = {
+  iters: N_ITERS,
+  warmup: N_WARMUP,
+  memIters: N_MEM,
+  burstN: N_BURST,
+  throughputOps: THROUGHPUT_OPS,
+  concurrencyLevels: CONCURRENCY_LEVELS,
+};
+
+for (const [name, factory] of Object.entries(FACTORIES)) {
+  console.error(`  scenario ${name}`);
+  const bare = factory();
+  const obs = withObservability(factory, name);
+  results.scenarios[name] = {
+    bare: await measure(runWorkflow(bare), { ...common, label: 'mastra bare' }),
+    obs: await measure(runWorkflow(obs), { ...common, label: 'mastra+obs' }),
+  };
+}
+
+console.log(JSON.stringify(results));
+process.exit(0);

--- a/benchmarks/mastra/bench_workflow.mjs
+++ b/benchmarks/mastra/bench_workflow.mjs
@@ -106,14 +106,15 @@ class MockedExporter extends BaseExporter {
 
 function withObservability(factory, name) {
   const wf = factory();
+  const observability = new Observability({
+    configs: { bench: { serviceName: 'bench', exporters: [new MockedExporter()] } },
+  });
   const mastra = new Mastra({
     workflows: { [name]: wf },
-    observability: new Observability({
-      configs: { bench: { serviceName: 'bench', exporters: [new MockedExporter()] } },
-    }),
+    observability,
     logger: false,
   });
-  return mastra.getWorkflow(name);
+  return { wf: mastra.getWorkflow(name), observability };
 }
 
 // ── Main ─────────────────────────────────────────────────────────────────────
@@ -135,6 +136,9 @@ const common = {
   warmup: N_WARMUP,
   memIters: N_MEM,
   burstN: N_BURST,
+  // The Timbal side pre-runs 10 concurrent executions before burst timing
+  // (bench_workflow.py); keep the concurrent warmup identical.
+  burstWarmup: 10,
   throughputOps: THROUGHPUT_OPS,
   concurrencyLevels: CONCURRENCY_LEVELS,
 };
@@ -142,10 +146,14 @@ const common = {
 for (const [name, factory] of Object.entries(FACTORIES)) {
   console.error(`  scenario ${name}`);
   const bare = factory();
-  const obs = withObservability(factory, name);
+  const { wf: obs, observability } = withObservability(factory, name);
   results.scenarios[name] = {
     bare: await measure(runWorkflow(bare), { ...common, label: 'mastra bare' }),
-    obs: await measure(runWorkflow(obs), { ...common, label: 'mastra+obs' }),
+    obs: await measure(runWorkflow(obs), {
+      ...common,
+      label: 'mastra+obs',
+      drain: () => observability.flush(),
+    }),
   };
 }
 

--- a/benchmarks/mastra/bench_workflow.py
+++ b/benchmarks/mastra/bench_workflow.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""
+Timbal Workflow vs Mastra Workflow — DAG benchmark (cross-language).
+
+Three scenarios with trivial handler functions (no LLM calls):
+  1. Sequential:    A → B → C → D
+  2. Fan-out/in:    A → [B, C, D] → E
+  3. Diamond:       A → [B, C] → D
+
+Timbal runs on CPython/asyncio in this process; Mastra runs on Node/V8 as a
+subprocess (bench_workflow.mjs) with the same procedure. Workflow construction
+is excluded on both sides; a Mastra run is createRun() + start() — its normal
+programmatic execution path. See README.md for cross-runtime caveats.
+
+Run:
+    uv run python benchmarks/mastra/bench_workflow.py
+    uv run python benchmarks/mastra/bench_workflow.py --quick
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import warnings
+
+logging.disable(logging.WARNING)
+os.environ.setdefault("TIMBAL_LOG_LEVEL", "CRITICAL")
+warnings.filterwarnings("ignore")
+
+import structlog  # noqa: E402
+
+structlog.configure(wrapper_class=structlog.make_filtering_bound_logger(logging.CRITICAL))
+
+import asyncio  # noqa: E402
+import gc  # noqa: E402
+import json  # noqa: E402
+import shutil  # noqa: E402
+import statistics  # noqa: E402
+import subprocess  # noqa: E402
+import sys  # noqa: E402
+import time  # noqa: E402
+import tracemalloc  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+parser = argparse.ArgumentParser(add_help=False)
+parser.add_argument("--quick", action="store_true")
+parser.add_argument("--timbal-only", action="store_true", help="Skip Mastra, measure Timbal only")
+parser.add_argument("--mastra-json", type=Path, default=None, help="Reuse a previous Mastra JSON result instead of running Node")
+_args, _ = parser.parse_known_args()
+
+N_ITERS = 50 if _args.quick else 200
+N_WARMUP = 5 if _args.quick else 20
+N_BURST = 100 if _args.quick else 500
+N_MEM = 50 if _args.quick else 200
+THROUGHPUT_OPS = 200 if _args.quick else 1000
+CONCURRENCY_LEVELS = [1, 10, 50, 200]
+WIDTH = 76
+
+BENCH_DIR = Path(__file__).parent
+
+# ── Display helpers ──────────────────────────────────────────────────────────
+
+RESET = "\033[0m"
+BOLD = "\033[1m"
+CYAN = "\033[36m"
+DIM = "\033[2m"
+
+
+def section(title: str) -> None:
+    print()
+    print(f"{BOLD}{CYAN}{'─' * WIDTH}{RESET}")
+    print(f"{BOLD}{CYAN}  {title}{RESET}")
+    print(f"{BOLD}{CYAN}{'─' * WIDTH}{RESET}")
+
+
+def subsection(title: str) -> None:
+    print(f"\n  {BOLD}{title}{RESET}")
+
+
+def fmt_us(us: float) -> str:
+    if us >= 1_000:
+        return f"{us / 1_000:>8.2f} ms"
+    return f"{us:>8.1f} µs"
+
+
+def pct(samples: list[float], p: float) -> float:
+    idx = min(int(len(samples) * p / 100), len(samples) - 1)
+    return sorted(samples)[idx]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# MASTRA — spawn the Node-side benchmark
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def run_mastra_side(script: str) -> dict | None:
+    if _args.timbal_only:
+        return None
+    if _args.mastra_json:
+        return json.loads(_args.mastra_json.read_text())
+    node = shutil.which("node")
+    if node is None:
+        print(f"{DIM}  node not found on PATH — running Timbal only.{RESET}")
+        return None
+    if not (BENCH_DIR / "node_modules").exists():
+        print(f"{DIM}  benchmarks/mastra/node_modules missing — run `npm install` in benchmarks/mastra first.{RESET}")
+        return None
+    cmd = [node, "--expose-gc", script] + (["--quick"] if _args.quick else [])
+    print(f"{DIM}  running Mastra side: {' '.join(cmd[1:])}…{RESET}")
+    sys.stdout.flush()
+    proc = subprocess.run(cmd, cwd=BENCH_DIR, stdout=subprocess.PIPE, stderr=sys.stderr, text=True, timeout=3600)
+    if proc.returncode != 0:
+        print(f"{DIM}  Mastra side failed (exit {proc.returncode}) — running Timbal only.{RESET}")
+        return None
+    return json.loads(proc.stdout)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TIMBAL — Workflow factories (identical DAG shapes to the Mastra side)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+from timbal import Workflow  # noqa: E402
+from timbal.state import get_run_context  # noqa: E402
+from timbal.state.tracing.providers.in_memory import InMemoryTracingProvider  # noqa: E402
+
+
+def _clear_traces():
+    InMemoryTracingProvider._storage.clear()
+
+
+def _timbal_sequential() -> Workflow:
+    """A → B → C → D"""
+
+    def step_a(x: int) -> int:
+        return x + 1
+
+    def step_b(x: int) -> int:
+        return x * 2
+
+    def step_c(x: int) -> int:
+        return x + 10
+
+    def step_d(x: int) -> int:
+        return x - 3
+
+    wf = Workflow(name="sequential")
+    wf.step(step_a)
+    wf.step(step_b, x=lambda: get_run_context().step_span("step_a").output)
+    wf.step(step_c, x=lambda: get_run_context().step_span("step_b").output)
+    wf.step(step_d, x=lambda: get_run_context().step_span("step_c").output)
+    return wf
+
+
+def _timbal_fanout() -> Workflow:
+    """A → [B, C, D] → E"""
+
+    def step_a(x: int) -> int:
+        return x + 1
+
+    def branch_b(x: int) -> int:
+        return x * 2
+
+    def branch_c(x: int) -> int:
+        return x * 3
+
+    def branch_d(x: int) -> int:
+        return x * 4
+
+    def step_e(b: int, c: int, d: int) -> int:
+        return b + c + d
+
+    wf = Workflow(name="fanout")
+    wf.step(step_a)
+    wf.step(branch_b, x=lambda: get_run_context().step_span("step_a").output)
+    wf.step(branch_c, x=lambda: get_run_context().step_span("step_a").output)
+    wf.step(branch_d, x=lambda: get_run_context().step_span("step_a").output)
+    wf.step(
+        step_e,
+        b=lambda: get_run_context().step_span("branch_b").output,
+        c=lambda: get_run_context().step_span("branch_c").output,
+        d=lambda: get_run_context().step_span("branch_d").output,
+    )
+    return wf
+
+
+def _timbal_diamond() -> Workflow:
+    """A → [B, C] → D"""
+
+    def step_a(x: int) -> int:
+        return x + 1
+
+    def path_b(x: int) -> int:
+        return x + 10
+
+    def path_c(x: int) -> int:
+        return x * 5
+
+    def combine(b: int, c: int) -> int:
+        return b + c
+
+    wf = Workflow(name="diamond")
+    wf.step(step_a)
+    wf.step(path_b, x=lambda: get_run_context().step_span("step_a").output)
+    wf.step(path_c, x=lambda: get_run_context().step_span("step_a").output)
+    wf.step(
+        combine,
+        b=lambda: get_run_context().step_span("path_b").output,
+        c=lambda: get_run_context().step_span("path_c").output,
+    )
+    return wf
+
+
+TIMBAL_FACTORIES = {
+    "sequential": _timbal_sequential,
+    "fanout": _timbal_fanout,
+    "diamond": _timbal_diamond,
+}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Timbal measurement (same procedure as the Node side)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def measure_timbal(name: str) -> dict:
+    wf = TIMBAL_FACTORIES[name]()
+
+    async def run():
+        await wf(x=3).collect()
+
+    # Latency
+    for _ in range(N_WARMUP):
+        await run()
+    _clear_traces()
+    gc.collect()
+    lat = []
+    for _ in range(N_ITERS):
+        t0 = time.perf_counter()
+        await run()
+        lat.append((time.perf_counter() - t0) * 1e6)
+    _clear_traces()
+
+    # Memory
+    for _ in range(N_WARMUP):
+        await run()
+    _clear_traces()
+    gc.collect()
+    tracemalloc.start()
+    for _ in range(N_MEM):
+        await run()
+        _clear_traces()
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    # Burst
+    await asyncio.gather(*[run() for _ in range(10)])
+    _clear_traces()
+    gc.collect()
+    burst: list[float] = []
+
+    async def timed():
+        t0 = time.perf_counter()
+        await run()
+        burst.append((time.perf_counter() - t0) * 1e6)
+
+    await asyncio.gather(*[timed() for _ in range(N_BURST)])
+    _clear_traces()
+
+    # Throughput
+    tp = {}
+    for conc in CONCURRENCY_LEVELS:
+        sem = asyncio.Semaphore(conc)
+
+        async def bounded():
+            async with sem:
+                await run()
+
+        gc.collect()
+        t0 = time.perf_counter()
+        await asyncio.gather(*[bounded() for _ in range(THROUGHPUT_OPS)])
+        tp[str(conc)] = THROUGHPUT_OPS / (time.perf_counter() - t0)
+        _clear_traces()
+
+    return {
+        "latency_us": {
+            "mean": statistics.mean(lat),
+            "p50": pct(lat, 50), "p75": pct(lat, 75), "p95": pct(lat, 95), "p99": pct(lat, 99),
+            "max": max(lat),
+        },
+        "mem_per_run_bytes": peak / N_MEM,
+        "burst_us": {
+            "p50": pct(burst, 50), "p75": pct(burst, 75), "p95": pct(burst, 95), "p99": pct(burst, 99),
+            "max": max(burst),
+        },
+        "throughput_ops_s": tp,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Combined output
+# ═══════════════════════════════════════════════════════════════════════════════
+
+SCENARIO_NAMES = {
+    "sequential": "Sequential  (A → B → C → D)",
+    "fanout": "Fan-out/in  (A → [B, C, D] → E)",
+    "diamond": "Diamond  (A → [B, C] → D)",
+}
+
+COL_W = 12
+
+
+def print_scenario(key: str, timbal: dict, mastra: dict | None) -> None:
+    section(f"Scenario: {SCENARIO_NAMES[key]}")
+
+    cols = ["Timbal"]
+    frames = [timbal]
+    if mastra:
+        cols += ["Mastra", "Mastra+obs"]
+        frames += [mastra["bare"], mastra["obs"]]
+
+    hdr = f"  {'':>{COL_W}}" + "".join(f"  {c:>{COL_W}}" for c in cols)
+    sep = f"  {'─' * COL_W}" + f"  {'─' * COL_W}" * len(cols)
+
+    subsection(f"Latency  (×{N_ITERS} sequential runs)")
+    print(hdr)
+    print(sep)
+    for label in ["mean", "p50", "p95", "p99"]:
+        vals = [f["latency_us"][label] for f in frames]
+        print(f"  {label:>{COL_W}}" + "".join(f"  {fmt_us(v):>{COL_W}}" for v in vals))
+
+    subsection(f"Memory per run  (×{N_MEM} runs) — different instruments, do not ratio across runtimes")
+    print(f"  {'framework':<{COL_W + 12}}  {'per run':>14}  {'method':<24}")
+    print(f"  {'─' * (COL_W + 12)}  {'─' * 14}  {'─' * 24}")
+    print(f"  {'Timbal':<{COL_W + 12}}  {timbal['mem_per_run_bytes']:>12,.0f} B  {'tracemalloc peak/N':<24}")
+    if mastra:
+        for name, f in [("Mastra", mastra["bare"]), ("Mastra+obs", mastra["obs"])]:
+            print(f"  {name:<{COL_W + 12}}  {f['mem_per_run_bytes']:>12,.0f} B  {'V8 heap growth/N (≈)':<24}")
+
+    subsection(f"Burst  ({N_BURST} concurrent runs)")
+    print(hdr)
+    print(sep)
+    for label in ["p50", "p75", "p95", "p99", "max"]:
+        vals = [f["burst_us"][label] for f in frames]
+        print(f"  {label:>{COL_W}}" + "".join(f"  {fmt_us(v):>{COL_W}}" for v in vals))
+
+    subsection(f"Throughput  ({THROUGHPUT_OPS} runs)")
+    print(hdr)
+    print(sep)
+    for conc in CONCURRENCY_LEVELS:
+        vals = [f["throughput_ops_s"][str(conc)] for f in frames]
+        print(f"  {conc:>{COL_W}}" + "".join(f"  {v:>10.0f}/s" for v in vals))
+
+
+async def main() -> None:
+    print()
+    print(f"{BOLD}{'═' * WIDTH}{RESET}")
+    print(f"{BOLD}  Timbal Workflow vs Mastra Workflow — DAG benchmark (cross-language){RESET}")
+    print(f"  {N_ITERS} iters · {N_BURST} burst · {N_MEM} mem runs · {THROUGHPUT_OPS} throughput ops")
+    print(f"  {DIM}Trivial handlers (no LLM). Pure DAG scheduling overhead.{RESET}")
+    print(f"  {DIM}Timbal: CPython {sys.version_info.major}.{sys.version_info.minor}/asyncio · Mastra: Node/V8 subprocess (createRun + start per run).{RESET}")
+    print(f"  {DIM}Cross-runtime comparison — see README.md for what is and isn't comparable.{RESET}")
+    print(f"{BOLD}{'═' * WIDTH}{RESET}")
+    print()
+
+    mastra = run_mastra_side("bench_workflow.mjs")
+    if mastra:
+        m = mastra["meta"]
+        print(f"{DIM}  Mastra side: node {m['node']} · @mastra/core {m['mastra_core']} · @mastra/observability {m['mastra_observability']} · ai {m['ai_sdk']}{RESET}")
+
+    for key in ["sequential", "fanout", "diamond"]:
+        timbal = await measure_timbal(key)
+        print_scenario(key, timbal, mastra["scenarios"][key] if mastra else None)
+
+    print()
+    print(f"{DIM}{'─' * WIDTH}")
+    print("  Both frameworks execute identical DAGs with trivial handlers.")
+    print("  Workflow construction excluded; Mastra runs include createRun() + start().")
+    print("  Each framework runs in its native runtime; numbers include runtime differences.")
+    print("  Memory uses per-runtime instruments (tracemalloc vs V8 heap) — not cross-comparable.")
+    print(f"{'─' * WIDTH}{RESET}")
+    print()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/benchmarks/mastra/package-lock.json
+++ b/benchmarks/mastra/package-lock.json
@@ -1,0 +1,3278 @@
+{
+  "name": "mastra",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mastra",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@mastra/core": "^1.57.0",
+        "@mastra/observability": "^1.16.5",
+        "ai": "^7.0.56",
+        "zod": "^4.4.3"
+      }
+    },
+    "node_modules/@a2a-js/sdk": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-0.3.14.tgz",
+      "integrity": "sha512-F6Ew1AtPzCLhTn8h9yiqTe7DiDf6XVrSnq9V1YqSl9eWqPm6anMveTiKdCSb/76cW0YiJc24rNaUrVezFFHbqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "uuid": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.10.2",
+        "@grpc/grpc-js": "^1.11.0",
+        "express": "^4.21.2 || ^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@bufbuild/protobuf": {
+          "optional": true
+        },
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "4.0.44",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.44.tgz",
+      "integrity": "sha512-dQ/AHH1do1iEpWEXdAge37FtpXV17fsj7NkL9w+xuzVgvmI7+dQFeDerul+F2I5czmxe61Lq+TnUREjU92UXYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.6",
+        "@ai-sdk/provider-utils": "5.0.23",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.6.tgz",
+      "integrity": "sha512-YYXjvs8F3q/BdEn9tBDoDuQACotfR7c5foGw/ADsM6iAVC1JabqEjQSkwHv/Kg2vNIr1c2AVHcQb+JYsYk76Qw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.3.tgz",
+      "integrity": "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.23.tgz",
+      "integrity": "sha512-mFvAAszenK8Xny3v+4Vntke5IcUkyzjss3gTBOxVWNrSIWmt/FhQ5gCgoJXW7IK11cklRaicMPwOXTnnBtaqFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.6",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^7.28.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils-v5": {
+      "name": "@ai-sdk/provider-utils",
+      "version": "3.0.30",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.30.tgz",
+      "integrity": "sha512-NCJ9JKow5ENAgEZxzvEvF20thwDiH+hutvzmrUDbloRX0azpJHNst8+7pZIVryYhLM9wgpT5/ShTSjPTFhkxEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.3",
+        "@standard-schema/spec": "^1.0.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils-v6": {
+      "name": "@ai-sdk/provider-utils",
+      "version": "4.0.40",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.40.tgz",
+      "integrity": "sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.14",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils-v6/node_modules/@ai-sdk/provider": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
+      "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils-v7": {
+      "name": "@ai-sdk/provider-utils",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.13.tgz",
+      "integrity": "sha512-fScDJMDnTbx32kLDQqp0MvPjvwkgiwvlBxlmIg7XW5PbS91LG6JjH3PQG+34oMFglqfpQA355e24OdGj5PPoDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.4",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils-v7/node_modules/@ai-sdk/provider": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.4.tgz",
+      "integrity": "sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils/node_modules/@ai-sdk/provider": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.6.tgz",
+      "integrity": "sha512-YYXjvs8F3q/BdEn9tBDoDuQACotfR7c5foGw/ADsM6iAVC1JabqEjQSkwHv/Kg2vNIr1c2AVHcQb+JYsYk76Qw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/provider-v5": {
+      "name": "@ai-sdk/provider",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.3.tgz",
+      "integrity": "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-v6": {
+      "name": "@ai-sdk/provider",
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
+      "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-v7": {
+      "name": "@ai-sdk/provider",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.4.tgz",
+      "integrity": "sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@isaacs/ttlcache": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-2.1.5.tgz",
+      "integrity": "sha512-VwGZqqjAWPICTmxUZnbpEfO60LhPWzquik+bmyXGY7pYRn6diEvCI5i6Ca+J6o2y4vS73HrpuMTo2dOvUevH8w==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lukeed/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/csprng": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@mastra/core": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@mastra/core/-/core-1.57.0.tgz",
+      "integrity": "sha512-2ud56Ow5wwyAFegxXkkOHcQfCG0W9Sz1ex2qVf3y/704zwwYZl/RBZXZV/7277RIxWFk8Bnw8pmGtGQ4tZVWEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@a2a-js/sdk": "~0.3.14",
+        "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@3.0.30",
+        "@ai-sdk/provider-utils-v6": "npm:@ai-sdk/provider-utils@4.0.40",
+        "@ai-sdk/provider-utils-v7": "npm:@ai-sdk/provider-utils@5.0.13",
+        "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.3",
+        "@ai-sdk/provider-v6": "npm:@ai-sdk/provider@3.0.14",
+        "@ai-sdk/provider-v7": "npm:@ai-sdk/provider@4.0.4",
+        "@isaacs/ttlcache": "^2.1.5",
+        "@lukeed/uuid": "^2.0.1",
+        "@mastra/schema-compat": "1.3.5",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@sindresorhus/slugify": "^2.2.1",
+        "@standard-schema/spec": "^1.1.0",
+        "ajv": "^8.20.0",
+        "chat": "^4.34.0",
+        "croner": "^10.0.1",
+        "dotenv": "^17.3.1",
+        "execa": "^9.6.1",
+        "fastq": "^1.20.1",
+        "gray-matter": "^4.0.3",
+        "ignore": "^7.0.5",
+        "jpeg-js": "^0.4.4",
+        "json-schema": "^0.4.0",
+        "lru-cache": "^11.2.7",
+        "p-map": "^7.0.4",
+        "p-retry": "^7.1.1",
+        "picomatch": "^4.0.3",
+        "posthog-node": "^5.37.0",
+        "tokenx": "^1.3.0",
+        "ws": "^8.21.0",
+        "xxhash-wasm": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@mastra/observability": {
+      "version": "1.16.5",
+      "resolved": "https://registry.npmjs.org/@mastra/observability/-/observability-1.16.5.tgz",
+      "integrity": "sha512-aADhcVMrvqebmGpVy4CCeIxz18BE3TBYDpDj11ymiy+PuC7RR2fN87NyuNA7AeYN1P3JV1KuDhnLpLSypjeINw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.13.0"
+      },
+      "peerDependencies": {
+        "@mastra/core": ">=1.16.0-0 <2.0.0-0",
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@mastra/schema-compat": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@mastra/schema-compat/-/schema-compat-1.3.5.tgz",
+      "integrity": "sha512-9CdBZZ2Fb8q6Ms4r6hs0msH8MTmVn99Zrc+i8BnNNuqKlIrywIoH3BghmPr5VsvkBUx7u/GjdYAsJ6i9nPcZZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema-to-zod": "^2.7.0",
+        "zod-from-json-schema": "^0.5.2",
+        "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.46.9",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.46.9.tgz",
+      "integrity": "sha512-EXO6y5ih+jBkTCpUCuYgQmajuDZuvy6vMvflkub6pLQyi0GPlCPWVSvZZkOeQw9e2MxoD5GteeGCt9R8+UJ/yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.402.2"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.402.2",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.402.2.tgz",
+      "integrity": "sha512-ZZTiS4dLwF4/D0YTzS3gGSLFnhuNOY5yu4d9VGS9trGe5GW6FjIXo20p18K5BPW2RZSYSld8sdnSAY3AUXleUQ==",
+      "license": "MIT"
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sindresorhus/slugify": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-2.2.1.tgz",
+      "integrity": "sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/transliterate": "^1.0.0",
+        "escape-string-regexp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sindresorhus/transliterate": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/transliterate/-/transliterate-1.6.0.tgz",
+      "integrity": "sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ai": {
+      "version": "7.0.56",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.56.tgz",
+      "integrity": "sha512-Lp7q9tZFl/TGOpBBNgt2wZ85SoCvJJVlHQksMkqrgiFUnIGOw+L2FWJ0gXuNEngLQTp9+t32k8QuIB7Jc5uKRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "4.0.44",
+        "@ai-sdk/provider": "4.0.6",
+        "@ai-sdk/provider-utils": "5.0.23"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.6.tgz",
+      "integrity": "sha512-YYXjvs8F3q/BdEn9tBDoDuQACotfR7c5foGw/ADsM6iAVC1JabqEjQSkwHv/Kg2vNIr1c2AVHcQb+JYsYk76Qw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chat": {
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/chat/-/chat-4.36.0.tgz",
+      "integrity": "sha512-3A5HjnjilStMazAgY2PESloyT8g+GsoEf5uvqzPtvpGJrNh9oGWQ7IRZzw4+pFFTbUnCEtsclEAc2KMloRRZRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@workflow/serde": "4.1.0-beta.2",
+        "mdast-util-to-string": "^4.0.0",
+        "remark-gfm": "^4.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "remend": "^1.2.1",
+        "unified": "^11.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "ai": "^6.0.182 || ^7.0.0",
+        "workflow": "^5.0.0-beta.35",
+        "zod": "^3.0.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ai": {
+          "optional": true
+        },
+        "workflow": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/chat/node_modules/@workflow/serde": {
+      "version": "4.1.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0-beta.2.tgz",
+      "integrity": "sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/croner": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/croner/-/croner-10.0.1.tgz",
+      "integrity": "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==",
+      "funding": [
+        {
+          "type": "other",
+          "url": "https://paypal.me/hexagonpp"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/hexagon"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-network-error": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+      "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-to-zod": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-zod/-/json-schema-to-zod-2.8.1.tgz",
+      "integrity": "sha512-fRr1mHgZ7hboLKBUdR428gd9dIHUFGivUqOeiDcSmyXkNZCtB1uGaZLvsjZ4GaN5pwBIs+TGIOf6s+Rp5/R/zA==",
+      "license": "ISC",
+      "bin": {
+        "json-schema-to-zod": "dist/cjs/cli.js"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
+      "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/posthog-node": {
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.48.1.tgz",
+      "integrity": "sha512-BxLX2SqGEQhPqCPTalpyo0RRv1NMbf7UaN7q9d/ED77ksD6XOmE7ko2vIKO8F0zPL1NtKxIi+DYXap9lvR0RaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "^1.46.9"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remend": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/remend/-/remend-1.3.0.tgz",
+      "integrity": "sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tokenx": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tokenx/-/tokenx-1.6.0.tgz",
+      "integrity": "sha512-CKTjk345ajvBAUp5xUI9a5KKN0zU0lBueVHQbCskH1Hp6WkUKsPW2qGCYNs0pxNyfzxfo+IIjdt2W4sMbw/qBw==",
+      "license": "MIT"
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+      "license": "MIT"
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-from-json-schema": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/zod-from-json-schema/-/zod-from-json-schema-0.5.6.tgz",
+      "integrity": "sha512-U33AJ7ZWS6y9XNSzMWcdy8hRAvZmWhTtpYJu0SXPT5AArbc9nq2ur7Magzmn5RF9KBV4b3FP0nCpmqqlfXlR9w==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.0.17"
+      }
+    },
+    "node_modules/zod-from-json-schema-v3": {
+      "name": "zod-from-json-schema",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/zod-from-json-schema/-/zod-from-json-schema-0.0.5.tgz",
+      "integrity": "sha512-zYEoo86M1qpA1Pq6329oSyHLS785z/mTwfr9V1Xf/ZLhuuBGaMlDGu/pDVGVUe4H4oa1EFgWZT53DP0U3oT9CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.24.2"
+      }
+    },
+    "node_modules/zod-from-json-schema-v3/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/benchmarks/mastra/package.json
+++ b/benchmarks/mastra/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "timbal-bench-mastra",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Mastra side of the Timbal vs Mastra framework-overhead benchmarks",
+  "scripts": {
+    "bench:agent": "node --expose-gc bench_agent.mjs",
+    "bench:workflow": "node --expose-gc bench_workflow.mjs"
+  },
+  "dependencies": {
+    "@mastra/core": "^1.57.0",
+    "@mastra/observability": "^1.16.5",
+    "ai": "^7.0.56",
+    "zod": "^4.4.3"
+  }
+}

--- a/benchmarks/mastra/results/bench_agent.txt
+++ b/benchmarks/mastra/results/bench_agent.txt
@@ -18,33 +18,33 @@
   Latency  (×100 sequential runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-          mean      258.8 µs       2.46 ms       4.40 ms
-           p50      260.8 µs       2.33 ms       4.19 ms
-           p95      393.8 µs       3.61 ms       5.99 ms
-           p99      433.2 µs       4.89 ms       7.79 ms
+          mean      257.5 µs       2.45 ms       4.32 ms
+           p50      258.8 µs       2.28 ms       4.22 ms
+           p95      367.4 µs       3.46 ms       5.60 ms
+           p99      454.3 µs       4.74 ms       8.48 ms
 
   Memory per run  (×100 runs) — different instruments, do not ratio across runtimes
   framework                        per run  method                  
   ────────────────────────  ──────────────  ────────────────────────
   Timbal                             485 B  tracemalloc peak/N      
-  Mastra                         294,830 B  V8 heap growth/N (≈)    
-  Mastra+obs                     338,082 B  V8 heap growth/N (≈)    
+  Mastra                         295,423 B  V8 heap growth/N (≈)    
+  Mastra+obs                     348,079 B  V8 heap growth/N (≈)    
 
   Burst p50/p95  (20 concurrent runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-           p50      236.2 µs      27.21 ms      55.21 ms
-           p75      251.0 µs      34.34 ms      64.84 ms
-           p95      440.2 µs      37.95 ms      74.78 ms
-           p99      440.2 µs      37.95 ms      74.78 ms
-           max      440.2 µs      37.95 ms      74.78 ms
+           p50      229.2 µs      36.11 ms      57.35 ms
+           p75      265.7 µs      43.76 ms      67.30 ms
+           p95      454.5 µs      47.74 ms      77.27 ms
+           p99      454.5 µs      47.74 ms      77.27 ms
+           max      454.5 µs      47.74 ms      77.27 ms
 
   Throughput  (200 runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-             1        4016/s         509/s         274/s
-            10        4212/s         550/s         278/s
-            50        4003/s         535/s         270/s
+             1        4167/s         528/s         276/s
+            10        4211/s         480/s         278/s
+            50        4285/s         550/s         292/s
 
 ────────────────────────────────────────────────────────────────────────────
   Scenario 2: Multi-step  (LLM → add → LLM → mul → LLM → sub → LLM → answer)
@@ -53,33 +53,33 @@
   Latency  (×100 sequential runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-          mean      281.2 µs       3.88 ms       6.70 ms
-           p50      273.0 µs       3.79 ms       6.64 ms
-           p95      417.3 µs       5.23 ms       8.34 ms
-           p99      688.8 µs       6.99 ms      10.69 ms
+          mean      280.0 µs       3.62 ms       6.64 ms
+           p50      273.5 µs       3.55 ms       6.48 ms
+           p95      430.3 µs       5.17 ms       8.63 ms
+           p99      596.5 µs       6.83 ms      11.73 ms
 
   Memory per run  (×100 runs) — different instruments, do not ratio across runtimes
   framework                        per run  method                  
   ────────────────────────  ──────────────  ────────────────────────
   Timbal                             892 B  tracemalloc peak/N      
-  Mastra                         420,665 B  V8 heap growth/N (≈)    
-  Mastra+obs                     461,222 B  V8 heap growth/N (≈)    
+  Mastra                         419,700 B  V8 heap growth/N (≈)    
+  Mastra+obs                     477,121 B  V8 heap growth/N (≈)    
 
   Burst p50/p95  (10 concurrent runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-           p50      509.9 µs      32.86 ms      64.95 ms
-           p75      574.2 µs      35.21 ms      68.67 ms
-           p95      727.3 µs      37.58 ms      74.41 ms
-           p99      727.3 µs      37.58 ms      74.41 ms
-           max      727.3 µs      37.58 ms      74.41 ms
+           p50      507.6 µs      38.85 ms      60.07 ms
+           p75      519.2 µs      41.59 ms      64.33 ms
+           p95      602.7 µs      43.99 ms      70.21 ms
+           p99      602.7 µs      43.99 ms      70.21 ms
+           max      602.7 µs      43.99 ms      70.21 ms
 
   Throughput  (200 runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-             1        1926/s         271/s         135/s
-            10        1979/s         288/s         155/s
-            50        1961/s         311/s         163/s
+             1        2023/s         247/s         162/s
+            10        1973/s         270/s         161/s
+            50        1981/s         303/s         172/s
 
 ────────────────────────────────────────────────────────────────────────────
   Scenario 3: Parallel tools  (LLM → [add, mul, neg] → LLM → answer)
@@ -88,33 +88,33 @@
   Latency  (×100 sequential runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-          mean      282.5 µs       2.50 ms       4.49 ms
-           p50      278.5 µs       2.39 ms       4.41 ms
-           p95      406.9 µs       3.66 ms       5.86 ms
-           p99      773.4 µs       5.12 ms       8.64 ms
+          mean      276.3 µs       2.30 ms       4.36 ms
+           p50      272.4 µs       2.20 ms       4.26 ms
+           p95      378.9 µs       3.40 ms       5.89 ms
+           p99      739.1 µs       4.45 ms       7.16 ms
 
   Memory per run  (×100 runs) — different instruments, do not ratio across runtimes
   framework                        per run  method                  
   ────────────────────────  ──────────────  ────────────────────────
-  Timbal                             744 B  tracemalloc peak/N      
-  Mastra                         345,083 B  V8 heap growth/N (≈)    
-  Mastra+obs                     384,812 B  V8 heap growth/N (≈)    
+  Timbal                             775 B  tracemalloc peak/N      
+  Mastra                         343,909 B  V8 heap growth/N (≈)    
+  Mastra+obs                     389,618 B  V8 heap growth/N (≈)    
 
   Burst p50/p95  (15 concurrent runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-           p50       3.95 ms      24.22 ms      50.52 ms
-           p75       4.32 ms      30.89 ms      61.26 ms
-           p95       4.58 ms      34.00 ms      67.70 ms
-           p99       4.58 ms      34.00 ms      67.70 ms
-           max       4.58 ms      34.00 ms      67.70 ms
+           p50       3.71 ms      26.35 ms      50.08 ms
+           p75       3.96 ms      31.92 ms      59.17 ms
+           p95       4.20 ms      34.84 ms      65.71 ms
+           p99       4.20 ms      34.84 ms      65.71 ms
+           max       4.20 ms      34.84 ms      65.71 ms
 
   Throughput  (200 runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-             1        2130/s         411/s         228/s
-            10        2369/s         381/s         237/s
-            50        2588/s         306/s         248/s
+             1        2152/s         451/s         216/s
+            10        2592/s         435/s         239/s
+            50        2657/s         415/s         242/s
 
 ────────────────────────────────────────────────────────────────────────────
   All measurements reuse 1 pre-built agent (creation excluded).

--- a/benchmarks/mastra/results/bench_agent.txt
+++ b/benchmarks/mastra/results/bench_agent.txt
@@ -1,0 +1,125 @@
+
+════════════════════════════════════════════════════════════════════════════
+  Timbal vs Mastra — agent loop benchmark (cross-language)
+  100 iters · burst {1: 20, 2: 10, 3: 15} · 100 mem · 200 throughput
+  Timbal: CPython 3.11/asyncio, built-in tracing (always on).
+  Mastra: Node/V8 subprocess, AI SDK MockLanguageModelV4, bare + observability (export mocked).
+  Same scenarios, same fake-LLM-by-message-inspection, same procedure per side.
+  Cross-runtime comparison — see README.md for what is and isn't comparable.
+════════════════════════════════════════════════════════════════════════════
+
+  running Mastra side: --expose-gc bench_agent.mjs…
+  Mastra side: node v22.18.0 · @mastra/core 1.57.0 · @mastra/observability 1.16.5 · ai 7.0.56
+
+────────────────────────────────────────────────────────────────────────────
+  Scenario 1: Single tool call  (LLM → add → LLM → answer)
+────────────────────────────────────────────────────────────────────────────
+
+  Latency  (×100 sequential runs)
+                      Timbal        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────
+          mean      258.8 µs       2.46 ms       4.40 ms
+           p50      260.8 µs       2.33 ms       4.19 ms
+           p95      393.8 µs       3.61 ms       5.99 ms
+           p99      433.2 µs       4.89 ms       7.79 ms
+
+  Memory per run  (×100 runs) — different instruments, do not ratio across runtimes
+  framework                        per run  method                  
+  ────────────────────────  ──────────────  ────────────────────────
+  Timbal                             485 B  tracemalloc peak/N      
+  Mastra                         294,830 B  V8 heap growth/N (≈)    
+  Mastra+obs                     338,082 B  V8 heap growth/N (≈)    
+
+  Burst p50/p95  (20 concurrent runs)
+                      Timbal        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────
+           p50      236.2 µs      27.21 ms      55.21 ms
+           p75      251.0 µs      34.34 ms      64.84 ms
+           p95      440.2 µs      37.95 ms      74.78 ms
+           p99      440.2 µs      37.95 ms      74.78 ms
+           max      440.2 µs      37.95 ms      74.78 ms
+
+  Throughput  (200 runs)
+                      Timbal        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────
+             1        4016/s         509/s         274/s
+            10        4212/s         550/s         278/s
+            50        4003/s         535/s         270/s
+
+────────────────────────────────────────────────────────────────────────────
+  Scenario 2: Multi-step  (LLM → add → LLM → mul → LLM → sub → LLM → answer)
+────────────────────────────────────────────────────────────────────────────
+
+  Latency  (×100 sequential runs)
+                      Timbal        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────
+          mean      281.2 µs       3.88 ms       6.70 ms
+           p50      273.0 µs       3.79 ms       6.64 ms
+           p95      417.3 µs       5.23 ms       8.34 ms
+           p99      688.8 µs       6.99 ms      10.69 ms
+
+  Memory per run  (×100 runs) — different instruments, do not ratio across runtimes
+  framework                        per run  method                  
+  ────────────────────────  ──────────────  ────────────────────────
+  Timbal                             892 B  tracemalloc peak/N      
+  Mastra                         420,665 B  V8 heap growth/N (≈)    
+  Mastra+obs                     461,222 B  V8 heap growth/N (≈)    
+
+  Burst p50/p95  (10 concurrent runs)
+                      Timbal        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────
+           p50      509.9 µs      32.86 ms      64.95 ms
+           p75      574.2 µs      35.21 ms      68.67 ms
+           p95      727.3 µs      37.58 ms      74.41 ms
+           p99      727.3 µs      37.58 ms      74.41 ms
+           max      727.3 µs      37.58 ms      74.41 ms
+
+  Throughput  (200 runs)
+                      Timbal        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────
+             1        1926/s         271/s         135/s
+            10        1979/s         288/s         155/s
+            50        1961/s         311/s         163/s
+
+────────────────────────────────────────────────────────────────────────────
+  Scenario 3: Parallel tools  (LLM → [add, mul, neg] → LLM → answer)
+────────────────────────────────────────────────────────────────────────────
+
+  Latency  (×100 sequential runs)
+                      Timbal        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────
+          mean      282.5 µs       2.50 ms       4.49 ms
+           p50      278.5 µs       2.39 ms       4.41 ms
+           p95      406.9 µs       3.66 ms       5.86 ms
+           p99      773.4 µs       5.12 ms       8.64 ms
+
+  Memory per run  (×100 runs) — different instruments, do not ratio across runtimes
+  framework                        per run  method                  
+  ────────────────────────  ──────────────  ────────────────────────
+  Timbal                             744 B  tracemalloc peak/N      
+  Mastra                         345,083 B  V8 heap growth/N (≈)    
+  Mastra+obs                     384,812 B  V8 heap growth/N (≈)    
+
+  Burst p50/p95  (15 concurrent runs)
+                      Timbal        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────
+           p50       3.95 ms      24.22 ms      50.52 ms
+           p75       4.32 ms      30.89 ms      61.26 ms
+           p95       4.58 ms      34.00 ms      67.70 ms
+           p99       4.58 ms      34.00 ms      67.70 ms
+           max       4.58 ms      34.00 ms      67.70 ms
+
+  Throughput  (200 runs)
+                      Timbal        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────
+             1        2130/s         411/s         228/s
+            10        2369/s         381/s         237/s
+            50        2588/s         306/s         248/s
+
+────────────────────────────────────────────────────────────────────────────
+  All measurements reuse 1 pre-built agent (creation excluded).
+  LLMs faked via message inspection on both sides — no network, no API keys.
+  Each framework runs in its native runtime; numbers include runtime differences.
+  Memory uses per-runtime instruments (tracemalloc vs V8 heap) — not cross-comparable.
+────────────────────────────────────────────────────────────────────────────
+

--- a/benchmarks/mastra/results/bench_agent.txt
+++ b/benchmarks/mastra/results/bench_agent.txt
@@ -18,33 +18,33 @@
   Latency  (×100 sequential runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-          mean      257.5 µs       2.45 ms       4.32 ms
-           p50      258.8 µs       2.28 ms       4.22 ms
-           p95      367.4 µs       3.46 ms       5.60 ms
-           p99      454.3 µs       4.74 ms       8.48 ms
+          mean      268.0 µs       2.79 ms       4.62 ms
+           p50      271.9 µs       2.70 ms       4.53 ms
+           p95      426.9 µs       4.20 ms       6.02 ms
+           p99      586.7 µs       5.62 ms       9.80 ms
 
   Memory per run  (×100 runs) — different instruments, do not ratio across runtimes
   framework                        per run  method                  
   ────────────────────────  ──────────────  ────────────────────────
-  Timbal                             485 B  tracemalloc peak/N      
-  Mastra                         295,423 B  V8 heap growth/N (≈)    
-  Mastra+obs                     348,079 B  V8 heap growth/N (≈)    
+  Timbal                             492 B  tracemalloc peak/N      
+  Mastra                         294,563 B  V8 heap growth/N (≈)    
+  Mastra+obs                     345,372 B  V8 heap growth/N (≈)    
 
   Burst p50/p95  (20 concurrent runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-           p50      229.2 µs      36.11 ms      57.35 ms
-           p75      265.7 µs      43.76 ms      67.30 ms
-           p95      454.5 µs      47.74 ms      77.27 ms
-           p99      454.5 µs      47.74 ms      77.27 ms
-           max      454.5 µs      47.74 ms      77.27 ms
+           p50      252.4 µs      25.73 ms      61.40 ms
+           p75      324.0 µs      33.73 ms      72.39 ms
+           p95       1.56 ms      36.87 ms      84.40 ms
+           p99       1.56 ms      36.87 ms      84.40 ms
+           max       1.56 ms      36.87 ms      84.40 ms
 
   Throughput  (200 runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-             1        4167/s         528/s         276/s
-            10        4211/s         480/s         278/s
-            50        4285/s         550/s         292/s
+             1        3125/s         448/s         246/s
+            10        3828/s         511/s         259/s
+            50        3838/s         492/s         270/s
 
 ────────────────────────────────────────────────────────────────────────────
   Scenario 2: Multi-step  (LLM → add → LLM → mul → LLM → sub → LLM → answer)
@@ -53,33 +53,33 @@
   Latency  (×100 sequential runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-          mean      280.0 µs       3.62 ms       6.64 ms
-           p50      273.5 µs       3.55 ms       6.48 ms
-           p95      430.3 µs       5.17 ms       8.63 ms
-           p99      596.5 µs       6.83 ms      11.73 ms
+          mean      288.0 µs       4.75 ms       8.06 ms
+           p50      286.0 µs       4.66 ms       7.91 ms
+           p95      419.9 µs       6.15 ms      10.06 ms
+           p99      655.7 µs       8.48 ms      13.51 ms
 
   Memory per run  (×100 runs) — different instruments, do not ratio across runtimes
   framework                        per run  method                  
   ────────────────────────  ──────────────  ────────────────────────
-  Timbal                             892 B  tracemalloc peak/N      
-  Mastra                         419,700 B  V8 heap growth/N (≈)    
-  Mastra+obs                     477,121 B  V8 heap growth/N (≈)    
+  Timbal                             897 B  tracemalloc peak/N      
+  Mastra                         418,271 B  V8 heap growth/N (≈)    
+  Mastra+obs                     472,252 B  V8 heap growth/N (≈)    
 
   Burst p50/p95  (10 concurrent runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-           p50      507.6 µs      38.85 ms      60.07 ms
-           p75      519.2 µs      41.59 ms      64.33 ms
-           p95      602.7 µs      43.99 ms      70.21 ms
-           p99      602.7 µs      43.99 ms      70.21 ms
-           max      602.7 µs      43.99 ms      70.21 ms
+           p50      515.0 µs      34.04 ms      66.78 ms
+           p75      541.0 µs      36.71 ms      70.57 ms
+           p95      824.2 µs      39.32 ms      77.03 ms
+           p99      824.2 µs      39.32 ms      77.03 ms
+           max      824.2 µs      39.32 ms      77.03 ms
 
   Throughput  (200 runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-             1        2023/s         247/s         162/s
-            10        1973/s         270/s         161/s
-            50        1981/s         303/s         172/s
+             1        1858/s         220/s         130/s
+            10        1845/s         258/s         145/s
+            50        1836/s         283/s         154/s
 
 ────────────────────────────────────────────────────────────────────────────
   Scenario 3: Parallel tools  (LLM → [add, mul, neg] → LLM → answer)
@@ -88,33 +88,33 @@
   Latency  (×100 sequential runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-          mean      276.3 µs       2.30 ms       4.36 ms
-           p50      272.4 µs       2.20 ms       4.26 ms
-           p95      378.9 µs       3.40 ms       5.89 ms
-           p99      739.1 µs       4.45 ms       7.16 ms
+          mean      307.4 µs       2.87 ms       5.09 ms
+           p50      303.0 µs       2.76 ms       4.98 ms
+           p95      460.4 µs       4.24 ms       7.01 ms
+           p99      955.7 µs       5.01 ms       8.36 ms
 
   Memory per run  (×100 runs) — different instruments, do not ratio across runtimes
   framework                        per run  method                  
   ────────────────────────  ──────────────  ────────────────────────
-  Timbal                             775 B  tracemalloc peak/N      
-  Mastra                         343,909 B  V8 heap growth/N (≈)    
-  Mastra+obs                     389,618 B  V8 heap growth/N (≈)    
+  Timbal                             780 B  tracemalloc peak/N      
+  Mastra                         343,108 B  V8 heap growth/N (≈)    
+  Mastra+obs                     391,458 B  V8 heap growth/N (≈)    
 
   Burst p50/p95  (15 concurrent runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-           p50       3.71 ms      26.35 ms      50.08 ms
-           p75       3.96 ms      31.92 ms      59.17 ms
-           p95       4.20 ms      34.84 ms      65.71 ms
-           p99       4.20 ms      34.84 ms      65.71 ms
-           max       4.20 ms      34.84 ms      65.71 ms
+           p50       4.16 ms      25.52 ms      53.04 ms
+           p75       4.38 ms      32.94 ms      61.54 ms
+           p95       4.70 ms      36.41 ms      67.96 ms
+           p99       4.70 ms      36.41 ms      67.96 ms
+           max       4.70 ms      36.41 ms      67.96 ms
 
   Throughput  (200 runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-             1        2152/s         451/s         216/s
-            10        2592/s         435/s         239/s
-            50        2657/s         415/s         242/s
+             1        1946/s         348/s         215/s
+            10        2252/s         373/s         223/s
+            50        2420/s         380/s         227/s
 
 ────────────────────────────────────────────────────────────────────────────
   All measurements reuse 1 pre-built agent (creation excluded).

--- a/benchmarks/mastra/results/bench_agent.txt
+++ b/benchmarks/mastra/results/bench_agent.txt
@@ -18,33 +18,33 @@
   Latency  (×100 sequential runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-          mean      268.0 µs       2.79 ms       4.62 ms
-           p50      271.9 µs       2.70 ms       4.53 ms
-           p95      426.9 µs       4.20 ms       6.02 ms
-           p99      586.7 µs       5.62 ms       9.80 ms
+          mean      264.2 µs       2.77 ms       4.28 ms
+           p50      265.2 µs       2.63 ms       4.09 ms
+           p95      416.7 µs       3.89 ms       6.09 ms
+           p99      560.0 µs       5.30 ms      10.29 ms
 
   Memory per run  (×100 runs) — different instruments, do not ratio across runtimes
   framework                        per run  method                  
   ────────────────────────  ──────────────  ────────────────────────
   Timbal                             492 B  tracemalloc peak/N      
-  Mastra                         294,563 B  V8 heap growth/N (≈)    
-  Mastra+obs                     345,372 B  V8 heap growth/N (≈)    
+  Mastra                         296,746 B  V8 heap growth/N (≈)    
+  Mastra+obs                     355,216 B  V8 heap growth/N (≈)    
 
   Burst p50/p95  (20 concurrent runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-           p50      252.4 µs      25.73 ms      61.40 ms
-           p75      324.0 µs      33.73 ms      72.39 ms
-           p95       1.56 ms      36.87 ms      84.40 ms
-           p99       1.56 ms      36.87 ms      84.40 ms
-           max       1.56 ms      36.87 ms      84.40 ms
+           p50      262.3 µs      26.58 ms      55.22 ms
+           p75      290.1 µs      33.14 ms      65.60 ms
+           p95      441.8 µs      37.41 ms      74.79 ms
+           p99      441.8 µs      37.41 ms      74.79 ms
+           max      441.8 µs      37.41 ms      74.79 ms
 
   Throughput  (200 runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-             1        3125/s         448/s         246/s
-            10        3828/s         511/s         259/s
-            50        3838/s         492/s         270/s
+             1        4008/s         490/s         246/s
+            10        4172/s         512/s         264/s
+            50        4045/s         509/s         266/s
 
 ────────────────────────────────────────────────────────────────────────────
   Scenario 2: Multi-step  (LLM → add → LLM → mul → LLM → sub → LLM → answer)
@@ -53,33 +53,33 @@
   Latency  (×100 sequential runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-          mean      288.0 µs       4.75 ms       8.06 ms
-           p50      286.0 µs       4.66 ms       7.91 ms
-           p95      419.9 µs       6.15 ms      10.06 ms
-           p99      655.7 µs       8.48 ms      13.51 ms
+          mean      290.7 µs       3.90 ms       6.72 ms
+           p50      274.8 µs       3.74 ms       6.64 ms
+           p95      461.4 µs       5.85 ms       8.23 ms
+           p99      664.2 µs       7.03 ms      11.25 ms
 
   Memory per run  (×100 runs) — different instruments, do not ratio across runtimes
   framework                        per run  method                  
   ────────────────────────  ──────────────  ────────────────────────
   Timbal                             897 B  tracemalloc peak/N      
-  Mastra                         418,271 B  V8 heap growth/N (≈)    
-  Mastra+obs                     472,252 B  V8 heap growth/N (≈)    
+  Mastra                         421,457 B  V8 heap growth/N (≈)    
+  Mastra+obs                     476,681 B  V8 heap growth/N (≈)    
 
   Burst p50/p95  (10 concurrent runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-           p50      515.0 µs      34.04 ms      66.78 ms
-           p75      541.0 µs      36.71 ms      70.57 ms
-           p95      824.2 µs      39.32 ms      77.03 ms
-           p99      824.2 µs      39.32 ms      77.03 ms
-           max      824.2 µs      39.32 ms      77.03 ms
+           p50      485.8 µs      33.81 ms      71.28 ms
+           p75      497.7 µs      36.25 ms      76.76 ms
+           p95      640.2 µs      38.40 ms      83.00 ms
+           p99      640.2 µs      38.40 ms      83.00 ms
+           max      640.2 µs      38.40 ms      83.00 ms
 
   Throughput  (200 runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-             1        1858/s         220/s         130/s
-            10        1845/s         258/s         145/s
-            50        1836/s         283/s         154/s
+             1        1947/s         247/s         128/s
+            10        1854/s         284/s         144/s
+            50        1848/s         304/s         163/s
 
 ────────────────────────────────────────────────────────────────────────────
   Scenario 3: Parallel tools  (LLM → [add, mul, neg] → LLM → answer)
@@ -88,33 +88,33 @@
   Latency  (×100 sequential runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-          mean      307.4 µs       2.87 ms       5.09 ms
-           p50      303.0 µs       2.76 ms       4.98 ms
-           p95      460.4 µs       4.24 ms       7.01 ms
-           p99      955.7 µs       5.01 ms       8.36 ms
+          mean      291.4 µs       2.77 ms       5.20 ms
+           p50      278.2 µs       2.60 ms       4.65 ms
+           p95      434.1 µs       4.07 ms      12.15 ms
+           p99      803.9 µs       4.58 ms      15.77 ms
 
   Memory per run  (×100 runs) — different instruments, do not ratio across runtimes
   framework                        per run  method                  
   ────────────────────────  ──────────────  ────────────────────────
-  Timbal                             780 B  tracemalloc peak/N      
-  Mastra                         343,108 B  V8 heap growth/N (≈)    
-  Mastra+obs                     391,458 B  V8 heap growth/N (≈)    
+  Timbal                             799 B  tracemalloc peak/N      
+  Mastra                         348,384 B  V8 heap growth/N (≈)    
+  Mastra+obs                     392,720 B  V8 heap growth/N (≈)    
 
   Burst p50/p95  (15 concurrent runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-           p50       4.16 ms      25.52 ms      53.04 ms
-           p75       4.38 ms      32.94 ms      61.54 ms
-           p95       4.70 ms      36.41 ms      67.96 ms
-           p99       4.70 ms      36.41 ms      67.96 ms
-           max       4.70 ms      36.41 ms      67.96 ms
+           p50       4.39 ms      25.24 ms      51.79 ms
+           p75       4.70 ms      30.82 ms      61.20 ms
+           p95       5.12 ms      33.61 ms      68.17 ms
+           p99       5.12 ms      33.61 ms      68.17 ms
+           max       5.12 ms      33.61 ms      68.17 ms
 
   Throughput  (200 runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-             1        1946/s         348/s         215/s
-            10        2252/s         373/s         223/s
-            50        2420/s         380/s         227/s
+             1        1851/s         380/s         241/s
+            10        2244/s         374/s         239/s
+            50        2440/s         411/s         240/s
 
 ────────────────────────────────────────────────────────────────────────────
   All measurements reuse 1 pre-built agent (creation excluded).

--- a/benchmarks/mastra/results/bench_workflow.txt
+++ b/benchmarks/mastra/results/bench_workflow.txt
@@ -17,34 +17,34 @@
   Latency  (×200 sequential runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-          mean      360.3 µs      107.2 µs      328.3 µs
-           p50      338.6 µs       95.9 µs      293.1 µs
-           p95      503.3 µs      159.2 µs      504.0 µs
-           p99      591.6 µs      428.2 µs       1.11 ms
+          mean      368.0 µs      106.5 µs      337.1 µs
+           p50      332.0 µs       94.9 µs      295.3 µs
+           p95      493.1 µs      141.7 µs      524.5 µs
+           p99       1.09 ms      467.4 µs       1.20 ms
 
   Memory per run  (×200 runs) — different instruments, do not ratio across runtimes
   framework                        per run  method                  
   ────────────────────────  ──────────────  ────────────────────────
-  Timbal                             214 B  tracemalloc peak/N      
-  Mastra                          82,994 B  V8 heap growth/N (≈)    
-  Mastra+obs                      88,691 B  V8 heap growth/N (≈)    
+  Timbal                             228 B  tracemalloc peak/N      
+  Mastra                          82,973 B  V8 heap growth/N (≈)    
+  Mastra+obs                      87,979 B  V8 heap growth/N (≈)    
 
   Burst  (500 concurrent runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-           p50      76.35 ms      49.71 ms     145.79 ms
-           p75      82.18 ms      49.90 ms     146.25 ms
-           p95      87.20 ms      50.08 ms     146.65 ms
-           p99      88.12 ms      50.11 ms     146.73 ms
-           max      88.39 ms      50.17 ms     146.82 ms
+           p50      75.26 ms      48.73 ms     148.72 ms
+           p75      80.82 ms      48.92 ms     149.19 ms
+           p95      85.77 ms      49.10 ms     149.60 ms
+           p99      86.63 ms      49.13 ms     149.68 ms
+           max      86.91 ms      49.19 ms     149.75 ms
 
   Throughput  (1000 runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-             1        1893/s       14084/s        3631/s
-            10        4295/s       15317/s        4174/s
-            50        4383/s       15546/s        3867/s
-           200        4253/s       14178/s        3486/s
+             1        2466/s       14994/s        3818/s
+            10        3892/s       15954/s        4214/s
+            50        3959/s       16122/s        3883/s
+           200        4207/s       14149/s        3519/s
 
 ────────────────────────────────────────────────────────────────────────────
   Scenario: Fan-out/in  (A → [B, C, D] → E)
@@ -53,34 +53,34 @@
   Latency  (×200 sequential runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-          mean      471.4 µs      147.8 µs      376.2 µs
-           p50      450.4 µs      130.6 µs      330.3 µs
-           p95      631.6 µs      224.3 µs      578.3 µs
-           p99      839.1 µs      614.3 µs       1.17 ms
+          mean      536.6 µs      145.7 µs      369.9 µs
+           p50      492.2 µs      129.3 µs      334.2 µs
+           p95      759.6 µs      198.2 µs      557.3 µs
+           p99       1.10 ms      553.2 µs       1.16 ms
 
   Memory per run  (×200 runs) — different instruments, do not ratio across runtimes
   framework                        per run  method                  
   ────────────────────────  ──────────────  ────────────────────────
-  Timbal                             368 B  tracemalloc peak/N      
-  Mastra                          83,313 B  V8 heap growth/N (≈)    
-  Mastra+obs                      93,387 B  V8 heap growth/N (≈)    
+  Timbal                             361 B  tracemalloc peak/N      
+  Mastra                          82,822 B  V8 heap growth/N (≈)    
+  Mastra+obs                      93,057 B  V8 heap growth/N (≈)    
 
   Burst  (500 concurrent runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-           p50     139.53 ms      81.62 ms     184.78 ms
-           p75     144.23 ms      81.96 ms     185.23 ms
-           p95     148.21 ms      82.29 ms     185.61 ms
-           p99     149.14 ms      82.35 ms     185.71 ms
-           max     149.33 ms      82.42 ms     185.83 ms
+           p50     148.65 ms      80.89 ms     190.59 ms
+           p75     153.39 ms      81.25 ms     191.07 ms
+           p95     157.46 ms      81.61 ms     191.48 ms
+           p99     158.19 ms      81.66 ms     191.55 ms
+           max     158.42 ms      81.71 ms     191.65 ms
 
   Throughput  (1000 runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-             1        2081/s        8461/s        3031/s
-            10        3233/s        9159/s        3231/s
-            50        3125/s        9366/s        3167/s
-           200        3099/s        7746/s        2900/s
+             1        1869/s        8501/s        3106/s
+            10        3000/s        9470/s        3306/s
+            50        3000/s        9216/s        3256/s
+           200        2926/s        7860/s        2959/s
 
 ────────────────────────────────────────────────────────────────────────────
   Scenario: Diamond  (A → [B, C] → D)
@@ -89,34 +89,34 @@
   Latency  (×200 sequential runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-          mean      422.6 µs      116.4 µs      331.5 µs
-           p50      404.2 µs      104.6 µs      286.0 µs
-           p95      567.5 µs      139.3 µs      514.8 µs
-           p99      725.1 µs      633.0 µs       1.27 ms
+          mean      474.4 µs      119.6 µs      307.5 µs
+           p50      432.4 µs      105.3 µs      270.8 µs
+           p95      709.2 µs      159.0 µs      431.5 µs
+           p99      873.5 µs      578.7 µs       1.18 ms
 
   Memory per run  (×200 runs) — different instruments, do not ratio across runtimes
   framework                        per run  method                  
   ────────────────────────  ──────────────  ────────────────────────
-  Timbal                             321 B  tracemalloc peak/N      
-  Mastra                          84,053 B  V8 heap growth/N (≈)    
-  Mastra+obs                      86,383 B  V8 heap growth/N (≈)    
+  Timbal                             290 B  tracemalloc peak/N      
+  Mastra                          83,147 B  V8 heap growth/N (≈)    
+  Mastra+obs                      88,203 B  V8 heap growth/N (≈)    
 
   Burst  (500 concurrent runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-           p50     126.63 ms      61.28 ms     150.45 ms
-           p75     130.68 ms      61.63 ms     150.95 ms
-           p95     134.61 ms      61.99 ms     151.37 ms
-           p99     135.61 ms      62.04 ms     151.44 ms
-           max     135.84 ms      62.11 ms     151.52 ms
+           p50     126.72 ms      59.55 ms     137.42 ms
+           p75     131.98 ms      59.92 ms     137.91 ms
+           p95     136.07 ms      60.22 ms     138.31 ms
+           p99     136.90 ms      60.29 ms     138.38 ms
+           max     137.19 ms      60.37 ms     138.44 ms
 
   Throughput  (1000 runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-             1        2149/s       10154/s        3479/s
-            10        3346/s       10996/s        2576/s
-            50        3989/s       10760/s        3486/s
-           200        3708/s        9546/s        3332/s
+             1        2068/s       10217/s        3524/s
+            10        3495/s       11184/s        3963/s
+            50        3559/s       10545/s        3728/s
+           200        3494/s        9708/s        3452/s
 
 ────────────────────────────────────────────────────────────────────────────
   Both frameworks execute identical DAGs with trivial handlers.

--- a/benchmarks/mastra/results/bench_workflow.txt
+++ b/benchmarks/mastra/results/bench_workflow.txt
@@ -1,0 +1,127 @@
+
+════════════════════════════════════════════════════════════════════════════
+  Timbal Workflow vs Mastra Workflow — DAG benchmark (cross-language)
+  200 iters · 500 burst · 200 mem runs · 1000 throughput ops
+  Trivial handlers (no LLM). Pure DAG scheduling overhead.
+  Timbal: CPython 3.11/asyncio · Mastra: Node/V8 subprocess (createRun + start per run).
+  Cross-runtime comparison — see README.md for what is and isn't comparable.
+════════════════════════════════════════════════════════════════════════════
+
+  running Mastra side: --expose-gc bench_workflow.mjs…
+  Mastra side: node v22.18.0 · @mastra/core 1.57.0 · @mastra/observability 1.16.5 · ai 7.0.56
+
+────────────────────────────────────────────────────────────────────────────
+  Scenario: Sequential  (A → B → C → D)
+────────────────────────────────────────────────────────────────────────────
+
+  Latency  (×200 sequential runs)
+                      Timbal        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────
+          mean      360.3 µs      107.2 µs      328.3 µs
+           p50      338.6 µs       95.9 µs      293.1 µs
+           p95      503.3 µs      159.2 µs      504.0 µs
+           p99      591.6 µs      428.2 µs       1.11 ms
+
+  Memory per run  (×200 runs) — different instruments, do not ratio across runtimes
+  framework                        per run  method                  
+  ────────────────────────  ──────────────  ────────────────────────
+  Timbal                             214 B  tracemalloc peak/N      
+  Mastra                          82,994 B  V8 heap growth/N (≈)    
+  Mastra+obs                      88,691 B  V8 heap growth/N (≈)    
+
+  Burst  (500 concurrent runs)
+                      Timbal        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────
+           p50      76.35 ms      49.71 ms     145.79 ms
+           p75      82.18 ms      49.90 ms     146.25 ms
+           p95      87.20 ms      50.08 ms     146.65 ms
+           p99      88.12 ms      50.11 ms     146.73 ms
+           max      88.39 ms      50.17 ms     146.82 ms
+
+  Throughput  (1000 runs)
+                      Timbal        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────
+             1        1893/s       14084/s        3631/s
+            10        4295/s       15317/s        4174/s
+            50        4383/s       15546/s        3867/s
+           200        4253/s       14178/s        3486/s
+
+────────────────────────────────────────────────────────────────────────────
+  Scenario: Fan-out/in  (A → [B, C, D] → E)
+────────────────────────────────────────────────────────────────────────────
+
+  Latency  (×200 sequential runs)
+                      Timbal        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────
+          mean      471.4 µs      147.8 µs      376.2 µs
+           p50      450.4 µs      130.6 µs      330.3 µs
+           p95      631.6 µs      224.3 µs      578.3 µs
+           p99      839.1 µs      614.3 µs       1.17 ms
+
+  Memory per run  (×200 runs) — different instruments, do not ratio across runtimes
+  framework                        per run  method                  
+  ────────────────────────  ──────────────  ────────────────────────
+  Timbal                             368 B  tracemalloc peak/N      
+  Mastra                          83,313 B  V8 heap growth/N (≈)    
+  Mastra+obs                      93,387 B  V8 heap growth/N (≈)    
+
+  Burst  (500 concurrent runs)
+                      Timbal        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────
+           p50     139.53 ms      81.62 ms     184.78 ms
+           p75     144.23 ms      81.96 ms     185.23 ms
+           p95     148.21 ms      82.29 ms     185.61 ms
+           p99     149.14 ms      82.35 ms     185.71 ms
+           max     149.33 ms      82.42 ms     185.83 ms
+
+  Throughput  (1000 runs)
+                      Timbal        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────
+             1        2081/s        8461/s        3031/s
+            10        3233/s        9159/s        3231/s
+            50        3125/s        9366/s        3167/s
+           200        3099/s        7746/s        2900/s
+
+────────────────────────────────────────────────────────────────────────────
+  Scenario: Diamond  (A → [B, C] → D)
+────────────────────────────────────────────────────────────────────────────
+
+  Latency  (×200 sequential runs)
+                      Timbal        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────
+          mean      422.6 µs      116.4 µs      331.5 µs
+           p50      404.2 µs      104.6 µs      286.0 µs
+           p95      567.5 µs      139.3 µs      514.8 µs
+           p99      725.1 µs      633.0 µs       1.27 ms
+
+  Memory per run  (×200 runs) — different instruments, do not ratio across runtimes
+  framework                        per run  method                  
+  ────────────────────────  ──────────────  ────────────────────────
+  Timbal                             321 B  tracemalloc peak/N      
+  Mastra                          84,053 B  V8 heap growth/N (≈)    
+  Mastra+obs                      86,383 B  V8 heap growth/N (≈)    
+
+  Burst  (500 concurrent runs)
+                      Timbal        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────
+           p50     126.63 ms      61.28 ms     150.45 ms
+           p75     130.68 ms      61.63 ms     150.95 ms
+           p95     134.61 ms      61.99 ms     151.37 ms
+           p99     135.61 ms      62.04 ms     151.44 ms
+           max     135.84 ms      62.11 ms     151.52 ms
+
+  Throughput  (1000 runs)
+                      Timbal        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────
+             1        2149/s       10154/s        3479/s
+            10        3346/s       10996/s        2576/s
+            50        3989/s       10760/s        3486/s
+           200        3708/s        9546/s        3332/s
+
+────────────────────────────────────────────────────────────────────────────
+  Both frameworks execute identical DAGs with trivial handlers.
+  Workflow construction excluded; Mastra runs include createRun() + start().
+  Each framework runs in its native runtime; numbers include runtime differences.
+  Memory uses per-runtime instruments (tracemalloc vs V8 heap) — not cross-comparable.
+────────────────────────────────────────────────────────────────────────────
+

--- a/benchmarks/mastra/results/bench_workflow.txt
+++ b/benchmarks/mastra/results/bench_workflow.txt
@@ -17,34 +17,34 @@
   Latency  (×200 sequential runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-          mean      370.9 µs      110.6 µs      365.9 µs
-           p50      355.0 µs       94.7 µs      303.0 µs
-           p95      476.3 µs      174.1 µs      753.7 µs
-           p99      653.9 µs      477.1 µs       1.56 ms
+          mean      322.3 µs      105.7 µs      328.3 µs
+           p50      315.1 µs       95.8 µs      289.4 µs
+           p95      364.1 µs      135.5 µs      508.2 µs
+           p99      438.0 µs      484.4 µs       1.26 ms
 
   Memory per run  (×200 runs) — different instruments, do not ratio across runtimes
   framework                        per run  method                  
   ────────────────────────  ──────────────  ────────────────────────
-  Timbal                             227 B  tracemalloc peak/N      
-  Mastra                          82,972 B  V8 heap growth/N (≈)    
-  Mastra+obs                      89,012 B  V8 heap growth/N (≈)    
+  Timbal                             258 B  tracemalloc peak/N      
+  Mastra                          82,979 B  V8 heap growth/N (≈)    
+  Mastra+obs                      88,540 B  V8 heap growth/N (≈)    
 
   Burst  (500 concurrent runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-           p50      77.99 ms      52.22 ms     154.31 ms
-           p75      84.51 ms      52.48 ms     154.76 ms
-           p95      90.05 ms      52.66 ms     155.16 ms
-           p99      91.12 ms      52.68 ms     155.25 ms
-           max      91.49 ms      52.76 ms     155.33 ms
+           p50      84.61 ms      48.33 ms     157.90 ms
+           p75      90.77 ms      48.53 ms     158.49 ms
+           p95     104.12 ms      48.70 ms     158.92 ms
+           p99     106.23 ms      48.73 ms     159.00 ms
+           max     107.55 ms      48.79 ms     159.07 ms
 
   Throughput  (1000 runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-             1        2523/s       14097/s        3661/s
-            10        3954/s       15770/s        3973/s
-            50        3996/s       15825/s        3740/s
-           200        4034/s       12451/s        3394/s
+             1        2036/s       13960/s        3753/s
+            10        4373/s       13091/s        4071/s
+            50        4230/s       14871/s        3392/s
+           200        4617/s       13621/s        3514/s
 
 ────────────────────────────────────────────────────────────────────────────
   Scenario: Fan-out/in  (A → [B, C, D] → E)
@@ -53,34 +53,34 @@
   Latency  (×200 sequential runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-          mean      504.2 µs      148.4 µs      386.7 µs
-           p50      486.0 µs      127.3 µs      341.4 µs
-           p95      659.4 µs      199.4 µs      614.2 µs
-           p99      737.5 µs      675.6 µs       1.45 ms
+          mean      530.6 µs      150.1 µs      373.4 µs
+           p50      467.6 µs      130.7 µs      337.9 µs
+           p95      806.3 µs      201.5 µs      646.2 µs
+           p99       1.66 ms      684.2 µs       1.14 ms
 
   Memory per run  (×200 runs) — different instruments, do not ratio across runtimes
   framework                        per run  method                  
   ────────────────────────  ──────────────  ────────────────────────
-  Timbal                             332 B  tracemalloc peak/N      
-  Mastra                          82,955 B  V8 heap growth/N (≈)    
-  Mastra+obs                      91,526 B  V8 heap growth/N (≈)    
+  Timbal                             365 B  tracemalloc peak/N      
+  Mastra                          83,200 B  V8 heap growth/N (≈)    
+  Mastra+obs                      92,211 B  V8 heap growth/N (≈)    
 
   Burst  (500 concurrent runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-           p50     149.51 ms      86.92 ms     193.62 ms
-           p75     154.65 ms      87.24 ms     194.05 ms
-           p95     159.15 ms      87.55 ms     194.43 ms
-           p99     159.97 ms      87.60 ms     194.50 ms
-           max     160.24 ms      87.66 ms     194.63 ms
+           p50     133.56 ms      82.91 ms     180.03 ms
+           p75     138.28 ms      83.30 ms     180.53 ms
+           p95     142.29 ms      83.67 ms     180.98 ms
+           p99     143.17 ms      83.74 ms     181.05 ms
+           max     143.37 ms      83.82 ms     181.17 ms
 
   Throughput  (1000 runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-             1        1883/s        8193/s        2978/s
-            10        3025/s        9074/s        3183/s
-            50        2979/s        9041/s        3073/s
-           200        2865/s        7320/s        2838/s
+             1        1996/s        8670/s        3130/s
+            10        3131/s        9433/s        3440/s
+            50        3462/s        9512/s        3279/s
+           200        3201/s        7995/s        2403/s
 
 ────────────────────────────────────────────────────────────────────────────
   Scenario: Diamond  (A → [B, C] → D)
@@ -89,34 +89,34 @@
   Latency  (×200 sequential runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-          mean      432.1 µs      126.8 µs      320.8 µs
-           p50      408.4 µs      107.1 µs      276.7 µs
-           p95      590.0 µs      172.1 µs      511.0 µs
-           p99      684.2 µs      774.2 µs       1.31 ms
+          mean      392.4 µs      118.5 µs      333.7 µs
+           p50      381.7 µs      104.9 µs      289.5 µs
+           p95      459.2 µs      161.5 µs      625.5 µs
+           p99      632.3 µs      576.8 µs       1.15 ms
 
   Memory per run  (×200 runs) — different instruments, do not ratio across runtimes
   framework                        per run  method                  
   ────────────────────────  ──────────────  ────────────────────────
-  Timbal                             310 B  tracemalloc peak/N      
-  Mastra                          83,157 B  V8 heap growth/N (≈)    
-  Mastra+obs                      90,475 B  V8 heap growth/N (≈)    
+  Timbal                             335 B  tracemalloc peak/N      
+  Mastra                          83,130 B  V8 heap growth/N (≈)    
+  Mastra+obs                      88,893 B  V8 heap growth/N (≈)    
 
   Burst  (500 concurrent runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-           p50     131.23 ms      63.63 ms     157.71 ms
-           p75     136.21 ms      64.01 ms     158.19 ms
-           p95     140.37 ms      64.34 ms     158.62 ms
-           p99     141.10 ms      64.46 ms     158.75 ms
-           max     141.36 ms      64.52 ms     158.83 ms
+           p50     113.30 ms      59.09 ms     148.40 ms
+           p75     117.71 ms      59.42 ms     148.88 ms
+           p95     121.70 ms      59.71 ms     149.36 ms
+           p99     122.41 ms      59.79 ms     149.45 ms
+           max     122.61 ms      59.85 ms     149.53 ms
 
   Throughput  (1000 runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-             1        2122/s        9776/s        3378/s
-            10        3557/s       10772/s        3805/s
-            50        3628/s       10050/s        3485/s
-           200        3243/s        8884/s        3212/s
+             1        2427/s       10223/s        3567/s
+            10        4039/s       11265/s        4014/s
+            50        4384/s       10743/s        3698/s
+           200        3971/s        9778/s        3391/s
 
 ────────────────────────────────────────────────────────────────────────────
   Both frameworks execute identical DAGs with trivial handlers.

--- a/benchmarks/mastra/results/bench_workflow.txt
+++ b/benchmarks/mastra/results/bench_workflow.txt
@@ -17,34 +17,34 @@
   Latency  (×200 sequential runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-          mean      368.0 µs      106.5 µs      337.1 µs
-           p50      332.0 µs       94.9 µs      295.3 µs
-           p95      493.1 µs      141.7 µs      524.5 µs
-           p99       1.09 ms      467.4 µs       1.20 ms
+          mean      370.9 µs      110.6 µs      365.9 µs
+           p50      355.0 µs       94.7 µs      303.0 µs
+           p95      476.3 µs      174.1 µs      753.7 µs
+           p99      653.9 µs      477.1 µs       1.56 ms
 
   Memory per run  (×200 runs) — different instruments, do not ratio across runtimes
   framework                        per run  method                  
   ────────────────────────  ──────────────  ────────────────────────
-  Timbal                             228 B  tracemalloc peak/N      
-  Mastra                          82,973 B  V8 heap growth/N (≈)    
-  Mastra+obs                      87,979 B  V8 heap growth/N (≈)    
+  Timbal                             227 B  tracemalloc peak/N      
+  Mastra                          82,972 B  V8 heap growth/N (≈)    
+  Mastra+obs                      89,012 B  V8 heap growth/N (≈)    
 
   Burst  (500 concurrent runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-           p50      75.26 ms      48.73 ms     148.72 ms
-           p75      80.82 ms      48.92 ms     149.19 ms
-           p95      85.77 ms      49.10 ms     149.60 ms
-           p99      86.63 ms      49.13 ms     149.68 ms
-           max      86.91 ms      49.19 ms     149.75 ms
+           p50      77.99 ms      52.22 ms     154.31 ms
+           p75      84.51 ms      52.48 ms     154.76 ms
+           p95      90.05 ms      52.66 ms     155.16 ms
+           p99      91.12 ms      52.68 ms     155.25 ms
+           max      91.49 ms      52.76 ms     155.33 ms
 
   Throughput  (1000 runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-             1        2466/s       14994/s        3818/s
-            10        3892/s       15954/s        4214/s
-            50        3959/s       16122/s        3883/s
-           200        4207/s       14149/s        3519/s
+             1        2523/s       14097/s        3661/s
+            10        3954/s       15770/s        3973/s
+            50        3996/s       15825/s        3740/s
+           200        4034/s       12451/s        3394/s
 
 ────────────────────────────────────────────────────────────────────────────
   Scenario: Fan-out/in  (A → [B, C, D] → E)
@@ -53,34 +53,34 @@
   Latency  (×200 sequential runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-          mean      536.6 µs      145.7 µs      369.9 µs
-           p50      492.2 µs      129.3 µs      334.2 µs
-           p95      759.6 µs      198.2 µs      557.3 µs
-           p99       1.10 ms      553.2 µs       1.16 ms
+          mean      504.2 µs      148.4 µs      386.7 µs
+           p50      486.0 µs      127.3 µs      341.4 µs
+           p95      659.4 µs      199.4 µs      614.2 µs
+           p99      737.5 µs      675.6 µs       1.45 ms
 
   Memory per run  (×200 runs) — different instruments, do not ratio across runtimes
   framework                        per run  method                  
   ────────────────────────  ──────────────  ────────────────────────
-  Timbal                             361 B  tracemalloc peak/N      
-  Mastra                          82,822 B  V8 heap growth/N (≈)    
-  Mastra+obs                      93,057 B  V8 heap growth/N (≈)    
+  Timbal                             332 B  tracemalloc peak/N      
+  Mastra                          82,955 B  V8 heap growth/N (≈)    
+  Mastra+obs                      91,526 B  V8 heap growth/N (≈)    
 
   Burst  (500 concurrent runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-           p50     148.65 ms      80.89 ms     190.59 ms
-           p75     153.39 ms      81.25 ms     191.07 ms
-           p95     157.46 ms      81.61 ms     191.48 ms
-           p99     158.19 ms      81.66 ms     191.55 ms
-           max     158.42 ms      81.71 ms     191.65 ms
+           p50     149.51 ms      86.92 ms     193.62 ms
+           p75     154.65 ms      87.24 ms     194.05 ms
+           p95     159.15 ms      87.55 ms     194.43 ms
+           p99     159.97 ms      87.60 ms     194.50 ms
+           max     160.24 ms      87.66 ms     194.63 ms
 
   Throughput  (1000 runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-             1        1869/s        8501/s        3106/s
-            10        3000/s        9470/s        3306/s
-            50        3000/s        9216/s        3256/s
-           200        2926/s        7860/s        2959/s
+             1        1883/s        8193/s        2978/s
+            10        3025/s        9074/s        3183/s
+            50        2979/s        9041/s        3073/s
+           200        2865/s        7320/s        2838/s
 
 ────────────────────────────────────────────────────────────────────────────
   Scenario: Diamond  (A → [B, C] → D)
@@ -89,34 +89,34 @@
   Latency  (×200 sequential runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-          mean      474.4 µs      119.6 µs      307.5 µs
-           p50      432.4 µs      105.3 µs      270.8 µs
-           p95      709.2 µs      159.0 µs      431.5 µs
-           p99      873.5 µs      578.7 µs       1.18 ms
+          mean      432.1 µs      126.8 µs      320.8 µs
+           p50      408.4 µs      107.1 µs      276.7 µs
+           p95      590.0 µs      172.1 µs      511.0 µs
+           p99      684.2 µs      774.2 µs       1.31 ms
 
   Memory per run  (×200 runs) — different instruments, do not ratio across runtimes
   framework                        per run  method                  
   ────────────────────────  ──────────────  ────────────────────────
-  Timbal                             290 B  tracemalloc peak/N      
-  Mastra                          83,147 B  V8 heap growth/N (≈)    
-  Mastra+obs                      88,203 B  V8 heap growth/N (≈)    
+  Timbal                             310 B  tracemalloc peak/N      
+  Mastra                          83,157 B  V8 heap growth/N (≈)    
+  Mastra+obs                      90,475 B  V8 heap growth/N (≈)    
 
   Burst  (500 concurrent runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-           p50     126.72 ms      59.55 ms     137.42 ms
-           p75     131.98 ms      59.92 ms     137.91 ms
-           p95     136.07 ms      60.22 ms     138.31 ms
-           p99     136.90 ms      60.29 ms     138.38 ms
-           max     137.19 ms      60.37 ms     138.44 ms
+           p50     131.23 ms      63.63 ms     157.71 ms
+           p75     136.21 ms      64.01 ms     158.19 ms
+           p95     140.37 ms      64.34 ms     158.62 ms
+           p99     141.10 ms      64.46 ms     158.75 ms
+           max     141.36 ms      64.52 ms     158.83 ms
 
   Throughput  (1000 runs)
                       Timbal        Mastra    Mastra+obs
   ────────────  ────────────  ────────────  ────────────
-             1        2068/s       10217/s        3524/s
-            10        3495/s       11184/s        3963/s
-            50        3559/s       10545/s        3728/s
-           200        3494/s        9708/s        3452/s
+             1        2122/s        9776/s        3378/s
+            10        3557/s       10772/s        3805/s
+            50        3628/s       10050/s        3485/s
+           200        3243/s        8884/s        3212/s
 
 ────────────────────────────────────────────────────────────────────────────
   Both frameworks execute identical DAGs with trivial handlers.


### PR DESCRIPTION
First cross-language benchmark: Mastra is TypeScript, so each side runs in its native runtime (Timbal on CPython/asyncio, Mastra on Node/V8 via a subprocess) with everything else held identical -- same agent/DAG scenarios, same stateless fake-LLM-by-message-inspection, same warmup/batch counts, monotonic ns timers, forced GC between batches.

- bench_agent: single tool / 3-step chain / parallel tools. Timbal p50 261-279 us vs Mastra 2.3-3.8 ms bare, 4.2-6.6 ms with observability.
- bench_workflow: sequential / fan-out / diamond DAGs. Bare Mastra on V8 is ~3x faster than Timbal on trivial DAGs (reported as-is); at observability parity it is a wash.
- Observability per benchmark philosophy: Timbal tracing always on; Mastra shown bare and with @mastra/observability (exporter sink mocked).
- Memory measured per-runtime (tracemalloc vs V8 heap growth) and explicitly never ratio'd across languages. README documents what is and is not comparable. Full-mode results in results/.