### PR TITLE
feat(benchmarks): runtime calibration suite + raw AI SDK baseline

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -50,6 +50,11 @@ uv run --with google-adk python benchmarks/google_adk/bench_callbacks.py --quick
 cd benchmarks/mastra && npm install && cd ../..
 uv run python benchmarks/mastra/bench_agent.py --quick
 uv run python benchmarks/mastra/bench_workflow.py --quick
+
+# Runtime calibration: LangGraph Python vs LangGraph.js (needs Node >= 20)
+cd benchmarks/langgraph_js && npm install && cd ../..
+uv run --no-sync --with langgraph --with langchain-core python benchmarks/langgraph_js/bench_agent.py --quick
+uv run --no-sync --with langgraph --with langchain-core python benchmarks/langgraph_js/bench_workflow.py --quick
 ```
 
 No API keys required. All LLM calls are faked by inspecting message history.
@@ -174,7 +179,8 @@ zero provider-specific code in user land.
 | `pydantic/` | Timbal vs PydanticAI/Pydantic Graph + Logfire — agents, graph-style workflows, control flow | WIP |
 | `openai_agents/` | Timbal vs OpenAI Agents SDK - agents, handoffs, agent-as-tool | WIP |
 | `google_adk/` | Timbal vs Google ADK - agents, sub-agent transfer, callbacks | WIP |
-| `mastra/` | Timbal vs Mastra (TypeScript) — cross-language: agents and DAG workflows, each in its native runtime | WIP |
+| `mastra/` | Timbal vs Mastra (TypeScript) — cross-language: agents and DAG workflows, each in its native runtime; includes a raw Vercel AI SDK baseline | WIP |
+| `langgraph_js/` | Runtime calibration: LangGraph Python vs LangGraph.js — same framework on CPython and V8, isolating the runtime factor for all cross-language tables | WIP |
 | `rust/` | Timbal (Python) vs timbal-rs (Rust) — same agent loop, native runtimes | WIP |
 
 **Coming next:** deeper Google ADK orchestration benchmarks.

--- a/benchmarks/langgraph_js/README.md
+++ b/benchmarks/langgraph_js/README.md
@@ -1,0 +1,101 @@
+# Runtime Calibration - LangGraph Python vs LangGraph.js
+
+This directory answers one question the cross-language benchmarks
+(`benchmarks/mastra/`) cannot answer on their own: **how much of a
+Python-vs-TypeScript performance gap is the language runtime, and how much is
+the framework?**
+
+LangGraph ships the same architecture in both languages — a prebuilt react
+agent over a Pregel graph (`create_react_agent` / `createReactAgent`,
+`StateGraph` in both). Running identical scenarios on both implementations
+isolates the CPython-vs-V8 factor. The **LG.py ÷ LG.js ratio is the
+calibration number**: apply it mentally when reading any Timbal (Python) vs
+TypeScript-framework table in this repo.
+
+Timbal appears in every table for reference, with its built-in tracing on as
+always. The calibration ratio itself is computed bare-vs-bare (no
+observability on either LangGraph side).
+
+**Environment:** Apple Silicon M-series, CPython 3.11, Node 22,
+`langgraph` (Python) latest, `@langchain/langgraph` 1.4.9. No API keys — all
+LLMs faked via message-history inspection on all three sides, same procedure
+per side (see `benchmarks/mastra/README.md` for the cross-runtime methodology;
+this directory follows it exactly).
+
+---
+
+## Files
+
+| File | What it does |
+|------|--------------|
+| `bench_agent.py` | Orchestrator: Timbal + LangGraph Python in-process, spawns `bench_agent.mjs`, prints combined tables + calibration ratios |
+| `bench_agent.mjs` | LangGraph.js react-agent loop, JSON on stdout |
+| `bench_workflow.py` | Orchestrator for StateGraph DAGs |
+| `bench_workflow.mjs` | LangGraph.js StateGraph DAGs, JSON on stdout |
+| `bench_lib.mjs` | Shared Node harness (copied from `benchmarks/mastra`) |
+
+## Setup & running
+
+```bash
+cd benchmarks/langgraph_js && npm install && cd ../..
+
+# langgraph (Python) is not in the repo lock — use an ephemeral overlay:
+uv run --no-sync --with langgraph --with langchain-core python benchmarks/langgraph_js/bench_agent.py --quick
+uv run --no-sync --with langgraph --with langchain-core python benchmarks/langgraph_js/bench_agent.py
+uv run --no-sync --with langgraph --with langchain-core python benchmarks/langgraph_js/bench_workflow.py --quick
+uv run --no-sync --with langgraph --with langchain-core python benchmarks/langgraph_js/bench_workflow.py
+```
+
+Flags: `--timbal-only`, `--lgjs-json <file>` (replay a saved Node-side result).
+
+---
+
+## Results
+
+Full-mode run, 2026-08-10. Raw outputs in `results/`.
+
+### The calibration numbers
+
+| Workload | LG.py ÷ LG.js (latency p50) | Interpretation |
+|----------|:---------------------------:|----------------|
+| Agent loop, single tool | 2.06x | V8 meaningfully faster |
+| Agent loop, 3-step chain | 3.41x | V8 meaningfully faster |
+| Agent loop, parallel tools | 3.25x | V8 meaningfully faster |
+| DAG sequential | 1.01x | runtime is a wash |
+| DAG fan-out/in | 1.06x | runtime is a wash |
+| DAG diamond | 1.24x | runtime is a wash |
+
+Two clean findings:
+
+1. **Agent loops: the runtime factor is 2–3.4x.** Message-heavy agent loops
+   (object churn, serialization, schema handling) benefit substantially from
+   V8's JIT and allocator.
+2. **Trivial DAG scheduling: the runtime factor is ~1x.** Pregel's superstep
+   machinery costs about the same on both runtimes — scheduling overhead is
+   dominated by the framework's own bookkeeping, not language speed.
+
+### What this means for the Mastra benchmark
+
+- Timbal's ~10x agent-loop advantage over Mastra (`benchmarks/mastra`) is
+  measured *against* a 2–3.4x runtime headwind. Runtime-adjusted, the
+  architectural gap is larger than the raw tables show, not smaller.
+- Mastra's ~3x bare-workflow win over Timbal is **not** explained by V8: the
+  same-framework DAG ratio is ~1x. That win is Mastra's lean workflow engine
+  (and it disappears once its observability is enabled).
+
+### Reference tables (agent loop, p50)
+
+| Scenario | Timbal (traced) | LG.py (bare) | LG.js (bare) |
+|----------|----------------:|-------------:|-------------:|
+| Single tool | 280.4 µs | 2.84 ms | 1.38 ms |
+| 3-step chain | 289.0 µs | 6.28 ms | 1.84 ms |
+| Parallel tools | 285.5 µs | 3.39 ms | 1.04 ms |
+
+Worth noting: Timbal with tracing on is ~4–6x faster than LangGraph.js bare —
+a Python framework beating the same competitor's TypeScript implementation on
+V8's home turf. Framework design dominates runtime choice at this scale.
+
+Full latency/memory/burst/throughput tables for all six scenarios are in
+`results/bench_agent.txt` and `results/bench_workflow.txt`. Memory columns use
+per-runtime instruments (tracemalloc vs V8 heap growth) and must not be
+ratio'd across languages.

--- a/benchmarks/langgraph_js/bench_agent.mjs
+++ b/benchmarks/langgraph_js/bench_agent.mjs
@@ -1,0 +1,145 @@
+/**
+ * LangGraph.js side of the runtime-calibration agent benchmark. Run by
+ * bench_agent.py — do not run directly unless debugging (JSON on stdout,
+ * progress on stderr).
+ *
+ * Purpose: LangGraph exists in both Python and TypeScript with the same
+ * architecture (prebuilt react agent over a Pregel graph). Running the exact
+ * scenarios of benchmarks/langchain/bench_agent.py on LangGraph.js isolates
+ * the language-runtime factor (CPython vs V8) from framework design — the
+ * variable no cross-framework, cross-language benchmark can separate on its
+ * own.
+ *
+ * Scenarios (identical to every other framework in benchmarks/):
+ *   1. Single tool call:    LLM → add → LLM → answer
+ *   2. Multi-step (3 tools): LLM → add → LLM → mul → LLM → sub → LLM → answer
+ *   3. Parallel tools:      LLM → [add, mul, neg] concurrent → LLM → answer
+ *
+ * The fake LLM subclasses BaseChatModel and picks its response by counting
+ * ToolMessages in the history — stateless, mirroring the Python _FakeLLM.
+ *
+ * Usage: node --expose-gc bench_agent.mjs [--quick]
+ */
+
+import { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import { AIMessage, ToolMessage } from '@langchain/core/messages';
+import { tool } from '@langchain/core/tools';
+import { createReactAgent } from '@langchain/langgraph/prebuilt';
+import { z } from 'zod';
+
+import { measure, meta, readParams } from './bench_lib.mjs';
+
+const { quick } = readParams();
+
+const N_ITERS = quick ? 20 : 100;
+const N_WARMUP = quick ? 3 : 10;
+const N_MEM = quick ? 20 : 100;
+const N_BURST = { 1: 20, 2: 10, 3: 15 };
+const THROUGHPUT_OPS = quick ? 30 : 200;
+const CONCURRENCY_LEVELS = [1, 10, 50];
+
+// ── Fake tool-calling chat model (stateless — step from message history) ─────
+
+class FakeToolLLM extends BaseChatModel {
+  constructor(responses) {
+    super({});
+    this.responses = responses;
+  }
+  _llmType() {
+    return 'fake-tool-llm';
+  }
+  bindTools() {
+    return this;
+  }
+  async _generate(messages) {
+    const step = messages.filter((m) => m instanceof ToolMessage || m.getType?.() === 'tool').length;
+    return { generations: [{ message: this.responses[step % this.responses.length], text: '' }] };
+  }
+}
+
+// ── Tools ────────────────────────────────────────────────────────────────────
+
+const num = z.number();
+const TOOLS = {
+  add: tool(async ({ a, b }) => a + b, {
+    name: 'add',
+    description: 'Add two numbers.',
+    schema: z.object({ a: num, b: num }),
+  }),
+  multiply: tool(async ({ a, b }) => a * b, {
+    name: 'multiply',
+    description: 'Multiply two numbers.',
+    schema: z.object({ a: num, b: num }),
+  }),
+  subtract: tool(async ({ a, b }) => a - b, {
+    name: 'subtract',
+    description: 'Subtract b from a.',
+    schema: z.object({ a: num, b: num }),
+  }),
+  negate: tool(async ({ x }) => -x, {
+    name: 'negate',
+    description: 'Negate a number.',
+    schema: z.object({ x: num }),
+  }),
+};
+
+const tc = (id, name, args) => ({ name, args, id, type: 'tool_call' });
+
+function makeAgent(scenario) {
+  const responses = {
+    1: [
+      new AIMessage({ content: '', tool_calls: [tc('c1', 'add', { a: 1, b: 2 })] }),
+      new AIMessage({ content: '3' }),
+    ],
+    2: [
+      new AIMessage({ content: '', tool_calls: [tc('c1', 'add', { a: 1, b: 2 })] }),
+      new AIMessage({ content: '', tool_calls: [tc('c2', 'multiply', { a: 3, b: 4 })] }),
+      new AIMessage({ content: '', tool_calls: [tc('c3', 'subtract', { a: 12, b: 3 })] }),
+      new AIMessage({ content: '9' }),
+    ],
+    3: [
+      new AIMessage({
+        content: '',
+        tool_calls: [tc('c1', 'add', { a: 1, b: 2 }), tc('c2', 'multiply', { a: 3, b: 4 }), tc('c3', 'negate', { x: 5 })],
+      }),
+      new AIMessage({ content: 'done' }),
+    ],
+  }[scenario];
+
+  const tools = {
+    1: [TOOLS.add],
+    2: [TOOLS.add, TOOLS.multiply, TOOLS.subtract],
+    3: [TOOLS.add, TOOLS.multiply, TOOLS.negate],
+  }[scenario];
+
+  return createReactAgent({ llm: new FakeToolLLM(responses), tools });
+}
+
+const INPUT = { messages: [{ role: 'user', content: 'go' }] };
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+const results = {
+  meta: await meta(),
+  params: { quick, N_ITERS, N_WARMUP, N_MEM, N_BURST, THROUGHPUT_OPS, CONCURRENCY_LEVELS },
+  scenarios: {},
+};
+
+for (const scenario of [1, 2, 3]) {
+  console.error(`  scenario ${scenario}`);
+  const agent = makeAgent(scenario);
+  results.scenarios[scenario] = {
+    bare: await measure(() => agent.invoke(INPUT), {
+      iters: N_ITERS,
+      warmup: N_WARMUP,
+      memIters: N_MEM,
+      burstN: N_BURST[scenario],
+      throughputOps: THROUGHPUT_OPS,
+      concurrencyLevels: CONCURRENCY_LEVELS,
+      label: 'lg.js',
+    }),
+  };
+}
+
+console.log(JSON.stringify(results));
+process.exit(0);

--- a/benchmarks/langgraph_js/bench_agent.py
+++ b/benchmarks/langgraph_js/bench_agent.py
@@ -1,27 +1,25 @@
 #!/usr/bin/env python3
 """
-Timbal vs Mastra — full agent loop benchmark (cross-language).
+Runtime calibration — LangGraph Python vs LangGraph.js (vs Timbal) agent loop.
 
-Three scenarios, identical pipelines on both frameworks:
-  1. Single tool call:   prompt → LLM → tool(add) → LLM → answer
-  2. Multi-step (3 tools): prompt → LLM → add → LLM → mul → LLM → sub → LLM → answer
-  3. Parallel tools:     prompt → LLM → [add, mul, neg] concurrent → LLM → answer
+LangGraph ships the same architecture in Python and TypeScript: a prebuilt
+react agent over a Pregel graph. Running identical scenarios on both isolates
+the language-runtime factor (CPython vs V8) that cross-framework,
+cross-language benchmarks (e.g. benchmarks/mastra) cannot separate on their
+own. The LG.js/LG.py ratio is the calibration number: apply it mentally when
+reading any Timbal-vs-TypeScript-framework table.
 
-Mastra is a TypeScript framework, so each side runs in its native runtime:
-Timbal on CPython/asyncio (in this process), Mastra on Node/V8 (spawned as a
-subprocess running bench_agent.mjs with the same methodology). Numbers compare
-the full framework+runtime stacks — the thing a user actually deploys — not
-language-neutral algorithm quality. See README.md for what is and isn't
-comparable; memory in particular uses different instruments per runtime
-(tracemalloc vs V8 heap growth) and must not be ratio'd across languages.
+Scenarios (identical to benchmarks/langchain and benchmarks/mastra):
+  1. Single tool call   2. Multi-step (3 tools)   3. Parallel tools
 
-All LLMs are faked via message-history inspection. Observability: Timbal
-built-in tracing (always on); Mastra shown both bare and with
-@mastra/observability enabled (export mocked).
+All LLMs faked via message-history inspection. All columns are bare (no
+observability) except Timbal, whose built-in tracing is always on — the
+calibration ratio itself is computed LG.py-bare vs LG.js-bare, same framework,
+same (lack of) tracing.
 
 Run:
-    uv run python benchmarks/mastra/bench_agent.py
-    uv run python benchmarks/mastra/bench_agent.py --quick
+    uv run --no-sync --with langgraph --with langchain-core python benchmarks/langgraph_js/bench_agent.py
+    uv run --no-sync --with langgraph --with langchain-core python benchmarks/langgraph_js/bench_agent.py --quick
 """
 
 from __future__ import annotations
@@ -52,8 +50,8 @@ from pathlib import Path  # noqa: E402
 
 parser = argparse.ArgumentParser(add_help=False)
 parser.add_argument("--quick", action="store_true")
-parser.add_argument("--timbal-only", action="store_true", help="Skip Mastra, measure Timbal only")
-parser.add_argument("--mastra-json", type=Path, default=None, help="Reuse a previous Mastra JSON result instead of running Node")
+parser.add_argument("--timbal-only", action="store_true", help="Skip LangGraph on both runtimes")
+parser.add_argument("--lgjs-json", type=Path, default=None, help="Reuse a previous LG.js JSON result instead of running Node")
 _args, _ = parser.parse_known_args()
 
 N_ITERS = 20 if _args.quick else 100
@@ -97,28 +95,28 @@ def pct(samples: list[float], p: float) -> float:
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# MASTRA — spawn the Node-side benchmark
+# LANGGRAPH.JS — spawn the Node-side benchmark
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-def run_mastra_side(script: str) -> dict | None:
+def run_lgjs_side(script: str) -> dict | None:
     if _args.timbal_only:
         return None
-    if _args.mastra_json:
-        return json.loads(_args.mastra_json.read_text())
+    if _args.lgjs_json:
+        return json.loads(_args.lgjs_json.read_text())
     node = shutil.which("node")
     if node is None:
-        print(f"{DIM}  node not found on PATH — running Timbal only.{RESET}")
+        print(f"{DIM}  node not found on PATH — skipping LangGraph.js.{RESET}")
         return None
     if not (BENCH_DIR / "node_modules").exists():
-        print(f"{DIM}  benchmarks/mastra/node_modules missing — run `npm install` in benchmarks/mastra first.{RESET}")
+        print(f"{DIM}  benchmarks/langgraph_js/node_modules missing — run `npm install` there first.{RESET}")
         return None
     cmd = [node, "--expose-gc", script] + (["--quick"] if _args.quick else [])
-    print(f"{DIM}  running Mastra side: {' '.join(cmd[1:])}…{RESET}")
+    print(f"{DIM}  running LangGraph.js side: {' '.join(cmd[1:])}…{RESET}")
     sys.stdout.flush()
     proc = subprocess.run(cmd, cwd=BENCH_DIR, stdout=subprocess.PIPE, stderr=sys.stderr, text=True, timeout=3600)
     if proc.returncode != 0:
-        print(f"{DIM}  Mastra side failed (exit {proc.returncode}) — running Timbal only.{RESET}")
+        print(f"{DIM}  LangGraph.js side failed (exit {proc.returncode}).{RESET}")
         return None
     return json.loads(proc.stdout)
 
@@ -194,44 +192,125 @@ def _make_timbal_agent(scenario: int):
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# Timbal measurement (same procedure as the Node side)
+# LANGGRAPH PYTHON — same fake LLM pattern as benchmarks/langchain
+# ═══════════════════════════════════════════════════════════════════════════════
+
+try:
+    from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+    from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+    from langchain_core.tools import StructuredTool
+    from langgraph.prebuilt import create_react_agent
+
+    HAS_LANGGRAPH_PY = True
+except ImportError:
+    HAS_LANGGRAPH_PY = False
+
+if HAS_LANGGRAPH_PY:
+    class _FakeLLM(FakeMessagesListChatModel):
+        """Stateless fake LLM: counts ToolMessages to find the current step."""
+
+        def bind_tools(self, tools, **kw):
+            return self
+
+        def _step(self, messages) -> int:
+            return sum(1 for m in messages if isinstance(m, ToolMessage))
+
+        async def _agenerate(self, messages, stop=None, run_manager=None, **kwargs):
+            from langchain_core.outputs import ChatGeneration, ChatResult
+            idx = self._step(messages) % len(self.responses)
+            return ChatResult(generations=[ChatGeneration(message=self.responses[idx])])
+
+        def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+            from langchain_core.outputs import ChatGeneration, ChatResult
+            idx = self._step(messages) % len(self.responses)
+            return ChatResult(generations=[ChatGeneration(message=self.responses[idx])])
+
+    def _lg_responses(scenario: int) -> list:
+        if scenario == 1:
+            return [
+                AIMessage(content="", tool_calls=[{"name": "add", "args": {"a": 1, "b": 2}, "id": "c1", "type": "tool_call"}]),
+                AIMessage(content="3"),
+            ]
+        elif scenario == 2:
+            return [
+                AIMessage(content="", tool_calls=[{"name": "add", "args": {"a": 1, "b": 2}, "id": "c1", "type": "tool_call"}]),
+                AIMessage(content="", tool_calls=[{"name": "multiply", "args": {"a": 3, "b": 4}, "id": "c2", "type": "tool_call"}]),
+                AIMessage(content="", tool_calls=[{"name": "subtract", "args": {"a": 12, "b": 3}, "id": "c3", "type": "tool_call"}]),
+                AIMessage(content="9"),
+            ]
+        return [
+            AIMessage(content="", tool_calls=[
+                {"name": "add", "args": {"a": 1, "b": 2}, "id": "c1", "type": "tool_call"},
+                {"name": "multiply", "args": {"a": 3, "b": 4}, "id": "c2", "type": "tool_call"},
+                {"name": "negate", "args": {"x": 5}, "id": "c3", "type": "tool_call"},
+            ]),
+            AIMessage(content="done"),
+        ]
+
+    def _make_lg_graph(scenario: int):
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        def multiply(a: int, b: int) -> int:
+            """Multiply two numbers."""
+            return a * b
+
+        def subtract(a: int, b: int) -> int:
+            """Subtract b from a."""
+            return a - b
+
+        def negate(x: int) -> int:
+            """Negate a number."""
+            return -x
+
+        td = {n.__name__: StructuredTool.from_function(n) for n in (add, multiply, subtract, negate)}
+        tools = {
+            1: [td["add"]],
+            2: [td["add"], td["multiply"], td["subtract"]],
+            3: [td["add"], td["multiply"], td["negate"]],
+        }[scenario]
+        return create_react_agent(_FakeLLM(responses=_lg_responses(scenario)), tools)
+
+    _LG_INPUT = {"messages": [HumanMessage(content="go")]}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Measurement (same procedure as the Node side)
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-async def measure_timbal(scenario: int) -> dict:
-    agent = _make_timbal_agent(scenario)
+async def measure_python(run, scenario: int, clear=None) -> dict:
+    async def _noop():
+        pass
 
-    async def run():
-        await agent(prompt="go").collect()
+    clear = clear or (lambda: None)
 
-    # Latency
     for _ in range(N_WARMUP):
         await run()
-    _clear_traces()
+    clear()
     gc.collect()
     lat = []
     for _ in range(N_ITERS):
         t0 = time.perf_counter()
         await run()
         lat.append((time.perf_counter() - t0) * 1e6)
-    _clear_traces()
+    clear()
 
-    # Memory
     for _ in range(N_WARMUP):
         await run()
-    _clear_traces()
+    clear()
     gc.collect()
     tracemalloc.start()
     for _ in range(N_MEM):
         await run()
-        _clear_traces()
+        clear()
     _, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
 
-    # Burst
     n_burst = N_BURST[scenario]
     await asyncio.gather(*[run() for _ in range(5)])
-    _clear_traces()
+    clear()
     gc.collect()
     burst: list[float] = []
 
@@ -241,9 +320,8 @@ async def measure_timbal(scenario: int) -> dict:
         burst.append((time.perf_counter() - t0) * 1e6)
 
     await asyncio.gather(*[timed() for _ in range(n_burst)])
-    _clear_traces()
+    clear()
 
-    # Throughput
     tp = {}
     for conc in CONCURRENCY_LEVELS:
         sem = asyncio.Semaphore(conc)
@@ -256,7 +334,7 @@ async def measure_timbal(scenario: int) -> dict:
         t0 = time.perf_counter()
         await asyncio.gather(*[bounded() for _ in range(THROUGHPUT_OPS)])
         tp[str(conc)] = THROUGHPUT_OPS / (time.perf_counter() - t0)
-        _clear_traces()
+        clear()
 
     return {
         "latency_us": {
@@ -286,17 +364,17 @@ SCENARIO_NAMES = {
 COL_W = 12
 
 
-def print_scenario(key: str, timbal: dict, mastra: dict | None) -> None:
+def print_scenario(key: str, timbal: dict, lgpy: dict | None, lgjs: dict | None) -> None:
     section(f"Scenario {key}: {SCENARIO_NAMES[key]}")
 
     cols = ["Timbal"]
     frames = [timbal]
-    if mastra:
-        if "aisdk" in mastra:  # absent when replaying pre-AI-SDK JSON results
-            cols.append("AI SDK")
-            frames.append(mastra["aisdk"])
-        cols += ["Mastra", "Mastra+obs"]
-        frames += [mastra["bare"], mastra["obs"]]
+    if lgpy:
+        cols.append("LG.py")
+        frames.append(lgpy)
+    if lgjs:
+        cols.append("LG.js")
+        frames.append(lgjs)
 
     hdr = f"  {'':>{COL_W}}" + "".join(f"  {c:>{COL_W}}" for c in cols)
     sep = f"  {'─' * COL_W}" + f"  {'─' * COL_W}" * len(cols)
@@ -312,11 +390,10 @@ def print_scenario(key: str, timbal: dict, mastra: dict | None) -> None:
     print(f"  {'framework':<{COL_W + 12}}  {'per run':>14}  {'method':<24}")
     print(f"  {'─' * (COL_W + 12)}  {'─' * 14}  {'─' * 24}")
     print(f"  {'Timbal':<{COL_W + 12}}  {timbal['mem_per_run_bytes']:>12,.0f} B  {'tracemalloc peak/N':<24}")
-    if mastra:
-        node_rows = [("AI SDK", mastra["aisdk"])] if "aisdk" in mastra else []
-        node_rows += [("Mastra", mastra["bare"]), ("Mastra+obs", mastra["obs"])]
-        for name, f in node_rows:
-            print(f"  {name:<{COL_W + 12}}  {f['mem_per_run_bytes']:>12,.0f} B  {'V8 heap growth/N (≈)':<24}")
+    if lgpy:
+        print(f"  {'LG.py':<{COL_W + 12}}  {lgpy['mem_per_run_bytes']:>12,.0f} B  {'tracemalloc peak/N':<24}")
+    if lgjs:
+        print(f"  {'LG.js':<{COL_W + 12}}  {lgjs['mem_per_run_bytes']:>12,.0f} B  {'V8 heap growth/N (≈)':<24}")
 
     n_burst = N_BURST[int(key)]
     subsection(f"Burst p50/p95  ({n_burst} concurrent runs)")
@@ -333,34 +410,65 @@ def print_scenario(key: str, timbal: dict, mastra: dict | None) -> None:
         vals = [f["throughput_ops_s"][str(conc)] for f in frames]
         print(f"  {conc:>{COL_W}}" + "".join(f"  {v:>10.0f}/s" for v in vals))
 
+    if lgpy and lgjs:
+        subsection("Runtime calibration  (LG.py ÷ LG.js — same framework, so ≈ CPython/V8 factor)")
+        p50 = lgpy["latency_us"]["p50"] / lgjs["latency_us"]["p50"]
+        mean = lgpy["latency_us"]["mean"] / lgjs["latency_us"]["mean"]
+        tp10 = lgjs["throughput_ops_s"]["10"] / lgpy["throughput_ops_s"]["10"]
+        print(f"  latency p50: {p50:.2f}x  ·  latency mean: {mean:.2f}x  ·  throughput c=10: {tp10:.2f}x")
+
 
 async def main() -> None:
     print()
     print(f"{BOLD}{'═' * WIDTH}{RESET}")
-    print(f"{BOLD}  Timbal vs Mastra — agent loop benchmark (cross-language){RESET}")
+    print(f"{BOLD}  Runtime calibration — LangGraph Python vs LangGraph.js (agent loop){RESET}")
     print(f"  {N_ITERS} iters · burst {N_BURST} · {N_MEM} mem · {THROUGHPUT_OPS} throughput")
-    print(f"  {DIM}Timbal: CPython {sys.version_info.major}.{sys.version_info.minor}/asyncio, built-in tracing (always on).{RESET}")
-    print(f"  {DIM}Mastra: Node/V8 subprocess, AI SDK MockLanguageModelV4, bare + observability (export mocked).{RESET}")
-    print(f"  {DIM}Same scenarios, same fake-LLM-by-message-inspection, same procedure per side.{RESET}")
-    print(f"  {DIM}Cross-runtime comparison — see README.md for what is and isn't comparable.{RESET}")
+    print(f"  {DIM}Same framework, both runtimes: the LG.py÷LG.js ratio isolates CPython vs V8.{RESET}")
+    print(f"  {DIM}Timbal shown for reference (built-in tracing always on; LG columns are bare).{RESET}")
     print(f"{BOLD}{'═' * WIDTH}{RESET}")
     print()
 
-    mastra = run_mastra_side("bench_agent.mjs")
-    if mastra:
-        m = mastra["meta"]
-        print(f"{DIM}  Mastra side: node {m['node']} · @mastra/core {m['mastra_core']} · @mastra/observability {m['mastra_observability']} · ai {m['ai_sdk']}{RESET}")
+    if not HAS_LANGGRAPH_PY and not _args.timbal_only:
+        print(f"{DIM}  langgraph (Python) not importable — run via:{RESET}")
+        print(f"{DIM}  uv run --no-sync --with langgraph --with langchain-core python {Path(__file__).relative_to(Path.cwd())}{RESET}")
 
+    lgjs = run_lgjs_side("bench_agent.mjs")
+    if lgjs:
+        m = lgjs["meta"]
+        print(f"{DIM}  LG.js side: node {m['node']} · @langchain/langgraph {m['langgraph']} · @langchain/core {m['langchain_core']}{RESET}")
+
+    ratios = []
     for key in ["1", "2", "3"]:
-        timbal = await measure_timbal(int(key))
-        print_scenario(key, timbal, mastra["scenarios"][key] if mastra else None)
+        scenario = int(key)
+        t_agent = _make_timbal_agent(scenario)
+
+        async def t_run(agent=t_agent):
+            await agent(prompt="go").collect()
+
+        timbal = await measure_python(t_run, scenario, clear=_clear_traces)
+
+        lgpy = None
+        if HAS_LANGGRAPH_PY and not _args.timbal_only:
+            graph = _make_lg_graph(scenario)
+
+            async def lg_run(g=graph):
+                await g.ainvoke(_LG_INPUT)
+
+            lgpy = await measure_python(lg_run, scenario)
+
+        lgjs_s = lgjs["scenarios"][key]["bare"] if lgjs else None
+        print_scenario(key, timbal, lgpy, lgjs_s)
+        if lgpy and lgjs_s:
+            ratios.append(lgpy["latency_us"]["p50"] / lgjs_s["latency_us"]["p50"])
 
     print()
     print(f"{DIM}{'─' * WIDTH}")
-    print("  All measurements reuse 1 pre-built agent (creation excluded).")
-    print("  LLMs faked via message inspection on both sides — no network, no API keys.")
-    print("  Each framework runs in its native runtime; numbers include runtime differences.")
-    print("  Memory uses per-runtime instruments (tracemalloc vs V8 heap) — not cross-comparable.")
+    if ratios:
+        print(f"  Calibration summary: LG.py ÷ LG.js latency p50 spans {min(ratios):.2f}-{max(ratios):.2f}x across")
+        print("  identical agent loops (>1 = V8 faster). Apply that factor when reading any")
+        print("  Timbal (Python) vs TypeScript-framework table in benchmarks/.")
+    print("  All measurements reuse pre-built agents/graphs (creation excluded).")
+    print("  LLMs faked via message inspection on all sides — no network, no API keys.")
     print(f"{'─' * WIDTH}{RESET}")
     print()
 

--- a/benchmarks/langgraph_js/bench_lib.mjs
+++ b/benchmarks/langgraph_js/bench_lib.mjs
@@ -1,0 +1,165 @@
+/**
+ * Shared measurement harness for the LangGraph.js side of the runtime
+ * calibration benchmarks (copied from benchmarks/mastra/bench_lib.mjs — each
+ * benchmark directory is self-contained). Mirrors the Python-side methodology:
+ *
+ *   - monotonic ns timer (process.hrtime.bigint ~ time.perf_counter)
+ *   - warmup runs before every measured batch
+ *   - forced GC between batches (requires --expose-gc)
+ *   - latency: sequential runs, percentiles over per-run wall time
+ *   - burst: N concurrent runs, per-run wall time percentiles
+ *   - throughput: worker-pool bounded concurrency, ops/s
+ *   - memory: peak V8 heapUsed growth over a batch / N runs
+ *     (approximate — see NOTES.md; NOT comparable with Python tracemalloc)
+ *
+ * All progress goes to stderr; the caller prints JSON results to stdout.
+ */
+
+if (typeof globalThis.gc !== 'function') {
+  console.error('error: run with node --expose-gc');
+  process.exit(1);
+}
+
+const nowUs = () => process.hrtime.bigint();
+const elapsedUs = (t0) => Number(process.hrtime.bigint() - t0) / 1e3;
+
+export function pct(samples, p) {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const idx = Math.min(Math.floor((sorted.length * p) / 100), sorted.length - 1);
+  return sorted[idx];
+}
+
+export function summarize(samples) {
+  const mean = samples.reduce((a, b) => a + b, 0) / samples.length;
+  return {
+    mean,
+    p50: pct(samples, 50),
+    p75: pct(samples, 75),
+    p95: pct(samples, 95),
+    p99: pct(samples, 99),
+    max: Math.max(...samples),
+  };
+}
+
+/**
+ * `drain` is the Node analogue of the Python side's `_clear_traces()`: it is
+ * awaited wherever the Timbal harness resets its in-memory tracing storage
+ * (after warmup and between measured batches), so pending async observability
+ * work (span export through the event bus) never bleeds into a timed phase.
+ * Runners without observability pass no drain.
+ */
+const drainAndGc = async (drain) => {
+  if (drain) await drain();
+  globalThis.gc();
+};
+
+export async function latency(fn, iters, warmup, drain) {
+  for (let i = 0; i < warmup; i++) await fn();
+  await drainAndGc(drain);
+  const samples = [];
+  for (let i = 0; i < iters; i++) {
+    const t0 = nowUs();
+    await fn();
+    samples.push(elapsedUs(t0));
+  }
+  await drainAndGc(drain);
+  return samples;
+}
+
+export async function memory(fn, iters, warmup, drain) {
+  for (let i = 0; i < warmup; i++) await fn();
+  await drainAndGc(drain);
+  const baseline = process.memoryUsage().heapUsed;
+  let peak = baseline;
+  for (let i = 0; i < iters; i++) {
+    await fn();
+    // Sample BEFORE draining: tracemalloc's peak is a continuous high-water
+    // mark that includes this run's allocations up to the moment Timbal calls
+    // _clear_traces(), so the heap must be read while buffered observability
+    // work is still resident.
+    const cur = process.memoryUsage().heapUsed;
+    if (cur > peak) peak = cur;
+    // Then drain, mirroring the per-run _clear_traces() on the Python side
+    // (no GC — the Python side doesn't collect per run either).
+    if (drain) await drain();
+  }
+  return { peak_growth_bytes: peak - baseline, per_run_bytes: (peak - baseline) / iters };
+}
+
+export async function burst(fn, n, warmup, drain) {
+  await Promise.all(Array.from({ length: Math.min(warmup, n) }, () => fn()));
+  await drainAndGc(drain);
+  const samples = [];
+  const t0 = nowUs();
+  await Promise.all(
+    Array.from({ length: n }, async () => {
+      const s = nowUs();
+      await fn();
+      samples.push(elapsedUs(s));
+    }),
+  );
+  const wallMs = elapsedUs(t0) / 1e3;
+  await drainAndGc(drain);
+  return { samples, wallMs };
+}
+
+export async function throughput(fn, ops, concurrency, drain) {
+  await drainAndGc(drain);
+  let next = 0;
+  const t0 = nowUs();
+  const workers = Array.from({ length: Math.min(concurrency, ops) }, async () => {
+    while (next < ops) {
+      next++;
+      await fn();
+    }
+  });
+  await Promise.all(workers);
+  const elapsed = elapsedUs(t0);
+  if (drain) await drain();
+  return ops / (elapsed / 1e6);
+}
+
+/** Full measurement suite for one runner. Returns a JSON-friendly record. */
+export async function measure(
+  fn,
+  { iters, warmup, memIters, burstN, burstWarmup = 5, throughputOps, concurrencyLevels, label, drain },
+) {
+  console.error(`    [${label}] latency ×${iters}…`);
+  const lat = summarize(await latency(fn, iters, warmup, drain));
+
+  console.error(`    [${label}] memory ×${memIters}…`);
+  const mem = await memory(fn, memIters, warmup, drain);
+
+  console.error(`    [${label}] burst ×${burstN}…`);
+  const b = await burst(fn, burstN, burstWarmup, drain);
+
+  const tp = {};
+  for (const c of concurrencyLevels) {
+    console.error(`    [${label}] throughput c=${c}…`);
+    tp[c] = await throughput(fn, throughputOps, c, drain);
+  }
+
+  return {
+    latency_us: lat,
+    mem_per_run_bytes: mem.per_run_bytes,
+    mem_peak_growth_bytes: mem.peak_growth_bytes,
+    burst_us: summarize(b.samples),
+    burst_wall_ms: b.wallMs,
+    throughput_ops_s: tp,
+  };
+}
+
+export function readParams() {
+  const quick = process.argv.includes('--quick');
+  return { quick };
+}
+
+export async function meta() {
+  const { readFileSync } = await import('node:fs');
+  const read = (p) => JSON.parse(readFileSync(new URL(p, import.meta.url), 'utf8')).version;
+  return {
+    node: process.version,
+    langgraph: read('./node_modules/@langchain/langgraph/package.json'),
+    langchain_core: read('./node_modules/@langchain/core/package.json'),
+  };
+}

--- a/benchmarks/langgraph_js/bench_workflow.mjs
+++ b/benchmarks/langgraph_js/bench_workflow.mjs
@@ -1,0 +1,123 @@
+/**
+ * LangGraph.js side of the runtime-calibration DAG benchmark. Run by
+ * bench_workflow.py — do not run directly unless debugging.
+ *
+ * StateGraph shapes identical to benchmarks/langchain/bench_workflow.py:
+ *   1. Sequential:  A → B → C → D
+ *   2. Fan-out/in:  A → [B, C, D] → E
+ *   3. Diamond:     A → [B, C] → D
+ *
+ * Trivial handlers, no LLM — pure Pregel scheduling overhead on V8.
+ *
+ * Usage: node --expose-gc bench_workflow.mjs [--quick]
+ */
+
+import { Annotation, StateGraph, START, END } from '@langchain/langgraph';
+
+import { measure, meta, readParams } from './bench_lib.mjs';
+
+const { quick } = readParams();
+
+const N_ITERS = quick ? 50 : 200;
+const N_WARMUP = quick ? 5 : 20;
+const N_MEM = quick ? 50 : 200;
+const N_BURST = quick ? 100 : 500;
+const THROUGHPUT_OPS = quick ? 200 : 1000;
+const CONCURRENCY_LEVELS = [1, 10, 50, 200];
+
+// ── Graph factories (identical shapes to benchmarks/langchain) ───────────────
+
+function sequential() {
+  const S = Annotation.Root({ x: Annotation(), a: Annotation(), b: Annotation(), c: Annotation(), d: Annotation() });
+  return new StateGraph(S)
+    .addNode('A', (s) => ({ a: s.x + 1 }))
+    .addNode('B', (s) => ({ b: s.a * 2 }))
+    .addNode('C', (s) => ({ c: s.b + 10 }))
+    .addNode('D', (s) => ({ d: s.c - 3 }))
+    .addEdge(START, 'A')
+    .addEdge('A', 'B')
+    .addEdge('B', 'C')
+    .addEdge('C', 'D')
+    .addEdge('D', END)
+    .compile();
+}
+
+function fanout() {
+  const S = Annotation.Root({
+    x: Annotation(),
+    a: Annotation(),
+    bb: Annotation(),
+    cc: Annotation(),
+    dd: Annotation(),
+    e: Annotation(),
+  });
+  return new StateGraph(S)
+    .addNode('A', (s) => ({ a: s.x + 1 }))
+    .addNode('B', (s) => ({ bb: s.a * 2 }))
+    .addNode('C', (s) => ({ cc: s.a * 3 }))
+    .addNode('D', (s) => ({ dd: s.a * 4 }))
+    .addNode('E', (s) => ({ e: s.bb + s.cc + s.dd }))
+    .addEdge(START, 'A')
+    .addEdge('A', 'B')
+    .addEdge('A', 'C')
+    .addEdge('A', 'D')
+    .addEdge('B', 'E')
+    .addEdge('C', 'E')
+    .addEdge('D', 'E')
+    .addEdge('E', END)
+    .compile();
+}
+
+function diamond() {
+  const S = Annotation.Root({
+    x: Annotation(),
+    a: Annotation(),
+    b: Annotation(),
+    c: Annotation(),
+    combined: Annotation(),
+  });
+  return new StateGraph(S)
+    .addNode('A', (s) => ({ a: s.x + 1 }))
+    .addNode('B', (s) => ({ b: s.a + 10 }))
+    .addNode('C', (s) => ({ c: s.a * 5 }))
+    .addNode('D', (s) => ({ combined: s.b + s.c }))
+    .addEdge(START, 'A')
+    .addEdge('A', 'B')
+    .addEdge('A', 'C')
+    .addEdge('B', 'D')
+    .addEdge('C', 'D')
+    .addEdge('D', END)
+    .compile();
+}
+
+const FACTORIES = { sequential, fanout, diamond };
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+const results = {
+  meta: await meta(),
+  params: { quick, N_ITERS, N_WARMUP, N_MEM, N_BURST, THROUGHPUT_OPS, CONCURRENCY_LEVELS },
+  scenarios: {},
+};
+
+const common = {
+  iters: N_ITERS,
+  warmup: N_WARMUP,
+  memIters: N_MEM,
+  burstN: N_BURST,
+  // Matches the 10 concurrent pre-runs on the Python side before burst timing.
+  burstWarmup: 10,
+  throughputOps: THROUGHPUT_OPS,
+  concurrencyLevels: CONCURRENCY_LEVELS,
+};
+
+for (const [name, factory] of Object.entries(FACTORIES)) {
+  console.error(`  scenario ${name}`);
+  const graph = factory();
+  results.scenarios[name] = {
+    bare: await measure(() => graph.invoke({ x: 3 }), { ...common, label: 'lg.js' }),
+  };
+}
+
+console.log(JSON.stringify(results));
+process.exit(0);

--- a/benchmarks/langgraph_js/bench_workflow.py
+++ b/benchmarks/langgraph_js/bench_workflow.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+"""
+Runtime calibration — LangGraph Python vs LangGraph.js (vs Timbal) DAG workflows.
+
+Same StateGraph shapes on both LangGraph runtimes, plus Timbal Workflow for
+reference. The LG.py÷LG.js ratio isolates CPython-vs-V8 for identical Pregel
+scheduling — the calibration factor for reading cross-language DAG benchmarks
+like benchmarks/mastra/bench_workflow.py.
+
+Scenarios: sequential (A→B→C→D), fan-out/in (A→[B,C,D]→E), diamond (A→[B,C]→D).
+Trivial handlers, no LLM.
+
+Run:
+    uv run --no-sync --with langgraph --with langchain-core python benchmarks/langgraph_js/bench_workflow.py
+    uv run --no-sync --with langgraph --with langchain-core python benchmarks/langgraph_js/bench_workflow.py --quick
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import warnings
+
+logging.disable(logging.WARNING)
+os.environ.setdefault("TIMBAL_LOG_LEVEL", "CRITICAL")
+warnings.filterwarnings("ignore")
+
+import structlog  # noqa: E402
+
+structlog.configure(wrapper_class=structlog.make_filtering_bound_logger(logging.CRITICAL))
+
+import asyncio  # noqa: E402
+import gc  # noqa: E402
+import json  # noqa: E402
+import shutil  # noqa: E402
+import statistics  # noqa: E402
+import subprocess  # noqa: E402
+import sys  # noqa: E402
+import time  # noqa: E402
+import tracemalloc  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+parser = argparse.ArgumentParser(add_help=False)
+parser.add_argument("--quick", action="store_true")
+parser.add_argument("--timbal-only", action="store_true", help="Skip LangGraph on both runtimes")
+parser.add_argument("--lgjs-json", type=Path, default=None, help="Reuse a previous LG.js JSON result instead of running Node")
+_args, _ = parser.parse_known_args()
+
+N_ITERS = 50 if _args.quick else 200
+N_WARMUP = 5 if _args.quick else 20
+N_BURST = 100 if _args.quick else 500
+N_MEM = 50 if _args.quick else 200
+THROUGHPUT_OPS = 200 if _args.quick else 1000
+CONCURRENCY_LEVELS = [1, 10, 50, 200]
+WIDTH = 76
+
+BENCH_DIR = Path(__file__).parent
+
+# ── Display helpers ──────────────────────────────────────────────────────────
+
+RESET = "\033[0m"
+BOLD = "\033[1m"
+CYAN = "\033[36m"
+DIM = "\033[2m"
+
+
+def section(title: str) -> None:
+    print()
+    print(f"{BOLD}{CYAN}{'─' * WIDTH}{RESET}")
+    print(f"{BOLD}{CYAN}  {title}{RESET}")
+    print(f"{BOLD}{CYAN}{'─' * WIDTH}{RESET}")
+
+
+def subsection(title: str) -> None:
+    print(f"\n  {BOLD}{title}{RESET}")
+
+
+def fmt_us(us: float) -> str:
+    if us >= 1_000:
+        return f"{us / 1_000:>8.2f} ms"
+    return f"{us:>8.1f} µs"
+
+
+def pct(samples: list[float], p: float) -> float:
+    idx = min(int(len(samples) * p / 100), len(samples) - 1)
+    return sorted(samples)[idx]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# LANGGRAPH.JS — spawn the Node-side benchmark
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def run_lgjs_side(script: str) -> dict | None:
+    if _args.timbal_only:
+        return None
+    if _args.lgjs_json:
+        return json.loads(_args.lgjs_json.read_text())
+    node = shutil.which("node")
+    if node is None:
+        print(f"{DIM}  node not found on PATH — skipping LangGraph.js.{RESET}")
+        return None
+    if not (BENCH_DIR / "node_modules").exists():
+        print(f"{DIM}  benchmarks/langgraph_js/node_modules missing — run `npm install` there first.{RESET}")
+        return None
+    cmd = [node, "--expose-gc", script] + (["--quick"] if _args.quick else [])
+    print(f"{DIM}  running LangGraph.js side: {' '.join(cmd[1:])}…{RESET}")
+    sys.stdout.flush()
+    proc = subprocess.run(cmd, cwd=BENCH_DIR, stdout=subprocess.PIPE, stderr=sys.stderr, text=True, timeout=3600)
+    if proc.returncode != 0:
+        print(f"{DIM}  LangGraph.js side failed (exit {proc.returncode}).{RESET}")
+        return None
+    return json.loads(proc.stdout)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TIMBAL — Workflow factories (identical shapes)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+from timbal import Workflow  # noqa: E402
+from timbal.state import get_run_context  # noqa: E402
+from timbal.state.tracing.providers.in_memory import InMemoryTracingProvider  # noqa: E402
+
+
+def _clear_traces():
+    InMemoryTracingProvider._storage.clear()
+
+
+def _timbal_sequential() -> Workflow:
+    def step_a(x: int) -> int:
+        return x + 1
+
+    def step_b(x: int) -> int:
+        return x * 2
+
+    def step_c(x: int) -> int:
+        return x + 10
+
+    def step_d(x: int) -> int:
+        return x - 3
+
+    wf = Workflow(name="sequential")
+    wf.step(step_a)
+    wf.step(step_b, x=lambda: get_run_context().step_span("step_a").output)
+    wf.step(step_c, x=lambda: get_run_context().step_span("step_b").output)
+    wf.step(step_d, x=lambda: get_run_context().step_span("step_c").output)
+    return wf
+
+
+def _timbal_fanout() -> Workflow:
+    def step_a(x: int) -> int:
+        return x + 1
+
+    def branch_b(x: int) -> int:
+        return x * 2
+
+    def branch_c(x: int) -> int:
+        return x * 3
+
+    def branch_d(x: int) -> int:
+        return x * 4
+
+    def step_e(b: int, c: int, d: int) -> int:
+        return b + c + d
+
+    wf = Workflow(name="fanout")
+    wf.step(step_a)
+    wf.step(branch_b, x=lambda: get_run_context().step_span("step_a").output)
+    wf.step(branch_c, x=lambda: get_run_context().step_span("step_a").output)
+    wf.step(branch_d, x=lambda: get_run_context().step_span("step_a").output)
+    wf.step(
+        step_e,
+        b=lambda: get_run_context().step_span("branch_b").output,
+        c=lambda: get_run_context().step_span("branch_c").output,
+        d=lambda: get_run_context().step_span("branch_d").output,
+    )
+    return wf
+
+
+def _timbal_diamond() -> Workflow:
+    def step_a(x: int) -> int:
+        return x + 1
+
+    def path_b(x: int) -> int:
+        return x + 10
+
+    def path_c(x: int) -> int:
+        return x * 5
+
+    def combine(b: int, c: int) -> int:
+        return b + c
+
+    wf = Workflow(name="diamond")
+    wf.step(step_a)
+    wf.step(path_b, x=lambda: get_run_context().step_span("step_a").output)
+    wf.step(path_c, x=lambda: get_run_context().step_span("step_a").output)
+    wf.step(
+        combine,
+        b=lambda: get_run_context().step_span("path_b").output,
+        c=lambda: get_run_context().step_span("path_c").output,
+    )
+    return wf
+
+
+TIMBAL_FACTORIES = {
+    "sequential": _timbal_sequential,
+    "fanout": _timbal_fanout,
+    "diamond": _timbal_diamond,
+}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# LANGGRAPH PYTHON — StateGraph factories (identical to benchmarks/langchain)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+try:
+    from langgraph.graph import END, START, StateGraph
+    from typing_extensions import TypedDict
+
+    HAS_LANGGRAPH_PY = True
+except ImportError:
+    HAS_LANGGRAPH_PY = False
+
+if HAS_LANGGRAPH_PY:
+    class SeqState(TypedDict):
+        x: int
+        a: int
+        b: int
+        c: int
+        d: int
+
+    def _lg_sequential():
+        g = StateGraph(SeqState)
+        g.add_node("A", lambda s: {"a": s["x"] + 1})
+        g.add_node("B", lambda s: {"b": s["a"] * 2})
+        g.add_node("C", lambda s: {"c": s["b"] + 10})
+        g.add_node("D", lambda s: {"d": s["c"] - 3})
+        g.add_edge(START, "A")
+        g.add_edge("A", "B")
+        g.add_edge("B", "C")
+        g.add_edge("C", "D")
+        g.add_edge("D", END)
+        return g.compile()
+
+    class FanState(TypedDict):
+        x: int
+        a: int
+        bb: int
+        cc: int
+        dd: int
+        e: int
+
+    def _lg_fanout():
+        g = StateGraph(FanState)
+        g.add_node("A", lambda s: {"a": s["x"] + 1})
+        g.add_node("B", lambda s: {"bb": s["a"] * 2})
+        g.add_node("C", lambda s: {"cc": s["a"] * 3})
+        g.add_node("D", lambda s: {"dd": s["a"] * 4})
+        g.add_node("E", lambda s: {"e": s["bb"] + s["cc"] + s["dd"]})
+        g.add_edge(START, "A")
+        g.add_edge("A", "B")
+        g.add_edge("A", "C")
+        g.add_edge("A", "D")
+        g.add_edge("B", "E")
+        g.add_edge("C", "E")
+        g.add_edge("D", "E")
+        g.add_edge("E", END)
+        return g.compile()
+
+    class DiamondState(TypedDict):
+        x: int
+        a: int
+        b: int
+        c: int
+        combined: int
+
+    def _lg_diamond():
+        g = StateGraph(DiamondState)
+        g.add_node("A", lambda s: {"a": s["x"] + 1})
+        g.add_node("B", lambda s: {"b": s["a"] + 10})
+        g.add_node("C", lambda s: {"c": s["a"] * 5})
+        g.add_node("D", lambda s: {"combined": s["b"] + s["c"]})
+        g.add_edge(START, "A")
+        g.add_edge("A", "B")
+        g.add_edge("A", "C")
+        g.add_edge("B", "D")
+        g.add_edge("C", "D")
+        g.add_edge("D", END)
+        return g.compile()
+
+    LG_FACTORIES = {"sequential": _lg_sequential, "fanout": _lg_fanout, "diamond": _lg_diamond}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Measurement (same procedure as the Node side)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+async def measure_python(run, clear=None) -> dict:
+    clear = clear or (lambda: None)
+
+    for _ in range(N_WARMUP):
+        await run()
+    clear()
+    gc.collect()
+    lat = []
+    for _ in range(N_ITERS):
+        t0 = time.perf_counter()
+        await run()
+        lat.append((time.perf_counter() - t0) * 1e6)
+    clear()
+
+    for _ in range(N_WARMUP):
+        await run()
+    clear()
+    gc.collect()
+    tracemalloc.start()
+    for _ in range(N_MEM):
+        await run()
+        clear()
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    await asyncio.gather(*[run() for _ in range(10)])
+    clear()
+    gc.collect()
+    burst: list[float] = []
+
+    async def timed():
+        t0 = time.perf_counter()
+        await run()
+        burst.append((time.perf_counter() - t0) * 1e6)
+
+    await asyncio.gather(*[timed() for _ in range(N_BURST)])
+    clear()
+
+    tp = {}
+    for conc in CONCURRENCY_LEVELS:
+        sem = asyncio.Semaphore(conc)
+
+        async def bounded():
+            async with sem:
+                await run()
+
+        gc.collect()
+        t0 = time.perf_counter()
+        await asyncio.gather(*[bounded() for _ in range(THROUGHPUT_OPS)])
+        tp[str(conc)] = THROUGHPUT_OPS / (time.perf_counter() - t0)
+        clear()
+
+    return {
+        "latency_us": {
+            "mean": statistics.mean(lat),
+            "p50": pct(lat, 50), "p75": pct(lat, 75), "p95": pct(lat, 95), "p99": pct(lat, 99),
+            "max": max(lat),
+        },
+        "mem_per_run_bytes": peak / N_MEM,
+        "burst_us": {
+            "p50": pct(burst, 50), "p75": pct(burst, 75), "p95": pct(burst, 95), "p99": pct(burst, 99),
+            "max": max(burst),
+        },
+        "throughput_ops_s": tp,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Combined output
+# ═══════════════════════════════════════════════════════════════════════════════
+
+SCENARIO_NAMES = {
+    "sequential": "Sequential  (A → B → C → D)",
+    "fanout": "Fan-out/in  (A → [B, C, D] → E)",
+    "diamond": "Diamond  (A → [B, C] → D)",
+}
+
+COL_W = 12
+
+
+def print_scenario(key: str, timbal: dict, lgpy: dict | None, lgjs: dict | None) -> None:
+    section(f"Scenario: {SCENARIO_NAMES[key]}")
+
+    cols = ["Timbal"]
+    frames = [timbal]
+    if lgpy:
+        cols.append("LG.py")
+        frames.append(lgpy)
+    if lgjs:
+        cols.append("LG.js")
+        frames.append(lgjs)
+
+    hdr = f"  {'':>{COL_W}}" + "".join(f"  {c:>{COL_W}}" for c in cols)
+    sep = f"  {'─' * COL_W}" + f"  {'─' * COL_W}" * len(cols)
+
+    subsection(f"Latency  (×{N_ITERS} sequential runs)")
+    print(hdr)
+    print(sep)
+    for label in ["mean", "p50", "p95", "p99"]:
+        vals = [f["latency_us"][label] for f in frames]
+        print(f"  {label:>{COL_W}}" + "".join(f"  {fmt_us(v):>{COL_W}}" for v in vals))
+
+    subsection(f"Memory per run  (×{N_MEM} runs) — different instruments, do not ratio across runtimes")
+    print(f"  {'framework':<{COL_W + 12}}  {'per run':>14}  {'method':<24}")
+    print(f"  {'─' * (COL_W + 12)}  {'─' * 14}  {'─' * 24}")
+    print(f"  {'Timbal':<{COL_W + 12}}  {timbal['mem_per_run_bytes']:>12,.0f} B  {'tracemalloc peak/N':<24}")
+    if lgpy:
+        print(f"  {'LG.py':<{COL_W + 12}}  {lgpy['mem_per_run_bytes']:>12,.0f} B  {'tracemalloc peak/N':<24}")
+    if lgjs:
+        print(f"  {'LG.js':<{COL_W + 12}}  {lgjs['mem_per_run_bytes']:>12,.0f} B  {'V8 heap growth/N (≈)':<24}")
+
+    subsection(f"Burst  ({N_BURST} concurrent runs)")
+    print(hdr)
+    print(sep)
+    for label in ["p50", "p75", "p95", "p99", "max"]:
+        vals = [f["burst_us"][label] for f in frames]
+        print(f"  {label:>{COL_W}}" + "".join(f"  {fmt_us(v):>{COL_W}}" for v in vals))
+
+    subsection(f"Throughput  ({THROUGHPUT_OPS} runs)")
+    print(hdr)
+    print(sep)
+    for conc in CONCURRENCY_LEVELS:
+        vals = [f["throughput_ops_s"][str(conc)] for f in frames]
+        print(f"  {conc:>{COL_W}}" + "".join(f"  {v:>10.0f}/s" for v in vals))
+
+    if lgpy and lgjs:
+        subsection("Runtime calibration  (LG.py ÷ LG.js — same framework, so ≈ CPython/V8 factor)")
+        p50 = lgpy["latency_us"]["p50"] / lgjs["latency_us"]["p50"]
+        mean = lgpy["latency_us"]["mean"] / lgjs["latency_us"]["mean"]
+        tp10 = lgjs["throughput_ops_s"]["10"] / lgpy["throughput_ops_s"]["10"]
+        tp200 = lgjs["throughput_ops_s"]["200"] / lgpy["throughput_ops_s"]["200"]
+        print(f"  latency p50: {p50:.2f}x  ·  mean: {mean:.2f}x  ·  throughput c=10: {tp10:.2f}x  ·  c=200: {tp200:.2f}x")
+
+
+async def main() -> None:
+    print()
+    print(f"{BOLD}{'═' * WIDTH}{RESET}")
+    print(f"{BOLD}  Runtime calibration — LangGraph Python vs LangGraph.js (DAG workflows){RESET}")
+    print(f"  {N_ITERS} iters · {N_BURST} burst · {N_MEM} mem runs · {THROUGHPUT_OPS} throughput ops")
+    print(f"  {DIM}Same framework, both runtimes: the LG.py÷LG.js ratio isolates CPython vs V8.{RESET}")
+    print(f"  {DIM}Timbal shown for reference (built-in tracing always on; LG columns are bare).{RESET}")
+    print(f"{BOLD}{'═' * WIDTH}{RESET}")
+    print()
+
+    if not HAS_LANGGRAPH_PY and not _args.timbal_only:
+        print(f"{DIM}  langgraph (Python) not importable — run via:{RESET}")
+        print(f"{DIM}  uv run --no-sync --with langgraph --with langchain-core python {Path(__file__).relative_to(Path.cwd())}{RESET}")
+
+    lgjs = run_lgjs_side("bench_workflow.mjs")
+    if lgjs:
+        m = lgjs["meta"]
+        print(f"{DIM}  LG.js side: node {m['node']} · @langchain/langgraph {m['langgraph']} · @langchain/core {m['langchain_core']}{RESET}")
+
+    ratios = []
+    for key in ["sequential", "fanout", "diamond"]:
+        wf = TIMBAL_FACTORIES[key]()
+
+        async def t_run(w=wf):
+            await w(x=3).collect()
+
+        timbal = await measure_python(t_run, clear=_clear_traces)
+
+        lgpy = None
+        if HAS_LANGGRAPH_PY and not _args.timbal_only:
+            graph = LG_FACTORIES[key]()
+
+            async def lg_run(g=graph):
+                await g.ainvoke({"x": 3})
+
+            lgpy = await measure_python(lg_run)
+
+        lgjs_s = lgjs["scenarios"][key]["bare"] if lgjs else None
+        print_scenario(key, timbal, lgpy, lgjs_s)
+        if lgpy and lgjs_s:
+            ratios.append(lgpy["latency_us"]["p50"] / lgjs_s["latency_us"]["p50"])
+
+    print()
+    print(f"{DIM}{'─' * WIDTH}")
+    if ratios:
+        print(f"  Calibration summary: LG.py ÷ LG.js latency p50 spans {min(ratios):.2f}-{max(ratios):.2f}x across")
+        print("  identical DAGs (>1 = V8 faster). Apply that factor when reading any Timbal")
+        print("  (Python) vs TypeScript-framework workflow table in benchmarks/.")
+    print("  Graph compilation and Workflow construction excluded from timing.")
+    print(f"{'─' * WIDTH}{RESET}")
+    print()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/benchmarks/langgraph_js/package-lock.json
+++ b/benchmarks/langgraph_js/package-lock.json
@@ -1,0 +1,308 @@
+{
+  "name": "langgraph_js",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "langgraph_js",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@langchain/core": "^1.2.5",
+        "@langchain/langgraph": "^1.4.9",
+        "zod": "^4.4.3"
+      }
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "license": "MIT"
+    },
+    "node_modules/@langchain/core": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.5.tgz",
+      "integrity": "sha512-4lXj3fTPQYGdEtOG9gWDnvmp6wpXNMo9MmWzfZxxPUxMcjulZJa93pYAZ90luFLg2YVdVuUl2tuwdD7tY5K9MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": ">=0.5.0 <1.0.0",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@langchain/langgraph": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.9.tgz",
+      "integrity": "sha512-EvD9rS66Cya09y6rbMgD3Ir8miAkJQFo7FyJOPRPO736Kz3y5TeyeBDOS8ctff/jRc788bPijHx2NVFM79Qqig==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/langgraph-checkpoint": "^1.1.3",
+        "@langchain/langgraph-sdk": "~1.9.28",
+        "@langchain/protocol": "^0.0.18",
+        "@standard-schema/spec": "1.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.48",
+        "zod": "^3.25.32 || ^4.2.0"
+      }
+    },
+    "node_modules/@langchain/langgraph-checkpoint": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.3.tgz",
+      "integrity": "sha512-wgzdQNeEsdw1e+4lvlj0tdq/RYR/k1vPin10g0ymGoehZDDgd9nvIllGXSXN4TFgF9sf5qQP/KTkOcLfeseIhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.48"
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk": {
+      "version": "1.9.28",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.28.tgz",
+      "integrity": "sha512-4j3XuM0PvtmAbL8mPfBS99ez3+ytRfgbOpAR/nOeaejTRF3Q9dNw2QnaGLGng8wLPtGLoSj+SYgUOVxy9Bv9vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/protocol": "^0.0.18",
+        "@types/json-schema": "^7.0.15",
+        "p-queue": "^9.0.1",
+        "p-retry": "^7.1.1"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.48",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19",
+        "svelte": "^4.0.0 || ^5.0.0",
+        "vue": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.3.tgz",
+      "integrity": "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/protocol": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.18.tgz",
+      "integrity": "sha512-XW1egQtPfsGI41w2AMZNFZrUIwFSQHTjVMZs0OaTpCAvht/QLoaPN8FQcsysMVypOhupG28J29yOorrc70otBQ==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/is-network-error": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+      "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
+    "node_modules/langsmith": {
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.8.9.tgz",
+      "integrity": "sha512-6ikTB5SO+3SlBQ/+oH8K/JzhglxB8AM4RAe5bHzgWSEIHTgTe+b71bSjf1fDvlYuEXoiPn6uP10BbczrbznUnA==",
+      "license": "MIT",
+      "dependencies": {
+        "p-queue": "6.6.2"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*",
+        "ws": ">=7"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/benchmarks/langgraph_js/package.json
+++ b/benchmarks/langgraph_js/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "timbal-bench-langgraph-js",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "LangGraph.js side of the runtime-calibration benchmarks (same framework, CPython vs V8)",
+  "scripts": {
+    "bench:agent": "node --expose-gc bench_agent.mjs",
+    "bench:workflow": "node --expose-gc bench_workflow.mjs"
+  },
+  "dependencies": {
+    "@langchain/core": "^1.2.5",
+    "@langchain/langgraph": "^1.4.9",
+    "zod": "^4.4.3"
+  }
+}

--- a/benchmarks/langgraph_js/results/bench_agent.txt
+++ b/benchmarks/langgraph_js/results/bench_agent.txt
@@ -1,0 +1,133 @@
+
+════════════════════════════════════════════════════════════════════════════
+  Runtime calibration — LangGraph Python vs LangGraph.js (agent loop)
+  100 iters · burst {1: 20, 2: 10, 3: 15} · 100 mem · 200 throughput
+  Same framework, both runtimes: the LG.py÷LG.js ratio isolates CPython vs V8.
+  Timbal shown for reference (built-in tracing always on; LG columns are bare).
+════════════════════════════════════════════════════════════════════════════
+
+  running LangGraph.js side: --expose-gc bench_agent.mjs…
+  LG.js side: node v22.18.0 · @langchain/langgraph 1.4.9 · @langchain/core 1.2.5
+
+────────────────────────────────────────────────────────────────────────────
+  Scenario 1: Single tool call  (LLM → add → LLM → answer)
+────────────────────────────────────────────────────────────────────────────
+
+  Latency  (×100 sequential runs)
+                      Timbal         LG.py         LG.js
+  ────────────  ────────────  ────────────  ────────────
+          mean      271.2 µs       2.92 ms       1.44 ms
+           p50      280.4 µs       2.84 ms       1.38 ms
+           p95      414.2 µs       3.65 ms       2.05 ms
+           p99      482.3 µs       3.90 ms       2.70 ms
+
+  Memory per run  (×100 runs) — different instruments, do not ratio across runtimes
+  framework                        per run  method                  
+  ────────────────────────  ──────────────  ────────────────────────
+  Timbal                             492 B  tracemalloc peak/N      
+  LG.py                            1,092 B  tracemalloc peak/N      
+  LG.js                          182,473 B  V8 heap growth/N (≈)    
+
+  Burst p50/p95  (20 concurrent runs)
+                      Timbal         LG.py         LG.js
+  ────────────  ────────────  ────────────  ────────────
+           p50      243.0 µs      25.15 ms      19.65 ms
+           p75      261.3 µs      26.47 ms      19.67 ms
+           p95      461.1 µs      27.88 ms      19.77 ms
+           p99      461.1 µs      27.88 ms      19.77 ms
+           max      461.1 µs      27.88 ms      19.77 ms
+
+  Throughput  (200 runs)
+                      Timbal         LG.py         LG.js
+  ────────────  ────────────  ────────────  ────────────
+             1        3986/s         348/s         917/s
+            10        3926/s         539/s        1151/s
+            50        3892/s         670/s        1165/s
+
+  Runtime calibration  (LG.py ÷ LG.js — same framework, so ≈ CPython/V8 factor)
+  latency p50: 2.06x  ·  latency mean: 2.02x  ·  throughput c=10: 2.13x
+
+────────────────────────────────────────────────────────────────────────────
+  Scenario 2: Multi-step  (LLM → add → LLM → mul → LLM → sub → LLM → answer)
+────────────────────────────────────────────────────────────────────────────
+
+  Latency  (×100 sequential runs)
+                      Timbal         LG.py         LG.js
+  ────────────  ────────────  ────────────  ────────────
+          mean      293.9 µs       6.34 ms       1.95 ms
+           p50      289.0 µs       6.28 ms       1.84 ms
+           p95      427.6 µs       7.65 ms       2.74 ms
+           p99      892.2 µs       9.43 ms       3.25 ms
+
+  Memory per run  (×100 runs) — different instruments, do not ratio across runtimes
+  framework                        per run  method                  
+  ────────────────────────  ──────────────  ────────────────────────
+  Timbal                             897 B  tracemalloc peak/N      
+  LG.py                            1,647 B  tracemalloc peak/N      
+  LG.js                          199,648 B  V8 heap growth/N (≈)    
+
+  Burst p50/p95  (10 concurrent runs)
+                      Timbal         LG.py         LG.js
+  ────────────  ────────────  ────────────  ────────────
+           p50      511.3 µs      31.86 ms      22.07 ms
+           p75      569.0 µs      32.44 ms      22.09 ms
+           p95      766.9 µs      33.18 ms      22.20 ms
+           p99      766.9 µs      33.18 ms      22.20 ms
+           max      766.9 µs      33.18 ms      22.20 ms
+
+  Throughput  (200 runs)
+                      Timbal         LG.py         LG.js
+  ────────────  ────────────  ────────────  ────────────
+             1        1876/s         154/s         533/s
+            10        1865/s         255/s         637/s
+            50        1872/s         303/s         616/s
+
+  Runtime calibration  (LG.py ÷ LG.js — same framework, so ≈ CPython/V8 factor)
+  latency p50: 3.41x  ·  latency mean: 3.25x  ·  throughput c=10: 2.50x
+
+────────────────────────────────────────────────────────────────────────────
+  Scenario 3: Parallel tools  (LLM → [add, mul, neg] → LLM → answer)
+────────────────────────────────────────────────────────────────────────────
+
+  Latency  (×100 sequential runs)
+                      Timbal         LG.py         LG.js
+  ────────────  ────────────  ────────────  ────────────
+          mean      295.1 µs       3.49 ms       1.15 ms
+           p50      285.5 µs       3.39 ms       1.04 ms
+           p95      429.5 µs       4.24 ms       1.87 ms
+           p99       1.02 ms       5.36 ms       2.24 ms
+
+  Memory per run  (×100 runs) — different instruments, do not ratio across runtimes
+  framework                        per run  method                  
+  ────────────────────────  ──────────────  ────────────────────────
+  Timbal                             772 B  tracemalloc peak/N      
+  LG.py                            1,841 B  tracemalloc peak/N      
+  LG.js                          177,952 B  V8 heap growth/N (≈)    
+
+  Burst p50/p95  (15 concurrent runs)
+                      Timbal         LG.py         LG.js
+  ────────────  ────────────  ────────────  ────────────
+           p50       4.76 ms      26.47 ms      13.70 ms
+           p75       5.00 ms      27.26 ms      13.72 ms
+           p95       5.40 ms      28.10 ms      13.81 ms
+           p99       5.40 ms      28.10 ms      13.81 ms
+           max       5.40 ms      28.10 ms      13.81 ms
+
+  Throughput  (200 runs)
+                      Timbal         LG.py         LG.js
+  ────────────  ────────────  ────────────  ────────────
+             1        1735/s         275/s         978/s
+            10        2179/s         437/s        1090/s
+            50        2377/s         476/s        1203/s
+
+  Runtime calibration  (LG.py ÷ LG.js — same framework, so ≈ CPython/V8 factor)
+  latency p50: 3.25x  ·  latency mean: 3.03x  ·  throughput c=10: 2.49x
+
+────────────────────────────────────────────────────────────────────────────
+  Calibration summary: LG.py ÷ LG.js latency p50 spans 2.06-3.41x across
+  identical agent loops (>1 = V8 faster). Apply that factor when reading any
+  Timbal (Python) vs TypeScript-framework table in benchmarks/.
+  All measurements reuse pre-built agents/graphs (creation excluded).
+  LLMs faked via message inspection on all sides — no network, no API keys.
+────────────────────────────────────────────────────────────────────────────
+

--- a/benchmarks/langgraph_js/results/bench_workflow.txt
+++ b/benchmarks/langgraph_js/results/bench_workflow.txt
@@ -1,0 +1,135 @@
+
+════════════════════════════════════════════════════════════════════════════
+  Runtime calibration — LangGraph Python vs LangGraph.js (DAG workflows)
+  200 iters · 500 burst · 200 mem runs · 1000 throughput ops
+  Same framework, both runtimes: the LG.py÷LG.js ratio isolates CPython vs V8.
+  Timbal shown for reference (built-in tracing always on; LG columns are bare).
+════════════════════════════════════════════════════════════════════════════
+
+  running LangGraph.js side: --expose-gc bench_workflow.mjs…
+  LG.js side: node v22.18.0 · @langchain/langgraph 1.4.9 · @langchain/core 1.2.5
+
+────────────────────────────────────────────────────────────────────────────
+  Scenario: Sequential  (A → B → C → D)
+────────────────────────────────────────────────────────────────────────────
+
+  Latency  (×200 sequential runs)
+                      Timbal         LG.py         LG.js
+  ────────────  ────────────  ────────────  ────────────
+          mean      344.6 µs       1.34 ms       1.34 ms
+           p50      334.5 µs       1.29 ms       1.27 ms
+           p95      414.0 µs       1.72 ms       2.06 ms
+           p99      606.1 µs       1.93 ms       2.75 ms
+
+  Memory per run  (×200 runs) — different instruments, do not ratio across runtimes
+  framework                        per run  method                  
+  ────────────────────────  ──────────────  ────────────────────────
+  Timbal                             250 B  tracemalloc peak/N      
+  LG.py                              345 B  tracemalloc peak/N      
+  LG.js                          106,205 B  V8 heap growth/N (≈)    
+
+  Burst  (500 concurrent runs)
+                      Timbal         LG.py         LG.js
+  ────────────  ────────────  ────────────  ────────────
+           p50      77.64 ms     360.88 ms     529.63 ms
+           p75      83.23 ms     386.95 ms     530.63 ms
+           p95      87.73 ms     404.49 ms     531.41 ms
+           p99      88.78 ms     408.29 ms     531.57 ms
+           max      89.06 ms     409.51 ms     531.69 ms
+
+  Throughput  (1000 runs)
+                      Timbal         LG.py         LG.js
+  ────────────  ────────────  ────────────  ────────────
+             1        2653/s         808/s        1135/s
+            10        4238/s        1208/s        1238/s
+            50        4159/s        1225/s        1214/s
+           200        4072/s        1141/s        1098/s
+
+  Runtime calibration  (LG.py ÷ LG.js — same framework, so ≈ CPython/V8 factor)
+  latency p50: 1.01x  ·  mean: 1.00x  ·  throughput c=10: 1.02x  ·  c=200: 0.96x
+
+────────────────────────────────────────────────────────────────────────────
+  Scenario: Fan-out/in  (A → [B, C, D] → E)
+────────────────────────────────────────────────────────────────────────────
+
+  Latency  (×200 sequential runs)
+                      Timbal         LG.py         LG.js
+  ────────────  ────────────  ────────────  ────────────
+          mean      478.8 µs       1.27 ms       1.30 ms
+           p50      462.6 µs       1.23 ms       1.17 ms
+           p95      617.0 µs       1.57 ms       2.27 ms
+           p99      781.5 µs       1.70 ms       3.92 ms
+
+  Memory per run  (×200 runs) — different instruments, do not ratio across runtimes
+  framework                        per run  method                  
+  ────────────────────────  ──────────────  ────────────────────────
+  Timbal                             335 B  tracemalloc peak/N      
+  LG.py                              506 B  tracemalloc peak/N      
+  LG.js                          110,453 B  V8 heap growth/N (≈)    
+
+  Burst  (500 concurrent runs)
+                      Timbal         LG.py         LG.js
+  ────────────  ────────────  ────────────  ────────────
+           p50     149.85 ms     506.82 ms     578.47 ms
+           p75     154.43 ms     533.38 ms     579.43 ms
+           p95     158.16 ms     547.84 ms     580.07 ms
+           p99     159.03 ms     552.00 ms     580.22 ms
+           max     159.29 ms     553.32 ms     580.32 ms
+
+  Throughput  (1000 runs)
+                      Timbal         LG.py         LG.js
+  ────────────  ────────────  ────────────  ────────────
+             1        2012/s         779/s         985/s
+            10        3230/s        1115/s        1083/s
+            50        3059/s        1049/s        1021/s
+           200        2858/s         989/s         979/s
+
+  Runtime calibration  (LG.py ÷ LG.js — same framework, so ≈ CPython/V8 factor)
+  latency p50: 1.06x  ·  mean: 0.98x  ·  throughput c=10: 0.97x  ·  c=200: 0.99x
+
+────────────────────────────────────────────────────────────────────────────
+  Scenario: Diamond  (A → [B, C] → D)
+────────────────────────────────────────────────────────────────────────────
+
+  Latency  (×200 sequential runs)
+                      Timbal         LG.py         LG.js
+  ────────────  ────────────  ────────────  ────────────
+          mean      468.0 µs       1.14 ms      978.4 µs
+           p50      425.0 µs       1.12 ms      902.4 µs
+           p95      697.2 µs       1.33 ms       1.57 ms
+           p99      947.8 µs       1.53 ms       2.09 ms
+
+  Memory per run  (×200 runs) — different instruments, do not ratio across runtimes
+  framework                        per run  method                  
+  ────────────────────────  ──────────────  ────────────────────────
+  Timbal                             305 B  tracemalloc peak/N      
+  LG.py                              392 B  tracemalloc peak/N      
+  LG.js                          105,915 B  V8 heap growth/N (≈)    
+
+  Burst  (500 concurrent runs)
+                      Timbal         LG.py         LG.js
+  ────────────  ────────────  ────────────  ────────────
+           p50     131.39 ms     373.05 ms     477.41 ms
+           p75     135.86 ms     395.16 ms     478.24 ms
+           p95     140.05 ms     412.20 ms     478.87 ms
+           p99     140.81 ms     416.61 ms     479.11 ms
+           max     141.04 ms     417.84 ms     479.21 ms
+
+  Throughput  (1000 runs)
+                      Timbal         LG.py         LG.js
+  ────────────  ────────────  ────────────  ────────────
+             1        2264/s         667/s        1177/s
+            10        3747/s        1270/s        1277/s
+            50        3914/s        1261/s        1239/s
+           200        3383/s        1118/s        1152/s
+
+  Runtime calibration  (LG.py ÷ LG.js — same framework, so ≈ CPython/V8 factor)
+  latency p50: 1.24x  ·  mean: 1.16x  ·  throughput c=10: 1.01x  ·  c=200: 1.03x
+
+────────────────────────────────────────────────────────────────────────────
+  Calibration summary: LG.py ÷ LG.js latency p50 spans 1.01-1.24x across
+  identical DAGs (>1 = V8 faster). Apply that factor when reading any Timbal
+  (Python) vs TypeScript-framework workflow table in benchmarks/.
+  Graph compilation and Workflow construction excluded from timing.
+────────────────────────────────────────────────────────────────────────────
+

--- a/benchmarks/mastra/README.md
+++ b/benchmarks/mastra/README.md
@@ -39,6 +39,12 @@ nothing to do with either framework's design: V8 JIT-compiles hot loops (CPython
 Timbal's wins happen *despite* that handicap; Mastra's wins should be read with
 it in mind.
 
+**That runtime factor is now measured, not guessed:** `benchmarks/langgraph_js/`
+runs LangGraph — the same framework, same architecture — on both CPython and
+V8. Result: V8 makes identical agent loops **2.1–3.4x** faster and identical
+DAG scheduling **~1.0–1.2x** faster (a wash). Use those factors when reading
+the tables below.
+
 ### What is explicitly NOT comparable
 
 **Memory.** Python is measured with `tracemalloc` (exact peak of every traced
@@ -68,6 +74,12 @@ agents have no tracing, so Mastra gets two columns:
 
 The honest apples-to-apples column against Timbal is **Mastra+obs**; the bare
 column shows what Mastra costs with tracing off, which Timbal doesn't offer.
+
+The agent benchmark also includes an **AI SDK** column: raw Vercel AI SDK
+`generateText` with the same tools and mock model — the substrate Mastra is
+built on. It is a bare library call (no tracing, no memory, no agent
+abstractions), included to decompose Mastra's cost into "the substrate" vs
+"Mastra's layer on top", and as a best-case V8 baseline.
 
 ---
 
@@ -137,8 +149,9 @@ progress on stderr).
 
 ## Results
 
-Full-mode run, 2026-08-07: Apple Silicon M-series, CPython 3.11, Node v22.18,
-`@mastra/core` 1.57.0, `@mastra/observability` 1.16.5, `ai` 7.0.56.
+Full-mode runs, 2026-08-07 (workflow) and 2026-08-10 (agent, adding the AI SDK
+column): Apple Silicon M-series, CPython 3.11, Node v22.18, `@mastra/core`
+1.57.0, `@mastra/observability` 1.16.5, `ai` 7.0.56.
 Raw outputs:
 
 - `results/bench_agent.txt`
@@ -149,23 +162,32 @@ Raw outputs:
 Full loop: prompt -> fake LLM -> tool call(s) -> fake LLM -> answer. Timbal has
 tracing built in and always on; compare against Mastra+obs for parity.
 
-| Scenario | Timbal p50 | Mastra p50 | Mastra+obs p50 |
-|----------|-----------:|-----------:|---------------:|
-| Single tool | 265.2 µs | 2.63 ms | 4.09 ms |
-| 3-step chain | 274.8 µs | 3.74 ms | 6.64 ms |
-| Parallel tools | 278.2 µs | 2.60 ms | 4.65 ms |
+| Scenario | Timbal p50 | AI SDK p50 | Mastra p50 | Mastra+obs p50 |
+|----------|-----------:|-----------:|-----------:|---------------:|
+| Single tool | 265.3 µs | 156.1 µs | 2.33 ms | 4.20 ms |
+| 3-step chain | 296.3 µs | 340.6 µs | 3.99 ms | 6.92 ms |
+| Parallel tools | 285.9 µs | 219.8 µs | 2.55 ms | 4.33 ms |
 
-| Scenario | Timbal c=10 | Mastra c=10 | Mastra+obs c=10 |
-|----------|------------:|------------:|----------------:|
-| Single tool | 4,172/s | 512/s | 264/s |
-| 3-step chain | 1,854/s | 284/s | 144/s |
-| Parallel tools | 2,244/s | 374/s | 239/s |
+| Scenario | Timbal c=10 | AI SDK c=10 | Mastra c=10 | Mastra+obs c=10 |
+|----------|------------:|------------:|------------:|----------------:|
+| Single tool | 3,982/s | 7,996/s | 555/s | 278/s |
+| 3-step chain | 1,916/s | 3,215/s | 288/s | 159/s |
+| Parallel tools | 2,094/s | 5,497/s | 418/s | 233/s |
 
-Timbal's agent loop is roughly an order of magnitude faster per run and in
-throughput — despite the V8-vs-CPython runtime handicap running the other way.
+Timbal's agent loop is roughly an order of magnitude faster than Mastra per
+run and in throughput — despite the V8-vs-CPython runtime handicap running the
+other way (measured at 2.1–3.4x for agent loops in `benchmarks/langgraph_js/`).
 Mastra's `generate()` path does substantially more per call (message-list
 management, schema conversion, processor pipeline), and enabling observability
 roughly doubles its cost, while Timbal's numbers already include tracing.
+
+The AI SDK column decomposes Mastra's cost: raw `generateText` runs the
+single-tool loop in ~156 µs, so **Mastra adds roughly 15x on top of its own
+substrate**. It also shows the runtime effect honestly — a bare V8 library
+call edges Timbal on single-round scenarios and loses on the 3-step chain,
+while carrying none of Timbal's agent semantics (tracing, memory, structured
+events, multi-turn state). A full traced agent runtime landing within ~2x of a
+bare substrate call is the context for every other column.
 
 ### Workflow DAG
 
@@ -184,16 +206,20 @@ Trivial handlers, no LLM — pure scheduling overhead.
 | Diamond | 4,039/s | 11,265/s | 4,014/s |
 
 This one cuts the other way and we report it as-is: Mastra's bare workflow
-engine on V8 is ~3x faster than Timbal on trivial DAGs. That advantage is a mix
-of a lean run path and V8 JIT-compiling the hot loop — the benchmark cannot and
-does not separate the two. With observability enabled (the production-parity
-column), Mastra lands at rough parity with Timbal on latency and throughput,
-with Timbal keeping tracing on for every number.
+engine on V8 is ~3x faster than Timbal on trivial DAGs. The calibration suite
+(`benchmarks/langgraph_js/`) settles what we previously couldn't separate:
+identical DAGs run at ~1.0–1.2x across CPython and V8, so this win is
+**Mastra's lean engine, not the runtime**. Credit where due. With
+observability enabled (the production-parity column), the advantage disappears
+— rough parity with Timbal on latency and throughput, with Timbal keeping
+tracing on for every number.
 
 ### Takeaway
 
 For agent workloads — the workload both frameworks exist for — Timbal's loop is
-~9-24x faster with tracing on both sides. For raw DAG scheduling of trivial
-steps, Mastra without tracing is faster; with tracing it's a wash. As always,
-framework overhead vanishes behind real LLM latency; these numbers measure the
-floor each framework sets, not the ceiling of your app.
+~9-23x faster with tracing on both sides, and the runtime calibration says
+that gap is architectural, not linguistic. For raw DAG scheduling of trivial
+steps, Mastra without tracing is genuinely faster (engine design, not V8);
+with tracing it's a wash. As always, framework overhead vanishes behind real
+LLM latency; these numbers measure the floor each framework sets, not the
+ceiling of your app.

--- a/benchmarks/mastra/bench_agent.mjs
+++ b/benchmarks/mastra/bench_agent.mjs
@@ -12,15 +12,19 @@
  * response by counting tool results in the message history — no shared counter
  * state, safe for concurrent runs on a single shared agent.
  *
- * Two variants per scenario:
- *   - bare: plain `new Agent(...)` — no tracing (Mastra's default standalone path)
- *   - obs:  agent registered in a `Mastra` instance with `@mastra/observability`
- *           enabled and the exporter mocked (spans built, export dropped) —
- *           the equivalent of LangGraph+LangSmith-with-HTTP-mocked
+ * Three variants per scenario:
+ *   - aisdk: raw Vercel AI SDK `generateText` with the same tools and mock
+ *            model — the substrate Mastra is built on. Isolates what Mastra's
+ *            agent layer adds on top of its own foundation.
+ *   - bare:  plain `new Agent(...)` — no tracing (Mastra's default standalone path)
+ *   - obs:   agent registered in a `Mastra` instance with `@mastra/observability`
+ *            enabled and the exporter mocked (spans built, export dropped) —
+ *            the equivalent of LangGraph+LangSmith-with-HTTP-mocked
  *
  * Usage: node --expose-gc bench_agent.mjs [--quick]
  */
 
+import { generateText, tool, stepCountIs } from 'ai';
 import { Mastra } from '@mastra/core';
 import { Agent } from '@mastra/core/agent';
 import { createTool } from '@mastra/core/tools';
@@ -129,6 +133,43 @@ function makeModel(scenario) {
   });
 }
 
+// ── Raw AI SDK runner (Mastra's substrate) ───────────────────────────────────
+
+const AISDK_TOOLS = {
+  add: tool({
+    description: 'Add two numbers.',
+    inputSchema: z.object({ a: num, b: num }),
+    execute: async ({ a, b }) => a + b,
+  }),
+  multiply: tool({
+    description: 'Multiply two numbers.',
+    inputSchema: z.object({ a: num, b: num }),
+    execute: async ({ a, b }) => a * b,
+  }),
+  subtract: tool({
+    description: 'Subtract b from a.',
+    inputSchema: z.object({ a: num, b: num }),
+    execute: async ({ a, b }) => a - b,
+  }),
+  negate: tool({
+    description: 'Negate a number.',
+    inputSchema: z.object({ x: num }),
+    execute: async ({ x }) => -x,
+  }),
+};
+
+const AISDK_SCENARIO_TOOLS = {
+  1: { add: AISDK_TOOLS.add },
+  2: { add: AISDK_TOOLS.add, multiply: AISDK_TOOLS.multiply, subtract: AISDK_TOOLS.subtract },
+  3: { add: AISDK_TOOLS.add, multiply: AISDK_TOOLS.multiply, negate: AISDK_TOOLS.negate },
+};
+
+function makeAiSdkRunner(scenario) {
+  const model = makeModel(scenario);
+  const tools = AISDK_SCENARIO_TOOLS[scenario];
+  return () => generateText({ model, tools, stopWhen: stepCountIs(10), prompt: 'go' });
+}
+
 // ── Agent factories ──────────────────────────────────────────────────────────
 
 function makeBareAgent(scenario) {
@@ -183,10 +224,12 @@ for (const scenario of [1, 2, 3]) {
     concurrencyLevels: CONCURRENCY_LEVELS,
   };
 
+  const aisdkRun = makeAiSdkRunner(scenario);
   const bare = makeBareAgent(scenario);
   const { agent: obs, observability } = makeObsAgent(scenario);
 
   results.scenarios[scenario] = {
+    aisdk: await measure(aisdkRun, { ...common, label: 'ai sdk raw' }),
     bare: await measure(() => bare.generate('go'), { ...common, label: 'mastra bare' }),
     obs: await measure(() => obs.generate('go'), {
       ...common,

--- a/benchmarks/mastra/results/bench_agent.txt
+++ b/benchmarks/mastra/results/bench_agent.txt
@@ -16,105 +16,108 @@
 ────────────────────────────────────────────────────────────────────────────
 
   Latency  (×100 sequential runs)
-                      Timbal        Mastra    Mastra+obs
-  ────────────  ────────────  ────────────  ────────────
-          mean      264.2 µs       2.77 ms       4.28 ms
-           p50      265.2 µs       2.63 ms       4.09 ms
-           p95      416.7 µs       3.89 ms       6.09 ms
-           p99      560.0 µs       5.30 ms      10.29 ms
+                      Timbal        AI SDK        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────  ────────────
+          mean      267.8 µs      188.7 µs       2.47 ms       4.28 ms
+           p50      265.3 µs      156.1 µs       2.33 ms       4.20 ms
+           p95      387.5 µs      302.0 µs       3.44 ms       6.08 ms
+           p99      506.1 µs      989.0 µs       4.55 ms       8.80 ms
 
   Memory per run  (×100 runs) — different instruments, do not ratio across runtimes
   framework                        per run  method                  
   ────────────────────────  ──────────────  ────────────────────────
   Timbal                             492 B  tracemalloc peak/N      
-  Mastra                         296,746 B  V8 heap growth/N (≈)    
-  Mastra+obs                     355,216 B  V8 heap growth/N (≈)    
+  AI SDK                         165,692 B  V8 heap growth/N (≈)    
+  Mastra                         294,137 B  V8 heap growth/N (≈)    
+  Mastra+obs                     351,993 B  V8 heap growth/N (≈)    
 
   Burst p50/p95  (20 concurrent runs)
-                      Timbal        Mastra    Mastra+obs
-  ────────────  ────────────  ────────────  ────────────
-           p50      262.3 µs      26.58 ms      55.22 ms
-           p75      290.1 µs      33.14 ms      65.60 ms
-           p95      441.8 µs      37.41 ms      74.79 ms
-           p99      441.8 µs      37.41 ms      74.79 ms
-           max      441.8 µs      37.41 ms      74.79 ms
+                      Timbal        AI SDK        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────  ────────────
+           p50      244.1 µs       2.75 ms      24.57 ms      57.02 ms
+           p75      301.4 µs       2.82 ms      31.00 ms      66.62 ms
+           p95      405.5 µs       3.06 ms      34.16 ms      76.33 ms
+           p99      405.5 µs       3.06 ms      34.16 ms      76.33 ms
+           max      405.5 µs       3.06 ms      34.16 ms      76.33 ms
 
   Throughput  (200 runs)
-                      Timbal        Mastra    Mastra+obs
-  ────────────  ────────────  ────────────  ────────────
-             1        4008/s         490/s         246/s
-            10        4172/s         512/s         264/s
-            50        4045/s         509/s         266/s
+                      Timbal        AI SDK        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────  ────────────
+             1        3896/s        6414/s         509/s         259/s
+            10        3982/s        7996/s         555/s         278/s
+            50        3933/s        8677/s         560/s         278/s
 
 ────────────────────────────────────────────────────────────────────────────
   Scenario 2: Multi-step  (LLM → add → LLM → mul → LLM → sub → LLM → answer)
 ────────────────────────────────────────────────────────────────────────────
 
   Latency  (×100 sequential runs)
-                      Timbal        Mastra    Mastra+obs
-  ────────────  ────────────  ────────────  ────────────
-          mean      290.7 µs       3.90 ms       6.72 ms
-           p50      274.8 µs       3.74 ms       6.64 ms
-           p95      461.4 µs       5.85 ms       8.23 ms
-           p99      664.2 µs       7.03 ms      11.25 ms
+                      Timbal        AI SDK        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────  ────────────
+          mean      289.6 µs      412.6 µs       4.08 ms       7.19 ms
+           p50      296.3 µs      340.6 µs       3.99 ms       6.92 ms
+           p95      412.8 µs      638.5 µs       5.52 ms       9.52 ms
+           p99      669.3 µs       1.44 ms       7.30 ms      12.20 ms
 
   Memory per run  (×100 runs) — different instruments, do not ratio across runtimes
   framework                        per run  method                  
   ────────────────────────  ──────────────  ────────────────────────
   Timbal                             897 B  tracemalloc peak/N      
-  Mastra                         421,457 B  V8 heap growth/N (≈)    
-  Mastra+obs                     476,681 B  V8 heap growth/N (≈)    
+  AI SDK                         173,953 B  V8 heap growth/N (≈)    
+  Mastra                         421,182 B  V8 heap growth/N (≈)    
+  Mastra+obs                     477,366 B  V8 heap growth/N (≈)    
 
   Burst p50/p95  (10 concurrent runs)
-                      Timbal        Mastra    Mastra+obs
-  ────────────  ────────────  ────────────  ────────────
-           p50      485.8 µs      33.81 ms      71.28 ms
-           p75      497.7 µs      36.25 ms      76.76 ms
-           p95      640.2 µs      38.40 ms      83.00 ms
-           p99      640.2 µs      38.40 ms      83.00 ms
-           max      640.2 µs      38.40 ms      83.00 ms
+                      Timbal        AI SDK        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────  ────────────
+           p50      502.4 µs       2.79 ms      36.46 ms      61.93 ms
+           p75      506.9 µs       2.82 ms      38.54 ms      65.70 ms
+           p95      723.2 µs       3.14 ms      41.01 ms      71.36 ms
+           p99      723.2 µs       3.14 ms      41.01 ms      71.36 ms
+           max      723.2 µs       3.14 ms      41.01 ms      71.36 ms
 
   Throughput  (200 runs)
-                      Timbal        Mastra    Mastra+obs
-  ────────────  ────────────  ────────────  ────────────
-             1        1947/s         247/s         128/s
-            10        1854/s         284/s         144/s
-            50        1848/s         304/s         163/s
+                      Timbal        AI SDK        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────  ────────────
+             1        1902/s        2891/s         268/s         156/s
+            10        1916/s        3215/s         288/s         159/s
+            50        1900/s        3359/s         308/s         168/s
 
 ────────────────────────────────────────────────────────────────────────────
   Scenario 3: Parallel tools  (LLM → [add, mul, neg] → LLM → answer)
 ────────────────────────────────────────────────────────────────────────────
 
   Latency  (×100 sequential runs)
-                      Timbal        Mastra    Mastra+obs
-  ────────────  ────────────  ────────────  ────────────
-          mean      291.4 µs       2.77 ms       5.20 ms
-           p50      278.2 µs       2.60 ms       4.65 ms
-           p95      434.1 µs       4.07 ms      12.15 ms
-           p99      803.9 µs       4.58 ms      15.77 ms
+                      Timbal        AI SDK        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────  ────────────
+          mean      284.2 µs      253.2 µs       2.63 ms       4.51 ms
+           p50      285.9 µs      219.8 µs       2.55 ms       4.33 ms
+           p95      406.7 µs      334.9 µs       3.74 ms       6.23 ms
+           p99      648.7 µs       1.33 ms       4.25 ms       7.90 ms
 
   Memory per run  (×100 runs) — different instruments, do not ratio across runtimes
   framework                        per run  method                  
   ────────────────────────  ──────────────  ────────────────────────
-  Timbal                             799 B  tracemalloc peak/N      
-  Mastra                         348,384 B  V8 heap growth/N (≈)    
-  Mastra+obs                     392,720 B  V8 heap growth/N (≈)    
+  Timbal                             777 B  tracemalloc peak/N      
+  AI SDK                         165,226 B  V8 heap growth/N (≈)    
+  Mastra                         347,644 B  V8 heap growth/N (≈)    
+  Mastra+obs                     387,434 B  V8 heap growth/N (≈)    
 
   Burst p50/p95  (15 concurrent runs)
-                      Timbal        Mastra    Mastra+obs
-  ────────────  ────────────  ────────────  ────────────
-           p50       4.39 ms      25.24 ms      51.79 ms
-           p75       4.70 ms      30.82 ms      61.20 ms
-           p95       5.12 ms      33.61 ms      68.17 ms
-           p99       5.12 ms      33.61 ms      68.17 ms
-           max       5.12 ms      33.61 ms      68.17 ms
+                      Timbal        AI SDK        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────  ────────────
+           p50       3.87 ms       2.86 ms      29.20 ms      50.67 ms
+           p75       4.13 ms       2.90 ms      34.05 ms      59.25 ms
+           p95       4.42 ms       3.16 ms      37.47 ms      65.96 ms
+           p99       4.42 ms       3.16 ms      37.47 ms      65.96 ms
+           max       4.42 ms       3.16 ms      37.47 ms      65.96 ms
 
   Throughput  (200 runs)
-                      Timbal        Mastra    Mastra+obs
-  ────────────  ────────────  ────────────  ────────────
-             1        1851/s         380/s         241/s
-            10        2244/s         374/s         239/s
-            50        2440/s         411/s         240/s
+                      Timbal        AI SDK        Mastra    Mastra+obs
+  ────────────  ────────────  ────────────  ────────────  ────────────
+             1        1582/s        4594/s         408/s         234/s
+            10        2094/s        5497/s         418/s         233/s
+            50        2480/s        5354/s         415/s         247/s
 
 ────────────────────────────────────────────────────────────────────────────
   All measurements reuse 1 pre-built agent (creation excluded).


### PR DESCRIPTION
Two additions that turn the cross-language caveats from prose into measurements:

- benchmarks/langgraph_js: LangGraph Python vs LangGraph.js — the same framework and architecture on CPython and V8, isolating the language runtime factor. Result: identical agent loops run 2.1-3.4x faster on V8; identical DAG scheduling is a wash (1.0-1.2x). Orchestrators print the LG.py / LG.js calibration ratio per scenario; Timbal shown for reference.
- benchmarks/mastra: new "AI SDK" column in bench_agent — raw Vercel AI SDK generateText with the same tools and mock model, the substrate Mastra is built on. Decomposition: Mastra adds ~15x over its own substrate; a bare V8 library call edges Timbal on single-round scenarios (156 vs 265 us) while carrying no agent semantics.

Mastra README updated to cite the measured runtime factors instead of hedging: Timbal's ~10x agent win is architectural (survives a 2-3.4x runtime headwind); Mastra's ~3x bare-workflow win is its lean engine, not V8 (DAG runtime factor ~1x).