### PR TITLE
chore: keep the rust WIP out of the Python sdist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,10 @@ node_modules/
 # Internal planning docs
 planning/
 
+# Local rust WIP — do not ship in the Python package
+/rust/
+/benchmarks/rust/
+
 .claude/
 .cursor/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ exclude = [
   "/sandbox",
   "/scripts",
   "/benchmarks",
+  "/rust",
 ]
 
 [tool.uv]


### PR DESCRIPTION
## Summary
- rust/ and benchmarks/rust/ are local WIP and must not ship in the next Python release
- Ignore both trees so they cannot be added by accident
- Exclude /rust from the hatch sdist (/benchmarks was already excluded)

## Test plan
- [ ] git status does not list rust/ or benchmarks/rust/
- [ ] git check-ignore -v rust/timbal/src/lib.rs hits .gitignore
- [ ] uv build sdist does not contain a rust/ prefix


Made with [Cursor](https://cursor.com)