### PR TITLE
fix(voice): feed CallRecorder from streaming TTS

### DIFF
--- a/python/tests/voice/test_session.py
+++ b/python/tests/voice/test_session.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncIterator
 from contextlib import aclosing
+from pathlib import Path
 
 import pytest
 from timbal import Agent
@@ -1914,6 +1915,32 @@ class TestStreamingTTS:
         assert session._turn_tts_stream is None
         assert session._turn_tts_pump is None
         assert any(isinstance(e, SessionInterrupted) for e in events)
+
+    async def test_streaming_tts_feeds_call_recorder(self, tmp_path: Path) -> None:
+        """Streaming TTS must call CallRecorder.add_agent.
+
+        ElevenLabs (and any ``open_stream`` provider) goes through
+        ``_pump_tts_stream``, not ``_speak``. Skipping add_agent there left
+        split recordings as caller-left / silence-right.
+        """
+        from timbal.voice.recording import CallRecorder
+
+        tts = StreamingMockTTS(bytes_per_char=10)
+        recorder = CallRecorder(tmp_path / "call.mp3", sample_rate=16_000, layout="split")
+        session = VoiceSession(
+            agent=Agent(
+                name="t",
+                model=TestModel(responses=[self.RESPONSE]),
+                tools=[],
+            ),
+            stt=MockSTT(script=[TranscriptEvent(type="committed", text="hi")]),
+            tts=tts,
+            recorder=recorder,
+            turn_detector="heuristic",
+        )
+        await _collect_events(session)
+        assert recorder._agent_bytes > 0
+        assert recorder._closed
 
 
 # ---------------------------------------------------------------------------

--- a/python/timbal/voice/session.py
+++ b/python/timbal/voice/session.py
@@ -2117,6 +2117,8 @@ class VoiceSession:
                 self._turn_audio_bytes += len(chunk)
                 if self._record_audio:
                     self._output_audio_chunks.append(chunk)
+                if self._recorder is not None:
+                    self._recorder.add_agent(chunk)
                 record[1] += len(chunk)
                 await self._emit(AudioOutput(data=chunk))
                 self.playback.on_audio_emitted(len(chunk))


### PR DESCRIPTION
_pump_tts_stream never called add_agent, so split recordings were caller-only.