### PR TITLE
fix(voice): tag LiveKit mic publish as Microphone

### DIFF
--- a/python/timbal/server/voice.html
+++ b/python/timbal/server/voice.html
@@ -2427,7 +2427,13 @@ async function startLivekit(gen, dial) {
     if (lkRoom === room) lkRoom = null;
     return;
   }
-  await room.localParticipant.publishTrack(micStream.getAudioTracks()[0]);
+  // A MediaStreamTrack published bare is source=Unknown. Tokens that pin
+  // canPublishSources:["microphone"] (platform preview) reject that with
+  // "failed to publish track, insufficient permissions" — join already
+  // succeeded; this is not the browser mic prompt.
+  await room.localParticipant.publishTrack(micStream.getAudioTracks()[0], {
+    source: Track.Source.Microphone,
+  });
   if (gen !== startGen) return;
   sessionSampleRate = sr;
   sendHello();


### PR DESCRIPTION
Bare MediaStreamTrack publishes as source=Unknown. Tokens that pin canPublishSources:["microphone"] reject that after join already succeeded.