### PR TITLE
feat(core): scope background tasks to the session, not the Agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ timbal/
 │   │   ├── state/
 │   │   │   ├── __init__.py   # get_run_context, get_call_id, etc.
 │   │   │   ├── context.py    # RunContext definition
+│   │   │   ├── background.py # Session-scoped background-task store
 │   │   │   └── tracing/
 │   │   │       ├── providers/
 │   │   │       │   ├── base.py       # TracingProvider ABC + Exporter ABC
@@ -393,6 +394,30 @@ class MyProvider(TracingProvider):
         # persist run_context._trace keyed by run_context.id
         ...
 ```
+
+---
+
+## Background Tasks
+
+`background_mode="auto"|"always"` detaches a child (`python/timbal/state/background.py`). The spawn returns `{"task_id", "status": "running"}` immediately; the child's events go to an append-only log, not the parent's stream.
+
+```python
+from timbal.state import (
+ cancel_background_task,
+ get_background_task, # peek a bounded summary — does NOT drain
+ list_background_tasks,
+ read_background_transcript, # raw events from a cursor: (task_id, after=)
+)
+
+Tool(name="build", handler=..., background_mode="always",
+ on_background_cancel=lambda record: remote.stop(record.metadata["run_id"]))
+```
+
+- Tasks live on a `BackgroundTaskStore` bound to the `RunContext`, inherited across sequential turns via `parent_id`. Concurrent runs of the same Agent get isolated stores (no shared `parent_id`), so a foreign `task_id` is `not_found`. Process-local — does not survive a restart.
+- Once *this session* has a task, the agent auto-gains `get_background_task` / `list_background_tasks` / `cancel_background_task`.
+- The log is peekable, not consume-once: the parent agent and a frontend can both watch one child. `record.log.subscribe(after=)` replays then streams live.
+- `get_background_task` returns `{status, task_id, name, title, input, started_at, summary: {text, tools_in_flight, event_count}, transcript_cursor}` (+ `result`/`error` when done). `summary.text` is capped — for briefing, not for dumping a build into context.
+- Cancel stops in-flight work: the Task is cancelled *and* the handler generator is closed (an async gen suspended at a yield would otherwise never run its `finally`), then `on_background_cancel` fires for work the loop can't reach.
 
 ---
 

--- a/docs/agents/background-tasks.mdx
+++ b/docs/agents/background-tasks.mdx
@@ -5,6 +5,8 @@ description: "Execute long-running operations asynchronously"
 
 Background tasks let runnables execute asynchronously while the agent continues. When a tool runs in the background, it immediately returns a `task_id` and `status: "running"` instead of blocking until completion.
 
+Tasks belong to the **session** that started them: the agent stays talkable, can run several children at once, and can answer questions about any of them on a later turn.
+
 ## Configuring Background Mode
 
 The `background_mode` parameter controls when a runnable executes asynchronously:
@@ -43,18 +45,96 @@ result = await agent(prompt="Install project dependencies in the background").co
 Background tools return immediately with a task handle:
 
 ```python
-{"task_id": "a3k9f2", "status": "running"}
+{"task_id": "k4d9x2mq7c1a", "status": "running"}
 ```
 
-Once at least one background task is running, the agent automatically exposes a `get_background_task` tool. Call it with the `task_id` to poll status and drain queued events:
+Once this session has at least one background task, the agent automatically gains three tools — `get_background_task`, `list_background_tasks`, and `cancel_background_task` — so it can brief the user or stop a child on a follow-up turn without you wiring anything.
+
+`get_background_task` **peeks**; it does not drain. Calling it twice returns the same thing, so the agent polling a child never steals events from a frontend streaming the same child.
 
 ```python
-from timbal.state import get_run_context
+from timbal.state import get_background_task
 
-# After starting a background task...
-span = get_run_context().current_span()
-status = span.runnable.get_background_task("a3k9f2")
-# {"status": "running" | "completed" | "error" | "cancelled" | "not_found", "events": [...], ...}
+get_background_task("k4d9x2mq7c1a")
 ```
 
-Or let the agent poll for you on a follow-up turn — it will see `get_background_task` in its tool list and can call it with the `task_id` from the earlier tool result.
+```python
+{
+    "status": "running",           # running | completed | error | cancelled | not_found
+    "task_id": "k4d9x2mq7c1a",
+    "name": "build_site",
+    "title": "Build the marketing site",
+    "input": {"prompt": "Build the marketing site"},
+    "started_at": 1755385200000,   # Unix ms
+    "summary": {
+        "text": "...",             # trailing assistant text, capped at 1000 chars
+        "tools_in_flight": ["write_file", "bash"],
+        "event_count": 42,
+    },
+    "transcript_cursor": 42,       # pass as `after` to read raw events
+}
+```
+
+The summary is deliberately bounded — it's for briefing the user, not for dumping a long build into the context window. When the task finishes, the snapshot also carries `result` (or `error` on failure). Durable child ids seen on the child's events, such as its `run_id`, are lifted onto the snapshot as they arrive.
+
+## Reading the Raw Transcript
+
+For the full event stream, read from a cursor. This does not drain either — the same `after` returns the same events, so it's safe to call from more than one place.
+
+```python
+from timbal.state import read_background_transcript
+
+page = read_background_transcript("k4d9x2mq7c1a")
+# {"status": "running", "task_id": ..., "events": [...], "cursor": 42}
+
+# Later, pick up where you left off
+page = read_background_transcript("k4d9x2mq7c1a", after=page["cursor"])
+```
+
+To follow a child live instead of polling, subscribe to its log. `subscribe` replays from `after` and then yields events as they arrive, so you cannot miss one that lands mid-replay.
+
+```python
+from timbal.state.background import current_background_store
+
+record = current_background_store().get("k4d9x2mq7c1a")
+async for event in record.log.subscribe():
+    print(event)
+```
+
+## Listing and Cancelling
+
+```python
+from timbal.state import cancel_background_task, list_background_tasks
+
+list_background_tasks()
+# [{"task_id": "k4d9x2mq7c1a", "name": "build_site", "status": "running",
+#   "started_at": 1755385200000, "title": "Build the marketing site"}]
+
+cancel_background_task("k4d9x2mq7c1a")   # returns the final snapshot
+```
+
+Cancelling stops the child's in-flight work: the task is cancelled and its handler is closed, so a handler holding a subprocess or a socket runs its `finally` instead of being abandoned mid-flight.
+
+## Session Scope
+
+The task store is bound to the `RunContext` and inherited across sequential turns via `parent_id`. In practice:
+
+- A finished turn can still list, peek, and cancel the children it started, because the next turn passes the previous run as `parent_id`.
+- Two concurrent runs of the same `Agent` object — no shared `parent_id` — get isolated stores. Neither sees the other's tasks, and `get_background_task` with a foreign `task_id` returns `not_found`.
+- The store is process-local, so it does not survive a restart. Use a durable job store if a child must outlive the process.
+
+## Stopping External Work
+
+Cancelling an `asyncio.Task` can only reach work the event loop owns. If a child drives something outside the process, use `on_background_cancel` to tear it down. The hook receives the task record, whose `metadata` carries the child's ids once its events have arrived.
+
+```python
+def stop_remote_build(record):
+    remote_api.stop(record.metadata["run_id"])
+
+Tool(
+    name="build_site",
+    handler=start_remote_build,
+    background_mode="always",
+    on_background_cancel=stop_remote_build,
+)
+```

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -51,6 +51,20 @@ def reset_platform_config_cache(request):
 
 
 @pytest.fixture(autouse=True)
+def clear_background_task_stores():
+    """Drop the process-local background-task registry between tests.
+
+    Stores are keyed by run_id and inherited via parent_id. Without a reset,
+    a leftover parent_id from a previous test can leak children into the next.
+    """
+    from timbal.state.background import clear_background_stores
+
+    clear_background_stores()
+    yield
+    clear_background_stores()
+
+
+@pytest.fixture(autouse=True)
 def clear_in_memory_tracing_storage():
     """Clear InMemoryTracingProvider storage between tests.
 

--- a/python/tests/core/test_background_tasks.py
+++ b/python/tests/core/test_background_tasks.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from collections.abc import AsyncGenerator
 
 import pytest
@@ -55,6 +56,22 @@ async def _fake_streaming_builder(prompt: str) -> AsyncGenerator[TextDelta, None
         yield TextDelta(id="b", text_delta=f"[{prompt}] chunk {i} ")
         await asyncio.sleep(0.08)
     yield TextDelta(id="b", text_delta=f"[{prompt}] done")
+
+
+async def _wait_for_first_event(task_id: str, timeout: float = 5.0) -> int:
+    """Wait until a background child has actually emitted, and return its cursor.
+
+    Spawning only *schedules* the child: nothing orders its first event against
+    the parent's turn ending, and the interleaving differs by Python version and
+    OS. Poll for the event rather than sleeping a guessed interval.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        cursor = read_background_transcript(task_id)["cursor"]
+        if cursor > 0:
+            return cursor
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"background task {task_id} never emitted an event")
 
 
 class TestBackgroundTasks:
@@ -582,6 +599,7 @@ class TestBackgroundMultitask:
         ids = list_background_tasks()
         assert len(ids) == 2
         first_id = ids[0]["task_id"]
+        await _wait_for_first_event(first_id)
         mid = get_background_task(first_id)
         assert mid["status"] == "running"
         assert mid["summary"]["event_count"] >= 1
@@ -622,7 +640,7 @@ class TestBackgroundMultitask:
 
         await parent(prompt="build").collect()
         task_id = list_background_tasks()[0]["task_id"]
-        await asyncio.sleep(0.12)
+        await _wait_for_first_event(task_id)
         a = read_background_transcript(task_id, after=0)
         assert a["status"] == "running"
         assert a["cursor"] >= 1
@@ -704,15 +722,9 @@ class TestBackgroundMultitask:
         assert get_background_task(task_id)["status"] == "running"
         from timbal.state.background import current_background_store
 
-        # collect() only *schedules* the child; with TestModel there are no real
-        # awaits, so wait until it has actually emitted. Cancelling a child that
-        # never started proves nothing about stopping in-flight work.
-        for _ in range(100):
-            if read_background_transcript(task_id)["cursor"] > 0:
-                break
-            await asyncio.sleep(0.01)
-        before = read_background_transcript(task_id)["cursor"]
-        assert before > 0, "child never started; nothing in flight to cancel"
+        # Cancelling a child that never started proves nothing about stopping
+        # in-flight work, so make sure there is something in flight first.
+        await _wait_for_first_event(task_id)
 
         record = current_background_store().get(task_id)
         result = cancel_background_task(task_id)

--- a/python/tests/core/test_background_tasks.py
+++ b/python/tests/core/test_background_tasks.py
@@ -4,8 +4,19 @@ from collections.abc import AsyncGenerator
 import pytest
 from timbal import Agent, Tool
 from timbal.core.test_model import TestModel
-from timbal.state import get_run_context
+from timbal.server.jobs import JOB_DONE_SENTINEL, JobStore
+from timbal.state import (
+    cancel_background_task,
+    get_background_task,
+    get_run_context,
+    list_background_tasks,
+    read_background_transcript,
+    set_call_id,
+    set_parent_call_id,
+    set_run_context,
+)
 from timbal.types.content import ToolUseContent
+from timbal.types.events.delta import TextDelta
 from timbal.types.events.output import OutputEvent
 from timbal.types.message import Message
 
@@ -22,643 +33,788 @@ def _tool_call(tool_name: str, input: dict, *, id: str = "c1", run_in_background
     )
 
 
+def _tool_calls(*calls: tuple[str, dict, str, bool]) -> Message:
+    """One assistant message with N parallel tool calls."""
+    return Message(
+        role="assistant",
+        content=[
+            ToolUseContent(
+                id=call_id,
+                name=name,
+                input={**input, **({"run_in_background": True} if bg else {})},
+            )
+            for name, input, call_id, bg in calls
+        ],
+        stop_reason="tool_use",
+    )
+
+
+async def _fake_streaming_builder(prompt: str) -> AsyncGenerator[TextDelta, None]:
+    """Same contract as sidecar ``build_turn``: async gen of Timbal deltas."""
+    for i in range(4):
+        yield TextDelta(id="b", text_delta=f"[{prompt}] chunk {i} ")
+        await asyncio.sleep(0.08)
+    yield TextDelta(id="b", text_delta=f"[{prompt}] done")
+
+
 class TestBackgroundTasks:
-    """Test background task execution and status checking."""
+    """Background spawn / peek / list — session bag, not Agent singleton."""
 
     @pytest.mark.asyncio
     async def test_background_task_execution_and_status(self):
-        """Background task is registered in _bg_tasks and get_background_task reports its status."""
-
         async def slow_task(duration: float) -> str:
             await asyncio.sleep(duration)
             return "done"
 
-        bg_tool = Tool(name="slow_task", description="Run a slow task", handler=slow_task, background_mode="auto")
-
         agent = Agent(
             name="bg_agent",
-            model=TestModel(responses=[
-                _tool_call("slow_task", {"duration": 0.2}, run_in_background=True),
-                "Task started in the background.",
-            ]),
-            tools=[bg_tool],
+            model=TestModel(
+                responses=[
+                    _tool_call("slow_task", {"duration": 0.2}, run_in_background=True),
+                    "Task started in the background.",
+                ]
+            ),
+            tools=[Tool(name="slow_task", description="Run a slow task", handler=slow_task, background_mode="auto")],
         )
 
         result = await agent(prompt="run slow task").collect()
         assert_has_output_event(result)
-
-        span = get_run_context().root_span()
-        agent_runnable = span.runnable
-        assert len(agent_runnable._bg_tasks) > 0
-
-        await asyncio.sleep(0.3)  # wait for task to finish
+        listed = list_background_tasks()
+        assert len(listed) == 1
+        assert listed[0]["status"] in ("running", "completed")
+        await asyncio.sleep(0.3)
 
     @pytest.mark.asyncio
     async def test_background_task_with_immediate_status_check(self):
-        """Agent can start a background task and immediately check its status."""
-
         async def slow_task(duration: float) -> str:
             await asyncio.sleep(duration)
             return "done"
 
-        bg_tool = Tool(name="slow_task", description="Run a slow task", handler=slow_task, background_mode="auto")
-
         agent = Agent(
             name="bg_agent",
-            model=TestModel(responses=[
-                _tool_call("slow_task", {"duration": 0.3}, run_in_background=True),
-                "The task is running.",
-            ]),
-            tools=[bg_tool],
+            model=TestModel(
+                responses=[
+                    _tool_call("slow_task", {"duration": 0.3}, run_in_background=True),
+                    "The task is running.",
+                ]
+            ),
+            tools=[Tool(name="slow_task", description="Run a slow task", handler=slow_task, background_mode="auto")],
         )
 
         result = await agent(prompt="run and check").collect()
         assert_has_output_event(result)
-
         await asyncio.sleep(0.4)
 
     @pytest.mark.asyncio
-    async def test_bg_tasks_dict_populated_when_running_background(self):
-        """_bg_tasks dictionary is populated when a tool runs in background."""
-
+    async def test_store_populated_when_running_background(self):
         async def slow_task(duration: float) -> str:
             await asyncio.sleep(duration)
             return "done"
 
-        bg_tool = Tool(name="slow_task", description="Run a slow task", handler=slow_task, background_mode="auto")
-
         agent = Agent(
             name="bg_agent",
-            model=TestModel(responses=[
-                _tool_call("slow_task", {"duration": 0.3}, run_in_background=True),
-                "Started.",
-            ]),
-            tools=[bg_tool],
+            model=TestModel(
+                responses=[
+                    _tool_call("slow_task", {"duration": 0.3}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[Tool(name="slow_task", description="Run a slow task", handler=slow_task, background_mode="auto")],
         )
 
         result = await agent(prompt="run in background").collect()
         assert_has_output_event(result)
-
-        span = get_run_context().root_span()
-        agent_runnable = span.runnable
-        assert agent_runnable._bg_tasks is not None
-        assert len(agent_runnable._bg_tasks) > 0
-
-        task_id = list(agent_runnable._bg_tasks.keys())[0]
-        task_info = agent_runnable._bg_tasks[task_id]
-        assert "task" in task_info
-        assert "event_queue" in task_info
-        assert isinstance(task_info["task"], asyncio.Task)
-
+        listed = list_background_tasks()
+        assert len(listed) == 1
+        snap = get_background_task(listed[0]["task_id"])
+        assert snap["status"] in ("running", "completed")
+        assert snap["name"] == "slow_task"
         await asyncio.sleep(0.4)
 
     @pytest.mark.asyncio
     async def test_agent_has_get_background_task_tool(self):
-        """get_background_task tool appears in the tool list once bg tasks exist."""
-
         async def slow_task(duration: float) -> str:
             await asyncio.sleep(duration)
             return "done"
 
-        bg_tool = Tool(name="slow_task", description="Run a slow task", handler=slow_task, background_mode="auto")
-
         agent = Agent(
             name="bg_agent",
-            model=TestModel(responses=[
-                _tool_call("slow_task", {"duration": 0.3}, run_in_background=True),
-                "Started.",
-            ]),
-            tools=[bg_tool],
+            model=TestModel(
+                responses=[
+                    _tool_call("slow_task", {"duration": 0.3}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[Tool(name="slow_task", description="Run a slow task", handler=slow_task, background_mode="auto")],
         )
 
         tool_names_seen = []
         async for event in agent(prompt="run in background"):
-            if (
-                isinstance(event, OutputEvent)
-                and event.path == "bg_agent.llm"
-                and len(get_run_context().current_span().runnable._bg_tasks) > 0
-            ):
+            if isinstance(event, OutputEvent) and event.path == "bg_agent.llm" and list_background_tasks():
                 tool_names_seen.extend(tool.name for tool in event.input["tools"])
 
         assert "get_background_task" in tool_names_seen
-
+        assert "list_background_tasks" in tool_names_seen
+        assert "cancel_background_task" in tool_names_seen
         await asyncio.sleep(0.4)
 
     @pytest.mark.asyncio
     async def test_background_task_with_events_and_logs(self):
-        """Background tool that yields multiple log steps completes successfully."""
-
-        async def build_interface(project_name: str) -> str:
-            steps = [
-                "Initializing build environment...",
-                "Installing dependencies...",
-                "Compiling TypeScript...",
-                "Building React components...",
-                "Optimizing bundle...",
-                "Build completed successfully!",
-            ]
-            for step in steps:
-                await asyncio.sleep(0.02)
-            return "\n".join(steps)
-
-        build_tool = Tool(
-            name="build_interface",
-            description="Build a web interface project",
-            handler=build_interface,
-            background_mode="auto",
-        )
+        async def build_interface(project_name: str) -> str:  # noqa: ARG001
+            return "ok"
 
         agent = Agent(
             name="build_agent",
-            model=TestModel(responses=[
-                _tool_call("build_interface", {"project_name": "my-app"}, run_in_background=True),
-                "Build started in the background.",
-            ]),
-            tools=[build_tool],
+            model=TestModel(
+                responses=[
+                    _tool_call("build_interface", {"project_name": "my-app"}, run_in_background=True),
+                    "Build started in the background.",
+                ]
+            ),
+            tools=[
+                Tool(
+                    name="build_interface",
+                    description="Build a web interface project",
+                    handler=build_interface,
+                    background_mode="auto",
+                )
+            ],
         )
 
         result = await agent(prompt="build my-app in background").collect()
         assert_has_output_event(result)
-
-        span = get_run_context().root_span()
-        assert len(span.runnable._bg_tasks) > 0
-
+        assert len(list_background_tasks()) == 1
         await asyncio.sleep(0.2)
 
     @pytest.mark.asyncio
     async def test_realtime_events_vs_background_events(self):
-        """Foreground tools stream events; background tools queue them."""
-
         async def streaming_task(steps: int) -> AsyncGenerator[str, None]:
             for i in range(steps):
                 yield f"Step {i + 1}/{steps} completed"
                 await asyncio.sleep(0.02)
 
-        realtime_tool = Tool(
-            name="realtime_task",
-            description="Streams events in real-time",
-            handler=streaming_task,
-            background_mode="never",
-        )
-
         realtime_agent = Agent(
             name="realtime_agent",
-            model=TestModel(responses=[
-                _tool_call("realtime_task", {"steps": 3}),
-                "Done.",
-            ]),
-            tools=[realtime_tool],
+            model=TestModel(
+                responses=[
+                    _tool_call("realtime_task", {"steps": 3}),
+                    "Done.",
+                ]
+            ),
+            tools=[
+                Tool(
+                    name="realtime_task",
+                    description="Streams events in real-time",
+                    handler=streaming_task,
+                    background_mode="never",
+                )
+            ],
         )
 
-        realtime_events = []
-        async for event in realtime_agent(prompt="run realtime task"):
-            realtime_events.append(event)
-
-        event_types = [e.type for e in realtime_events if hasattr(e, "type")]
-        assert "START" in event_types
-        assert "OUTPUT" in event_types
-
-        # Background mode: events go to queue
-        background_tool = Tool(
-            name="background_task",
-            description="Runs in background",
-            handler=streaming_task,
-            background_mode="always",
-        )
+        realtime_events = [event async for event in realtime_agent(prompt="run realtime task")]
+        assert "START" in [e.type for e in realtime_events if hasattr(e, "type")]
+        assert "OUTPUT" in [e.type for e in realtime_events if hasattr(e, "type")]
 
         background_agent = Agent(
             name="background_agent",
-            model=TestModel(responses=[
-                _tool_call("background_task", {"steps": 3}),
-                "Started in background.",
-            ]),
-            tools=[background_tool],
+            model=TestModel(
+                responses=[
+                    _tool_call("background_task", {"steps": 3}),
+                    "Started in background.",
+                ]
+            ),
+            tools=[
+                Tool(
+                    name="background_task",
+                    description="Runs in background",
+                    handler=streaming_task,
+                    background_mode="always",
+                )
+            ],
         )
 
-        bg_events = []
-        async for event in background_agent(prompt="run background task"):
-            bg_events.append(event)
-
+        bg_events = [event async for event in background_agent(prompt="run background task")]
         assert len(bg_events) > 0
-
         await asyncio.sleep(0.1)
-
-        span = get_run_context().root_span()
-        bg_agent_runnable = span.runnable
-        if bg_agent_runnable._bg_tasks:
-            task_id = list(bg_agent_runnable._bg_tasks.keys())[0]
-            event_queue = bg_agent_runnable._bg_tasks[task_id]["event_queue"]
-            assert event_queue.qsize() > 0
-
+        listed = list_background_tasks()
+        assert listed
+        transcript = read_background_transcript(listed[0]["task_id"])
+        assert transcript["cursor"] > 0
         await asyncio.sleep(0.1)
 
     @pytest.mark.asyncio
-    async def test_background_task_event_queue_detailed_inspection(self):
-        """Events from a background tool are queued and have the correct metadata."""
-
-        async def detailed_task(task_name: str) -> AsyncGenerator[dict, None]:
-            stages = [
+    async def test_background_task_event_log_detailed_inspection(self):
+        async def detailed_task(task_name: str) -> AsyncGenerator[dict, None]:  # noqa: ARG001
+            for stage_data in (
                 {"stage": "init", "progress": 0},
                 {"stage": "processing", "progress": 50},
-                {"stage": "finalizing", "progress": 90},
                 {"stage": "complete", "progress": 100},
-            ]
-            for stage_data in stages:
+            ):
                 yield stage_data
                 await asyncio.sleep(0.02)
 
-        detailed_tool = Tool(
-            name="detailed_task",
-            description="Task with detailed progress updates",
-            handler=detailed_task,
-            background_mode="always",
-        )
-
         agent = Agent(
             name="detailed_agent",
-            model=TestModel(responses=[
-                _tool_call("detailed_task", {"task_name": "analysis"}),
-                "Task queued.",
-            ]),
-            tools=[detailed_tool],
+            model=TestModel(
+                responses=[
+                    _tool_call("detailed_task", {"task_name": "analysis"}),
+                    "Task queued.",
+                ]
+            ),
+            tools=[
+                Tool(
+                    name="detailed_task",
+                    description="Task with detailed progress updates",
+                    handler=detailed_task,
+                    background_mode="always",
+                )
+            ],
         )
 
         result = await agent(prompt="run detailed_task").collect()
         assert_has_output_event(result)
+        await asyncio.sleep(0.15)
 
-        await asyncio.sleep(0.1)
+        task_id = list_background_tasks()[0]["task_id"]
+        first = read_background_transcript(task_id)
+        assert first["cursor"] > 0
+        for event in first["events"]:
+            if isinstance(event, dict) and event.get("path"):
+                assert "detailed_task" in event["path"]
 
-        span = get_run_context().root_span()
-        agent_runnable = span.runnable
-        assert len(agent_runnable._bg_tasks) > 0
+        # Peek does not drain — second read from 0 still has them.
+        second = read_background_transcript(task_id, after=0)
+        assert second["cursor"] == first["cursor"]
+        assert len(second["events"]) == len(first["events"])
 
-        task_id = list(agent_runnable._bg_tasks.keys())[0]
-        task_info = agent_runnable._bg_tasks[task_id]
-        event_queue = task_info["event_queue"]
-
-        all_events = []
-        while not event_queue.empty():
-            try:
-                all_events.append(event_queue.get_nowait())
-            except asyncio.QueueEmpty:
-                break
-
-        assert len(all_events) > 0
-        for event in all_events:
-            if hasattr(event, "path"):
-                assert "detailed_task" in event.path
-
-        await asyncio.sleep(0.1)
-
-        status = agent_runnable.get_background_task(task_id)
-        assert status["status"] in ["completed", "not_found"]
+        status = get_background_task(task_id)
+        assert status["status"] in ("completed", "running")
+        assert "events" not in status
+        assert status["summary"]["event_count"] >= 1
 
     @pytest.mark.asyncio
-    async def test_multiple_background_tasks_concurrently(self):
-        """Multiple background tasks can run at the same time."""
-
+    async def test_multiple_background_tasks_sequential_turns(self):
         async def slow_task(tag: str) -> str:
             await asyncio.sleep(0.2)
             return f"done:{tag}"
 
-        bg_tool = Tool(name="slow_task", description="Slow task", handler=slow_task, background_mode="auto")
-
         agent = Agent(
             name="multi_bg_agent",
-            model=TestModel(responses=[
-                _tool_call("slow_task", {"tag": "task1"}, id="c1", run_in_background=True),
-                "Task 1 started.",
-                _tool_call("slow_task", {"tag": "task2"}, id="c2", run_in_background=True),
-                "Task 2 started.",
-            ]),
-            tools=[bg_tool],
+            model=TestModel(
+                responses=[
+                    _tool_call("slow_task", {"tag": "task1"}, id="c1", run_in_background=True),
+                    "Task 1 started.",
+                    _tool_call("slow_task", {"tag": "task2"}, id="c2", run_in_background=True),
+                    "Task 2 started.",
+                ]
+            ),
+            tools=[Tool(name="slow_task", description="Slow task", handler=slow_task, background_mode="auto")],
         )
 
         result1 = await agent(prompt="start task 1").collect()
         assert_has_output_event(result1)
-
         result2 = await agent(prompt="start task 2").collect()
         assert_has_output_event(result2)
-
-        span = get_run_context().root_span()
-        assert len(span.runnable._bg_tasks) >= 1
-
+        assert len(list_background_tasks()) >= 2
         await asyncio.sleep(0.3)
 
     @pytest.mark.asyncio
     async def test_background_task_error_handling(self):
-        """Background tasks that raise are handled gracefully."""
-
         async def failing_tool(should_fail: bool = True) -> str:
             await asyncio.sleep(0.05)
             if should_fail:
                 raise ValueError("Intentional failure for testing")
             return "Success"
 
-        fail_tool = Tool(
-            name="failing_tool",
-            description="A tool that can fail",
-            handler=failing_tool,
-            background_mode="auto",
-        )
-
         agent = Agent(
             name="error_handling_agent",
-            model=TestModel(responses=[
-                _tool_call("failing_tool", {"should_fail": True}, run_in_background=True),
-                "Task started.",
-            ]),
-            tools=[fail_tool],
+            model=TestModel(
+                responses=[
+                    _tool_call("failing_tool", {"should_fail": True}, run_in_background=True),
+                    "Task started.",
+                ]
+            ),
+            tools=[
+                Tool(
+                    name="failing_tool",
+                    description="A tool that can fail",
+                    handler=failing_tool,
+                    background_mode="auto",
+                )
+            ],
         )
 
         result = await agent(prompt="run failing tool").collect()
         assert_has_output_event(result)
-
         await asyncio.sleep(0.2)
-
-        span = get_run_context().root_span()
-        agent_runnable = span.runnable
-        if agent_runnable._bg_tasks:
-            task_id = list(agent_runnable._bg_tasks.keys())[0]
-            task_info = agent_runnable._bg_tasks[task_id]
-            task = task_info["task"]
-            assert task.done()
+        snap = get_background_task(list_background_tasks()[0]["task_id"])
+        assert snap["status"] == "error"
+        assert "Intentional failure" in snap["error"]
 
     @pytest.mark.asyncio
     async def test_background_task_nonexistent_task_id(self):
-        """get_background_task returns not_found for an unknown task_id."""
         agent = Agent(name="check_missing_agent", model=TestModel())
-
         await agent(prompt="hi").collect()
-
         result = agent.get_background_task("nonexistent_task_id_12345")
         assert result["status"] == "not_found"
-        assert result["events"] == []
 
     @pytest.mark.asyncio
     async def test_background_mode_always(self):
-        """Tool with background_mode='always' creates a bg task automatically."""
-
         async def always_background_tool(message: str) -> str:
             await asyncio.sleep(0.1)
             return f"Processed: {message}"
 
-        always_bg_tool = Tool(
-            name="always_bg_tool",
-            description="Always runs in background",
-            handler=always_background_tool,
-            background_mode="always",
-        )
-
         agent = Agent(
             name="always_bg_agent",
-            model=TestModel(responses=[
-                _tool_call("always_bg_tool", {"message": "hello"}),
-                "Done.",
-            ]),
-            tools=[always_bg_tool],
+            model=TestModel(
+                responses=[
+                    _tool_call("always_bg_tool", {"message": "hello"}),
+                    "Done.",
+                ]
+            ),
+            tools=[
+                Tool(
+                    name="always_bg_tool",
+                    description="Always runs in background",
+                    handler=always_background_tool,
+                    background_mode="always",
+                )
+            ],
         )
 
         result = await agent(prompt="use always_bg_tool").collect()
         assert_has_output_event(result)
-
-        span = get_run_context().root_span()
-        assert len(span.runnable._bg_tasks) >= 1
-
+        assert len(list_background_tasks()) >= 1
         await asyncio.sleep(0.2)
 
     @pytest.mark.asyncio
     async def test_background_mode_never(self):
-        """Tool with background_mode='never' runs inline and creates no bg task."""
-
         async def never_background_tool(message: str) -> str:
             await asyncio.sleep(0.05)
             return f"Processed: {message}"
 
-        never_bg_tool = Tool(
-            name="never_bg_tool",
-            description="Never runs in background",
-            handler=never_background_tool,
-            background_mode="never",
-        )
-
         agent = Agent(
             name="never_bg_agent",
-            model=TestModel(responses=[
-                _tool_call("never_bg_tool", {"message": "test"}),
-                "Done.",
-            ]),
-            tools=[never_bg_tool],
+            model=TestModel(
+                responses=[
+                    _tool_call("never_bg_tool", {"message": "test"}),
+                    "Done.",
+                ]
+            ),
+            tools=[
+                Tool(
+                    name="never_bg_tool",
+                    description="Never runs in background",
+                    handler=never_background_tool,
+                    background_mode="never",
+                )
+            ],
         )
 
         result = await agent(prompt="use never_bg_tool").collect()
         assert_has_output_event(result)
-
-        span = get_run_context().root_span()
-        assert len(span.runnable._bg_tasks) == 0
+        assert list_background_tasks() == []
 
     @pytest.mark.asyncio
     async def test_background_task_cleanup_after_completion(self):
-        """Completed background task info is accessible until cleaned up."""
-
         async def quick_task(value: str) -> str:
             await asyncio.sleep(0.05)
             return f"Done: {value}"
 
-        quick_tool = Tool(
-            name="quick_task",
-            description="Quick task",
-            handler=quick_task,
-            background_mode="auto",
-        )
-
         agent = Agent(
             name="cleanup_agent",
-            model=TestModel(responses=[
-                _tool_call("quick_task", {"value": "test"}, run_in_background=True),
-                "Started.",
-            ]),
-            tools=[quick_tool],
+            model=TestModel(
+                responses=[
+                    _tool_call("quick_task", {"value": "test"}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[Tool(name="quick_task", description="Quick task", handler=quick_task, background_mode="auto")],
         )
 
         result = await agent(prompt="run quick task in background").collect()
         assert_has_output_event(result)
-
-        span = get_run_context().root_span()
-        agent_runnable = span.runnable
-        assert len(agent_runnable._bg_tasks) > 0
-
+        assert list_background_tasks()
         await asyncio.sleep(0.2)
-
-        task_id = list(agent_runnable._bg_tasks.keys())[0]
-        status = agent_runnable.get_background_task(task_id)
-        assert status["status"] in ["completed", "not_found"]
+        status = get_background_task(list_background_tasks()[0]["task_id"])
+        assert status["status"] == "completed"
+        assert status["result"] == "Done: test"
 
     @pytest.mark.asyncio
     async def test_background_task_with_structured_output(self):
-        """Background tool that returns structured data completes without error."""
-
         async def structured_task(count: int) -> dict:
             await asyncio.sleep(0.05)
             return {"count": count, "results": [f"item_{i}" for i in range(count)], "status": "completed"}
 
-        struct_tool = Tool(
-            name="structured_task",
-            description="Returns structured data",
-            handler=structured_task,
-            background_mode="auto",
-        )
-
         agent = Agent(
             name="structured_bg_agent",
-            model=TestModel(responses=[
-                _tool_call("structured_task", {"count": 3}, run_in_background=True),
-                "Task started.",
-            ]),
-            tools=[struct_tool],
+            model=TestModel(
+                responses=[
+                    _tool_call("structured_task", {"count": 3}, run_in_background=True),
+                    "Task started.",
+                ]
+            ),
+            tools=[
+                Tool(
+                    name="structured_task",
+                    description="Returns structured data",
+                    handler=structured_task,
+                    background_mode="auto",
+                )
+            ],
         )
 
         result = await agent(prompt="run structured_task").collect()
         assert_has_output_event(result)
-
         await asyncio.sleep(0.2)
-
-        span = get_run_context().root_span()
-        task_id = list(span.runnable._bg_tasks.keys())[0]
-        status = span.runnable.get_background_task(task_id)
-        assert status["status"] in ["completed", "not_found"]
-
-    @pytest.mark.asyncio
-    async def test_background_task_event_queue_retrieval(self):
-        """Event queue exists and is an asyncio.Queue for every background task."""
-
-        async def multi_step_task(steps: int) -> str:
-            for _ in range(steps):
-                await asyncio.sleep(0.02)
-            return f"Completed {steps} steps"
-
-        multi_tool = Tool(
-            name="multi_step",
-            description="Multi-step task",
-            handler=multi_step_task,
-            background_mode="auto",
-        )
-
-        agent = Agent(
-            name="queue_test_agent",
-            model=TestModel(responses=[
-                _tool_call("multi_step", {"steps": 3}, run_in_background=True),
-                "Started.",
-            ]),
-            tools=[multi_tool],
-        )
-
-        result = await agent(prompt="run multi_step").collect()
-        assert_has_output_event(result)
-
-        span = get_run_context().root_span()
-        agent_runnable = span.runnable
-        assert len(agent_runnable._bg_tasks) > 0
-
-        task_id = list(agent_runnable._bg_tasks.keys())[0]
-        task_info = agent_runnable._bg_tasks[task_id]
-        assert "event_queue" in task_info
-        assert isinstance(task_info["event_queue"], asyncio.Queue)
-
-        await asyncio.sleep(0.1)
-
-    @pytest.mark.asyncio
-    async def test_background_task_events_accumulation(self):
-        """Events generated by a background tool accumulate in the queue."""
-
-        async def event_generating_task(num_events: int) -> str:
-            for _ in range(num_events):
-                await asyncio.sleep(0.02)
-            return f"Generated {num_events} events"
-
-        event_tool = Tool(
-            name="event_gen_tool",
-            description="Generates events",
-            handler=event_generating_task,
-            background_mode="auto",
-        )
-
-        agent = Agent(
-            name="event_accumulation_agent",
-            model=TestModel(responses=[
-                _tool_call("event_gen_tool", {"num_events": 5}, run_in_background=True),
-                "Started.",
-            ]),
-            tools=[event_tool],
-        )
-
-        result = await agent(prompt="run event_gen_tool").collect()
-        assert_has_output_event(result)
-
-        span = get_run_context().root_span()
-        assert len(span.runnable._bg_tasks) > 0
-
-        await asyncio.sleep(0.2)
+        status = get_background_task(list_background_tasks()[0]["task_id"])
+        assert status["status"] == "completed"
 
     @pytest.mark.asyncio
     async def test_background_tasks_persist_across_agent_calls(self):
-        """Background tasks started in one call are still tracked in the next."""
-
         async def slow_task(duration: float) -> str:
             await asyncio.sleep(duration)
             return "done"
 
-        bg_tool = Tool(name="slow_task", description="Slow task", handler=slow_task, background_mode="auto")
-
         agent = Agent(
             name="persistence_agent",
-            model=TestModel(responses=[
-                _tool_call("slow_task", {"duration": 0.3}, run_in_background=True),
-                "Task started.",
-                "Still tracking it.",
-            ]),
-            tools=[bg_tool],
+            model=TestModel(
+                responses=[
+                    _tool_call("slow_task", {"duration": 0.3}, run_in_background=True),
+                    "Task started.",
+                    "Still tracking it.",
+                ]
+            ),
+            tools=[Tool(name="slow_task", description="Slow task", handler=slow_task, background_mode="auto")],
         )
 
         result1 = await agent(prompt="start task").collect()
         assert_has_output_event(result1)
+        ids_after_first = {t["task_id"] for t in list_background_tasks()}
+        assert ids_after_first
 
         result2 = await agent(prompt="check tasks").collect()
         assert_has_output_event(result2)
-
-        span = get_run_context().root_span()
-        assert span.runnable._bg_tasks is not None
-
+        ids_after_second = {t["task_id"] for t in list_background_tasks()}
+        assert ids_after_first <= ids_after_second
         await asyncio.sleep(0.4)
 
     @pytest.mark.asyncio
     async def test_get_background_task_tool_parameters(self):
-        """get_background_task can be called directly with a task_id."""
-
         async def slow_task(duration: float) -> str:
             await asyncio.sleep(duration)
             return "done"
 
-        bg_tool = Tool(name="slow_task", description="Slow task", handler=slow_task, background_mode="auto")
-
         agent = Agent(
             name="param_test_agent",
-            model=TestModel(responses=[
-                _tool_call("slow_task", {"duration": 0.2}, run_in_background=True),
-                "Started.",
-            ]),
-            tools=[bg_tool],
+            model=TestModel(
+                responses=[
+                    _tool_call("slow_task", {"duration": 0.2}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[Tool(name="slow_task", description="Slow task", handler=slow_task, background_mode="auto")],
         )
 
         result = await agent(prompt="run slow task").collect()
         assert_has_output_event(result)
-
-        span = get_run_context().root_span()
-        agent_runnable = span.runnable
-
-        if agent_runnable._bg_tasks:
-            task_id = list(agent_runnable._bg_tasks.keys())[0]
-            status = agent_runnable.get_background_task(task_id)
-            assert status["status"] in ["running", "completed"]
-
+        listed = list_background_tasks()
+        if listed:
+            status = agent.get_background_task(listed[0]["task_id"])
+            assert status["status"] in ("running", "completed")
         await asyncio.sleep(0.3)
+
+
+class TestBackgroundMultitask:
+    """Cursor-shaped multitask: parent stays talkable, N children, parent can answer."""
+
+    @pytest.mark.asyncio
+    async def test_one_iteration_two_background_children(self):
+        """§6 / 5.5.1 — one parent iteration, two run_in_background calls."""
+        parent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_calls(
+                        ("builder", {"prompt": "A"}, "c1", True),
+                        ("builder", {"prompt": "B"}, "c2", True),
+                    ),
+                    "Both started.",
+                ]
+            ),
+            tools=[Tool(name="builder", handler=_fake_streaming_builder, background_mode="auto")],
+        )
+
+        r1 = await parent(prompt="build A and B").collect()
+        assert_has_output_event(r1)
+        ids = list_background_tasks()
+        assert len(ids) == 2
+        names = {t["title"] for t in ids}
+        assert any("A" in (t or "") for t in names)
+        assert any("B" in (t or "") for t in names)
+        await asyncio.sleep(0.5)
+
+    @pytest.mark.asyncio
+    async def test_parent_output_while_children_still_run(self):
+        """§6 item (3) — THE load-bearing test.
+
+        Parent OUTPUT exists; both children still running. Next collect() on
+        the same Agent (session-chained RunContext) can peek and see running.
+        """
+        parent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_calls(
+                        ("builder", {"prompt": "A"}, "c1", True),
+                        ("builder", {"prompt": "B"}, "c2", True),
+                    ),
+                    "Both started.",
+                    _tool_call("get_background_task", {"task_id": "placeholder"}),
+                    "First one is still going.",
+                ]
+            ),
+            tools=[Tool(name="builder", handler=_fake_streaming_builder, background_mode="auto")],
+        )
+
+        r1 = await parent(prompt="build A and B").collect()
+        assert_has_output_event(r1)
+        ids = list_background_tasks()
+        assert len(ids) == 2
+        first_id = ids[0]["task_id"]
+        mid = get_background_task(first_id)
+        assert mid["status"] == "running"
+        assert mid["summary"]["event_count"] >= 1
+        assert mid["summary"]["text"]
+        other_id = ids[1]["task_id"]
+        assert get_background_task(other_id)["status"] == "running"
+
+        # Next parent turn — this is the dock: new /stream, same session.
+        parent.model = TestModel(
+            responses=[
+                _tool_call("get_background_task", {"task_id": first_id}),
+                "The first builder is still running.",
+            ]
+        )
+        r2 = await parent(prompt="what's the status of the first one?").collect()
+        assert_has_output_event(r2)
+        assert get_run_context().parent_id == r1.run_id
+        peek = get_background_task(first_id)
+        assert peek["status"] in ("running", "completed")
+        assert peek["summary"]["event_count"] >= 1
+        # Sibling still on the same bag, untouched by the peek.
+        assert get_background_task(other_id)["status"] in ("running", "completed")
+        await asyncio.sleep(0.5)
+
+    @pytest.mark.asyncio
+    async def test_streaming_peek_does_not_drain(self):
+        """5.5.2 — mid-flight peek, second peek still has the same events."""
+        parent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("builder", {"prompt": "long"}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[Tool(name="builder", handler=_fake_streaming_builder, background_mode="auto")],
+        )
+
+        await parent(prompt="build").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        await asyncio.sleep(0.12)
+        a = read_background_transcript(task_id, after=0)
+        assert a["status"] == "running"
+        assert a["cursor"] >= 1
+        b = read_background_transcript(task_id, after=0)
+        assert b["cursor"] >= a["cursor"]
+        assert len(b["events"]) >= len(a["events"])
+        snap = get_background_task(task_id)
+        assert "events" not in snap
+        assert snap["summary"]["text"]
+        await asyncio.sleep(0.4)
+
+    @pytest.mark.asyncio
+    async def test_agent_as_tool_background(self):
+        """5.5.4 — child Agent with its own tools, parent detaches, parent peeks."""
+
+        def ping(x: str) -> str:
+            return f"pong:{x}"
+
+        child = Agent(
+            name="specialist",
+            model=TestModel(
+                responses=[
+                    _tool_call("ping", {"x": "hi"}),
+                    "child done",
+                ]
+            ),
+            tools=[ping],
+            background_mode="auto",
+        )
+
+        parent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("specialist", {"prompt": "go"}, run_in_background=True),
+                    "specialist started",
+                ]
+            ),
+            tools=[child],
+        )
+
+        r1 = await parent(prompt="delegate").collect()
+        assert_has_output_event(r1)
+        listed = list_background_tasks()
+        assert len(listed) == 1
+        assert listed[0]["name"] == "specialist"
+        await asyncio.sleep(0.2)
+        snap = get_background_task(listed[0]["task_id"])
+        assert snap["status"] in ("running", "completed")
+        assert snap.get("run_id") or snap["summary"]["event_count"] >= 0
+
+    @pytest.mark.asyncio
+    async def test_cancel_stops_in_flight_work(self):
+        """5.5.5 — cancel → peek cancelled; handler actually stops."""
+        cancelled = {"hit": False}
+
+        async def stubborn(prompt: str) -> AsyncGenerator[TextDelta, None]:
+            try:
+                while True:
+                    yield TextDelta(id="s", text_delta=f"{prompt}...")
+                    await asyncio.sleep(0.05)
+            finally:
+                # Collector aclose() delivers GeneratorExit, not CancelledError.
+                cancelled["hit"] = True
+
+        parent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("builder", {"prompt": "loop"}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[Tool(name="builder", handler=stubborn, background_mode="auto")],
+        )
+
+        await parent(prompt="go").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        assert get_background_task(task_id)["status"] == "running"
+        from timbal.state.background import current_background_store
+
+        # collect() only *schedules* the child; with TestModel there are no real
+        # awaits, so wait until it has actually emitted. Cancelling a child that
+        # never started proves nothing about stopping in-flight work.
+        for _ in range(100):
+            if read_background_transcript(task_id)["cursor"] > 0:
+                break
+            await asyncio.sleep(0.01)
+        before = read_background_transcript(task_id)["cursor"]
+        assert before > 0, "child never started; nothing in flight to cancel"
+
+        record = current_background_store().get(task_id)
+        result = cancel_background_task(task_id)
+        assert result["status"] == "cancelled"
+
+        # Wait for the cancel to unwind AND the store's aclose to finalize the
+        # handler generator (that is what runs the handler's finally).
+        for _ in range(100):
+            if cancelled["hit"]:
+                break
+            await asyncio.sleep(0.01)
+
+        assert get_background_task(task_id)["status"] == "cancelled"
+        assert cancelled["hit"] is True, "handler generator was abandoned, not closed"
+        assert record.task.done()
+        after = read_background_transcript(task_id)["cursor"]
+        await asyncio.sleep(0.15)
+        assert read_background_transcript(task_id)["cursor"] == after, "child kept emitting after cancel"
+
+    @pytest.mark.asyncio
+    async def test_isolation_two_concurrent_parent_runs(self):
+        """5.5.6 — two concurrent parent runs on one Agent must not see each other."""
+
+        async def slow_task(tag: str) -> str:
+            await asyncio.sleep(0.25)
+            return tag
+
+        def _handler(messages):
+            from timbal.types.content import ToolResultContent
+
+            if any(isinstance(c, ToolResultContent) for m in messages for c in m.content):
+                return "Started."
+            prompt = messages[-1].collect_text()
+            tag = "A" if "A" in prompt else "B"
+            return _tool_call("builder", {"tag": tag}, id=tag, run_in_background=True)
+
+        parent = Agent(
+            name="composer",
+            model=TestModel(handler=_handler),
+            tools=[Tool(name="builder", handler=slow_task, background_mode="auto")],
+        )
+
+        async def run_one(prompt: str) -> list[str]:
+            set_run_context(None)
+            set_call_id(None)
+            set_parent_call_id(None)
+            await parent(prompt=prompt).collect()
+            return [t["task_id"] for t in list_background_tasks()]
+
+        set_run_context(None)
+        set_call_id(None)
+        set_parent_call_id(None)
+        left, right = await asyncio.gather(run_one("A"), run_one("B"))
+        assert len(left) == 1
+        assert len(right) == 1
+        assert left[0] != right[0]
+        await asyncio.sleep(0.3)
+
+    @pytest.mark.asyncio
+    async def test_job_store_cancel_parent_does_not_kill_children(self):
+        """5.6 — JobStore.cancel_job(parent) must not cancel _bg_tasks."""
+
+        async def stubborn(prompt: str) -> AsyncGenerator[TextDelta, None]:
+            for i in range(30):
+                yield TextDelta(id="s", text_delta=f"{prompt} {i} ")
+                await asyncio.sleep(0.05)
+
+        parent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("builder", {"prompt": "keep-going"}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[Tool(name="builder", handler=stubborn, background_mode="auto")],
+        )
+
+        jobs = JobStore()
+        job_id, job = jobs.create_job(parent, {"prompt": "go"})
+
+        run_id = None
+        while True:
+            event = await job.queue.get()
+            if event is JOB_DONE_SENTINEL:
+                break
+            if isinstance(event, OutputEvent) and str(event.path).endswith(".builder"):
+                run_id = event.run_id
+                break
+
+        assert run_id, "parent never spawned the builder"
+        jobs.cancel_job(job_id)
+        try:
+            await job.task
+        except asyncio.CancelledError:
+            pass
+
+        from timbal.state.background import store_for_run
+
+        bag = store_for_run(run_id)
+        assert bag is not None and len(bag) == 1
+        task_id = bag.list()[0]["task_id"]
+        assert bag.snapshot(task_id)["status"] == "running"
+        bag.cancel(task_id)
+        await asyncio.sleep(0.1)

--- a/python/timbal/core/agent.py
+++ b/python/timbal/core/agent.py
@@ -40,6 +40,12 @@ from ..guardrails.apply import (
 from ..guardrails.presets import build_guardrail_runner, coerce_rail, default_safety
 from ..guardrails.types import GuardrailContext, GuardrailStage, Verdict
 from ..state import get_run_context
+from ..state.background import (
+    CANCEL_BACKGROUND_TASK_DESCRIPTION,
+    GET_BACKGROUND_TASK_DESCRIPTION,
+    LIST_BACKGROUND_TASKS_DESCRIPTION,
+    current_background_store,
+)
 from ..types.content import (
     CustomContent,
     FileContent,
@@ -620,15 +626,12 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
             msg = memory[i]
             if msg.role != "assistant":
                 continue
-            tool_uses = [
-                c for c in msg.content
-                if isinstance(c, ToolUseContent) and not c.is_server_tool_use
-            ]
+            tool_uses = [c for c in msg.content if isinstance(c, ToolUseContent) and not c.is_server_tool_use]
             if not tool_uses:
                 # Most recent assistant message has no tool_uses to resume.
                 return []
             fulfilled: set[str] = set()
-            for later in memory[i + 1:]:
+            for later in memory[i + 1 :]:
                 for c in later.content:
                     if isinstance(c, ToolResultContent):
                         fulfilled.add(c.id)
@@ -984,14 +987,16 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
         if self._read_tool_result is not None:
             _register(self._read_tool_result)
 
-        if self._bg_tasks:
-            bg_tool = Tool(
-                name="get_background_task",
-                description="Get the status and events of a background task.",
-                handler=self.get_background_task,
-            )
-            bg_tool.nest(self._path)
-            _register(bg_tool)
+        store = current_background_store()
+        if store is not None and len(store) > 0:
+            for name, description, handler in (
+                ("get_background_task", GET_BACKGROUND_TASK_DESCRIPTION, self.get_background_task),
+                ("list_background_tasks", LIST_BACKGROUND_TASKS_DESCRIPTION, self.list_background_tasks),
+                ("cancel_background_task", CANCEL_BACKGROUND_TASK_DESCRIPTION, self.cancel_background_task),
+            ):
+                bg_tool = Tool(name=name, description=description, handler=handler)
+                bg_tool.nest(self._path)
+                _register(bg_tool)
 
         return tools, commands
 
@@ -1383,9 +1388,7 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
                         # replace the result with a notice — the tool_use must still get a
                         # paired result, and the model should know why it can't see it.
                         reason = outcome.verdict.reason or "content policy"
-                        replace_tool_result_text(
-                            c, f"[Blocked by guardrail '{outcome.rail.name}'] {reason}"
-                        )
+                        replace_tool_result_text(c, f"[Blocked by guardrail '{outcome.rail.name}'] {reason}")
                     elif outcome.replaced:
                         replace_tool_result_text(c, outcome.text)
             # Production-time offload: reduce an oversized result once, before it enters
@@ -1486,16 +1489,10 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
                                         yield pending_event
                                     pending_guardrail_events.clear()
                                     if isinstance(event, OutputEvent) and event.output is not None:
-                                        if (
-                                            event.status.code == "cancelled"
-                                            and event.status.reason in _PAUSE_REASONS
-                                        ):
+                                        if event.status.code == "cancelled" and event.status.reason in _PAUSE_REASONS:
                                             yield event
                                             raise PauseRequired(event)
-                                        if (
-                                            event.status.code == "cancelled"
-                                            and event.status.reason == "cancelled"
-                                        ):
+                                        if event.status.code == "cancelled" and event.status.reason == "cancelled":
                                             yield event
                                             raise RunCancelled(event.status.message or "Run cancelled by user.")
                                         current_span.memory.append(
@@ -1571,11 +1568,7 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
                 guard_step = _runner is not None and _runner.has_stage(GuardrailStage.MODEL_STEP)
                 _out_stages = (GuardrailStage.MODEL_OUTPUT, GuardrailStage.MODEL_STEP)
                 buffer_stream = (guard_output or guard_step) and _runner.needs_buffering(*_out_stages)
-                stream_scrub = (
-                    not buffer_stream
-                    and _runner is not None
-                    and bool(_runner.scrub_rails(*_out_stages))
-                )
+                stream_scrub = not buffer_stream and _runner is not None and bool(_runner.scrub_rails(*_out_stages))
                 # One scrubber per content block id: text and thinking deltas interleave,
                 # so a shared holdback buffer would stitch unrelated content together.
                 delta_scrubbers: dict[str, Any] = {}
@@ -1629,8 +1622,7 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
                         # message enters memory, so replace/redact verdicts persist and a
                         # blocked response never poisons history.
                         is_final = not interrupted and not any(
-                            isinstance(c, ToolUseContent) and not c.is_server_tool_use
-                            for c in event.output.content
+                            isinstance(c, ToolUseContent) and not c.is_server_tool_use for c in event.output.content
                         )
                         stages_to_run: list[GuardrailStage] = []
                         if guard_step and not interrupted:
@@ -1685,8 +1677,7 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
                                 # Retry budget exhausted (or mid-plan) — block with the reason.
                                 g_verdict = Verdict.block(
                                     g_verdict.reason,
-                                    blocked_message=g_verdict.blocked_message
-                                    or g_rail.blocked_message_for(g_stage),
+                                    blocked_message=g_verdict.blocked_message or g_rail.blocked_message_for(g_stage),
                                 )
                             if g_verdict is not None and g_verdict.action in ("block", "escalate"):
                                 # escalate has no human gate at the output edge — block.

--- a/python/timbal/core/runnable.py
+++ b/python/timbal/core/runnable.py
@@ -6,7 +6,6 @@ import inspect
 import json
 import logging
 import os
-import secrets
 import time
 import traceback
 from abc import ABC, abstractmethod
@@ -144,8 +143,6 @@ _TimbalCollector = None
 """Lazily imported TimbalCollector class — avoids importing collectors at module load."""
 
 
-ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"
-
 _BLOCKING_HANDLER_WARN_MS = float(os.getenv("TIMBAL_BLOCKING_WARN_MS", "100"))
 """Sync handlers running inline for longer than this (ms) get a one-time
 warning suggesting offload_blocking=True / an async handler. Set to 0 to warn
@@ -194,8 +191,7 @@ def _coerce_approval_resolution(value: Any) -> ApprovalResolution:
     if isinstance(value, dict):
         return ApprovalResolution.model_validate(value)
     raise ValueError(
-        "resume value for an approval gate must be a bool, dict, or ApprovalResolution; "
-        f"got {type(value).__name__}."
+        f"resume value for an approval gate must be a bool, dict, or ApprovalResolution; got {type(value).__name__}."
     )
 
 
@@ -312,6 +308,12 @@ class Runnable(ABC, BaseModel):
     background_mode: Literal["auto", "always", "never"] = "never"
     """Background execution mode"""
 
+    on_background_cancel: Callable[..., Any] | None = Field(default=None, exclude=True)
+    """Optional hook fired when ``cancel_background_task`` cancels this child.
+    Receives the ``BackgroundTask`` record (has ``task_id``, ``metadata`` with
+    child ``run_id`` / ``cursor_agent_id`` once those events have arrived).
+    Use this to stop external work the asyncio.Task cancel cannot reach."""
+
     offload_blocking: bool = False
     """If True, plain sync handlers run in the default thread pool so blocking
     code doesn't stall the event loop. Default False: sync handlers run inline
@@ -371,7 +373,7 @@ class Runnable(ABC, BaseModel):
     #   _dependencies, _default_fixed_params, _default_runtime_params,
     #   _pre_hook_is_coroutine, _pre_hook_dependencies,
     #   _post_hook_is_coroutine, _post_hook_dependencies,
-    #   _log_events, _bg_tasks
+    #   _log_events
     # Do not add class-level annotations for them — pydantic would turn any
     # annotated underscore name back into a (slow) private attribute.
 
@@ -496,7 +498,6 @@ class Runnable(ABC, BaseModel):
         self._dependencies: list[str] = []
         self._default_fixed_params: dict[str, Any] = {}
         self._default_runtime_params: dict[str, dict[str, Any]] = {}
-        self._bg_tasks: dict[str, Any] = {}
         self._blocking_warned: bool = False
         # Guardrail wiring (see timbal.guardrails). _agent_guardrails is injected by the
         # owning Agent; _guardrails_exempt marks framework-internal runnables (the LLM
@@ -833,45 +834,28 @@ class Runnable(ABC, BaseModel):
         return self.anthropic_schema
 
     def get_background_task(self, task_id: str) -> dict[str, Any]:
-        """Get the status and events of a background task."""
-        if task_id not in self._bg_tasks:
-            return {"status": "not_found", "events": []}
+        """Peek a summary of a session-scoped background task. Does not drain."""
+        from ..state.background import get_background_task as _get
 
-        task_info = self._bg_tasks[task_id]
-        task = task_info["task"]
+        return _get(task_id)
 
-        # Get all available events
-        events = []
-        queue = task_info["event_queue"]
-        while not queue.empty():
-            try:
-                events.append(queue.get_nowait())
-            except asyncio.QueueEmpty:
-                break
+    def list_background_tasks(self) -> list[dict[str, Any]]:
+        """List background tasks for the current session."""
+        from ..state.background import list_background_tasks as _list
 
-        # Determine status
-        if task.done():
-            # del self._bg_tasks[task_id] # Do not remove, to keep track of all background tasks
-            if task.cancelled():
-                return {"status": "cancelled", "events": events, "name": task_info["name"], "input": task_info["input"]}
-            elif task.exception():
-                return {
-                    "status": "error",
-                    "error": str(task.exception()),
-                    "events": events,
-                    "name": task_info["name"],
-                    "input": task_info["input"],
-                }
-            else:
-                return {
-                    "status": "completed",
-                    "result": task.result(),
-                    "events": events,
-                    "name": task_info["name"],
-                    "input": task_info["input"],
-                }
-        else:
-            return {"status": "running", "events": events, "name": task_info["name"], "input": task_info["input"]}
+        return _list()
+
+    def cancel_background_task(self, task_id: str) -> dict[str, Any]:
+        """Cancel a running background task in the current session."""
+        from ..state.background import cancel_background_task as _cancel
+
+        return _cancel(task_id)
+
+    def read_background_transcript(self, task_id: str, after: int = 0) -> dict[str, Any]:
+        """Raw events for a background task from cursor ``after``."""
+        from ..state.background import read_background_transcript as _read
+
+        return _read(task_id, after=after)
 
     async def _execute_runtime_callable(self, fn: Callable[..., Any], is_coroutine: bool) -> Any:
         """Execute a runtime callable handling async context automatically.
@@ -1066,7 +1050,7 @@ class Runnable(ABC, BaseModel):
                 )
 
     async def _execute_handler(
-        self, validated_input: dict[str, Any], run_context: Any, span: Any, event_queue: asyncio.Queue | None = None
+        self, validated_input: dict[str, Any], run_context: Any, span: Any, event_queue: Any | None = None
     ) -> AsyncGenerator[tuple[Event | None, Any, Any], None]:
         """Execute the handler with optional event streaming.
 
@@ -1104,6 +1088,8 @@ class Runnable(ABC, BaseModel):
             collector_type = get_collector_registry().get_collector_type(first_chunk)
             if collector_type:
                 collector = collector_type(async_gen=async_gen, start=handler_start)
+                if event_queue is not None and hasattr(event_queue, "_handler_aclose"):
+                    event_queue._handler_aclose = collector.aclose
 
                 # Yield collector immediately so it's available for interruption handling
                 yield (None, None, collector)
@@ -1523,24 +1509,27 @@ class Runnable(ABC, BaseModel):
     def _spawn_background_task(
         self, validated_input: dict[str, Any], input: dict[str, Any], run_context: Any, span: Any
     ) -> dict[str, Any]:
-        """Spawn the handler as a background task registered on the parent runnable.
+        """Spawn the handler as a background task on the session bag.
 
         Returns the ``{"task_id", "status"}`` placeholder output for the
-        launching span. The task streams its events into a queue polled via
-        :meth:`get_background_task` and records its real output on the span
-        when it completes.
+        launching span. Events go to an append-only log on the current
+        :class:`~timbal.state.background.BackgroundTaskStore` (inherited
+        across sequential turns via ``parent_id``). They are **not** yielded
+        back onto the parent stream after detach.
         """
+        from ..state.background import register_background_task
+
         parent_span = run_context.parent_span()
         if not parent_span:
             raise ValueError("Parent span not found. Cannot run in background.")
-        task_id = "".join(secrets.choice(ALPHABET) for _ in range(6))
-        event_queue = asyncio.Queue()
+        record_box: list[Any] = []
 
         async def _bg_handler_execution():
+            record = record_box[0]
             output = None
             try:
                 async for _, final_output, _handler_collector in self._execute_handler(
-                    validated_input, run_context, span, event_queue
+                    validated_input, run_context, span, record
                 ):
                     if final_output is not None:
                         output = final_output
@@ -1556,19 +1545,20 @@ class Runnable(ABC, BaseModel):
                     await self._execute_runtime_callable(self.post_hook, self._post_hook_is_coroutine)
 
             except asyncio.CancelledError:
-                # Re-raise so asyncio marks the task as cancelled
                 raise
+            finally:
+                record.log.close()
+            return output
 
         task = asyncio.create_task(_bg_handler_execution(), context=contextvars.copy_context())
-
-        # Store task with event queue in parent runnable if available
-        parent_span.runnable._bg_tasks[task_id] = {
-            "task": task,
-            "event_queue": event_queue,
-            "name": self.name,
-            "input": input,
-        }
-        return {"task_id": task_id, "status": "running"}
+        record = register_background_task(
+            name=self.name,
+            input=input,
+            task=task,
+            on_cancel=self.on_background_cancel,
+        )
+        record_box.append(record)
+        return {"task_id": record.task_id, "status": "running"}
 
     def __call__(self, **kwargs: Any) -> Any:
         """Execute the runnable, returning a TimbalCollector over its event stream.

--- a/python/timbal/state/__init__.py
+++ b/python/timbal/state/__init__.py
@@ -6,6 +6,8 @@ Public API:
     - RunContext: The data model for the run context.
     - get_run_context(): Retrieves the current run context.
     - get_or_create_run_context(): Retrieves the current run context, creating a new one if necessary.
+    - get_background_task / list_background_tasks / cancel_background_task /
+      read_background_transcript: session-scoped background children.
 
 The context is typically managed automatically by the framework. Advanced users
 may need to set the context manually when creating custom execution flows.
@@ -18,6 +20,18 @@ import re
 from contextvars import ContextVar
 from typing import Any
 
+from .background import (
+    cancel_background_task as cancel_background_task,
+)
+from .background import (
+    get_background_task as get_background_task,
+)
+from .background import (
+    list_background_tasks as list_background_tasks,
+)
+from .background import (
+    read_background_transcript as read_background_transcript,
+)
 from .context import RunContext
 
 # INTERNAL: This variable holds the context. Do not access directly.

--- a/python/timbal/state/background.py
+++ b/python/timbal/state/background.py
@@ -1,0 +1,500 @@
+"""Session-scoped background-task store.
+
+Background children (``background_mode="auto"|"always"``) used to live on the
+parent ``Runnable._bg_tasks`` dict. That is process-wide for a singleton Agent:
+two dock users share ids, ``get_background_task`` appears as soon as *anyone*
+has a child, and a 6-char id is a cross-tenant guess.
+
+Tasks now live on a :class:`BackgroundTaskStore` bound to the ``RunContext``
+and inherited across sequential turns via ``parent_id`` (same in-process
+session). Concurrent parent runs — no shared ``parent_id`` — get isolated
+stores.
+
+The event log is append-only. ``get_background_task`` peeks a summary; it does
+not drain. Raw events are ``read_background_transcript(after=)`` or
+:meth:`BackgroundEventLog.subscribe`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncIterator, Callable
+from typing import Any
+
+_SUMMARY_TEXT_CHARS = 1_000
+_TASK_ID_LEN = 12
+_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"
+
+# Process-local: run_id → store. Sequential turns find the bag via parent_id.
+# Concurrent siblings (no parent_id) each create a new store.
+_STORES_BY_RUN_ID: dict[str, BackgroundTaskStore] = {}
+
+_DONE = object()
+
+
+def _new_task_id() -> str:
+    import secrets
+
+    return "".join(secrets.choice(_ALPHABET) for _ in range(_TASK_ID_LEN))
+
+
+def _dump_event(event: Any) -> Any:
+    if hasattr(event, "model_dump"):
+        return event.model_dump()
+    return event
+
+
+_EVENT_CLASSES: dict[str, Any] = {}
+
+
+def _event_classes() -> dict[str, Any]:
+    """Event classes, imported on first use.
+
+    ``timbal.types`` imports back into ``timbal.state`` (File needs the run
+    context), so importing events at module scope here deadlocks a cold
+    interpreter: ``state/__init__`` → background → types → state (partial).
+    """
+    if not _EVENT_CLASSES:
+        from ..types.events import OutputEvent
+        from ..types.events.delta import DeltaEvent, Text, TextDelta, ToolUse
+
+        _EVENT_CLASSES.update(
+            delta_event=DeltaEvent,
+            output_event=OutputEvent,
+            text=Text,
+            text_delta=TextDelta,
+            tool_use=ToolUse,
+        )
+    return _EVENT_CLASSES
+
+
+def _event_text(event: Any, classes: dict[str, Any] | None = None) -> str:
+    classes = classes or _event_classes()
+    if isinstance(event, classes["delta_event"]):
+        item = event.item
+        if isinstance(item, classes["text_delta"]):
+            return item.text_delta
+        if isinstance(item, classes["text"]):
+            return item.text
+        return ""
+    if isinstance(event, classes["output_event"]) and event.output is not None:
+        output = event.output
+        collect = getattr(output, "collect_text", None)
+        if callable(collect):
+            try:
+                return collect() or ""
+            except Exception:
+                return ""
+        if isinstance(output, str):
+            return output
+    return ""
+
+
+def _event_tool_name(event: Any, classes: dict[str, Any] | None = None) -> str | None:
+    classes = classes or _event_classes()
+    if isinstance(event, classes["delta_event"]) and isinstance(event.item, classes["tool_use"]):
+        return event.item.name
+    return None
+
+
+def _lift_metadata(event: Any, metadata: dict[str, Any]) -> None:
+    """Copy durable child ids off START/OUTPUT onto the task record."""
+    run_id = getattr(event, "run_id", None)
+    if run_id and not metadata.get("run_id"):
+        metadata["run_id"] = run_id
+    event_meta = getattr(event, "metadata", None)
+    if not isinstance(event_meta, dict):
+        return
+    for key in ("cursor_agent_id", "agent_id"):
+        if event_meta.get(key) and not metadata.get(key):
+            metadata[key] = event_meta[key]
+
+
+def _title_from_input(name: str, input: dict[str, Any]) -> str:
+    for key in ("prompt", "tag", "message", "task_name", "project_name"):
+        value = input.get(key)
+        if isinstance(value, str) and value.strip():
+            text = value.strip()
+            return text if len(text) <= 80 else text[:77] + "..."
+        collect = getattr(value, "collect_text", None)
+        if callable(collect):
+            text = (collect() or "").strip()
+            if text:
+                return text if len(text) <= 80 else text[:77] + "..."
+    return name
+
+
+class BackgroundEventLog:
+    """Append-only log. ``put_nowait`` matches :class:`asyncio.Queue` so
+    ``_execute_handler`` can treat this as the event sink."""
+
+    def __init__(self) -> None:
+        self._events: list[Any] = []
+        self._subscribers: list[asyncio.Queue] = []
+
+    def put_nowait(self, event: Any) -> None:
+        self._events.append(event)
+        for queue in self._subscribers:
+            queue.put_nowait(event)
+
+    def peek(self, after: int = 0) -> list[Any]:
+        return list(self._events[after:])
+
+    def qsize(self) -> int:
+        return len(self._events)
+
+    def empty(self) -> bool:
+        return not self._events
+
+    async def subscribe(self, after: int = 0) -> AsyncIterator[Any]:
+        """Replay from ``after``, then yield live events until :meth:`close`."""
+        queue: asyncio.Queue = asyncio.Queue()
+        # Register before replay so we cannot drop events that arrive mid-replay.
+        self._subscribers.append(queue)
+        try:
+            for event in self._events[after:]:
+                yield event
+            while True:
+                event = await queue.get()
+                if event is _DONE:
+                    return
+                yield event
+        finally:
+            if queue in self._subscribers:
+                self._subscribers.remove(queue)
+
+    def close(self) -> None:
+        for queue in self._subscribers:
+            queue.put_nowait(_DONE)
+
+
+class BackgroundTask:
+    """One detached child: asyncio.Task + durable event log."""
+
+    def __init__(
+        self,
+        task_id: str,
+        *,
+        name: str,
+        input: dict[str, Any],
+        task: asyncio.Task,
+        started_at: int,
+        title: str | None = None,
+        on_cancel: Callable[..., Any] | None = None,
+    ) -> None:
+        self.task_id = task_id
+        self.name = name
+        self.input = input
+        self.task = task
+        self.started_at = started_at
+        self.title = title or _title_from_input(name, input)
+        self.log = BackgroundEventLog()
+        self.metadata: dict[str, Any] = {}
+        self.on_cancel = on_cancel
+        self._cancel_requested = False
+        self._handler_aclose: Callable[..., Any] | None = None
+
+    async def aclose_handler(self) -> None:
+        """Stop the child's handler gen, not just the wrapping asyncio.Task.
+
+        Cancelling the Task unwinds the consumer, but an async generator
+        suspended *at a yield* is left suspended — its ``finally`` never runs,
+        so a handler holding a subprocess/socket would leak. We must ``aclose``
+        it, and only after the Task has finished unwinding: calling ``aclose``
+        while the generator is still running raises "already running".
+        """
+        task = self.task
+        if not task.done():
+            try:
+                await asyncio.wait({task})
+            except asyncio.CancelledError:
+                pass
+        aclose = self._handler_aclose
+        self._handler_aclose = None
+        if aclose is None:
+            return
+        try:
+            await aclose()
+        except (asyncio.CancelledError, GeneratorExit):
+            pass
+        except Exception:
+            pass
+
+    def ingest(self, event: Any) -> None:
+        _lift_metadata(event, self.metadata)
+        self.log.put_nowait(event)
+
+    def put_nowait(self, event: Any) -> None:
+        """Queue-shaped sink used by ``_execute_handler``."""
+        self.ingest(event)
+
+    def status_code(self) -> str:
+        task = self.task
+        if self._cancel_requested or (task.done() and task.cancelled()):
+            return "cancelled"
+        if not task.done():
+            return "running"
+        if task.exception() is not None:
+            return "error"
+        return "completed"
+
+    def summarize(self) -> dict[str, Any]:
+        events = self.log.peek()
+        classes = _event_classes()
+        text_parts: list[str] = []
+        tools: list[str] = []
+        for event in events:
+            chunk = _event_text(event, classes)
+            if chunk:
+                text_parts.append(chunk)
+            tool_name = _event_tool_name(event, classes)
+            if tool_name:
+                tools.append(tool_name)
+        text = "".join(text_parts)
+        if len(text) > _SUMMARY_TEXT_CHARS:
+            text = text[-_SUMMARY_TEXT_CHARS:]
+        snapshot: dict[str, Any] = {
+            "status": self.status_code(),
+            "task_id": self.task_id,
+            "name": self.name,
+            "input": self.input,
+            "title": self.title,
+            "started_at": self.started_at,
+            "summary": {
+                "text": text,
+                "tools_in_flight": tools,
+                "event_count": len(events),
+            },
+            "transcript_cursor": len(events),
+        }
+        snapshot.update(self.metadata)
+        if self.task.done() and not self.task.cancelled():
+            exc = self.task.exception()
+            if exc is not None:
+                snapshot["error"] = str(exc)
+            else:
+                snapshot["result"] = self.task.result()
+        return snapshot
+
+    def listing(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "name": self.name,
+            "status": self.status_code(),
+            "started_at": self.started_at,
+            "title": self.title,
+        }
+
+
+class BackgroundTaskStore:
+    """Per-session bag of background children. Shared across sequential
+    ``RunContext``s in the same parent_id chain; not across concurrent runs."""
+
+    def __init__(self) -> None:
+        self._tasks: dict[str, BackgroundTask] = {}
+
+    def __len__(self) -> int:
+        return len(self._tasks)
+
+    def __contains__(self, task_id: str) -> bool:
+        return task_id in self._tasks
+
+    def add(self, record: BackgroundTask) -> None:
+        self._tasks[record.task_id] = record
+
+    def get(self, task_id: str) -> BackgroundTask | None:
+        return self._tasks.get(task_id)
+
+    def list(self) -> list[dict[str, Any]]:
+        return [record.listing() for record in self._tasks.values()]
+
+    def snapshot(self, task_id: str) -> dict[str, Any]:
+        record = self._tasks.get(task_id)
+        if record is None:
+            return {"status": "not_found", "task_id": task_id}
+        return record.summarize()
+
+    def transcript(self, task_id: str, after: int = 0) -> dict[str, Any]:
+        record = self._tasks.get(task_id)
+        if record is None:
+            return {"status": "not_found", "task_id": task_id, "events": [], "cursor": after}
+        events = record.log.peek(after)
+        return {
+            "status": record.status_code(),
+            "task_id": task_id,
+            "events": [_dump_event(event) for event in events],
+            "cursor": after + len(events),
+        }
+
+    def cancel(self, task_id: str) -> dict[str, Any]:
+        record = self._tasks.get(task_id)
+        if record is None:
+            return {"status": "not_found", "task_id": task_id}
+        if not record.task.done():
+            record._cancel_requested = True
+            record.task.cancel()
+            try:
+                asyncio.get_running_loop().create_task(record.aclose_handler())
+            except RuntimeError:
+                pass
+        if record.on_cancel is not None:
+            try:
+                record.on_cancel(record)
+            except Exception:
+                pass
+        return record.summarize()
+
+
+def bind_background_store(run_context: Any) -> BackgroundTaskStore | None:
+    """Inherit the parent session's bag, if there is one.
+
+    Runs on **every** ``RunContext`` construction, so it must stay cheap and
+    must not allocate: the overwhelming majority of runs never spawn a
+    background child. No store is created and nothing is registered in the
+    process-local map until :func:`ensure_background_store` is called from the
+    spawn path. Otherwise the map would grow by one entry per run forever.
+    """
+    store = None
+    parent_id = run_context.parent_id
+    if parent_id is not None:
+        store = _STORES_BY_RUN_ID.get(parent_id)
+        if store is not None:
+            # Keep the chain alive: the next turn parented on this run finds it.
+            _STORES_BY_RUN_ID[run_context.id] = store
+    run_context._bg_store = store
+    return store
+
+
+def ensure_background_store(run_context: Any) -> BackgroundTaskStore:
+    """Get (creating if needed) the session bag, and register it for chaining.
+
+    Called from the spawn path only — this is what puts a run in the
+    process-local map.
+    """
+    store = run_context._bg_store
+    if store is None:
+        store = BackgroundTaskStore()
+        run_context._bg_store = store
+    _STORES_BY_RUN_ID[run_context.id] = store
+    return store
+
+
+def store_for_run(run_id: str) -> BackgroundTaskStore | None:
+    """Look up the session bag registered for a run id (tests / JobStore)."""
+    return _STORES_BY_RUN_ID.get(run_id)
+
+
+def current_background_store() -> BackgroundTaskStore | None:
+    from . import get_run_context
+
+    run_context = get_run_context()
+    if run_context is None:
+        return None
+    return getattr(run_context, "_bg_store", None)
+
+
+def get_background_task(task_id: str) -> dict[str, Any]:
+    """Peek a summary of a background task. Does not drain the event log.
+
+    Use this to answer questions about an in-flight or finished background
+    tool. You get status, a short text summary, and any child ids (e.g.
+    ``cursor_agent_id``, ``run_id``). You must have a ``task_id`` from a
+    previous background-tool result or from ``list_background_tasks``.
+    Raw events: ``read_background_transcript``.
+    """
+    store = current_background_store()
+    if store is None:
+        return {"status": "not_found", "task_id": task_id}
+    return store.snapshot(task_id)
+
+
+def list_background_tasks() -> list[dict[str, Any]]:
+    """List background tools for this session (not other concurrent runs).
+
+    Returns ``[{task_id, name, status, started_at, title}]``. Use a ``task_id``
+    with ``get_background_task`` to answer questions about a child.
+    """
+    store = current_background_store()
+    if store is None:
+        return []
+    return store.list()
+
+
+def cancel_background_task(task_id: str) -> dict[str, Any]:
+    """Cancel a running background task and stop its in-flight work.
+
+    Cancels the asyncio.Task (the child's handler sees ``CancelledError``).
+    If the child registered ``on_background_cancel``, that hook runs too
+    (e.g. to stop an external harness).
+    """
+    store = current_background_store()
+    if store is None:
+        return {"status": "not_found", "task_id": task_id}
+    return store.cancel(task_id)
+
+
+def read_background_transcript(task_id: str, after: int = 0) -> dict[str, Any]:
+    """Raw events for a background task, from cursor ``after`` (inclusive).
+
+    Does not drain. A second read with the same ``after`` returns the same
+    events. ``cursor`` is the next index to pass.
+    """
+    store = current_background_store()
+    if store is None:
+        return {"status": "not_found", "task_id": task_id, "events": [], "cursor": after}
+    return store.transcript(task_id, after=after)
+
+
+def register_background_task(
+    *,
+    name: str,
+    input: dict[str, Any],
+    task: asyncio.Task,
+    on_cancel: Callable[..., Any] | None = None,
+    started_at: int | None = None,
+) -> BackgroundTask:
+    """Register a running child on the current session bag."""
+    from . import get_run_context
+
+    run_context = get_run_context()
+    if run_context is None:
+        raise RuntimeError("Cannot register a background task without a RunContext.")
+    store = ensure_background_store(run_context)
+    record = BackgroundTask(
+        _new_task_id(),
+        name=name,
+        input=input,
+        task=task,
+        started_at=started_at if started_at is not None else int(time.time() * 1000),
+        on_cancel=on_cancel,
+    )
+    store.add(record)
+    return record
+
+
+def clear_background_stores() -> None:
+    """Drop the process-local registry. Tests only."""
+    _STORES_BY_RUN_ID.clear()
+
+
+GET_BACKGROUND_TASK_DESCRIPTION = (
+    "Get a summary of an in-flight or finished background tool so you can "
+    "answer questions about it (status, last assistant text, tools it called, "
+    "error). You must have a task_id from a previous background-tool result "
+    "or from list_background_tasks. This does not return the full event log — "
+    "use it to brief the user, not to dump a long build."
+)
+
+LIST_BACKGROUND_TASKS_DESCRIPTION = (
+    "List background tools started in this session: task_id, name, status, "
+    "started_at, title. Use this when the user asks what builders/tasks are "
+    "running or to find a task_id for get_background_task / cancel_background_task. "
+    "You only see this session — not other users."
+)
+
+CANCEL_BACKGROUND_TASK_DESCRIPTION = (
+    "Cancel a running background tool by task_id (from a previous spawn result "
+    "or list_background_tasks). Stops the child's in-flight work. Use when the "
+    "user says to stop/cancel a builder or background task."
+)

--- a/python/timbal/state/context.py
+++ b/python/timbal/state/context.py
@@ -97,6 +97,8 @@ class RunContext(BaseModel):
     #   _trace: Trace
     #   _tracing_provider: type[TracingProvider] | None
     #   _session_data: dict | None
+    #   _bg_store: BackgroundTaskStore — session bag of detached children;
+    #       inherited across sequential turns via parent_id (see background.py)
     #   _resume_values: dict — active resume values keyed by id, supplied via
     #       ``resume=`` to fulfill a paused run. The id is an approval_id for an
     #       approval gate (value normalized to ``ApprovalResolution``) or a
@@ -165,15 +167,17 @@ class RunContext(BaseModel):
             if code == "cancelled" and reason == "input_required":
                 suspension = (span.metadata or {}).get("suspension")
                 if suspension and suspension.get("id"):
-                    pending.append({
-                        "interaction_id": suspension["id"],
-                        "kind": suspension.get("kind", "suspend"),
-                        "path": span.path,
-                        "call_id": span.call_id,
-                        "tool_call_id": suspension.get("tool_call_id"),
-                        "payload": suspension.get("payload", {}),
-                        "response_schema": suspension.get("response_schema"),
-                    })
+                    pending.append(
+                        {
+                            "interaction_id": suspension["id"],
+                            "kind": suspension.get("kind", "suspend"),
+                            "path": span.path,
+                            "call_id": span.call_id,
+                            "tool_call_id": suspension.get("tool_call_id"),
+                            "payload": suspension.get("payload", {}),
+                            "response_schema": suspension.get("response_schema"),
+                        }
+                    )
         return pending
 
     def model_post_init(self, __context: Any) -> None:
@@ -185,6 +189,7 @@ class RunContext(BaseModel):
         If no platform_config is provided, attempts to resolve it from
         environment variables and ~/.timbal/ config files.
         """
+        from .background import bind_background_store
         from .config_loader import resolve_platform_config
 
         # Plain instance attributes (see NOTE above).
@@ -193,6 +198,10 @@ class RunContext(BaseModel):
         self._resume_values: dict[str, Any] = {}
         self._used_resume_ids: set[str] = set()
         self._trace = Trace()
+        # Inherit the parent session's background-task bag (usually None) so a
+        # finished parent turn can still list/peek/cancel running builders.
+        # Allocates nothing unless this session actually has children.
+        bind_background_store(self)
 
         # Explicit provider set on the runnable — skip auto-detection entirely.
         # None means tracing is disabled; a class means use that provider.


### PR DESCRIPTION
Background children lived on `Runnable._bg_tasks`, a dict on the Agent instance. For a long-lived singleton Agent that is effectively process-wide: two concurrent users shared ids, `get_background_task` was injected as soon as *anyone* in the process had a child, and a 6-char id was a cross-tenant guess.

Tasks now live on a BackgroundTaskStore bound to the RunContext and inherited across sequential turns via parent_id, so a finished turn can still list, peek, and cancel its own children while concurrent runs stay isolated.

The event log is append-only rather than a consume-once asyncio.Queue: `get_background_task` peeks a summary without draining, so a parent agent and a frontend can both watch the same child. Raw events come from `read_background_transcript(after=)` or `BackgroundEventLog.subscribe`.

Adds `Runnable.on_background_cancel` so a child can stop external work that cancelling the asyncio.Task cannot reach.

Fixes two bugs this exposed:
- background handlers returned None instead of their output
- cancel abandoned the handler generator instead of closing it. A generator suspended at a yield never ran its finally, leaking whatever it held; aclose now waits for the task to unwind first, since closing a still-running generator raises "already running".

Downstream: task ids are now 12 chars, and the three background tools are injected only when *this* session has children.