### PR TITLE
fix(core): put handler-emitted events on the background log

### DIFF
--- a/docs/agents/background-tasks.mdx
+++ b/docs/agents/background-tasks.mdx
@@ -101,6 +101,8 @@ async for event in record.log.subscribe():
     print(event)
 ```
 
+A streaming handler can yield either form and both reach the log. Raw delta items are wrapped into `DeltaEvent`s under the parent's run. Already-formed Timbal events (`StartEvent`, `DeltaEvent`, `OutputEvent`) are logged as they are — which is how a child that runs its own agent, such as a coding harness or a remote worker, keeps its own `run_id` and metadata on the task record. Those are the ids `on_background_cancel` and resume need.
+
 ## Listing and Cancelling
 
 ```python

--- a/python/tests/core/test_background_tasks.py
+++ b/python/tests/core/test_background_tasks.py
@@ -1,6 +1,7 @@
 import asyncio
 import time
 from collections.abc import AsyncGenerator
+from typing import Any
 
 import pytest
 from timbal import Agent, Tool
@@ -17,8 +18,9 @@ from timbal.state import (
     set_run_context,
 )
 from timbal.types.content import ToolUseContent
-from timbal.types.events.delta import TextDelta
+from timbal.types.events.delta import DeltaEvent, TextDelta
 from timbal.types.events.output import OutputEvent
+from timbal.types.events.start import StartEvent
 from timbal.types.message import Message
 
 from ..conftest import assert_has_output_event
@@ -51,11 +53,44 @@ def _tool_calls(*calls: tuple[str, dict, str, bool]) -> Message:
 
 
 async def _fake_streaming_builder(prompt: str) -> AsyncGenerator[TextDelta, None]:
-    """Same contract as sidecar ``build_turn``: async gen of Timbal deltas."""
+    """Async gen of raw delta *items*, which the runnable wraps for us."""
     for i in range(4):
         yield TextDelta(id="b", text_delta=f"[{prompt}] chunk {i} ")
         await asyncio.sleep(0.08)
     yield TextDelta(id="b", text_delta=f"[{prompt}] done")
+
+
+CHILD_RUN_ID = "child-run-1"
+
+
+async def _fake_event_builder(prompt: str) -> AsyncGenerator[Any, None]:
+    """Async gen of already-formed Timbal *events* — the real sidecar contract.
+
+    A harness child (composer's Cursor ``build_turn``) does not yield delta
+    items for us to wrap: it runs its own agent and emits a complete
+    START/DELTA/OUTPUT stream under its own ``run_id``, which is the handle its
+    harness is cancellable by. Those ids only survive if the events themselves
+    reach the log.
+    """
+    ids = {
+        "run_id": CHILD_RUN_ID,
+        "path": "composer.builder",
+        "call_id": "child-call-1",
+        "parent_run_id": None,
+        "parent_call_id": None,
+    }
+    yield StartEvent(**ids)
+    for i in range(4):
+        yield DeltaEvent(**ids, item=TextDelta(id="b", text_delta=f"[{prompt}] chunk {i} "))
+        await asyncio.sleep(0.08)
+    yield OutputEvent(
+        **ids,
+        status={"code": "success"},
+        t0=0,
+        t1=1,
+        output=Message.validate(f"[{prompt}] done"),
+        metadata={"harness": "cursor", "cursor_agent_id": "cursor-agent-1"},
+    )
 
 
 async def _wait_for_first_event(task_id: str, timeout: float = 5.0) -> int:
@@ -651,6 +686,51 @@ class TestBackgroundMultitask:
         assert "events" not in snap
         assert snap["summary"]["text"]
         await asyncio.sleep(0.4)
+
+    @pytest.mark.asyncio
+    async def test_handler_yielding_timbal_events_reaches_the_log(self):
+        """5.5.2 — a child that speaks Timbal events natively, not delta items.
+
+        Regression: ``process_event`` returned already-formed ``BaseEvent``s
+        without queueing them, on the grounds that they were "already logged".
+        For a foreground run that is true — the caller sees them on the stream.
+        After detach there is no stream, so the log was the only copy and the
+        parent got ``event_count: 0``: no transcript to show, no summary to
+        brief the user with, and no child ``run_id`` on the record, which is
+        what ``on_background_cancel`` needs to stop the external harness.
+        """
+        parent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("builder", {"prompt": "harness"}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[Tool(name="builder", handler=_fake_event_builder, background_mode="auto")],
+        )
+
+        await parent(prompt="build").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        await _wait_for_first_event(task_id)
+
+        snap = get_background_task(task_id)
+        assert snap["summary"]["event_count"] >= 1
+        assert "[harness]" in snap["summary"]["text"]
+        # The child's own ids, not the parent's — these make it cancellable.
+        assert snap["run_id"] == CHILD_RUN_ID
+
+        # The events on the log are the child's, unwrapped.
+        events = read_background_transcript(task_id)["events"]
+        assert events
+        assert {event["path"] for event in events} == {"composer.builder"}
+
+        # ...and the terminal OUTPUT's ids land too, so a later turn can resume.
+        for _ in range(100):
+            if get_background_task(task_id)["status"] == "completed":
+                break
+            await asyncio.sleep(0.02)
+        assert get_background_task(task_id)["cursor_agent_id"] == "cursor-agent-1"
 
     @pytest.mark.asyncio
     async def test_agent_as_tool_background(self):

--- a/python/timbal/core/runnable.py
+++ b/python/timbal/core/runnable.py
@@ -1095,8 +1095,16 @@ class Runnable(ABC, BaseModel):
                 yield (None, None, collector)
 
                 def process_event(event):
-                    # If it's already a BaseEvent, it means we have already processed and logged it
+                    # Already a BaseEvent: a nested runnable (or a handler that
+                    # speaks Timbal events natively, e.g. a coding-harness
+                    # sidecar) built and logged it, so it needs no wrapping. It
+                    # still has to reach the sink — after detach the background
+                    # event log is the *only* copy of a child's stream, and
+                    # dropping these leaves the parent with an empty transcript
+                    # and no child ids to cancel or resume by.
                     if isinstance(event, BaseEvent):
+                        if event_queue:
+                            event_queue.put_nowait(event)
                         return event
                     # Wrap non-delta events in a CustomItem
                     if not isinstance(event, DeltaItem):


### PR DESCRIPTION
Follow-up to #131, found wiring the composer sidecar's Cursor builder onto it.

## The bug

`Runnable._execute_handler`'s `process_event` returned already-formed
`BaseEvent`s without writing them to the sink:

```python
# If it's already a BaseEvent, it means we have already processed and logged it
if isinstance(event, BaseEvent):
    return event
```

True for a foreground run — the caller sees them on the stream. After
detach there is no stream, so the background log is the only copy.

So a child that emits Timbal events *natively* — one that runs its own
agent and produces a complete `START`/`DELTA`/`OUTPUT` stream, e.g. a
coding harness or a remote worker — got an empty log:

- `get_background_task` → `event_count: 0`, empty `summary.text`, so the
  parent has nothing to brief the user with
- `read_background_transcript` → no events for a task panel to render
- no child ids lifted onto the record, so `record.metadata["run_id"]` is
  absent — which is exactly what the `on_background_cancel` example in
  `docs/agents/background-tasks.mdx` cancels by. The hook fires, finds
  nothing, and the external work keeps running.

Children yielding raw delta items were unaffected, which is why #131's
tests pass: `_fake_streaming_builder` yields `TextDelta`, a `DeltaItem`,
which takes the wrapping path and does get queued.

Before, same parent, two handler shapes:

```
DeltaItem   status=completed events= 3 text='item 0 item 1 item 2 ' run_id=<parent>
BaseEvent   status=completed events= 0 text=''                     run_id=None
```

## The fix

Queue them too. The write is guarded by `event_queue`, which only
`_spawn_background_task` passes (the foreground path at the other call
site passes nothing), so foreground behaviour is unchanged.

With the fix the second row becomes `events=6` and `run_id=child-run-1` —
the child's own id, which is what makes it cancellable and resumable.

## Tests

`test_handler_yielding_timbal_events_reaches_the_log` — the §5.5.2 case
from the composer handoff, using a handler that yields real
`StartEvent`/`DeltaEvent`/`OutputEvent`. Asserts the log fills, the
summary has the child's text, `run_id` is the *child's*, transcript
events keep the child's `path`, and `cursor_agent_id` lands off the
terminal `OUTPUT`. Verified to fail without the runnable change.

- `python/tests/core/test_background_tasks.py` — 24 passed
- `python/tests/core` — 966 passed

Also documents in `background-tasks.mdx` that a streaming handler may
yield either form, since which one you pick decides whether the child
keeps its own ids.

Made with [Cursor](https://cursor.com)