### PR TITLE
feat(server): make a run's events replayable after a disconnect

### DIFF
--- a/python/tests/core/test_background_tasks.py
+++ b/python/tests/core/test_background_tasks.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 from timbal import Agent, Tool
 from timbal.core.test_model import TestModel
-from timbal.server.jobs import JOB_DONE_SENTINEL, JobStore
+from timbal.server.jobs import JobStore
 from timbal.state import (
     cancel_background_task,
     get_background_task,
@@ -887,10 +887,7 @@ class TestBackgroundMultitask:
         job_id, job = jobs.create_job(parent, {"prompt": "go"})
 
         run_id = None
-        while True:
-            event = await job.queue.get()
-            if event is JOB_DONE_SENTINEL:
-                break
+        async for _, event in job.follow():
             if isinstance(event, OutputEvent) and str(event.path).endswith(".builder"):
                 run_id = event.run_id
                 break

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -235,7 +235,8 @@ class TestFastAPIApp:
         response = client.post("/run", json=test_data)
         assert response.status_code == 200
 
-        # Job should be removed after completion, so cancel returns 404
+        # A finished job is still addressable (it is retained so a late reader
+        # can replay it), but it is no longer cancellable.
         cancel_response = client.post(f"/cancel/{run_id}")
         assert cancel_response.status_code == 404
 
@@ -251,9 +252,104 @@ class TestFastAPIApp:
         response = client.post("/stream", json=test_data)
         assert response.status_code == 200
 
-        # Job should be removed after completion, so cancel returns 404
+        # A finished job is still addressable (it is retained so a late reader
+        # can replay it), but it is no longer cancellable.
         cancel_response = client.post(f"/cancel/{run_id}")
         assert cancel_response.status_code == 404
+
+
+class TestRunEventsEndpoint:
+    """`GET /runs/{run_id}/events` — the reconnect path for a dropped stream."""
+
+    @pytest.fixture
+    def tool_fixture_file(self):
+        return Path(__file__).parent / "fixtures" / "tool_fixture.py"
+
+    @pytest.fixture
+    def tool_app(self, tool_fixture_file, monkeypatch):
+        import_spec = ImportSpec(path=tool_fixture_file, target="tool_fixture")
+        monkeypatch.setenv("TIMBAL_RUNNABLE", f"{import_spec.path}::{import_spec.target}")
+        app = create_app()
+        app.state.runnable = import_spec.load()
+        app.state.job_store = JobStore()
+        return app
+
+    @pytest.fixture
+    def client(self, tool_app):
+        return TestClient(tool_app)
+
+    def test_a_finished_run_replays_from_the_start(self, client):
+        run_id = "replay-me"
+        client.post("/stream", json={"x": "test input", "context": {"id": run_id}})
+
+        body = client.get(f"/runs/{run_id}/events").json()
+
+        assert body["run_id"] == run_id
+        assert body["expired"] is False
+        assert body["done"] is True
+        assert [event["seq"] for event in body["events"]] == list(
+            range(1, len(body["events"]) + 1)
+        )
+        assert body["next_cursor"] == body["events"][-1]["seq"]
+
+    def test_a_cursor_returns_only_what_came_after_it(self, client):
+        run_id = "resume-me"
+        client.post("/stream", json={"x": "test input", "context": {"id": run_id}})
+
+        everything = client.get(f"/runs/{run_id}/events").json()["events"]
+        tail = client.get(f"/runs/{run_id}/events", params={"after": 1}).json()["events"]
+
+        assert [event["seq"] for event in tail] == [
+            event["seq"] for event in everything if event["seq"] > 1
+        ]
+
+    def test_paging_stops_short_of_done(self, client):
+        run_id = "page-me"
+        client.post("/stream", json={"x": "test input", "context": {"id": run_id}})
+
+        first = client.get(f"/runs/{run_id}/events", params={"limit": 1}).json()
+
+        assert len(first["events"]) == 1
+        assert first["next_cursor"] == 1
+        # More events are buffered, so the run being over must not read as done.
+        assert first["done"] is False
+
+        rest = client.get(
+            f"/runs/{run_id}/events", params={"after": first["next_cursor"]}
+        ).json()
+
+        assert rest["done"] is True
+
+    def test_an_unknown_run_is_expired_not_a_clean_ending(self, client):
+        """The whole point of the flag: this must not look like a drained stream."""
+        body = client.get("/runs/never-existed/events", params={"after": 7}).json()
+
+        assert body["expired"] is True
+        assert body["done"] is True
+        assert body["events"] == []
+        assert body["next_cursor"] == 7
+
+    def test_a_reaped_run_is_expired_too(self, tool_app):
+        tool_app.state.job_store = JobStore(retention_secs=0)
+        client = TestClient(tool_app)
+        run_id = "reap-me"
+        client.post("/stream", json={"x": "test input", "context": {"id": run_id}})
+
+        tool_app.state.job_store.reap()
+
+        assert client.get(f"/runs/{run_id}/events").json()["expired"] is True
+
+    def test_waiting_on_a_finished_run_returns_immediately(self, client):
+        run_id = "no-wait"
+        client.post("/stream", json={"x": "test input", "context": {"id": run_id}})
+
+        body = client.get(
+            f"/runs/{run_id}/events",
+            params={"after": 9999, "wait_ms": 30000},
+        ).json()
+
+        assert body["done"] is True
+        assert body["events"] == []
 
 
 class TestServerLifecycle:

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -7,7 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 from timbal import __version__
 from timbal.server.http import create_app
-from timbal.server.jobs import JobStore
+from timbal.server.jobs import JobStore, RunIdInUse
 from timbal.utils import ImportSpec
 
 
@@ -350,6 +350,30 @@ class TestRunEventsEndpoint:
 
         assert body["done"] is True
         assert body["events"] == []
+
+    def test_a_run_keeps_no_log_to_replay(self, client):
+        """`/run` has one reader and no reconnect, so it holds nothing to replay."""
+        run_id = "not-streamed"
+        client.post("/run", json={"x": "test input", "context": {"id": run_id}})
+
+        body = client.get(f"/runs/{run_id}/events").json()
+
+        assert body["expired"] is True
+        assert body["done"] is True
+        assert body["events"] == []
+
+    def test_a_run_id_already_in_use_is_a_conflict(self, tool_app, client, monkeypatch):
+        """Silently orphaning the run that already owns the id is the alternative."""
+
+        def already_taken(*_args, **_kwargs):
+            raise RunIdInUse("dup")
+
+        monkeypatch.setattr(tool_app.state.job_store, "create_job", already_taken)
+
+        response = client.post("/stream", json={"x": "test input", "context": {"id": "dup"}})
+
+        assert response.status_code == 409
+        assert "dup" in response.json()["detail"]
 
 
 class TestServerLifecycle:

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
+from pydantic import BaseModel
 from timbal import __version__
 from timbal.server.http import create_app
 from timbal.server.jobs import JobStore, RunIdInUse
@@ -395,6 +396,65 @@ class TestRunEventsEndpoint:
         assert tail["expired"] is False
         assert tail["events"]
         assert tail["done"] is True
+
+
+class _Tick(BaseModel):
+    n: int
+
+
+async def _burst(**kwargs):
+    """Emits its whole run before a reader is ever scheduled.
+
+    No awaits between yields, so the producer task drains to completion in one
+    slice of the event loop — which is how a reader deterministically ends up
+    behind a small ring's floor.
+    """
+    for n in range(5):
+        yield _Tick(n=n)
+
+
+class TestTruncationIsAnnounced:
+    """A reader the log outran must not be told the run ended cleanly."""
+
+    @pytest.fixture
+    def burst_app(self, monkeypatch):
+        monkeypatch.setenv("TIMBAL_RUNNABLE", "unused.py::unused")
+        app = create_app()
+        app.state.runnable = _burst
+        # One event of headroom: whatever the reader has not taken by the time
+        # the next event lands is gone.
+        app.state.job_store = JobStore(max_events=1)
+        return app
+
+    def test_a_stream_the_log_outran_says_so(self, burst_app):
+        client = TestClient(burst_app)
+
+        body = client.post("/stream", json={"context": {"id": "outrun-stream"}}).text
+
+        assert "event: expired" in body
+        assert '"expired": true' in body
+
+    def test_a_run_the_log_outran_fails_instead_of_lying(self, burst_app):
+        """Returning the last event it happened to see would report a mid-run
+        event as the run's output."""
+        client = TestClient(burst_app)
+
+        response = client.post("/run", json={"context": {"id": "outrun-run"}})
+
+        assert response.status_code == 500
+        assert "trimmed" in response.json()["detail"]
+
+    def test_an_uncut_stream_carries_no_expired_frame(self, monkeypatch):
+        monkeypatch.setenv("TIMBAL_RUNNABLE", "unused.py::unused")
+        app = create_app()
+        app.state.runnable = _burst
+        app.state.job_store = JobStore()
+        client = TestClient(app)
+
+        body = client.post("/stream", json={"context": {"id": "intact"}}).text
+
+        assert "event: expired" not in body
+        assert body.count("data: ") == 5
 
 
 class TestServerLifecycle:

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -375,6 +375,27 @@ class TestRunEventsEndpoint:
         assert response.status_code == 409
         assert "dup" in response.json()["detail"]
 
+    def test_a_cursor_behind_the_floor_is_expired(self, tool_app):
+        """Trimming the head must not look like replay-from-zero succeeded."""
+        tool_app.state.job_store = JobStore(max_events=1)
+        client = TestClient(tool_app)
+        run_id = "trimmed"
+        client.post("/stream", json={"x": "test input", "context": {"id": run_id}})
+
+        from_zero = client.get(f"/runs/{run_id}/events").json()
+        assert from_zero["expired"] is True
+        assert from_zero["events"] == []
+        assert from_zero["next_cursor"] == 0
+
+        job = tool_app.state.job_store.get_job(run_id)
+        assert job is not None
+        tail = client.get(
+            f"/runs/{run_id}/events", params={"after": job.forgotten_through}
+        ).json()
+        assert tail["expired"] is False
+        assert tail["events"]
+        assert tail["done"] is True
+
 
 class TestServerLifecycle:
     @pytest.fixture

--- a/python/tests/server/test_jobs.py
+++ b/python/tests/server/test_jobs.py
@@ -2,7 +2,7 @@ import asyncio
 import contextlib
 
 import pytest
-from timbal.server.jobs import Job, JobStore
+from timbal.server.jobs import Job, JobStore, RunIdInUse
 
 
 class MockRunnable:
@@ -343,6 +343,100 @@ class TestReconnect:
 
         await asyncio.wait_for(job.wait(after=99, timeout=30), timeout=1)
 
+    @pytest.mark.asyncio
+    async def test_follow_does_not_miss_an_event_that_lands_mid_read(self):
+        """The waiter has to be registered before the read, not after.
+
+        Register after and an append landing in between resolves nothing, so the
+        wake is lost — and when that append is a run's last event, `follow`
+        waits for an event that is never coming. Patching `read` to produce the
+        event as a side effect puts the append exactly in that window.
+        """
+        job = Job()
+        real_read = job.read
+        landed = False
+
+        def read_then_produce(after=0, limit=500):
+            nonlocal landed
+            batch = real_read(after, limit)
+            if not landed:
+                landed = True
+                job.append("a")
+                job.finish()
+            return batch
+
+        job.read = read_then_produce
+
+        assert await asyncio.wait_for(drain(job), timeout=1) == ["a"]
+
+
+class TestNonReplayable:
+    """`replayable=False` — the `/run` shape: one reader, no reconnection, no log."""
+
+    @pytest.mark.asyncio
+    async def test_events_are_forgotten_as_they_are_consumed(self):
+        store = JobStore()
+        events = ["a", "b", "c", "d", "e"]
+
+        _, job = store.create_job(MockRunnable(events=events), {}, replayable=False)
+
+        assert await drain(job) == events
+        # The reader saw everything, and none of it is still held.
+        assert job.events == []
+        assert job.last_seq == 5
+
+    @pytest.mark.asyncio
+    async def test_a_finished_job_leaves_the_store_at_once(self):
+        """Nothing can reconnect to it, so there is nothing to retain."""
+        store = JobStore()
+
+        job_id, job = store.create_job(MockRunnable(events=["a"]), {}, replayable=False)
+        await drain(job)
+        await job.task
+        await asyncio.sleep(0)
+
+        assert store.get_job(job_id) is None
+
+    @pytest.mark.asyncio
+    async def test_a_replayable_job_keeps_its_log_after_being_read(self):
+        """The contrast: reading a `/stream` job must not consume it."""
+        store = JobStore()
+
+        _, job = store.create_job(MockRunnable(events=["a", "b"]), {})
+
+        assert await drain(job) == ["a", "b"]
+        assert job.events == [(1, "a"), (2, "b")]
+        assert await drain(job) == ["a", "b"]
+
+
+class TestRunIdCollision:
+    """Run ids come from the client, so collisions are reachable from outside."""
+
+    @pytest.mark.asyncio
+    async def test_a_live_run_id_is_refused(self):
+        """Overwriting would leave the first run going, with nothing pointing at it."""
+        store = JobStore()
+
+        _, job = store.create_job(MockRunnable(events=["a"], delay=0.05), {}, job_id="dup")
+
+        with pytest.raises(RunIdInUse):
+            store.create_job(MockRunnable(events=["b"]), {}, job_id="dup")
+
+        assert store.get_job("dup") is job
+        assert await drain(job) == ["a"]
+
+    @pytest.mark.asyncio
+    async def test_a_finished_run_id_can_be_reused(self):
+        store = JobStore()
+
+        _, first = store.create_job(MockRunnable(events=["a"]), {}, job_id="dup")
+        await first.task
+
+        _, second = store.create_job(MockRunnable(events=["b"]), {}, job_id="dup")
+
+        assert store.get_job("dup") is second
+        assert await drain(second) == ["b"]
+
 
 class TestRetention:
     """A run stays readable for a while after it ends, so a late reconnect works."""
@@ -378,6 +472,16 @@ class TestRetention:
         store.reap()
 
         assert store.get_job(job_id) is job
+
+    @pytest.mark.asyncio
+    async def test_the_window_holds_without_a_sweep(self):
+        """An idle server gets no `create_job` calls, so `reap` alone is not enough."""
+        store = JobStore(retention_secs=0)
+
+        job_id, job = store.create_job(MockRunnable(events=["a"]), {})
+        await job.task
+
+        assert store.get_job(job_id) is None
 
     @pytest.mark.asyncio
     async def test_reap_never_touches_a_running_job(self):

--- a/python/tests/server/test_jobs.py
+++ b/python/tests/server/test_jobs.py
@@ -1,7 +1,8 @@
 import asyncio
+import contextlib
 
 import pytest
-from timbal.server.jobs import JOB_DONE_SENTINEL, Job, JobStore
+from timbal.server.jobs import Job, JobStore
 
 
 class MockRunnable:
@@ -24,15 +25,30 @@ class MockRunnable:
         self.completed = True
 
 
+async def drain(job, after: int = 0) -> list:
+    """Everything `job` yields from `after`, without the seqs."""
+    return [event async for _, event in job.follow(after)]
+
+
 class TestJob:
-    async def test_job_init(self):
+    def test_job_init(self):
         """Test Job initialization."""
-        task = asyncio.Future()
-        queue = asyncio.Queue()
-        job = Job(task, queue)
+        task = object()
+        job = Job(task)
 
         assert job.task is task
-        assert job.queue is queue
+        assert job.events == []
+        assert job.last_seq == 0
+        assert job.done is False
+        assert job.finished_at is None
+
+    def test_append_assigns_contiguous_seqs_from_one(self):
+        job = Job()
+        job.append("a")
+        job.append("b")
+
+        assert job.events == [(1, "a"), (2, "b")]
+        assert job.last_seq == 2
 
 
 class TestJobStore:
@@ -59,7 +75,7 @@ class TestJobStore:
         store = JobStore()
         runnable = MockRunnable(events=["event1"])
 
-        job_id, job = store.create_job(runnable, {}, job_id="custom-id")
+        job_id, _ = store.create_job(runnable, {}, job_id="custom-id")
 
         assert job_id == "custom-id"
 
@@ -81,152 +97,15 @@ class TestJobStore:
         assert store.get_job("unknown-id") is None
 
     @pytest.mark.asyncio
-    async def test_job_emits_events_to_queue(self):
-        """Test that job emits events to the queue."""
+    async def test_job_emits_events_to_the_log(self):
+        """Test that job events are readable in order."""
         store = JobStore()
         events = ["event1", "event2", "event3"]
         runnable = MockRunnable(events=events)
 
         _, job = store.create_job(runnable, {})
 
-        received_events = []
-        while True:
-            event = await job.queue.get()
-            if event is JOB_DONE_SENTINEL:
-                break
-            received_events.append(event)
-
-        assert received_events == events
-
-    @pytest.mark.asyncio
-    async def test_job_emits_done_sentinel(self):
-        """Test that job emits JOB_DONE_SENTINEL when complete."""
-        store = JobStore()
-        runnable = MockRunnable(events=["event1"])
-
-        _, job = store.create_job(runnable, {})
-
-        # Consume events
-        event1 = await job.queue.get()
-        assert event1 == "event1"
-
-        sentinel = await job.queue.get()
-        assert sentinel is JOB_DONE_SENTINEL
-
-    @pytest.mark.asyncio
-    async def test_job_removed_from_store_on_completion(self):
-        """Test that job is removed from store when task completes."""
-        store = JobStore()
-        runnable = MockRunnable(events=["event1"])
-
-        job_id, job = store.create_job(runnable, {})
-
-        # Job should be in store initially
-        assert store.get_job(job_id) is not None
-
-        # Consume all events
-        while True:
-            event = await job.queue.get()
-            if event is JOB_DONE_SENTINEL:
-                break
-
-        # Wait for the task to fully complete and callback to fire
-        await job.task
-
-        # Give the event loop a chance to process the done callback
-        await asyncio.sleep(0)
-
-        # Job should be removed from store
-        assert store.get_job(job_id) is None
-
-    @pytest.mark.asyncio
-    async def test_job_runs_to_completion_without_consumer(self):
-        """Test that job runs to completion even if no one consumes events."""
-        store = JobStore()
-        runnable = MockRunnable(events=["event1", "event2", "event3"])
-
-        job_id, job = store.create_job(runnable, {})
-
-        # Don't consume any events, just wait for the task to complete
-        await job.task
-
-        assert runnable.started is True
-        assert runnable.completed is True
-        assert runnable.events_emitted == ["event1", "event2", "event3"]
-
-    @pytest.mark.asyncio
-    async def test_job_runs_to_completion_with_slow_consumer(self):
-        """Test that job continues running even with a slow consumer."""
-        store = JobStore()
-        events = ["event1", "event2", "event3", "event4", "event5"]
-        runnable = MockRunnable(events=events, delay=0.01)
-
-        _, job = store.create_job(runnable, {})
-
-        # Consume only first 2 events slowly
-        event1 = await job.queue.get()
-        await asyncio.sleep(0.05)
-        event2 = await job.queue.get()
-
-        # Wait for the job to complete
-        await job.task
-
-        # Job should have completed regardless of consumer speed
-        assert runnable.completed is True
-        assert runnable.events_emitted == events
-
-    @pytest.mark.asyncio
-    async def test_job_runs_to_completion_when_consumer_stops(self):
-        """Test that job runs to completion even if consumer stops reading."""
-        store = JobStore()
-        events = ["event1", "event2", "event3", "event4", "event5"]
-        runnable = MockRunnable(events=events)
-
-        job_id, job = store.create_job(runnable, {})
-
-        # Consume only first event then "disconnect" (stop reading)
-        first_event = await job.queue.get()
-        assert first_event == "event1"
-
-        # Simulate consumer disconnect by just waiting for task to complete
-        await job.task
-
-        # Job should have run to completion
-        assert runnable.started is True
-        assert runnable.completed is True
-        assert runnable.events_emitted == events
-
-        # Remaining events should still be in queue
-        remaining = []
-        while not job.queue.empty():
-            event = job.queue.get_nowait()
-            remaining.append(event)
-
-        assert remaining == ["event2", "event3", "event4", "event5", JOB_DONE_SENTINEL]
-
-    @pytest.mark.asyncio
-    async def test_multiple_jobs_independent(self):
-        """Test that multiple jobs run independently."""
-        store = JobStore()
-        runnable1 = MockRunnable(events=["a1", "a2"], delay=0.01)
-        runnable2 = MockRunnable(events=["b1", "b2", "b3"], delay=0.01)
-
-        job_id1, job1 = store.create_job(runnable1, {})
-        job_id2, job2 = store.create_job(runnable2, {})
-
-        # Both jobs should be in store
-        assert store.get_job(job_id1) is not None
-        assert store.get_job(job_id2) is not None
-
-        # Wait for both to complete
-        await asyncio.gather(job1.task, job2.task)
-
-        assert runnable1.completed is True
-        assert runnable2.completed is True
-
-        # Both should be removed from store
-        assert store.get_job(job_id1) is None
-        assert store.get_job(job_id2) is None
+        assert await drain(job) == events
 
     @pytest.mark.asyncio
     async def test_job_passes_params_to_runnable(self):
@@ -245,27 +124,55 @@ class TestJobStore:
         assert received_params == {"x": "test", "y": 42}
 
     @pytest.mark.asyncio
-    async def test_job_emits_sentinel_on_error(self):
-        """Test that job emits JOB_DONE_SENTINEL even when runnable raises."""
+    async def test_job_runs_to_completion_without_consumer(self):
+        """Test that job runs to completion even if no one consumes events."""
         store = JobStore()
+        runnable = MockRunnable(events=["event1", "event2", "event3"])
 
-        async def failing_runnable(**kwargs):
-            yield "event1"
-            raise ValueError("Something went wrong")
+        _, job = store.create_job(runnable, {})
 
-        _, job = store.create_job(failing_runnable, {})
+        await job.task
 
-        # Should be able to get the first event
-        event1 = await job.queue.get()
-        assert event1 == "event1"
+        assert runnable.started is True
+        assert runnable.completed is True
+        assert runnable.events_emitted == ["event1", "event2", "event3"]
 
-        # Should get sentinel even after error (not hang forever)
-        sentinel = await job.queue.get()
-        assert sentinel is JOB_DONE_SENTINEL
+    @pytest.mark.asyncio
+    async def test_job_runs_to_completion_with_slow_consumer(self):
+        """Test that job continues running even with a slow consumer."""
+        store = JobStore()
+        events = ["event1", "event2", "event3", "event4", "event5"]
+        runnable = MockRunnable(events=events, delay=0.01)
 
-        # Task should have the exception
-        with pytest.raises(ValueError, match="Something went wrong"):
-            await job.task
+        _, job = store.create_job(runnable, {})
+
+        stream = job.follow()
+        await anext(stream)
+        await asyncio.sleep(0.05)
+        await anext(stream)
+
+        await job.task
+
+        assert runnable.completed is True
+        assert runnable.events_emitted == events
+
+    @pytest.mark.asyncio
+    async def test_job_completes_when_consumer_disconnects(self):
+        """The run outlives its reader — that is the point of the log."""
+        store = JobStore()
+        events = ["event1", "event2", "event3", "event4", "event5"]
+        runnable = MockRunnable(events=events)
+
+        _, job = store.create_job(runnable, {})
+
+        stream = job.follow()
+        assert await anext(stream) == (1, "event1")
+        await stream.aclose()
+
+        await job.task
+
+        assert runnable.completed is True
+        assert runnable.events_emitted == events
 
     @pytest.mark.asyncio
     async def test_job_completes_when_consumer_cancelled(self):
@@ -277,56 +184,225 @@ class TestJobStore:
         _, job = store.create_job(runnable, {})
 
         async def consumer():
-            """Consumer that will be cancelled after first event."""
-            event = await job.queue.get()
-            assert event == "event1"
-            # Simulate doing some work, then getting cancelled
-            await asyncio.sleep(1)  # Will be cancelled before this completes
+            async for _ in job.follow():
+                await asyncio.sleep(1)  # Will be cancelled before this completes
 
         consumer_task = asyncio.create_task(consumer())
-
-        # Let consumer get first event
         await asyncio.sleep(0.01)
 
-        # Cancel consumer (simulates HTTP disconnect)
         consumer_task.cancel()
-        try:
+        with contextlib.suppress(asyncio.CancelledError):
             await consumer_task
-        except asyncio.CancelledError:
-            pass
 
-        # Wait for job to complete
         await job.task
 
-        # Job should have completed fully
         assert runnable.completed is True
         assert runnable.events_emitted == events
 
     @pytest.mark.asyncio
-    async def test_queue_accumulates_events_without_consumer(self):
-        """Test that events accumulate in queue when no consumer is reading."""
+    async def test_multiple_jobs_independent(self):
+        """Test that multiple jobs run independently."""
+        store = JobStore()
+        runnable1 = MockRunnable(events=["a1", "a2"], delay=0.01)
+        runnable2 = MockRunnable(events=["b1", "b2", "b3"], delay=0.01)
+
+        job_id1, job1 = store.create_job(runnable1, {})
+        job_id2, job2 = store.create_job(runnable2, {})
+
+        assert store.get_job(job_id1) is not None
+        assert store.get_job(job_id2) is not None
+
+        await asyncio.gather(job1.task, job2.task)
+
+        assert await drain(job1) == ["a1", "a2"]
+        assert await drain(job2) == ["b1", "b2", "b3"]
+
+    @pytest.mark.asyncio
+    async def test_job_finishes_on_error(self):
+        """A crashed runnable still terminates the log instead of hanging readers."""
+        store = JobStore()
+
+        async def failing_runnable(**kwargs):
+            yield "event1"
+            raise ValueError("Something went wrong")
+
+        _, job = store.create_job(failing_runnable, {})
+
+        # Would hang forever if the failure skipped `finish()`.
+        assert await asyncio.wait_for(drain(job), timeout=1) == ["event1"]
+        assert job.done is True
+
+        with pytest.raises(ValueError, match="Something went wrong"):
+            await job.task
+
+
+class TestReconnect:
+    """Reading a run's log after the fact — the reason it is a log."""
+
+    @pytest.mark.asyncio
+    async def test_a_reader_that_missed_everything_replays_from_zero(self):
         store = JobStore()
         events = ["event1", "event2", "event3"]
-        runnable = MockRunnable(events=events)
 
-        _, job = store.create_job(runnable, {})
-
-        # Wait for job to complete without consuming anything
+        _, job = store.create_job(MockRunnable(events=events), {})
         await job.task
 
-        # All events should be in the queue
-        assert job.queue.qsize() == 4  # 3 events + sentinel
+        assert await drain(job) == events
 
-        # Can still consume them after job completion
-        received = []
-        while True:
-            event = await job.queue.get()
-            if event is JOB_DONE_SENTINEL:
-                break
-            received.append(event)
+    @pytest.mark.asyncio
+    async def test_a_reader_resumes_from_its_cursor(self):
+        store = JobStore()
 
-        assert received == events
+        _, job = store.create_job(MockRunnable(events=["a", "b", "c", "d"]), {})
+        await job.task
 
+        assert await drain(job, after=2) == ["c", "d"]
+
+    @pytest.mark.asyncio
+    async def test_two_readers_do_not_race_for_events(self):
+        """A queue hands each event to exactly one reader; a log does not."""
+        store = JobStore()
+        events = ["a", "b", "c"]
+
+        _, job = store.create_job(MockRunnable(events=events, delay=0.01), {})
+
+        both = await asyncio.gather(drain(job), drain(job))
+
+        assert both == [events, events]
+
+    @pytest.mark.asyncio
+    async def test_read_reports_the_cursor_to_come_back_with(self):
+        store = JobStore()
+
+        _, job = store.create_job(MockRunnable(events=["a", "b", "c"]), {})
+        await job.task
+
+        events, next_cursor, done = job.read()
+
+        assert [seq for seq, _ in events] == [1, 2, 3]
+        assert next_cursor == 3
+        assert done is True
+
+    @pytest.mark.asyncio
+    async def test_an_empty_batch_leaves_the_cursor_alone(self):
+        store = JobStore()
+
+        _, job = store.create_job(MockRunnable(events=["a"]), {})
+        await job.task
+
+        events, next_cursor, done = job.read(after=1)
+
+        assert events == []
+        assert next_cursor == 1
+        assert done is True
+
+    @pytest.mark.asyncio
+    async def test_a_truncated_page_is_not_done_even_when_the_run_is(self):
+        """`done` must mean "you have it all", or a paging client stops early."""
+        store = JobStore()
+
+        _, job = store.create_job(MockRunnable(events=["a", "b", "c"]), {})
+        await job.task
+
+        events, next_cursor, done = job.read(limit=2)
+
+        assert [event for _, event in events] == ["a", "b"]
+        assert next_cursor == 2
+        assert done is False
+
+        events, next_cursor, done = job.read(after=next_cursor, limit=2)
+
+        assert [event for _, event in events] == ["c"]
+        assert done is True
+
+    @pytest.mark.asyncio
+    async def test_wait_returns_once_an_event_lands(self):
+        store = JobStore()
+
+        _, job = store.create_job(MockRunnable(events=["a"], delay=0.05), {})
+
+        await asyncio.wait_for(job.wait(after=0, timeout=5), timeout=1)
+
+        assert job.last_seq >= 1
+
+    @pytest.mark.asyncio
+    async def test_wait_gives_up_quietly_on_timeout(self):
+        """Timeout is not an error — the caller re-reads either way."""
+        job = Job()
+
+        await asyncio.wait_for(job.wait(after=0, timeout=0.01), timeout=1)
+
+        assert job.last_seq == 0
+
+    @pytest.mark.asyncio
+    async def test_wait_does_not_block_when_the_run_is_over(self):
+        store = JobStore()
+
+        _, job = store.create_job(MockRunnable(events=["a"]), {})
+        await job.task
+
+        await asyncio.wait_for(job.wait(after=99, timeout=30), timeout=1)
+
+
+class TestRetention:
+    """A run stays readable for a while after it ends, so a late reconnect works."""
+
+    @pytest.mark.asyncio
+    async def test_a_finished_job_is_still_addressable(self):
+        store = JobStore()
+
+        job_id, job = store.create_job(MockRunnable(events=["a"]), {})
+        await job.task
+        await asyncio.sleep(0)
+
+        assert store.get_job(job_id) is job
+
+    @pytest.mark.asyncio
+    async def test_reap_forgets_a_job_past_its_window(self):
+        store = JobStore(retention_secs=0)
+
+        job_id, job = store.create_job(MockRunnable(events=["a"]), {})
+        await job.task
+
+        store.reap()
+
+        assert store.get_job(job_id) is None
+
+    @pytest.mark.asyncio
+    async def test_reap_keeps_a_job_inside_its_window(self):
+        store = JobStore(retention_secs=300)
+
+        job_id, job = store.create_job(MockRunnable(events=["a"]), {})
+        await job.task
+
+        store.reap()
+
+        assert store.get_job(job_id) is job
+
+    @pytest.mark.asyncio
+    async def test_reap_never_touches_a_running_job(self):
+        store = JobStore(retention_secs=0)
+
+        job_id, job = store.create_job(MockRunnable(events=["a", "b"], delay=0.05), {})
+        store.reap()
+
+        assert store.get_job(job_id) is job
+
+        await job.task
+
+    @pytest.mark.asyncio
+    async def test_creating_a_job_sweeps_expired_ones(self):
+        store = JobStore(retention_secs=0)
+
+        old_id, old_job = store.create_job(MockRunnable(events=["a"]), {})
+        await old_job.task
+
+        store.create_job(MockRunnable(events=["b"]), {})
+
+        assert store.get_job(old_id) is None
+
+
+class TestCancel:
     @pytest.mark.asyncio
     async def test_cancel_job_returns_true_for_running_job(self):
         """Test that cancel_job returns True for a running job."""
@@ -335,14 +411,8 @@ class TestJobStore:
 
         job_id, job = store.create_job(runnable, {})
 
-        # Job should be running
-        assert store.get_job(job_id) is not None
+        assert store.cancel_job(job_id) is True
 
-        # Cancel should return True
-        result = store.cancel_job(job_id)
-        assert result is True
-
-        # Wait for the task to be cancelled
         with pytest.raises(asyncio.CancelledError):
             await job.task
 
@@ -351,8 +421,19 @@ class TestJobStore:
         """Test that cancel_job returns False for unknown job ID."""
         store = JobStore()
 
-        result = store.cancel_job("unknown-id")
-        assert result is False
+        assert store.cancel_job("unknown-id") is False
+
+    @pytest.mark.asyncio
+    async def test_cancel_job_returns_false_for_a_retained_finished_job(self):
+        """Retention must not turn "already finished" into a successful cancel."""
+        store = JobStore()
+
+        job_id, job = store.create_job(MockRunnable(events=["a"]), {})
+        await job.task
+        await asyncio.sleep(0)
+
+        assert store.get_job(job_id) is job
+        assert store.cancel_job(job_id) is False
 
     @pytest.mark.asyncio
     async def test_cancel_job_stops_event_emission(self):
@@ -362,75 +443,26 @@ class TestJobStore:
         runnable = MockRunnable(events=events, delay=0.05)
 
         job_id, job = store.create_job(runnable, {})
-
-        # Wait for first event to be emitted
         await asyncio.sleep(0.02)
 
-        # Cancel the job
         store.cancel_job(job_id)
-
-        # Wait for cancellation to take effect
-        try:
+        with contextlib.suppress(asyncio.CancelledError):
             await job.task
-        except asyncio.CancelledError:
-            pass
 
-        # Not all events should have been emitted
         assert len(runnable.events_emitted) < len(events)
 
     @pytest.mark.asyncio
-    async def test_cancel_job_removes_job_from_store(self):
-        """Test that cancelled job is eventually removed from store."""
+    async def test_a_cancelled_job_terminates_its_log(self):
+        """Readers of a cancelled run must be released, not left hanging."""
         store = JobStore()
-        runnable = MockRunnable(events=["event1", "event2"], delay=0.1)
+        runnable = MockRunnable(events=["a", "b", "c"], delay=0.05)
 
         job_id, job = store.create_job(runnable, {})
-
-        # Job should be in store
-        assert store.get_job(job_id) is not None
-
-        # Cancel the job
+        await asyncio.sleep(0.02)
         store.cancel_job(job_id)
 
-        # Wait for the task to complete
-        try:
+        with contextlib.suppress(asyncio.CancelledError):
             await job.task
-        except asyncio.CancelledError:
-            pass
 
-        # Give the event loop a chance to process the done callback
-        await asyncio.sleep(0)
-
-        # Job should be removed from store
-        assert store.get_job(job_id) is None
-
-    @pytest.mark.asyncio
-    async def test_cancel_job_emits_sentinel(self):
-        """Test that cancelled job still emits JOB_DONE_SENTINEL."""
-        store = JobStore()
-        runnable = MockRunnable(events=["event1", "event2", "event3"], delay=0.1)
-
-        _, job = store.create_job(runnable, {})
-
-        # Wait a bit then cancel
-        await asyncio.sleep(0.05)
-        job.task.cancel()
-
-        # Wait for task to be cancelled
-        try:
-            await job.task
-        except asyncio.CancelledError:
-            pass
-
-        # Drain the queue - should eventually get sentinel
-        events = []
-        while True:
-            try:
-                event = job.queue.get_nowait()
-                events.append(event)
-                if event is JOB_DONE_SENTINEL:
-                    break
-            except asyncio.QueueEmpty:
-                break
-
-        assert JOB_DONE_SENTINEL in events
+        assert job.done is True
+        await asyncio.wait_for(drain(job), timeout=1)

--- a/python/tests/server/test_jobs.py
+++ b/python/tests/server/test_jobs.py
@@ -277,11 +277,12 @@ class TestReconnect:
         _, job = store.create_job(MockRunnable(events=["a", "b", "c"]), {})
         await job.task
 
-        events, next_cursor, done = job.read()
+        events, next_cursor, done, gapped = job.read()
 
         assert [seq for seq, _ in events] == [1, 2, 3]
         assert next_cursor == 3
         assert done is True
+        assert gapped is False
 
     @pytest.mark.asyncio
     async def test_an_empty_batch_leaves_the_cursor_alone(self):
@@ -290,11 +291,12 @@ class TestReconnect:
         _, job = store.create_job(MockRunnable(events=["a"]), {})
         await job.task
 
-        events, next_cursor, done = job.read(after=1)
+        events, next_cursor, done, gapped = job.read(after=1)
 
         assert events == []
         assert next_cursor == 1
         assert done is True
+        assert gapped is False
 
     @pytest.mark.asyncio
     async def test_a_truncated_page_is_not_done_even_when_the_run_is(self):
@@ -304,16 +306,18 @@ class TestReconnect:
         _, job = store.create_job(MockRunnable(events=["a", "b", "c"]), {})
         await job.task
 
-        events, next_cursor, done = job.read(limit=2)
+        events, next_cursor, done, gapped = job.read(limit=2)
 
         assert [event for _, event in events] == ["a", "b"]
         assert next_cursor == 2
         assert done is False
+        assert gapped is False
 
-        events, next_cursor, done = job.read(after=next_cursor, limit=2)
+        events, next_cursor, done, gapped = job.read(after=next_cursor, limit=2)
 
         assert [event for _, event in events] == ["c"]
         assert done is True
+        assert gapped is False
 
     @pytest.mark.asyncio
     async def test_wait_returns_once_an_event_lands(self):
@@ -407,6 +411,98 @@ class TestNonReplayable:
         assert await drain(job) == ["a", "b"]
         assert job.events == [(1, "a"), (2, "b")]
         assert await drain(job) == ["a", "b"]
+
+
+class TestBound:
+    """A replayable log is a ring — dropping the head must not look like a skip."""
+
+    @pytest.mark.asyncio
+    async def test_the_oldest_events_are_dropped_once_the_cap_is_hit(self):
+        store = JobStore(max_events=2)
+
+        _, job = store.create_job(MockRunnable(events=["a", "b", "c"]), {})
+        await job.task
+
+        assert job.forgotten_through == 1
+        assert job.events == [(2, "b"), (3, "c")]
+
+    @pytest.mark.asyncio
+    async def test_a_cursor_behind_the_floor_is_a_gap(self):
+        """Silently starting at the new head is the lie `expired` exists to catch."""
+        store = JobStore(max_events=2)
+
+        _, job = store.create_job(MockRunnable(events=["a", "b", "c"]), {})
+        await job.task
+
+        events, next_cursor, done, gapped = job.read(after=0)
+
+        assert events == []
+        assert next_cursor == 0
+        assert done is True
+        assert gapped is True
+
+    @pytest.mark.asyncio
+    async def test_a_cursor_on_the_floor_still_reads_the_tail(self):
+        store = JobStore(max_events=2)
+
+        _, job = store.create_job(MockRunnable(events=["a", "b", "c"]), {})
+        await job.task
+
+        events, _, done, gapped = job.read(after=job.forgotten_through)
+
+        assert [event for _, event in events] == ["b", "c"]
+        assert done is True
+        assert gapped is False
+
+    @pytest.mark.asyncio
+    async def test_byte_cap_drops_the_head_too(self):
+        store = JobStore(max_events=None, max_bytes=2)
+
+        _, job = store.create_job(MockRunnable(events=["aa", "bb", "cc"]), {})
+        await job.task
+
+        assert job.events == [(3, "cc")]
+        _, _, _, gapped = job.read(after=0)
+        assert gapped is True
+
+    @pytest.mark.asyncio
+    async def test_a_single_event_larger_than_the_byte_cap_is_kept(self):
+        """Dropping the tip would lose the live stream, not just the backlog."""
+        store = JobStore(max_events=None, max_bytes=2)
+
+        _, job = store.create_job(MockRunnable(events=["too-big"]), {})
+        await job.task
+
+        assert job.events == [(1, "too-big")]
+        _, _, _, gapped = job.read(after=0)
+        assert gapped is False
+
+    @pytest.mark.asyncio
+    async def test_follow_from_zero_on_a_trimmed_log_yields_nothing(self):
+        store = JobStore(max_events=1)
+
+        _, job = store.create_job(MockRunnable(events=["a", "b", "c"]), {})
+        await job.task
+
+        assert await drain(job) == []
+
+    @pytest.mark.asyncio
+    async def test_follow_from_the_floor_gets_the_tail(self):
+        store = JobStore(max_events=2)
+
+        _, job = store.create_job(MockRunnable(events=["a", "b", "c"]), {})
+        await job.task
+
+        assert await drain(job, after=job.forgotten_through) == ["b", "c"]
+
+    @pytest.mark.asyncio
+    async def test_wait_on_a_gapped_cursor_returns_immediately(self):
+        store = JobStore(max_events=1)
+
+        _, job = store.create_job(MockRunnable(events=["a", "b"]), {})
+        await job.task
+
+        await asyncio.wait_for(job.wait(after=0, timeout=30), timeout=1)
 
 
 class TestRunIdCollision:

--- a/python/tests/server/test_jobs.py
+++ b/python/tests/server/test_jobs.py
@@ -390,6 +390,22 @@ class TestNonReplayable:
         assert job.last_seq == 5
 
     @pytest.mark.asyncio
+    async def test_an_unread_log_is_still_capped(self):
+        """Forgetting-on-read only happens while a reader is attached.
+
+        The run outlives its reader by design, so without the ring a `/run`
+        whose handler went away appends into an unbounded list for the rest of
+        the run.
+        """
+        job = Job(replayable=False, max_events=10, max_bytes=None)
+
+        for i in range(100):
+            job.append(f"e{i}")
+
+        assert len(job.events) == 10
+        assert job.forgotten_through == 90
+
+    @pytest.mark.asyncio
     async def test_a_finished_job_leaves_the_store_at_once(self):
         """Nothing can reconnect to it, so there is nothing to retain."""
         store = JobStore()

--- a/python/timbal/server/README.md
+++ b/python/timbal/server/README.md
@@ -15,13 +15,15 @@ Two things are documented here: [running a runnable over HTTP](#runs-run-stream-
 | `GET /runs/{run_id}/events` | Replay a run's events after a cursor — the reconnect path. |
 | `POST /cancel/{run_id}` | Cancel a running run. `404` if unknown or already finished. |
 
-Set `context.id` on the request to choose the run id; otherwise one is generated and you can read it off the first event.
+Set `context.id` on the request to choose the run id; otherwise one is generated and you can read it off the first event. Naming an id that a *running* run already holds is a `409` — the alternative is silently orphaning that run, leaving it executing with nothing able to read or cancel it.
 
 ### A dropped connection does not stop the run
 
 Runs execute on their own task, decoupled from the HTTP response. When a client disconnects, the run keeps going and keeps appending to its **event log** — an append-only list where every event has a 1-based monotonic `seq`. Readers hold a cursor into that log rather than consuming from a queue, so a disconnect costs you nothing but your place, several readers can watch one run at once, and coming back is just asking for everything after the last `seq` you saw.
 
 Finished runs stay readable for a retention window (default 5 minutes, `JobStore(retention_secs=…)`) so a client that dropped right at the end can still collect the tail.
+
+Only `/stream` keeps a replayable log. A `/run` is read to completion by the one request that started it and nothing can reconnect to it, so its events are dropped as they are consumed rather than held — otherwise every non-streaming request would pin a whole run's deltas in memory for five minutes after answering. `/runs/{run_id}/events` reports `expired: true` for a `/run`.
 
 ### Reconnecting
 
@@ -30,8 +32,8 @@ Finished runs stay readable for a retention window (default 5 minutes, `JobStore
 | Query | Meaning |
 |---|---|
 | `after` | Last `seq` seen (exclusive). Default `0` = from the start. |
-| `limit` | Max events per response, clamped to `1..=2000`. Default `500`. |
-| `wait_ms` | Long-poll budget, clamped to `0..=30000`. Default `0` (return immediately). When `>0` and nothing is available past `after`, the request blocks until an event arrives, the run ends, or the timeout elapses. |
+| `limit` | Max events per response, clamped to 1–2000. Default `500`. |
+| `wait_ms` | Long-poll budget, clamped to 0–30000. Default `0` (return immediately). When `>0` and nothing is available past `after`, the request blocks until an event arrives, the run ends, or the timeout elapses. |
 
 ```json
 {
@@ -47,13 +49,17 @@ Feed `next_cursor` back as `after` on the next poll. It equals the last `seq` re
 
 **`done` means "you have everything", not "the run finished."** A terminal run whose events don't fit in one page reports `done: false` so you keep paging.
 
-**`expired: true` is the field you cannot ignore.** It means the log is gone — reaped after retention, or owned by a process that isn't this one. The response then looks *identical* to a cleanly drained stream (`done: true`, no events, cursor unmoved), so a client that only checks `done` stops early and silently loses the tail. Treat `expired` as **terminal but possibly incomplete** and reconcile from wherever you persist runs.
+**`expired: true` is the field you cannot ignore.** It means the log is unavailable — reaped after retention, never held by this process, or belonging to a `/run`. The response then looks *identical* to a cleanly drained stream (`done: true`, no events, cursor unmoved), so a client that only checks `done` stops early and silently loses the tail. Treat `expired` as **terminal but possibly incomplete** and reconcile from wherever you persist runs.
 
-`POST /stream` also emits the `seq` as the SSE `id:` field, so a browser `EventSource` echoes it back as `Last-Event-ID` on reconnect.
+`POST /stream` also emits the `seq` as the SSE `id:` field, so a client following the stream always knows the cursor to reconnect with without parsing the payload. It is *not* an `EventSource` resume: `/stream` is a POST, so `EventSource` cannot reach it, and nothing here reads `Last-Event-ID`. Reconnect through `/runs/{run_id}/events?after=`.
 
 ### Limits
 
-The log lives in the serving process's memory. A run whose process dies has nothing to replay (`expired: true` from any other process), and the log is unbounded for the run's lifetime — a run that streams forever grows it forever. Durable, cross-process replay needs a backing store behind this same cursor contract.
+**Single process.** The log and the job registry live in the serving process's memory, and nothing routes a request to the worker that owns a given run. Run the server with one worker, or pin runs to a worker at the load balancer. With `--workers > 1` (the CLI warns) both `/cancel/{run_id}` and `/runs/{run_id}/events` are a coin flip: a request landing on a sibling worker gets `404` and `expired: true` respectively, for a run that is alive and fine. `expired` cannot distinguish "gone" from "not mine", so a client would go reconciling against durable storage for a run still eight minutes from finishing.
+
+A run whose process dies has nothing to replay, and the log is unbounded for the run's lifetime — a run that streams forever grows it forever. Durable, cross-process replay needs a backing store behind this same cursor contract.
+
+**No authorization.** These routes carry none of their own, and CORS is wide open, so anything that can reach the port can replay any run whose id it can name — and ids are client-chosen, so they are guessable. Deploy behind something that authenticates and scopes by run.
 
 ---
 

--- a/python/timbal/server/README.md
+++ b/python/timbal/server/README.md
@@ -49,7 +49,7 @@ Feed `next_cursor` back as `after` on the next poll. It equals the last `seq` re
 
 **`done` means "you have everything", not "the run finished."** A terminal run whose events don't fit in one page reports `done: false` so you keep paging.
 
-**`expired: true` is the field you cannot ignore.** It means the log is unavailable — reaped after retention, never held by this process, or belonging to a `/run`. The response then looks *identical* to a cleanly drained stream (`done: true`, no events, cursor unmoved), so a client that only checks `done` stops early and silently loses the tail. Treat `expired` as **terminal but possibly incomplete** and reconcile from wherever you persist runs.
+**`expired: true` is the field you cannot ignore.** It means the log is unavailable — reaped after retention, never held by this process, belonging to a `/run`, or trimmed past your cursor. The response then looks *identical* to a cleanly drained stream (`done: true`, no events, cursor unmoved), so a client that only checks `done` stops early and silently loses the tail. Treat `expired` as **terminal but possibly incomplete** and reconcile from wherever you persist runs.
 
 `POST /stream` also emits the `seq` as the SSE `id:` field, so a client following the stream always knows the cursor to reconnect with without parsing the payload. It is *not* an `EventSource` resume: `/stream` is a POST, so `EventSource` cannot reach it, and nothing here reads `Last-Event-ID`. Reconnect through `/runs/{run_id}/events?after=`.
 
@@ -57,7 +57,7 @@ Feed `next_cursor` back as `after` on the next poll. It equals the last `seq` re
 
 **Single process.** The log and the job registry live in the serving process's memory, and nothing routes a request to the worker that owns a given run. Run the server with one worker, or pin runs to a worker at the load balancer. With `--workers > 1` (the CLI warns) both `/cancel/{run_id}` and `/runs/{run_id}/events` are a coin flip: a request landing on a sibling worker gets `404` and `expired: true` respectively, for a run that is alive and fine. `expired` cannot distinguish "gone" from "not mine", so a client would go reconciling against durable storage for a run still eight minutes from finishing.
 
-A run whose process dies has nothing to replay, and the log is unbounded for the run's lifetime — a run that streams forever grows it forever. Durable, cross-process replay needs a backing store behind this same cursor contract.
+A run whose process dies has nothing to replay. A replayable log is a ring: default 50 000 events or 32 MiB, whichever hits first (`JobStore(max_events=…, max_bytes=…)`). Older events are dropped and a reconnect whose cursor is behind the floor reports `expired: true` rather than silently skipping to the new head. Durable, cross-process replay needs a backing store behind this same cursor contract.
 
 **No authorization.** These routes carry none of their own, and CORS is wide open, so anything that can reach the port can replay any run whose id it can name — and ids are client-chosen, so they are guessable. Deploy behind something that authenticates and scopes by run.
 

--- a/python/timbal/server/README.md
+++ b/python/timbal/server/README.md
@@ -53,6 +53,15 @@ Feed `next_cursor` back as `after` on the next poll. It equals the last `seq` re
 
 `POST /stream` also emits the `seq` as the SSE `id:` field, so a client following the stream always knows the cursor to reconnect with without parsing the payload. It is *not* an `EventSource` resume: `/stream` is a POST, so `EventSource` cannot reach it, and nothing here reads `Last-Event-ID`. Reconnect through `/runs/{run_id}/events?after=`.
 
+A stream the log outran — a reader stalled long enough for the ring to drop events it had not taken — is closed with a final frame rather than just ending, since ending is indistinguishable from a clean finish:
+
+```
+event: expired
+data: {"run_id":"0198f3aa…","next_cursor":41,"done":true,"expired":true}
+```
+
+Same meaning as the field: terminal, possibly incomplete. A `/run` in that position answers `500` instead — its whole response is the run's last event, and the one it holds is not it.
+
 ### Limits
 
 **Single process.** The log and the job registry live in the serving process's memory, and nothing routes a request to the worker that owns a given run. Run the server with one worker, or pin runs to a worker at the load balancer. With `--workers > 1` (the CLI warns) both `/cancel/{run_id}` and `/runs/{run_id}/events` are a coin flip: a request landing on a sibling worker gets `404` and `expired: true` respectively, for a run that is alive and fine. `expired` cannot distinguish "gone" from "not mine", so a client would go reconciling against durable storage for a run still eight minutes from finishing.

--- a/python/timbal/server/README.md
+++ b/python/timbal/server/README.md
@@ -17,6 +17,8 @@ Two things are documented here: [running a runnable over HTTP](#runs-run-stream-
 
 Set `context.id` on the request to choose the run id; otherwise one is generated and you can read it off the first event. Naming an id that a *running* run already holds is a `409` — the alternative is silently orphaning that run, leaving it executing with nothing able to read or cancel it.
 
+Reusing the id of a run that has *finished* but is still inside its retention window is allowed, and rebinds the id: anything still polling `/runs/{run_id}/events` for the old run starts receiving the new one's events, with seqs counting from 1 again. Use fresh ids per run unless you mean that.
+
 ### A dropped connection does not stop the run
 
 Runs execute on their own task, decoupled from the HTTP response. When a client disconnects, the run keeps going and keeps appending to its **event log** — an append-only list where every event has a 1-based monotonic `seq`. Readers hold a cursor into that log rather than consuming from a queue, so a disconnect costs you nothing but your place, several readers can watch one run at once, and coming back is just asking for everything after the last `seq` you saw.

--- a/python/timbal/server/README.md
+++ b/python/timbal/server/README.md
@@ -2,7 +2,60 @@
 
 FastAPI app factory and CLI live in `http.py` (`python -m timbal.server`, or `run_server_cli`). The runnable is selected via `TIMBAL_RUNNABLE` (same object used for `/run`).
 
-This README documents how a **custom frontend** integrates with the **voice agent** over WebSocket (not the bundled `voice.html` playground).
+Two things are documented here: [running a runnable over HTTP](#runs-run-stream-and-reconnecting) (including how a dropped stream reconnects), and how a **custom frontend** integrates with the **voice agent** over WebSocket (not the bundled `voice.html` playground).
+
+---
+
+## Runs: `/run`, `/stream`, and reconnecting
+
+| Route | Purpose |
+|---|---|
+| `POST /run` | Run to completion, return the final `OUTPUT` event as JSON. |
+| `POST /stream` | Run and stream every event as SSE. |
+| `GET /runs/{run_id}/events` | Replay a run's events after a cursor — the reconnect path. |
+| `POST /cancel/{run_id}` | Cancel a running run. `404` if unknown or already finished. |
+
+Set `context.id` on the request to choose the run id; otherwise one is generated and you can read it off the first event.
+
+### A dropped connection does not stop the run
+
+Runs execute on their own task, decoupled from the HTTP response. When a client disconnects, the run keeps going and keeps appending to its **event log** — an append-only list where every event has a 1-based monotonic `seq`. Readers hold a cursor into that log rather than consuming from a queue, so a disconnect costs you nothing but your place, several readers can watch one run at once, and coming back is just asking for everything after the last `seq` you saw.
+
+Finished runs stay readable for a retention window (default 5 minutes, `JobStore(retention_secs=…)`) so a client that dropped right at the end can still collect the tail.
+
+### Reconnecting
+
+`GET /runs/{run_id}/events`:
+
+| Query | Meaning |
+|---|---|
+| `after` | Last `seq` seen (exclusive). Default `0` = from the start. |
+| `limit` | Max events per response, clamped to `1..=2000`. Default `500`. |
+| `wait_ms` | Long-poll budget, clamped to `0..=30000`. Default `0` (return immediately). When `>0` and nothing is available past `after`, the request blocks until an event arrives, the run ends, or the timeout elapses. |
+
+```json
+{
+  "run_id": "0198f3aa…",
+  "events": [{ "seq": 1, "data": { "type": "START", … } }],
+  "next_cursor": 1,
+  "done": false,
+  "expired": false
+}
+```
+
+Feed `next_cursor` back as `after` on the next poll. It equals the last `seq` returned, or your `after` unchanged when the batch is empty.
+
+**`done` means "you have everything", not "the run finished."** A terminal run whose events don't fit in one page reports `done: false` so you keep paging.
+
+**`expired: true` is the field you cannot ignore.** It means the log is gone — reaped after retention, or owned by a process that isn't this one. The response then looks *identical* to a cleanly drained stream (`done: true`, no events, cursor unmoved), so a client that only checks `done` stops early and silently loses the tail. Treat `expired` as **terminal but possibly incomplete** and reconcile from wherever you persist runs.
+
+`POST /stream` also emits the `seq` as the SSE `id:` field, so a browser `EventSource` echoes it back as `Last-Event-ID` on reconnect.
+
+### Limits
+
+The log lives in the serving process's memory. A run whose process dies has nothing to replay (`expired: true` from any other process), and the log is unbounded for the run's lifetime — a run that streams forever grows it forever. Durable, cross-process replay needs a backing store behind this same cursor contract.
+
+---
 
 ### Bundled voice playground
 

--- a/python/timbal/server/http.py
+++ b/python/timbal/server/http.py
@@ -187,8 +187,22 @@ def create_app() -> FastAPI:
         _, job = _create_job(run_id, req_data, replayable=False)
 
         output_event = None
-        async for _, event in job.follow():
+        last_seen = 0
+        async for seq, event in job.follow():
+            last_seen = seq
             output_event = event
+
+        if last_seen < job.last_seq:
+            # The log was trimmed past this reader, so the last event we hold
+            # is not the run's last event. Returning it would report some
+            # mid-run event as the final output, which is worse than failing.
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    "The run outpaced this request and its event log was trimmed, "
+                    "so the final output was lost. The run itself completed."
+                ),
+            )
 
         return JSONResponse(
             status_code=200,
@@ -208,7 +222,7 @@ def create_app() -> FastAPI:
             set_run_context(run_context)
             run_id = run_context.id
 
-        _, job = _create_job(run_id, req_data)
+        job_id, job = _create_job(run_id, req_data)
 
         async def event_streamer() -> AsyncGenerator[str, None]:
             # `id:` carries the seq so a client reading the stream always knows
@@ -217,8 +231,25 @@ def create_app() -> FastAPI:
             # `GET /runs/{run_id}/events?after=`: this route is a POST, so it is
             # not reachable by `EventSource` and nothing here consumes
             # `Last-Event-ID`.
+            last_seen = 0
             async for seq, event in job.follow():
+                last_seen = seq
                 yield f"id: {seq}\ndata: {json.dumps(event.model_dump(mode='json'))}\n\n"
+
+            if last_seen < job.last_seq:
+                # A reader the log outran (backpressure on a long run) has been
+                # cut off mid-stream. Ending the response here is byte-identical
+                # to a run that finished cleanly — the exact lie `expired`
+                # exists to catch — so say so before closing.
+                notice = json.dumps(
+                    {
+                        "run_id": job_id,
+                        "next_cursor": last_seen,
+                        "done": True,
+                        "expired": True,
+                    }
+                )
+                yield f"event: expired\ndata: {notice}\n\n"
 
         return StreamingResponse(event_streamer(), media_type="text/event-stream")
 

--- a/python/timbal/server/http.py
+++ b/python/timbal/server/http.py
@@ -36,6 +36,20 @@ logger = structlog.get_logger("timbal.server.http")
 MAX_WAIT_MS = 30_000
 
 
+def _expired_events(run_id: str, after: int) -> JSONResponse:
+    """Terminal but possibly incomplete — the log is not here to replay."""
+    return JSONResponse(
+        status_code=200,
+        content={
+            "run_id": run_id,
+            "events": [],
+            "next_cursor": after,
+            "done": True,
+            "expired": True,
+        },
+    )
+
+
 @asynccontextmanager
 async def lifespan(
     app: FastAPI,
@@ -222,13 +236,13 @@ def create_app() -> FastAPI:
         missed and to keep following (`wait_ms` long-polls instead of spinning).
 
         `expired` is the one field a client cannot skip. When the log is
-        unavailable — reaped after retention, never held by this process, or
-        belonging to a `/run` that kept no log — the honest answer looks exactly
-        like a clean end-of-stream (`done: true`, no events, the cursor
-        unmoved), so a client that only reads `done` stops early and silently
-        loses the tail. `expired: true` means *terminal but possibly
-        incomplete*: reconcile from wherever runs are persisted rather than
-        trusting this response as the end.
+        unavailable — reaped after retention, never held by this process,
+        belonging to a `/run` that kept no log, or trimmed past the cursor —
+        the honest answer looks exactly like a clean end-of-stream (`done:
+        true`, no events, the cursor unmoved), so a client that only reads
+        `done` stops early and silently loses the tail. `expired: true` means
+        *terminal but possibly incomplete*: reconcile from wherever runs are
+        persisted rather than trusting this response as the end.
 
         Note that "never held by this process" covers a run that is alive and
         well in a sibling worker: the log is process-local, so this route is
@@ -236,21 +250,16 @@ def create_app() -> FastAPI:
         """
         job = app.state.job_store.get_job(run_id)
         if job is None or not job.replayable:
-            return JSONResponse(
-                status_code=200,
-                content={
-                    "run_id": run_id,
-                    "events": [],
-                    "next_cursor": after,
-                    "done": True,
-                    "expired": True,
-                },
-            )
+            return _expired_events(run_id, after)
 
-        events, next_cursor, done = job.read(after, limit)
+        events, next_cursor, done, gapped = job.read(after, limit)
+        if gapped:
+            return _expired_events(run_id, after)
         if not events and not done and wait_ms > 0:
             await job.wait(after, min(wait_ms, MAX_WAIT_MS) / 1000)
-            events, next_cursor, done = job.read(after, limit)
+            events, next_cursor, done, gapped = job.read(after, limit)
+            if gapped:
+                return _expired_events(run_id, after)
 
         return JSONResponse(
             status_code=200,

--- a/python/timbal/server/http.py
+++ b/python/timbal/server/http.py
@@ -12,7 +12,7 @@ import structlog
 
 try:
     import uvicorn
-    from fastapi import FastAPI, Request, Response
+    from fastapi import FastAPI, HTTPException, Request, Response
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import JSONResponse, StreamingResponse
 except ImportError as e:
@@ -25,7 +25,7 @@ from .. import __version__
 from ..logs import setup_logging
 from ..state import RunContext, set_run_context
 from ..utils import ImportSpec, is_port_in_use
-from .jobs import DEFAULT_READ_LIMIT, JobStore
+from .jobs import DEFAULT_READ_LIMIT, JobStore, RunIdInUse
 from .voice import merge_voice_config
 
 logger = structlog.get_logger("timbal.server.http")
@@ -34,12 +34,6 @@ logger = structlog.get_logger("timbal.server.http")
 # `/events` endpoints. Long enough to be worth holding open, short enough to
 # stay under the usual proxy idle timeouts.
 MAX_WAIT_MS = 30_000
-
-
-def _dump(event):
-    """JSON-ready view of an event (events are Timbal models; tests use plain values)."""
-    model_dump = getattr(event, "model_dump", None)
-    return model_dump() if callable(model_dump) else event
 
 
 @asynccontextmanager
@@ -143,6 +137,24 @@ def create_app() -> FastAPI:
             content=return_model_schema,
         )
 
+    def _create_job(run_id: str | None, req_data: dict, replayable: bool = True):
+        """Start a job, turning a colliding client-supplied run id into a 409.
+
+        `context.id` is client-controlled, so two requests can name the same
+        run. Letting the second overwrite the first would leave the first still
+        executing with nothing pointing at it — unreadable, uncancellable, and
+        never reaped.
+        """
+        try:
+            return app.state.job_store.create_job(
+                app.state.runnable, req_data, job_id=run_id, replayable=replayable
+            )
+        except RunIdInUse as e:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Run id '{e.job_id}' is already in use by a running run.",
+            ) from e
+
     @app.post("/run")
     async def run(req: Request) -> Response:
         req_data = await req.json()
@@ -156,7 +168,9 @@ def create_app() -> FastAPI:
             set_run_context(run_context)
             run_id = run_context.id
 
-        _, job = app.state.job_store.create_job(app.state.runnable, req_data, job_id=run_id)
+        # Nothing can reconnect to a `/run`, so its events are dropped as they
+        # are consumed instead of being kept for the retention window.
+        _, job = _create_job(run_id, req_data, replayable=False)
 
         output_event = None
         async for _, event in job.follow():
@@ -180,14 +194,17 @@ def create_app() -> FastAPI:
             set_run_context(run_context)
             run_id = run_context.id
 
-        _, job = app.state.job_store.create_job(app.state.runnable, req_data, job_id=run_id)
+        _, job = _create_job(run_id, req_data)
 
         async def event_streamer() -> AsyncGenerator[str, None]:
-            # `id:` carries the seq so a browser's EventSource echoes it back as
-            # `Last-Event-ID` and resumes itself; anything else reconnects
-            # through `/runs/{run_id}/events?after=`.
+            # `id:` carries the seq so a client reading the stream always knows
+            # the cursor to reconnect with, without having to look inside the
+            # payload. Reconnection itself goes through
+            # `GET /runs/{run_id}/events?after=`: this route is a POST, so it is
+            # not reachable by `EventSource` and nothing here consumes
+            # `Last-Event-ID`.
             async for seq, event in job.follow():
-                yield f"id: {seq}\ndata: {json.dumps(_dump(event))}\n\n"
+                yield f"id: {seq}\ndata: {json.dumps(event.model_dump(mode='json'))}\n\n"
 
         return StreamingResponse(event_streamer(), media_type="text/event-stream")
 
@@ -204,16 +221,21 @@ def create_app() -> FastAPI:
         its log. Poll here with the last `seq` seen to collect whatever was
         missed and to keep following (`wait_ms` long-polls instead of spinning).
 
-        `expired` is the one field a client cannot skip. When the log is gone —
-        reaped after retention, or owned by a different process — the honest
-        answer looks exactly like a clean end-of-stream (`done: true`, no
-        events, the cursor unmoved), so a client that only reads `done` stops
-        early and silently loses the tail. `expired: true` means *terminal but
-        possibly incomplete*: reconcile from wherever runs are persisted rather
-        than trusting this response as the end.
+        `expired` is the one field a client cannot skip. When the log is
+        unavailable — reaped after retention, never held by this process, or
+        belonging to a `/run` that kept no log — the honest answer looks exactly
+        like a clean end-of-stream (`done: true`, no events, the cursor
+        unmoved), so a client that only reads `done` stops early and silently
+        loses the tail. `expired: true` means *terminal but possibly
+        incomplete*: reconcile from wherever runs are persisted rather than
+        trusting this response as the end.
+
+        Note that "never held by this process" covers a run that is alive and
+        well in a sibling worker: the log is process-local, so this route is
+        only meaningful when runs are pinned to one process.
         """
         job = app.state.job_store.get_job(run_id)
-        if job is None:
+        if job is None or not job.replayable:
             return JSONResponse(
                 status_code=200,
                 content={
@@ -234,7 +256,9 @@ def create_app() -> FastAPI:
             status_code=200,
             content={
                 "run_id": run_id,
-                "events": [{"seq": seq, "data": _dump(event)} for seq, event in events],
+                "events": [
+                    {"seq": seq, "data": event.model_dump(mode="json")} for seq, event in events
+                ],
                 "next_cursor": next_cursor,
                 "done": done,
                 "expired": False,
@@ -317,6 +341,22 @@ def run_server_cli(argv: list[str] | None = None) -> None:
     if is_port_in_use(args.port):
         print(f"Port {args.port} is already in use. Please use a different port.")  # noqa: T201
         sys.exit(1)
+
+    if args.workers > 1:
+        # The job store lives in one process's memory, and nothing routes a
+        # request to the worker that owns a given run. So `/cancel/{run_id}`
+        # 404s and `/runs/{run_id}/events` reports `expired` whenever the
+        # request lands on a sibling — for a run that is alive and fine.
+        logger.warning(
+            "multi_worker_runs_are_not_addressable_across_workers",
+            workers=args.workers,
+            detail=(
+                "Run cancellation and event replay are process-local. With more than one "
+                "worker, /cancel/{run_id} and /runs/{run_id}/events only work when the "
+                "request happens to reach the worker running that run. Use a single worker, "
+                "or pin runs to a worker at the load balancer."
+            ),
+        )
 
     os.environ["TIMBAL_RUNNABLE"] = import_spec
     uvicorn.run(

--- a/python/timbal/server/http.py
+++ b/python/timbal/server/http.py
@@ -25,10 +25,21 @@ from .. import __version__
 from ..logs import setup_logging
 from ..state import RunContext, set_run_context
 from ..utils import ImportSpec, is_port_in_use
-from .jobs import JOB_DONE_SENTINEL, JobStore
+from .jobs import DEFAULT_READ_LIMIT, JobStore
 from .voice import merge_voice_config
 
 logger = structlog.get_logger("timbal.server.http")
+
+# Ceiling on `/runs/{run_id}/events` long-polls, matching the platform's other
+# `/events` endpoints. Long enough to be worth holding open, short enough to
+# stay under the usual proxy idle timeouts.
+MAX_WAIT_MS = 30_000
+
+
+def _dump(event):
+    """JSON-ready view of an event (events are Timbal models; tests use plain values)."""
+    model_dump = getattr(event, "model_dump", None)
+    return model_dump() if callable(model_dump) else event
 
 
 @asynccontextmanager
@@ -148,10 +159,7 @@ def create_app() -> FastAPI:
         _, job = app.state.job_store.create_job(app.state.runnable, req_data, job_id=run_id)
 
         output_event = None
-        while True:
-            event = await job.queue.get()
-            if event is JOB_DONE_SENTINEL:
-                break
+        async for _, event in job.follow():
             output_event = event
 
         return JSONResponse(
@@ -175,13 +183,63 @@ def create_app() -> FastAPI:
         _, job = app.state.job_store.create_job(app.state.runnable, req_data, job_id=run_id)
 
         async def event_streamer() -> AsyncGenerator[str, None]:
-            while True:
-                event = await job.queue.get()
-                if event is JOB_DONE_SENTINEL:
-                    break
-                yield f"data: {json.dumps(event.model_dump())}\n\n"
+            # `id:` carries the seq so a browser's EventSource echoes it back as
+            # `Last-Event-ID` and resumes itself; anything else reconnects
+            # through `/runs/{run_id}/events?after=`.
+            async for seq, event in job.follow():
+                yield f"id: {seq}\ndata: {json.dumps(_dump(event))}\n\n"
 
         return StreamingResponse(event_streamer(), media_type="text/event-stream")
+
+    @app.get("/runs/{run_id}/events")
+    async def run_events(
+        run_id: str,
+        after: int = 0,
+        limit: int = DEFAULT_READ_LIMIT,
+        wait_ms: int = 0,
+    ) -> Response:
+        """Replay a run's events after a cursor — the reconnect path for `/stream`.
+
+        A dropped connection does not stop the run: the job keeps producing into
+        its log. Poll here with the last `seq` seen to collect whatever was
+        missed and to keep following (`wait_ms` long-polls instead of spinning).
+
+        `expired` is the one field a client cannot skip. When the log is gone —
+        reaped after retention, or owned by a different process — the honest
+        answer looks exactly like a clean end-of-stream (`done: true`, no
+        events, the cursor unmoved), so a client that only reads `done` stops
+        early and silently loses the tail. `expired: true` means *terminal but
+        possibly incomplete*: reconcile from wherever runs are persisted rather
+        than trusting this response as the end.
+        """
+        job = app.state.job_store.get_job(run_id)
+        if job is None:
+            return JSONResponse(
+                status_code=200,
+                content={
+                    "run_id": run_id,
+                    "events": [],
+                    "next_cursor": after,
+                    "done": True,
+                    "expired": True,
+                },
+            )
+
+        events, next_cursor, done = job.read(after, limit)
+        if not events and not done and wait_ms > 0:
+            await job.wait(after, min(wait_ms, MAX_WAIT_MS) / 1000)
+            events, next_cursor, done = job.read(after, limit)
+
+        return JSONResponse(
+            status_code=200,
+            content={
+                "run_id": run_id,
+                "events": [{"seq": seq, "data": _dump(event)} for seq, event in events],
+                "next_cursor": next_cursor,
+                "done": done,
+                "expired": False,
+            },
+        )
 
     @app.post("/cancel/{run_id}")
     async def cancel(run_id: str) -> Response:

--- a/python/timbal/server/jobs.py
+++ b/python/timbal/server/jobs.py
@@ -1,46 +1,188 @@
 import asyncio
+import time
+from collections.abc import AsyncGenerator
+from typing import Any
 
 from uuid_extensions import uuid7
 
-JOB_DONE_SENTINEL = object()
+# How long a finished job stays readable before the store forgets it. The window
+# is what makes reconnection work at the edges: a consumer that dropped just
+# before the run ended still has this long to come back, collect the tail, and
+# see the terminal flag. Without it, "job not found" is the reward for
+# reconnecting a second too late.
+DEFAULT_RETENTION_SECS = 300.0
+
+# Batch ceilings for `Job.read`, mirroring the platform's `/events` endpoints so
+# a client written against one is written against both.
+DEFAULT_READ_LIMIT = 500
+MAX_READ_LIMIT = 2000
 
 
 class Job:
-    def __init__(self, task: asyncio.Task, queue: asyncio.Queue):
+    """A running (or recently finished) run, plus its replayable event log.
+
+    Events are appended to a log and addressed by a 1-based monotonic ``seq``,
+    not handed out through a queue. A queue can only be read once, so the first
+    consumer to disconnect takes the events with it — fine for a script, useless
+    when the consumer is a browser and the run is a ten-minute agent turn that
+    keeps going after the socket drops. With a log every reader holds its own
+    cursor, so reconnecting is just asking for everything after the last ``seq``
+    it saw, and two readers (a tab and a task panel) can watch one run without
+    racing each other for events.
+
+    The log is unbounded for the run's lifetime and freed when the store reaps
+    the job. A run that streams forever will grow it forever — the same exposure
+    the undrained queue had, and it ends the same way, with the run.
+    """
+
+    def __init__(self, task: asyncio.Task | None = None) -> None:
         self.task = task
-        self.queue = queue
+        # (seq, event), contiguous from seq 1, so the event with seq S always
+        # sits at index S-1 — which is what lets `read` slice instead of scan.
+        self.events: list[tuple[int, Any]] = []
+        self.next_seq = 1
+        self.done = False
+        self.finished_at: float | None = None
+        self._waiters: list[asyncio.Future] = []
+
+    @property
+    def last_seq(self) -> int:
+        """Highest seq appended so far (0 before the first event)."""
+        return self.next_seq - 1
+
+    def append(self, event: Any) -> None:
+        self.events.append((self.next_seq, event))
+        self.next_seq += 1
+        self._wake()
+
+    def finish(self) -> None:
+        self.done = True
+        self.finished_at = time.monotonic()
+        self._wake()
+
+    def _wake(self) -> None:
+        """Release every long-poll waiter.
+
+        Deliberately synchronous, which is why `append` and `finish` are too:
+        the producer calls `finish` from a ``finally`` that may already be
+        unwinding a cancellation, and awaiting a lock there is how you get a
+        cancelled run whose readers hang until their timeout.
+        """
+        for waiter in self._waiters:
+            if not waiter.done():
+                waiter.set_result(None)
+        self._waiters.clear()
+
+    def read(
+        self,
+        after: int = 0,
+        limit: int = DEFAULT_READ_LIMIT,
+    ) -> tuple[list[tuple[int, Any]], int, bool]:
+        """``(events, next_cursor, done)`` for the events after ``after``.
+
+        ``next_cursor`` is the last seq in the batch, or ``after`` untouched
+        when the batch is empty, so it can always be fed straight back in.
+        ``done`` means the run finished *and* this batch reached the end: a
+        terminal run whose events don't fit in one page reports ``False`` so
+        the caller keeps paging instead of stopping on the flag.
+        """
+        limit = max(1, min(limit, MAX_READ_LIMIT))
+        start = max(after, 0)
+        batch = self.events[start : start + limit]
+        next_cursor = batch[-1][0] if batch else after
+        return batch, next_cursor, self.done and next_cursor >= self.last_seq
+
+    async def wait(self, after: int = 0, timeout: float = 0.0) -> None:
+        """Block until something lands past ``after``, the run ends, or timeout.
+
+        Returns rather than raising on timeout — the caller re-reads either way.
+        """
+        if timeout <= 0 or self.done or self.last_seq > after:
+            return
+        await self._sleep(timeout)
+
+    async def follow(self, after: int = 0) -> AsyncGenerator[tuple[int, Any], None]:
+        """Yield ``(seq, event)`` from ``after`` until the run is done.
+
+        The streaming face of `read`, for SSE. Starting at a non-zero ``after``
+        replays the backlog first and then continues live, so a reconnecting
+        stream and a fresh one are the same code path.
+        """
+        cursor = after
+        while True:
+            batch, cursor, done = self.read(cursor, limit=MAX_READ_LIMIT)
+            for entry in batch:
+                yield entry
+            if done:
+                return
+            if not batch:
+                await self._sleep(None)
+
+    async def _sleep(self, timeout: float | None) -> None:
+        waiter = asyncio.get_running_loop().create_future()
+        self._waiters.append(waiter)
+        try:
+            if timeout is None:
+                await waiter
+            else:
+                await asyncio.wait_for(waiter, timeout)
+        except (TimeoutError, asyncio.TimeoutError):
+            pass
+        finally:
+            if waiter in self._waiters:
+                self._waiters.remove(waiter)
 
 
 class JobStore:
-    def __init__(self):
+    def __init__(self, retention_secs: float = DEFAULT_RETENTION_SECS) -> None:
         self._jobs: dict[str, Job] = {}
+        self._retention_secs = retention_secs
 
     def create_job(self, runnable, params, job_id: str | None = None) -> tuple[str, Job]:
         _job_id: str = job_id if job_id is not None else uuid7(as_type="hex")  # type: ignore
-        queue = asyncio.Queue()
-        task = asyncio.create_task(self._run(runnable, params, queue))
-        task.add_done_callback(lambda _: self._jobs.pop(_job_id, None))
-        job = Job(task, queue)
+        # Finished jobs are held for the retention window rather than dropped on
+        # completion, so reaping happens here — one sweep per new job, no timer.
+        self.reap()
+        job = Job()
+        job.task = asyncio.create_task(self._run(runnable, params, job))
         self._jobs[_job_id] = job
         return _job_id, job
 
     def get_job(self, job_id: str) -> Job | None:
+        """The job, or ``None`` once it has been reaped (or never existed here).
+
+        Callers must not read ``None`` as "finished cleanly" — it also covers a
+        run this process never had. Both mean the log is unavailable, which is
+        what the `/events` route reports as ``expired``.
+        """
         return self._jobs.get(job_id)
 
     def cancel_job(self, job_id: str) -> bool:
         """Cancel a running job by its ID.
 
-        Returns True if the job was found and cancelled, False otherwise.
+        Returns True if the job was found and cancelled, False otherwise —
+        including for a job that is merely being retained after finishing,
+        which is not cancellable however addressable it still is.
         """
         job = self._jobs.get(job_id)
-        if job is None:
+        if job is None or job.done:
             return False
-        job.task.cancel()
-        return True
+        return job.task.cancel() if job.task is not None else False
 
-    async def _run(self, runnable, params, queue):
+    def reap(self, now: float | None = None) -> None:
+        """Forget jobs whose retention window has passed."""
+        now = time.monotonic() if now is None else now
+        expired = [
+            job_id
+            for job_id, job in self._jobs.items()
+            if job.finished_at is not None and now - job.finished_at >= self._retention_secs
+        ]
+        for job_id in expired:
+            del self._jobs[job_id]
+
+    async def _run(self, runnable, params, job: Job):
         try:
             async for event in runnable(**params):
-                await queue.put(event)
+                job.append(event)
         finally:
-            await queue.put(JOB_DONE_SENTINEL)
+            job.finish()

--- a/python/timbal/server/jobs.py
+++ b/python/timbal/server/jobs.py
@@ -89,7 +89,11 @@ class Job:
         return self.next_seq - 1
 
     def append(self, event: Any) -> None:
-        nbytes = _event_nbytes(event)
+        # Sizing an event means serializing it, and `/stream` serializes it
+        # again to frame it — so the byte cap costs every event a second dump.
+        # Worth it to bound memory by the thing that actually fills it, but not
+        # worth paying when the cap is off.
+        nbytes = _event_nbytes(event) if self._max_bytes > 0 else 0
         self.events.append((self.next_seq, event))
         self._sizes.append(nbytes)
         self._nbytes += nbytes

--- a/python/timbal/server/jobs.py
+++ b/python/timbal/server/jobs.py
@@ -7,15 +7,27 @@ from uuid_extensions import uuid7
 
 # How long a finished job stays readable before the store forgets it. The window
 # is what makes reconnection work at the edges: a consumer that dropped just
-# before the run ended still has this long to come back, collect the tail, and
-# see the terminal flag. Without it, "job not found" is the reward for
-# reconnecting a second too late.
+# before the run ended still has this long to come back for the tail.
 DEFAULT_RETENTION_SECS = 300.0
 
-# Batch ceilings for `Job.read`, mirroring the platform's `/events` endpoints so
-# a client written against one is written against both.
+# Batch ceilings for `Job.read`, mirroring the platform's other `/events`
+# endpoints so a client written against one is written against both.
 DEFAULT_READ_LIMIT = 500
 MAX_READ_LIMIT = 2000
+
+
+class RunIdInUse(Exception):
+    """A caller supplied a run id that a still-running job already owns.
+
+    Run ids come from the client (`context.id`), so a collision is reachable
+    from the outside. Overwriting the entry would leave the first run executing
+    with nothing pointing at it: unreadable, uncancellable, and invisible to
+    the reaper.
+    """
+
+    def __init__(self, job_id: str) -> None:
+        super().__init__(f"run id {job_id!r} is already in use by a running job")
+        self.job_id = job_id
 
 
 class Job:
@@ -23,23 +35,26 @@ class Job:
 
     Events are appended to a log and addressed by a 1-based monotonic ``seq``,
     not handed out through a queue. A queue can only be read once, so the first
-    consumer to disconnect takes the events with it — fine for a script, useless
-    when the consumer is a browser and the run is a ten-minute agent turn that
-    keeps going after the socket drops. With a log every reader holds its own
-    cursor, so reconnecting is just asking for everything after the last ``seq``
-    it saw, and two readers (a tab and a task panel) can watch one run without
-    racing each other for events.
+    consumer to disconnect takes the events with it. With a log every reader
+    holds its own cursor, so reconnecting is just asking for everything after
+    the last ``seq`` it saw, and two readers can watch one run without racing
+    each other for events.
 
-    The log is unbounded for the run's lifetime and freed when the store reaps
-    the job. A run that streams forever will grow it forever — the same exposure
-    the undrained queue had, and it ends the same way, with the run.
+    ``replayable=False`` opts out of keeping the log: events are forgotten as
+    the single attached reader passes them. That is what `/run` wants — it reads
+    to completion in one pass, discards everything but the final event, and
+    nothing can reconnect to it — and it keeps that path O(unread) rather than
+    holding an entire run's deltas until the retention window lapses.
     """
 
-    def __init__(self, task: asyncio.Task | None = None) -> None:
+    def __init__(self, task: asyncio.Task | None = None, *, replayable: bool = True) -> None:
         self.task = task
-        # (seq, event), contiguous from seq 1, so the event with seq S always
-        # sits at index S-1 — which is what lets `read` slice instead of scan.
+        self.replayable = replayable
+        # (seq, event) for every seq past `forgotten_through`, contiguous, so
+        # seq S sits at index S - forgotten_through - 1 — which is what lets
+        # `read` slice instead of scan.
         self.events: list[tuple[int, Any]] = []
+        self.forgotten_through = 0
         self.next_seq = 1
         self.done = False
         self.finished_at: float | None = None
@@ -59,6 +74,13 @@ class Job:
         self.done = True
         self.finished_at = time.monotonic()
         self._wake()
+
+    def expired(self, retention_secs: float, now: float | None = None) -> bool:
+        """Whether this job's retention window has lapsed."""
+        if self.finished_at is None:
+            return False
+        now = time.monotonic() if now is None else now
+        return now - self.finished_at >= retention_secs
 
     def _wake(self) -> None:
         """Release every long-poll waiter.
@@ -87,9 +109,10 @@ class Job:
         the caller keeps paging instead of stopping on the flag.
         """
         limit = max(1, min(limit, MAX_READ_LIMIT))
-        start = max(after, 0)
-        batch = self.events[start : start + limit]
-        next_cursor = batch[-1][0] if batch else after
+        start = max(after, self.forgotten_through)
+        offset = start - self.forgotten_through
+        batch = self.events[offset : offset + limit]
+        next_cursor = batch[-1][0] if batch else start
         return batch, next_cursor, self.done and next_cursor >= self.last_seq
 
     async def wait(self, after: int = 0, timeout: float = 0.0) -> None:
@@ -97,9 +120,17 @@ class Job:
 
         Returns rather than raising on timeout — the caller re-reads either way.
         """
-        if timeout <= 0 or self.done or self.last_seq > after:
+        if timeout <= 0:
             return
-        await self._sleep(timeout)
+        waiter = self._waiter()
+        try:
+            if self.done or self.last_seq > after:
+                return
+            await asyncio.wait_for(waiter, timeout)
+        except TimeoutError:
+            pass
+        finally:
+            self._discard(waiter)
 
     async def follow(self, after: int = 0) -> AsyncGenerator[tuple[int, Any], None]:
         """Yield ``(seq, event)`` from ``after`` until the run is done.
@@ -110,27 +141,42 @@ class Job:
         """
         cursor = after
         while True:
+            # Registered before the read, not after: an `append` landing in
+            # between has to resolve a waiter that already exists. Register
+            # second and that wake is lost — and for the last event of a run,
+            # lost means this generator waits for an event that never comes.
+            waiter = self._waiter()
             batch, cursor, done = self.read(cursor, limit=MAX_READ_LIMIT)
+            if not batch and not done:
+                try:
+                    await waiter
+                finally:
+                    self._discard(waiter)
+                continue
+
+            self._discard(waiter)
             for entry in batch:
                 yield entry
+            if not self.replayable:
+                self._forget_through(cursor)
             if done:
                 return
-            if not batch:
-                await self._sleep(None)
 
-    async def _sleep(self, timeout: float | None) -> None:
+    def _waiter(self) -> asyncio.Future:
         waiter = asyncio.get_running_loop().create_future()
         self._waiters.append(waiter)
-        try:
-            if timeout is None:
-                await waiter
-            else:
-                await asyncio.wait_for(waiter, timeout)
-        except (TimeoutError, asyncio.TimeoutError):
-            pass
-        finally:
-            if waiter in self._waiters:
-                self._waiters.remove(waiter)
+        return waiter
+
+    def _discard(self, waiter: asyncio.Future) -> None:
+        if waiter in self._waiters:
+            self._waiters.remove(waiter)
+
+    def _forget_through(self, seq: int) -> None:
+        """Drop the log up to ``seq``. Only sound with a single reader."""
+        keep = seq - self.forgotten_through
+        if keep > 0:
+            del self.events[:keep]
+            self.forgotten_through = seq
 
 
 class JobStore:
@@ -138,24 +184,54 @@ class JobStore:
         self._jobs: dict[str, Job] = {}
         self._retention_secs = retention_secs
 
-    def create_job(self, runnable, params, job_id: str | None = None) -> tuple[str, Job]:
+    def create_job(
+        self,
+        runnable,
+        params,
+        job_id: str | None = None,
+        replayable: bool = True,
+    ) -> tuple[str, Job]:
+        """Start ``runnable`` on its own task, tracked under ``job_id``.
+
+        Raises `RunIdInUse` if a running job already holds that id. Pass
+        ``replayable=False`` for a consumer that reads the run to completion in
+        one pass and needs no reconnection (see `Job`).
+        """
         _job_id: str = job_id if job_id is not None else uuid7(as_type="hex")  # type: ignore
-        # Finished jobs are held for the retention window rather than dropped on
-        # completion, so reaping happens here — one sweep per new job, no timer.
+        # `get_job` expires lazily, one id at a time; sweep here as well so the
+        # dict itself stays bounded when finished jobs are never read back.
         self.reap()
-        job = Job()
+        existing = self.get_job(_job_id)
+        if existing is not None and not existing.done:
+            raise RunIdInUse(_job_id)
+
+        job = Job(replayable=replayable)
         job.task = asyncio.create_task(self._run(runnable, params, job))
+        # A job nobody can reconnect to has nothing to retain, so it goes as
+        # soon as it ends instead of waiting out the window.
+        if not replayable:
+            job.task.add_done_callback(lambda _: self._forget(_job_id, job))
         self._jobs[_job_id] = job
         return _job_id, job
 
-    def get_job(self, job_id: str) -> Job | None:
-        """The job, or ``None`` once it has been reaped (or never existed here).
+    def get_job(self, job_id: str, now: float | None = None) -> Job | None:
+        """The job, or ``None`` once its window has lapsed (or it never existed here).
 
-        Callers must not read ``None`` as "finished cleanly" — it also covers a
+        Expiry is evaluated here rather than only in `reap`, so the retention
+        window holds on an idle server too — otherwise a job's lifetime depends
+        on whether more traffic happens to arrive.
+
+        Callers must not read ``None`` as "finished cleanly": it also covers a
         run this process never had. Both mean the log is unavailable, which is
         what the `/events` route reports as ``expired``.
         """
-        return self._jobs.get(job_id)
+        job = self._jobs.get(job_id)
+        if job is None:
+            return None
+        if job.expired(self._retention_secs, now):
+            self._forget(job_id, job)
+            return None
+        return job
 
     def cancel_job(self, job_id: str) -> bool:
         """Cancel a running job by its ID.
@@ -170,14 +246,16 @@ class JobStore:
         return job.task.cancel() if job.task is not None else False
 
     def reap(self, now: float | None = None) -> None:
-        """Forget jobs whose retention window has passed."""
+        """Forget every job whose retention window has passed."""
         now = time.monotonic() if now is None else now
-        expired = [
-            job_id
-            for job_id, job in self._jobs.items()
-            if job.finished_at is not None and now - job.finished_at >= self._retention_secs
-        ]
-        for job_id in expired:
+        for job_id in [
+            job_id for job_id, job in self._jobs.items() if job.expired(self._retention_secs, now)
+        ]:
+            del self._jobs[job_id]
+
+    def _forget(self, job_id: str, job: Job) -> None:
+        """Drop ``job_id``, but only while it still refers to ``job``."""
+        if self._jobs.get(job_id) is job:
             del self._jobs[job_id]
 
     async def _run(self, runnable, params, job: Job):

--- a/python/timbal/server/jobs.py
+++ b/python/timbal/server/jobs.py
@@ -221,9 +221,15 @@ class Job:
         )
 
     def _trim(self) -> None:
-        """Drop the oldest events until the ring fits. Never drops the tip."""
-        if not self.replayable:
-            return
+        """Drop the oldest events until the ring fits. Never drops the tip.
+
+        Applies to non-replayable logs too. Those are normally kept small by
+        `follow` forgetting each batch as it is consumed, but that only happens
+        while a reader is attached — and the run deliberately outlives its
+        reader, so a `/run` whose handler went away (shutdown, an outer
+        timeout) would otherwise append into an unbounded list for the rest of
+        the run. Forgetting stays the fast path; this is the backstop.
+        """
         drop = 0
         n = len(self.events)
         nbytes = self._nbytes

--- a/python/timbal/server/jobs.py
+++ b/python/timbal/server/jobs.py
@@ -15,6 +15,12 @@ DEFAULT_RETENTION_SECS = 300.0
 DEFAULT_READ_LIMIT = 500
 MAX_READ_LIMIT = 2000
 
+# Ring-buffer cap on a replayable log. `None` (or 0) means unlimited. A single
+# event larger than `max_bytes` is kept — dropping the tip would lose the live
+# stream, not just the reconnect backlog.
+DEFAULT_MAX_EVENTS = 50_000
+DEFAULT_MAX_BYTES = 32 * 1024 * 1024
+
 
 class RunIdInUse(Exception):
     """A caller supplied a run id that a still-running job already owns.
@@ -45,15 +51,32 @@ class Job:
     to completion in one pass, discards everything but the final event, and
     nothing can reconnect to it — and it keeps that path O(unread) rather than
     holding an entire run's deltas until the retention window lapses.
+
+    A replayable log is a ring: once ``max_events`` / ``max_bytes`` is exceeded
+    the oldest entries are dropped and ``forgotten_through`` advances. Reconnect
+    from a cursor still inside the window works; ``after < forgotten_through``
+    is a gap — the same class of lie ``expired`` exists to catch — not a silent
+    skip to the new head.
     """
 
-    def __init__(self, task: asyncio.Task | None = None, *, replayable: bool = True) -> None:
+    def __init__(
+        self,
+        task: asyncio.Task | None = None,
+        *,
+        replayable: bool = True,
+        max_events: int | None = DEFAULT_MAX_EVENTS,
+        max_bytes: int | None = DEFAULT_MAX_BYTES,
+    ) -> None:
         self.task = task
         self.replayable = replayable
+        self._max_events = max_events or 0
+        self._max_bytes = max_bytes or 0
         # (seq, event) for every seq past `forgotten_through`, contiguous, so
         # seq S sits at index S - forgotten_through - 1 — which is what lets
         # `read` slice instead of scan.
         self.events: list[tuple[int, Any]] = []
+        self._sizes: list[int] = []
+        self._nbytes = 0
         self.forgotten_through = 0
         self.next_seq = 1
         self.done = False
@@ -66,8 +89,12 @@ class Job:
         return self.next_seq - 1
 
     def append(self, event: Any) -> None:
+        nbytes = _event_nbytes(event)
         self.events.append((self.next_seq, event))
+        self._sizes.append(nbytes)
+        self._nbytes += nbytes
         self.next_seq += 1
+        self._trim()
         self._wake()
 
     def finish(self) -> None:
@@ -99,28 +126,33 @@ class Job:
         self,
         after: int = 0,
         limit: int = DEFAULT_READ_LIMIT,
-    ) -> tuple[list[tuple[int, Any]], int, bool]:
-        """``(events, next_cursor, done)`` for the events after ``after``.
+    ) -> tuple[list[tuple[int, Any]], int, bool, bool]:
+        """``(events, next_cursor, done, gapped)`` for the events after ``after``.
 
         ``next_cursor`` is the last seq in the batch, or ``after`` untouched
         when the batch is empty, so it can always be fed straight back in.
         ``done`` means the run finished *and* this batch reached the end: a
         terminal run whose events don't fit in one page reports ``False`` so
         the caller keeps paging instead of stopping on the flag.
+        ``gapped`` means ``after`` is behind the retained window — the events
+        between the cursor and the floor were dropped. The caller must treat
+        that as ``expired``, not skip to the new head.
         """
+        if after < self.forgotten_through:
+            return [], after, True, True
         limit = max(1, min(limit, MAX_READ_LIMIT))
-        start = max(after, self.forgotten_through)
+        start = max(after, 0)
         offset = start - self.forgotten_through
         batch = self.events[offset : offset + limit]
-        next_cursor = batch[-1][0] if batch else start
-        return batch, next_cursor, self.done and next_cursor >= self.last_seq
+        next_cursor = batch[-1][0] if batch else after
+        return batch, next_cursor, self.done and next_cursor >= self.last_seq, False
 
     async def wait(self, after: int = 0, timeout: float = 0.0) -> None:
         """Block until something lands past ``after``, the run ends, or timeout.
 
         Returns rather than raising on timeout — the caller re-reads either way.
         """
-        if timeout <= 0:
+        if timeout <= 0 or after < self.forgotten_through:
             return
         waiter = self._waiter()
         try:
@@ -146,7 +178,10 @@ class Job:
             # second and that wake is lost — and for the last event of a run,
             # lost means this generator waits for an event that never comes.
             waiter = self._waiter()
-            batch, cursor, done = self.read(cursor, limit=MAX_READ_LIMIT)
+            batch, cursor, done, gapped = self.read(cursor, limit=MAX_READ_LIMIT)
+            if gapped:
+                self._discard(waiter)
+                return
             if not batch and not done:
                 try:
                     await waiter
@@ -175,14 +210,55 @@ class Job:
         """Drop the log up to ``seq``. Only sound with a single reader."""
         keep = seq - self.forgotten_through
         if keep > 0:
+            self._nbytes -= sum(self._sizes[:keep])
             del self.events[:keep]
+            del self._sizes[:keep]
             self.forgotten_through = seq
+
+    def _over_cap(self, n: int, nbytes: int) -> bool:
+        return (self._max_events > 0 and n > self._max_events) or (
+            self._max_bytes > 0 and nbytes > self._max_bytes
+        )
+
+    def _trim(self) -> None:
+        """Drop the oldest events until the ring fits. Never drops the tip."""
+        if not self.replayable:
+            return
+        drop = 0
+        n = len(self.events)
+        nbytes = self._nbytes
+        while n - drop > 1 and self._over_cap(n - drop, nbytes):
+            nbytes -= self._sizes[drop]
+            drop += 1
+        if drop:
+            del self.events[:drop]
+            del self._sizes[:drop]
+            self._nbytes = nbytes
+            self.forgotten_through += drop
+
+
+def _event_nbytes(event: Any) -> int:
+    dump_json = getattr(event, "model_dump_json", None)
+    if callable(dump_json):
+        return len(dump_json())
+    if isinstance(event, str):
+        return len(event)
+    if isinstance(event, (bytes, bytearray)):
+        return len(event)
+    return len(repr(event))
 
 
 class JobStore:
-    def __init__(self, retention_secs: float = DEFAULT_RETENTION_SECS) -> None:
+    def __init__(
+        self,
+        retention_secs: float = DEFAULT_RETENTION_SECS,
+        max_events: int | None = DEFAULT_MAX_EVENTS,
+        max_bytes: int | None = DEFAULT_MAX_BYTES,
+    ) -> None:
         self._jobs: dict[str, Job] = {}
         self._retention_secs = retention_secs
+        self._max_events = max_events
+        self._max_bytes = max_bytes
 
     def create_job(
         self,
@@ -205,7 +281,11 @@ class JobStore:
         if existing is not None and not existing.done:
             raise RunIdInUse(_job_id)
 
-        job = Job(replayable=replayable)
+        job = Job(
+            replayable=replayable,
+            max_events=self._max_events,
+            max_bytes=self._max_bytes,
+        )
         job.task = asyncio.create_task(self._run(runnable, params, job))
         # A job nobody can reconnect to has nothing to retain, so it goes as
         # soon as it ends instead of waiting out the window.


### PR DESCRIPTION
## The problem

A run already outlives its HTTP response — the job runs on its own task, so a closed tab or a dropped connection never stopped it. But the events went into an `asyncio.Queue`, and reading a queue drains it. Whatever arrived while nobody was attached was simply gone, and there was no way back into a run in progress: no reattach route, no replay, nothing but the final trace once it landed.

So the work survived a disconnect and the *observation* of it didn't, which is the wrong way round for anything long-running.

## What changed

Replace the queue with an append-only log. Every event gets a 1-based monotonic `seq`, readers hold their own cursor instead of consuming, and reconnecting is just asking for everything after the last `seq` you saw. Two readers can now watch one run without racing for its events.

Finished jobs are retained for a window (default 5 minutes) rather than dropped the instant they complete, so a client that died right at the end still has time to come back for the tail.

New route alongside the SSE one:

```
GET /runs/{run_id}/events?after=&limit=&wait_ms=
```

```json
{
  "run_id": "0198f3aa…",
  "events": [{ "seq": 1, "data": { "type": "START", … } }],
  "next_cursor": 1,
  "done": false,
  "expired": false
}
```

This follows the cursor + long-poll contract the platform already uses for compose turns and eval runs, deliberately — same field names, same semantics, so a client written against one is written against all three.

### `expired` is the part worth copying

When the log is unavailable the honest response is byte-identical to a cleanly drained stream: `done: true`, no events, cursor unmoved. A client that only checks `done` therefore stops early and silently loses the tail — a bug that looks like nothing at all. `expired: true` means **terminal but possibly incomplete**: reconcile from durable storage instead of trusting this as the end.

`done` is also "you have everything", not "the run finished" — a terminal run whose events don't fit in one page reports `done: false` so paging clients keep going.

### Only `/stream` keeps a log

`/run` is read to completion by the one request that started it and nothing can reconnect to it, so its events are forgotten as they are consumed (`replayable=False`) rather than held for the retention window. Otherwise every non-streaming request would pin a whole run's deltas in memory for five minutes after answering — a regression against the queue, which was drained as it went. `/runs/{run_id}/events` reports `expired: true` for a `/run`.

`/stream` emits the `seq` as the SSE `id:` field so a client following the stream always knows the cursor to reconnect with, without parsing the payload. Note this is *not* an `EventSource` resume: `/stream` is a POST, so `EventSource` cannot reach it, and nothing reads `Last-Event-ID`. Reconnection goes through `/runs/{run_id}/events?after=`.

## Breaking change

`Job.queue` and `JOB_DONE_SENTINEL` are gone. Consumers iterate `job.follow()`, or call `job.read(after, limit)` for a cursor batch:

```python
# before
while True:
    event = await job.queue.get()
    if event is JOB_DONE_SENTINEL:
        break
    ...

# after
async for seq, event in job.follow():
    ...
```

Both in-tree consumers (`/run`, `/stream`) are updated here. `timbal.server.jobs` is server-internal — nothing in the public API surface touches it — but the monolith's composer sidecar imports it and needs the same one-line change when it bumps its pin.

`cancel_job` now returns `False` for a retained-but-finished job, so `POST /cancel/{run_id}` still answers `404` after completion exactly as before.

Naming a `context.id` that a *running* run already holds is now a `409` instead of silently overwriting the entry, which used to leave the first run executing with nothing pointing at it — unreadable, uncancellable, and invisible to the reaper. Reusing a finished id still works.

## Limits

**Single process.** The log and the job registry live in one process's memory, and nothing routes a request to the worker that owns a given run. This is not only about a process dying: under `--workers > 1` (a supported mode — the CLI now warns) `/cancel/{run_id}` and `/runs/{run_id}/events` are a coin flip, because a request landing on a sibling worker gets `404` and `expired: true` respectively for a run that is alive and fine. `expired` cannot distinguish "gone" from "not mine", so such a client goes reconciling against durable storage for a run still minutes from finishing. Run one worker, or pin runs to a worker at the load balancer.

**Ring-buffered, not unbounded.** A replayable log is capped at 50 000 events or 32 MiB, whichever hits first (`JobStore(max_events=…, max_bytes=…)`). Older events drop and `forgotten_through` advances. A reconnect whose cursor is behind that floor reports `expired: true` — same as a reaped run — rather than silently skipping to the new head. The live tip is never dropped, even if a single event is larger than `max_bytes`.

**No authorization.** These routes carry none of their own and CORS is wide open, so anything that can reach the port can replay any run whose id it can name — and ids are client-chosen, so they are guessable. Deploy behind something that authenticates and scopes by run.

Durable, cross-process replay wants a backing store behind this same cursor contract; the point of matching the contract now is that it becomes a swap rather than a redesign.

## Test plan

- [x] `pytest python/tests` — 3892 passed, 6 skipped, 7 xfailed
- [x] Log semantics: contiguous seqs, cursor resume, two concurrent readers both get every event, paging, `next_cursor` on an empty batch
- [x] Truncated terminal page reports `done: false`
- [x] Retention: finished job stays addressable, the window is honoured by `get_job` on an idle server (not only by a `reap` that traffic triggers), `reap` never touches a running job
- [x] `replayable=False`: events forgotten as consumed, job leaves the store on completion, a replayable job is unaffected by re-reading
- [x] Run id collision: a live id raises, a finished id can be reused, the route answers `409`
- [x] Cancellation: a cancelled or crashed run still terminates its log, so readers are released instead of hanging
- [x] Long-poll waiter is registered before the read — verified with teeth: flipping the order back makes `test_follow_does_not_miss_an_event_that_lands_mid_read` hang and fail on timeout
- [x] Route level: replay from zero, resume from a cursor, unknown run and reaped run both report `expired`, a `/run` reports `expired`, long-poll returns immediately on a finished run
- [x] Ring buffer: cap drops the head, `after < forgotten_through` is `gapped`/`expired` (cursor unmoved), a cursor on the floor still reads the tail, byte cap too, a single oversized event is kept, `follow(0)` on a trimmed log yields nothing

Made with [Cursor](https://cursor.com)

