### PR TITLE
Add xai/grok-4.6 and enforce model catalog/doc sync in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,11 @@ on:
     branches: [main]
     paths:
       - "python/**"
+      - "docs/models/**"
       - "pyproject.toml"
       - "uv.lock"
       - "scripts/audit_models.py"
+      - "scripts/generate_models.py"
       - ".github/workflows/ci.yml"
   workflow_dispatch:
     inputs:

--- a/docs/models/fireworks.mdx
+++ b/docs/models/fireworks.mdx
@@ -20,6 +20,18 @@ description: "Open-source models via Fireworks serverless inference with specs, 
   - <Icon icon="keyboard" size={14} /> Text input
   </Card>
 
+  <Card title="deepseek-v4-flash">
+  <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> Reasoning · <Icon icon="bolt" size={14} /> <Icon icon="bolt" size={14} /> <Icon icon="bolt" size={14} /> <Icon icon="bolt" size={14} /> <Icon icon="bolt" size={14} /> Speed
+
+  `fireworks/accounts/fireworks/models/deepseek-v4-flash`
+
+  Retired April preview slug kept for backward compatibility. Serverless removed on Fireworks — migrate to `deepseek-v4-flash-0731`.
+
+  - &#36;0.14 / &#36;0.28
+  - <Icon icon="window-maximize" size={14} /> 1M context
+  - <Icon icon="keyboard" size={14} /> Text input
+  </Card>
+
   <Card title="deepseek-v4-flash-0731">
   <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> Reasoning · <Icon icon="bolt" size={14} /> <Icon icon="bolt" size={14} /> <Icon icon="bolt" size={14} /> <Icon icon="bolt" size={14} /> <Icon icon="bolt" size={14} /> Speed
 

--- a/docs/models/openai.mdx
+++ b/docs/models/openai.mdx
@@ -36,6 +36,20 @@ description: "GPT-5, GPT-4, and o-series models with specs, pricing, and capabil
   - <Icon icon="brain" size={14} /> Extended thinking
   </Card>
 
+  <Card title="gpt-5.5-2026-04-23">
+  <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> Reasoning · <Icon icon="bolt" size={14} /> <Icon icon="bolt" size={14} /> <Icon icon="bolt" size={14} /> Speed
+
+  `openai/gpt-5.5-2026-04-23`
+
+  Dated snapshot of GPT-5.5 for reproducible runs; same capabilities and pricing as the rolling `gpt-5.5` slug.
+
+  - &#36;5 / &#36;30 per 1M tokens (input / output); cached input &#36;0.50 / 1M
+  - <Icon icon="window-maximize" size={14} /> 1.05M context
+  - <Icon icon="right-from-bracket" size={14} /> 128K max output
+  - <Icon icon="keyboard" size={14} /> Text, Image input
+  - <Icon icon="brain" size={14} /> Extended thinking
+  </Card>
+
   <Card title="gpt-5.6-sol">
   <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> Reasoning · <Icon icon="bolt" size={14} /> <Icon icon="bolt" size={14} /> <Icon icon="bolt" size={14} /> Speed
 

--- a/docs/models/overview.mdx
+++ b/docs/models/overview.mdx
@@ -37,7 +37,7 @@ Every model supported by Timbal with full specs, pricing, capability scores, and
     Open-source models via TogetherAI
   </Card>
   <Card title="xAI" icon="https://timbalusercontent.com/assets/grok_favicon.svg" href="/models/xai">
-    Grok 4 and Grok 4 Fast
+    Grok 4.6, Grok 4.5, and Grok 4.3
   </Card>
   <Card title="Xiaomi MiMo" icon="https://timbalusercontent.com/assets/xiaomi_favicon_rounded.svg" href="/models/xiaomi">
     MiMo V2 Pro, Omni, and Flash

--- a/docs/models/xai.mdx
+++ b/docs/models/xai.mdx
@@ -1,9 +1,29 @@
 ---
 title: "xAI"
-description: "Grok 4.5 and Grok 4.3 models with specs, pricing, and capabilities"
+description: "Grok 4.6, Grok 4.5, and Grok 4.3 models with specs, pricing, and capabilities"
 ---
 
 <Note>Source: [xAI model docs](https://docs.x.ai/docs/models). Search includes Web Search and X Search, priced at &#36;2.50-&#36;5/1K calls. Cached input: &#36;0.05/1M.</Note>
+
+## Grok 4.6
+
+<CardGroup cols={2}>
+  <Card title="grok-4.6">
+  <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> Reasoning · <Icon icon="bolt" size={14} /> <Icon icon="bolt" size={14} /> <Icon icon="bolt" size={14} /> Speed
+
+  `xai/grok-4.6`
+
+  xAI's August 2026 flagship for coding, long-running agents, and ambitious interactive work.
+
+  - &#36;2 / &#36;6 (&#36;4 / &#36;12 above 200K prompt tokens)
+  - <Icon icon="window-maximize" size={14} /> 500K context
+  - <Icon icon="keyboard" size={14} /> Text, Image input
+  - <Icon icon="brain" size={14} /> Configurable reasoning
+  - <Icon icon="globe" size={14} /> Web search
+  </Card>
+</CardGroup>
+
+---
 
 ## Grok 4.5
 

--- a/python/tests/core/test_frontier_models.py
+++ b/python/tests/core/test_frontier_models.py
@@ -4,12 +4,12 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from timbal.core.models import Model, get_context_window
 from timbal.state import set_run_context
 from timbal.state.context import RunContext
 
 NEW_MODEL_IDS = [
+    "xai/grok-4.6",
     "xai/grok-4.5",
     "xai/grok-4.3",
     "fireworks/accounts/fireworks/models/minimax-m2p7",
@@ -89,8 +89,16 @@ class TestXaiRouterDispatch:
         mock_client.responses.create = fake_create
         return mock_client, captured_kwargs
 
+    @pytest.mark.parametrize(
+        "model_id,api_name",
+        [
+            ("xai/grok-4.6", "grok-4.6"),
+            ("xai/grok-4.5", "grok-4.5"),
+            ("xai/grok-4.3", "grok-4.3"),
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_grok_45_uses_responses_path(self):
+    async def test_grok_models_use_responses_path(self, model_id: str, api_name: str):
         from timbal.core.llm import _llm_router
 
         _make_run_context()
@@ -101,36 +109,14 @@ class TestXaiRouterDispatch:
                 with patch("timbal.core.llm.router.TIMBAL_OPENAI_API", "responses"):
                     try:
                         async for _ in _llm_router(
-                            model="xai/grok-4.5",
+                            model=model_id,
                             max_tokens=32,
                         ):
                             pass
                     except (RuntimeError, StopAsyncIteration):
                         pass
 
-        assert captured_kwargs.get("model") == "grok-4.5"
-        assert captured_kwargs.get("max_output_tokens") == 32
-
-    @pytest.mark.asyncio
-    async def test_grok_43_uses_responses_path(self):
-        from timbal.core.llm import _llm_router
-
-        _make_run_context()
-        mock_client, captured_kwargs = self._make_mock_client_and_capturer()
-
-        with patch("timbal.core.llm.clients._get_client", return_value=mock_client):
-            with patch.dict(os.environ, {"XAI_API_KEY": "key"}):
-                with patch("timbal.core.llm.router.TIMBAL_OPENAI_API", "responses"):
-                    try:
-                        async for _ in _llm_router(
-                            model="xai/grok-4.3",
-                            max_tokens=32,
-                        ):
-                            pass
-                    except (RuntimeError, StopAsyncIteration):
-                        pass
-
-        assert captured_kwargs.get("model") == "grok-4.3"
+        assert captured_kwargs.get("model") == api_name
         assert captured_kwargs.get("max_output_tokens") == 32
 
 

--- a/python/tests/core/test_frontier_models_integration.py
+++ b/python/tests/core/test_frontier_models_integration.py
@@ -38,6 +38,12 @@ LIVE_MODELS = [
         id="google-gemini-3.5-flash-lite",
     ),
     pytest.param(
+        "xai/grok-4.6",
+        "XAI_API_KEY",
+        None,
+        id="xai-grok-4.6",
+    ),
+    pytest.param(
         "xai/grok-4.5",
         "XAI_API_KEY",
         None,
@@ -99,8 +105,8 @@ async def test_frontier_model_llm_router_streams(model: str, env_key: str, fallb
     _skip_if_no_key(env_key, fallback_env)
 
     from timbal.core.llm import _llm_router
-    from timbal.types.message import Message
     from timbal.types.content import TextContent
+    from timbal.types.message import Message
 
     chunks = []
     async for chunk in _llm_router(

--- a/python/timbal/core/models.py
+++ b/python/timbal/core/models.py
@@ -119,6 +119,7 @@ Model = Literal[
     "google/gemini-2.5-flash-lite",
     "google/gemini-2.5-flash-image",
     "google/gemini-2.5-flash-preview-tts",
+    "xai/grok-4.6",
     "xai/grok-4.5",
     "xai/grok-4.3",
     "groq/llama-3.3-70b-versatile",

--- a/python/timbal/models.yaml
+++ b/python/timbal/models.yaml
@@ -665,6 +665,15 @@ models:
   output_price: 10.0
   context_window: 1000000
   capabilities: [audio]
+- id: xai/grok-4.6
+  provider: xai
+  display_name: Grok 4.6
+  description: xAI's August 2026 flagship for coding, long-running agents, and ambitious interactive work.
+  notes: Long-context surcharge applies above 200k tokens ($4/$12 per 1M).
+  input_price: 2.0
+  output_price: 6.0
+  context_window: 500000
+  capabilities: [vision, tools, reasoning]
 - id: xai/grok-4.5
   provider: xai
   display_name: Grok 4.5

--- a/scripts/audit_models.py
+++ b/scripts/audit_models.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import os
+import re
 import sys
 from dataclasses import dataclass
 from enum import Enum
@@ -34,6 +35,10 @@ import yaml
 
 ROOT = Path(__file__).parent.parent
 MODELS_YAML = ROOT / "python/timbal/models.yaml"
+MODELS_PY = ROOT / "python/timbal/core/models.py"
+DOCS_MODELS_DIR = ROOT / "docs/models"
+
+_LITERAL_PATTERN = re.compile(r"Model = Literal\[(.*?)\]", re.DOTALL)
 
 STANDARD_CAPABILITIES = frozenset(
     {"vision", "tools", "reasoning", "audio", "video", "image_generation"}
@@ -161,6 +166,56 @@ def _offline_audit(models: list[dict]) -> list[str]:
         if m.get("requires_activation") and m.get("dedicated_only"):
             errors.append(f"model has both requires_activation and dedicated_only: {mid}")
 
+    return errors
+
+
+def _literal_model_ids() -> list[str]:
+    source = MODELS_PY.read_text()
+    match = _LITERAL_PATTERN.search(source)
+    if not match:
+        raise ValueError(f"could not find Model = Literal[...] block in {MODELS_PY}")
+    return re.findall(r'"([^"]+)"', match.group(1))
+
+
+def _check_models_py_sync(models: list[dict]) -> list[str]:
+    """Ensure core/models.py Literal matches models.yaml (ids and order)."""
+    errors: list[str] = []
+    yaml_ids = [m["id"] for m in models]
+    try:
+        literal_ids = _literal_model_ids()
+    except ValueError as exc:
+        return [str(exc)]
+
+    yaml_set = set(yaml_ids)
+    literal_set = set(literal_ids)
+    for mid in yaml_ids:
+        if mid not in literal_set:
+            errors.append(f"models.yaml id missing from core/models.py Literal: {mid}")
+    for mid in literal_ids:
+        if mid not in yaml_set:
+            errors.append(f"core/models.py Literal id missing from models.yaml: {mid}")
+    if not errors and yaml_ids != literal_ids:
+        errors.append(
+            "models.yaml and core/models.py have the same ids but different order — run scripts/generate_models.py"
+        )
+    return errors
+
+
+def _check_docs_sync(models: list[dict]) -> list[str]:
+    """Ensure every catalog model appears in docs/models/{provider}.mdx."""
+    errors: list[str] = []
+    doc_cache: dict[str, str] = {}
+    for m in models:
+        provider = m["provider"]
+        doc_path = DOCS_MODELS_DIR / f"{provider}.mdx"
+        if not doc_path.exists():
+            errors.append(f"no docs file for provider {provider} (model {m['id']})")
+            continue
+        if provider not in doc_cache:
+            doc_cache[provider] = doc_path.read_text()
+        if f"`{m['id']}`" not in doc_cache[provider]:
+            rel = doc_path.relative_to(ROOT)
+            errors.append(f"model id not documented in {rel}: {m['id']}")
     return errors
 
 
@@ -516,12 +571,14 @@ def main() -> int:
         return 1
 
     errors = _offline_audit(models)
+    errors.extend(_check_models_py_sync(models))
+    errors.extend(_check_docs_sync(models))
     if errors:
         print("OFFLINE ERRORS:")
         for err in errors:
             print(f"  ✗ {err}")
     else:
-        print(f"Offline checks passed ({len(models)} models)")
+        print(f"Offline checks passed ({len(models)} models; models.py + docs in sync)")
 
     exit_code = 1 if errors else 0
 


### PR DESCRIPTION
## Summary
- Register `xai/grok-4.6` in `models.yaml`, regenerate `core/models.py`, and document it in `docs/models/xai.mdx` with frontier router/integration tests.
- Extend `scripts/audit_models.py --offline` to fail when `models.yaml`, the generated `Model` Literal, or provider docs drift apart.
- Backfill two missing doc entries (`openai/gpt-5.5-2026-04-23`, retired Fireworks `deepseek-v4-flash`) and widen CI path filters for model docs/generator changes.

## Test plan
- [x] `uv run python scripts/audit_models.py --offline`
- [x] `uv run pytest python/tests/core/test_models.py python/tests/core/test_frontier_models.py`
- [x] CI green on all matrix cells