### PR TITLE
fix(agent): tolerate native-event tools with foreign call_ids

### DIFF
--- a/python/tests/core/test_background_tasks.py
+++ b/python/tests/core/test_background_tasks.py
@@ -733,6 +733,58 @@ class TestBackgroundMultitask:
         assert get_background_task(task_id)["cursor_agent_id"] == "cursor-agent-1"
 
     @pytest.mark.asyncio
+    async def test_foreground_native_event_tool_does_not_keyerror(self):
+        """Foreground builder yielding foreign-call_id BaseEvents must not KeyError.
+
+        Regression: ``_link_tool_call_span`` indexed ``_trace[event.call_id]`` on
+        every START. Harness StartEvents mint their own call_id, so the first
+        yielded event crashed the agent. Background spawn avoided the path;
+        ``run_in_background=false`` (schema default) did not.
+        """
+        memory_snapshots: list[list[Message]] = []
+
+        def _capture_memory() -> None:
+            memory_snapshots.append(list(get_run_context().current_span().memory))
+
+        parent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("builder", {"prompt": "harness"}, run_in_background=False),
+                    "Built.",
+                ]
+            ),
+            tools=[Tool(name="builder", handler=_fake_event_builder, background_mode="auto")],
+            post_hook=_capture_memory,
+        )
+
+        events = [event async for event in parent(prompt="build")]
+        result = next(e for e in events if isinstance(e, OutputEvent) and e.path == "composer")
+        assert result.status.code == "success"
+        assert_has_output_event(result)
+
+        # Tool Runnable START is first; harness events are rewritten onto its call_id.
+        tool_starts = [e for e in events if isinstance(e, StartEvent) and e.path == "composer.builder"]
+        assert tool_starts
+        tool_span_call_id = tool_starts[0].call_id
+        assert tool_span_call_id != "child-call-1"
+
+        harness_events = [e for e in events if getattr(e, "run_id", None) == CHILD_RUN_ID]
+        assert harness_events, "harness BaseEvents must reach the parent stream"
+        assert all(e.call_id == tool_span_call_id for e in harness_events)
+
+        # Harness OutputEvent shares the tool path but must not become a second tool_result.
+        assert memory_snapshots
+        tool_results = [
+            block
+            for msg in memory_snapshots[-1]
+            if msg.role == "tool"
+            for block in msg.content
+            if getattr(block, "type", None) == "tool_result"
+        ]
+        assert len(tool_results) == 1
+
+    @pytest.mark.asyncio
     async def test_agent_as_tool_background(self):
         """5.5.4 — child Agent with its own tools, parent detaches, parent peeks."""
 

--- a/python/tests/core/test_event_stream_shape.py
+++ b/python/tests/core/test_event_stream_shape.py
@@ -250,6 +250,12 @@ class TestNestedGrandchildStream:
         for i, e in enumerate(events):
             if e.path == "main_agent.specialist.llm":
                 assert sub_start < i < sub_output, _shape(events)
+        # Nested call_ids must stay distinct — multiplex must not flatten them onto
+        # the tool span (that rewrite is only for foreign native-event call_ids).
+        specialist_start = events[sub_start]
+        nested_llm = next(e for e in events if e.path == "main_agent.specialist.llm" and e.type == "START")
+        assert nested_llm.call_id != specialist_start.call_id
+        assert nested_llm.parent_call_id == specialist_start.call_id
 
     async def test_workflow_in_workflow_grandchild_events_surface(self):
         def leaf(x: int = 1) -> int:

--- a/python/timbal/core/agent.py
+++ b/python/timbal/core/agent.py
@@ -1089,35 +1089,37 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
         tool_call: ToolUseContent,
         tool_span_call_id: str | None,
         tool_span_parent_call_id: str | None,
-        adopt_foreign: bool,
-    ) -> tuple[Any, str | None, str | None, bool]:
+    ) -> tuple[Any, str | None, str | None]:
         """Link tool_call_id, capture the tool span, adopt foreign native events.
 
-        Hot path for ordinary tools (every event already shares the Runnable
-        call_id): after the first in-trace START this is a few attribute checks
-        and no dict lookups or writes. Foreign BaseEvents (coding harness) flip
-        ``adopt_foreign`` once and then rewrite ids in place for FE grouping.
+        Ordinary tools: after the Runnable START, every event already shares that
+        call_id — early return, no dict writes. Nested runnables (agent-as-tool)
+        keep their in-trace call_ids. Only BaseEvents whose call_id is absent
+        from ``_trace`` (coding harness) are rewritten onto the tool span for FE
+        grouping.
         """
         if event.type == "START":
             span = get_run_context()._trace.get(event.call_id)
             if span is not None:
                 span.metadata["tool_call_id"] = tool_call.id
                 if tool_span_call_id is None:
-                    tool_span_call_id = span.call_id
-                    tool_span_parent_call_id = span.parent_call_id
-            elif tool_span_call_id is not None:
-                adopt_foreign = True
-        elif (
-            not adopt_foreign
-            and tool_span_call_id is not None
-            and event.call_id != tool_span_call_id
-        ):
-            adopt_foreign = True
+                    return event, span.call_id, span.parent_call_id
+                return event, tool_span_call_id, tool_span_parent_call_id
+            # Foreign START (not in this run's trace).
+            if tool_span_call_id is not None:
+                event.call_id = tool_span_call_id
+                event.parent_call_id = tool_span_parent_call_id
+            return event, tool_span_call_id, tool_span_parent_call_id
 
-        if adopt_foreign and tool_span_call_id is not None:
+        # Hot path: same call_id as the tool span (plain tools, tool's own deltas).
+        if tool_span_call_id is None or event.call_id == tool_span_call_id:
+            return event, tool_span_call_id, tool_span_parent_call_id
+
+        # Different call_id: nested runnable (in trace) vs native harness (not).
+        if event.call_id not in get_run_context()._trace:
             event.call_id = tool_span_call_id
             event.parent_call_id = tool_span_parent_call_id
-        return event, tool_span_call_id, tool_span_parent_call_id, adopt_foreign
+        return event, tool_span_call_id, tool_span_parent_call_id
 
     async def _multiplex_tools(self, tools: list[Tool], tool_calls: list[ToolUseContent]) -> AsyncGenerator[Any, None]:
         """Execute multiple tool calls concurrently and multiplex their events."""
@@ -1138,21 +1140,17 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
             current_task = asyncio.current_task()
             tool_span_call_id: str | None = None
             tool_span_parent_call_id: str | None = None
-            adopt_foreign = False
             try:
                 # Raw stream: the collector wrapper is only needed at the public
                 # API boundary; internal consumers forward events themselves.
                 async for event in tool._stream(**tool_call.input):
                     if current_task is not None and current_task.cancelling():
                         raise asyncio.CancelledError
-                    event, tool_span_call_id, tool_span_parent_call_id, adopt_foreign = (
-                        self._prepare_multiplex_event(
-                            event,
-                            tool_call,
-                            tool_span_call_id,
-                            tool_span_parent_call_id,
-                            adopt_foreign,
-                        )
+                    event, tool_span_call_id, tool_span_parent_call_id = self._prepare_multiplex_event(
+                        event,
+                        tool_call,
+                        tool_span_call_id,
+                        tool_span_parent_call_id,
                     )
                     yield tool_call, event
             except (asyncio.CancelledError, GeneratorExit, InterruptError):
@@ -1169,21 +1167,17 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
         async def consume_tool(tool_call: ToolUseContent):
             tool_span_call_id: str | None = None
             tool_span_parent_call_id: str | None = None
-            adopt_foreign = False
             try:
                 tool = self._resolve_tool_for_call(tools, tool_call)
                 if tool is None:
                     queue.put_nowait((tool_call, self._build_unknown_tool_event(tool_call, tools)))
                     return
                 async for event in tool._stream(**tool_call.input):
-                    event, tool_span_call_id, tool_span_parent_call_id, adopt_foreign = (
-                        self._prepare_multiplex_event(
-                            event,
-                            tool_call,
-                            tool_span_call_id,
-                            tool_span_parent_call_id,
-                            adopt_foreign,
-                        )
+                    event, tool_span_call_id, tool_span_parent_call_id = self._prepare_multiplex_event(
+                        event,
+                        tool_call,
+                        tool_span_call_id,
+                        tool_span_parent_call_id,
                     )
                     queue.put_nowait((tool_call, event))
             except (asyncio.CancelledError, GeneratorExit, InterruptError):

--- a/python/timbal/core/agent.py
+++ b/python/timbal/core/agent.py
@@ -1085,10 +1085,46 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
 
     @staticmethod
     def _link_tool_call_span(event: Any, tool_call: ToolUseContent) -> None:
-        """Link the LLM tool_call id to the tool's span for memory resolution."""
-        if event.type == "START":
-            tool_call_span = get_run_context()._trace[event.call_id]
-            tool_call_span.metadata["tool_call_id"] = tool_call.id
+        """Link the LLM tool_call id to the tool's span for memory resolution.
+
+        Handlers that yield pre-built ``BaseEvent``s (coding harness, etc.) may
+        emit START events whose ``call_id`` is not in this run's trace. Those are
+        ignored — the tool's own Runnable START already carries the link.
+        """
+        if event.type != "START":
+            return
+        tool_call_span = get_run_context()._trace.get(event.call_id)
+        if tool_call_span is None:
+            return
+        tool_call_span.metadata["tool_call_id"] = tool_call.id
+
+    @staticmethod
+    def _adopt_native_tool_event(
+        event: Any,
+        tool_span_call_id: str | None,
+        tool_span_parent_call_id: str | None,
+    ) -> Any:
+        """Rewrite foreign BaseEvent ids onto the tool span for FE nesting.
+
+        Native-event tools mint their own ``call_id``s. On the parent stream
+        those must sit under the tool span or the FE can't group them with the
+        originating ``tool_use``. Mutates in place (events are SlotModels).
+        """
+        if tool_span_call_id is None or getattr(event, "call_id", None) == tool_span_call_id:
+            return event
+        event.call_id = tool_span_call_id
+        event.parent_call_id = tool_span_parent_call_id
+        return event
+
+    @staticmethod
+    def _tool_span_ids_from_start(event: Any) -> tuple[str | None, str | None]:
+        """Return ``(call_id, parent_call_id)`` for an in-trace tool START, else Nones."""
+        if event.type != "START":
+            return None, None
+        span = get_run_context()._trace.get(event.call_id)
+        if span is None:
+            return None, None
+        return span.call_id, span.parent_call_id
 
     async def _multiplex_tools(self, tools: list[Tool], tool_calls: list[ToolUseContent]) -> AsyncGenerator[Any, None]:
         """Execute multiple tool calls concurrently and multiplex their events."""
@@ -1107,6 +1143,8 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
             # so detect the still-pending cancel request and re-raise before
             # forwarding post-cancel events (keeps LLM-output salvage semantics).
             current_task = asyncio.current_task()
+            tool_span_call_id: str | None = None
+            tool_span_parent_call_id: str | None = None
             try:
                 # Raw stream: the collector wrapper is only needed at the public
                 # API boundary; internal consumers forward events themselves.
@@ -1114,6 +1152,12 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
                     if current_task is not None and current_task.cancelling():
                         raise asyncio.CancelledError
                     self._link_tool_call_span(event, tool_call)
+                    if tool_span_call_id is None:
+                        captured_call_id, captured_parent = self._tool_span_ids_from_start(event)
+                        if captured_call_id is not None:
+                            tool_span_call_id = captured_call_id
+                            tool_span_parent_call_id = captured_parent
+                    event = self._adopt_native_tool_event(event, tool_span_call_id, tool_span_parent_call_id)
                     yield tool_call, event
             except (asyncio.CancelledError, GeneratorExit, InterruptError):
                 raise
@@ -1127,6 +1171,8 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
         tasks = []
 
         async def consume_tool(tool_call: ToolUseContent):
+            tool_span_call_id: str | None = None
+            tool_span_parent_call_id: str | None = None
             try:
                 tool = self._resolve_tool_for_call(tools, tool_call)
                 if tool is None:
@@ -1134,6 +1180,12 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
                     return
                 async for event in tool._stream(**tool_call.input):
                     self._link_tool_call_span(event, tool_call)
+                    if tool_span_call_id is None:
+                        captured_call_id, captured_parent = self._tool_span_ids_from_start(event)
+                        if captured_call_id is not None:
+                            tool_span_call_id = captured_call_id
+                            tool_span_parent_call_id = captured_parent
+                    event = self._adopt_native_tool_event(event, tool_span_call_id, tool_span_parent_call_id)
                     queue.put_nowait((tool_call, event))
             except (asyncio.CancelledError, GeneratorExit, InterruptError):
                 raise
@@ -1308,6 +1360,12 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
         async def _process_tool_event(event: BaseEvent, tool_call_id: str, append_to_messages: bool = True):
             """Helper to process tool output events and create tool results."""
             if not isinstance(event, OutputEvent) or event.path.count(".") != self._path.count(".") + 1:
+                return
+            # Native-event handlers (coding harness) forward their own OutputEvent
+            # under the tool path. Only the Runnable-emitted completion (same
+            # run_id as this agent turn) should become a tool_result — otherwise
+            # we double-append and break the next LLM call.
+            if event.run_id != run_context.id:
                 return
             if event.status.code == "cancelled" and event.status.reason in _PAUSE_REASONS:
                 # Gated (approval) or suspended (input_required) tool: leave the

--- a/python/timbal/core/agent.py
+++ b/python/timbal/core/agent.py
@@ -1084,47 +1084,40 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
         return tool
 
     @staticmethod
-    def _link_tool_call_span(event: Any, tool_call: ToolUseContent) -> None:
-        """Link the LLM tool_call id to the tool's span for memory resolution.
-
-        Handlers that yield pre-built ``BaseEvent``s (coding harness, etc.) may
-        emit START events whose ``call_id`` is not in this run's trace. Those are
-        ignored — the tool's own Runnable START already carries the link.
-        """
-        if event.type != "START":
-            return
-        tool_call_span = get_run_context()._trace.get(event.call_id)
-        if tool_call_span is None:
-            return
-        tool_call_span.metadata["tool_call_id"] = tool_call.id
-
-    @staticmethod
-    def _adopt_native_tool_event(
+    def _prepare_multiplex_event(
         event: Any,
+        tool_call: ToolUseContent,
         tool_span_call_id: str | None,
         tool_span_parent_call_id: str | None,
-    ) -> Any:
-        """Rewrite foreign BaseEvent ids onto the tool span for FE nesting.
+        adopt_foreign: bool,
+    ) -> tuple[Any, str | None, str | None, bool]:
+        """Link tool_call_id, capture the tool span, adopt foreign native events.
 
-        Native-event tools mint their own ``call_id``s. On the parent stream
-        those must sit under the tool span or the FE can't group them with the
-        originating ``tool_use``. Mutates in place (events are SlotModels).
+        Hot path for ordinary tools (every event already shares the Runnable
+        call_id): after the first in-trace START this is a few attribute checks
+        and no dict lookups or writes. Foreign BaseEvents (coding harness) flip
+        ``adopt_foreign`` once and then rewrite ids in place for FE grouping.
         """
-        if tool_span_call_id is None or getattr(event, "call_id", None) == tool_span_call_id:
-            return event
-        event.call_id = tool_span_call_id
-        event.parent_call_id = tool_span_parent_call_id
-        return event
+        if event.type == "START":
+            span = get_run_context()._trace.get(event.call_id)
+            if span is not None:
+                span.metadata["tool_call_id"] = tool_call.id
+                if tool_span_call_id is None:
+                    tool_span_call_id = span.call_id
+                    tool_span_parent_call_id = span.parent_call_id
+            elif tool_span_call_id is not None:
+                adopt_foreign = True
+        elif (
+            not adopt_foreign
+            and tool_span_call_id is not None
+            and event.call_id != tool_span_call_id
+        ):
+            adopt_foreign = True
 
-    @staticmethod
-    def _tool_span_ids_from_start(event: Any) -> tuple[str | None, str | None]:
-        """Return ``(call_id, parent_call_id)`` for an in-trace tool START, else Nones."""
-        if event.type != "START":
-            return None, None
-        span = get_run_context()._trace.get(event.call_id)
-        if span is None:
-            return None, None
-        return span.call_id, span.parent_call_id
+        if adopt_foreign and tool_span_call_id is not None:
+            event.call_id = tool_span_call_id
+            event.parent_call_id = tool_span_parent_call_id
+        return event, tool_span_call_id, tool_span_parent_call_id, adopt_foreign
 
     async def _multiplex_tools(self, tools: list[Tool], tool_calls: list[ToolUseContent]) -> AsyncGenerator[Any, None]:
         """Execute multiple tool calls concurrently and multiplex their events."""
@@ -1145,19 +1138,22 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
             current_task = asyncio.current_task()
             tool_span_call_id: str | None = None
             tool_span_parent_call_id: str | None = None
+            adopt_foreign = False
             try:
                 # Raw stream: the collector wrapper is only needed at the public
                 # API boundary; internal consumers forward events themselves.
                 async for event in tool._stream(**tool_call.input):
                     if current_task is not None and current_task.cancelling():
                         raise asyncio.CancelledError
-                    self._link_tool_call_span(event, tool_call)
-                    if tool_span_call_id is None:
-                        captured_call_id, captured_parent = self._tool_span_ids_from_start(event)
-                        if captured_call_id is not None:
-                            tool_span_call_id = captured_call_id
-                            tool_span_parent_call_id = captured_parent
-                    event = self._adopt_native_tool_event(event, tool_span_call_id, tool_span_parent_call_id)
+                    event, tool_span_call_id, tool_span_parent_call_id, adopt_foreign = (
+                        self._prepare_multiplex_event(
+                            event,
+                            tool_call,
+                            tool_span_call_id,
+                            tool_span_parent_call_id,
+                            adopt_foreign,
+                        )
+                    )
                     yield tool_call, event
             except (asyncio.CancelledError, GeneratorExit, InterruptError):
                 raise
@@ -1173,19 +1169,22 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
         async def consume_tool(tool_call: ToolUseContent):
             tool_span_call_id: str | None = None
             tool_span_parent_call_id: str | None = None
+            adopt_foreign = False
             try:
                 tool = self._resolve_tool_for_call(tools, tool_call)
                 if tool is None:
                     queue.put_nowait((tool_call, self._build_unknown_tool_event(tool_call, tools)))
                     return
                 async for event in tool._stream(**tool_call.input):
-                    self._link_tool_call_span(event, tool_call)
-                    if tool_span_call_id is None:
-                        captured_call_id, captured_parent = self._tool_span_ids_from_start(event)
-                        if captured_call_id is not None:
-                            tool_span_call_id = captured_call_id
-                            tool_span_parent_call_id = captured_parent
-                    event = self._adopt_native_tool_event(event, tool_span_call_id, tool_span_parent_call_id)
+                    event, tool_span_call_id, tool_span_parent_call_id, adopt_foreign = (
+                        self._prepare_multiplex_event(
+                            event,
+                            tool_call,
+                            tool_span_call_id,
+                            tool_span_parent_call_id,
+                            adopt_foreign,
+                        )
+                    )
                     queue.put_nowait((tool_call, event))
             except (asyncio.CancelledError, GeneratorExit, InterruptError):
                 raise


### PR DESCRIPTION
## Summary
- `_link_tool_call_span` no longer KeyErrors when a tool yields pre-built BaseEvents whose call_id is not in the parent `_trace` (foreground coding harness / builder).
- On the parent stream, foreign native events are rewritten onto the tool span call_id / parent_call_id so FE grouping stays consistent.
- `_process_tool_event` ignores OutputEvents from a foreign run_id so harness completions do not double-append tool_results.
- Hot path: ordinary tools pay ~one call_id compare per event after START (no dict writes); adopt flips once for foreign streams.

## Test plan
- [x] foreground native-event regression + background native-event test
- [x] `test_event_stream_shape.py`
- [ ] Live dock: foreground builder (`run_in_background=false`) streams without dying on first harness event