### PR TITLE
feat(agent): push background task completions into the next parent turn

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -414,7 +414,7 @@ Tool(name="build", handler=..., background_mode="always",
 ```
 
 - Tasks live on a `BackgroundTaskStore` bound to the `RunContext`, inherited across sequential turns via `parent_id`. Concurrent runs of the same Agent get isolated stores (no shared `parent_id`), so a foreign `task_id` is `not_found`. Process-local — does not survive a restart.
-- Once *this session* has a task, the agent auto-gains `get_background_task` / `list_background_tasks` / `cancel_background_task`.
+- Once *this session* has a task, the agent auto-gains `get_background_task` / `list_background_tasks` / `cancel_background_task`. Opt in to `read_background_transcript` with `background_transcript_tool=True`.
 - The log is peekable, not consume-once: the parent agent and a frontend can both watch one child. `record.log.subscribe(after=)` replays then streams live.
 - `get_background_task` returns `{status, task_id, name, title, input, started_at, summary: {text, phase, pct, last_tool, tools_in_flight, event_count}, transcript_cursor}` (+ `result`/`error` when done). `summary.text` is capped — for briefing, not for dumping a build into context.
 - Cancel stops in-flight work: the Task is cancelled *and* the handler generator is closed (an async gen suspended at a yield would otherwise never run its `finally`), then `on_background_cancel` fires for work the loop can't reach.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -417,6 +417,7 @@ Tool(name="build", handler=..., background_mode="always",
 - Once *this session* has a task, the agent auto-gains `get_background_task` / `list_background_tasks` / `cancel_background_task`. Opt in to `read_background_transcript` with `background_transcript_tool=True`.
 - The log is peekable, not consume-once: the parent agent and a frontend can both watch one child. `record.log.subscribe(after=)` replays then streams live.
 - `get_background_task` returns `{status, task_id, name, title, input, started_at, summary: {text, phase, pct, last_tool, tools_in_flight, event_count}, transcript_cursor}` (+ `result`/`error` when done). `summary.text` is capped — for briefing, not for dumping a build into context.
+- `background_timeout` → store enforces wall-clock deadline; status `timed_out`. `background_stall_timeout` → no log events within window; status `stalled` (timer resets on every event).
 - Cancel stops in-flight work: the Task is cancelled *and* the handler generator is closed (an async gen suspended at a yield would otherwise never run its `finally`), then `on_background_cancel` fires for work the loop can't reach.
 - `wait_for_background(task_id, timeout=..., after=...)` blocks until terminal (no `after`) or until the log advances past `after` — app/frontends; does not ack completion notices.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -416,7 +416,7 @@ Tool(name="build", handler=..., background_mode="always",
 - Tasks live on a `BackgroundTaskStore` bound to the `RunContext`, inherited across sequential turns via `parent_id`. Concurrent runs of the same Agent get isolated stores (no shared `parent_id`), so a foreign `task_id` is `not_found`. Process-local — does not survive a restart.
 - Once *this session* has a task, the agent auto-gains `get_background_task` / `list_background_tasks` / `cancel_background_task`.
 - The log is peekable, not consume-once: the parent agent and a frontend can both watch one child. `record.log.subscribe(after=)` replays then streams live.
-- `get_background_task` returns `{status, task_id, name, title, input, started_at, summary: {text, tools_in_flight, event_count}, transcript_cursor}` (+ `result`/`error` when done). `summary.text` is capped — for briefing, not for dumping a build into context.
+- `get_background_task` returns `{status, task_id, name, title, input, started_at, summary: {text, phase, pct, last_tool, tools_in_flight, event_count}, transcript_cursor}` (+ `result`/`error` when done). `summary.text` is capped — for briefing, not for dumping a build into context.
 - Cancel stops in-flight work: the Task is cancelled *and* the handler generator is closed (an async gen suspended at a yield would otherwise never run its `finally`), then `on_background_cancel` fires for work the loop can't reach.
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -418,6 +418,7 @@ Tool(name="build", handler=..., background_mode="always",
 - The log is peekable, not consume-once: the parent agent and a frontend can both watch one child. `record.log.subscribe(after=)` replays then streams live.
 - `get_background_task` returns `{status, task_id, name, title, input, started_at, summary: {text, phase, pct, last_tool, tools_in_flight, event_count}, transcript_cursor}` (+ `result`/`error` when done). `summary.text` is capped — for briefing, not for dumping a build into context.
 - Cancel stops in-flight work: the Task is cancelled *and* the handler generator is closed (an async gen suspended at a yield would otherwise never run its `finally`), then `on_background_cancel` fires for work the loop can't reach.
+- `wait_for_background(task_id, timeout=..., after=...)` blocks until terminal (no `after`) or until the log advances past `after` — app/frontends; does not ack completion notices.
 
 ---
 

--- a/docs/agents/background-tasks.mdx
+++ b/docs/agents/background-tasks.mdx
@@ -133,17 +133,37 @@ agent = Agent(
 
 ## Reading the Raw Transcript
 
-For the full event stream, read from a cursor. This does not drain either — the same `after` returns the same events, so it's safe to call from more than one place.
+For the full event stream, read from a logical cursor. This does not drain either — the same `after` returns the same events while they remain in the ring, so it's safe to call from more than one place.
+
+When the ring has dropped older events, `gapped` is `true` and `after` is behind `forgotten_through` — treat that like an expired reconnect, not a silent skip to the new head.
 
 ```python
 from timbal.state import read_background_transcript
 
 page = read_background_transcript("k4d9x2mq7c1a")
-# {"status": "running", "task_id": ..., "events": [...], "cursor": 42}
+# {"status": "running", "task_id": ..., "events": [...], "cursor": 42,
+#  "gapped": false, "forgotten_through": 0}
 
 # Later, pick up where you left off
 page = read_background_transcript("k4d9x2mq7c1a", after=page["cursor"])
 ```
+
+## Log retention
+
+Each child's event log is a **ring buffer** (defaults: 50k events / 32 MiB — same idea as HTTP `JobStore`). Oldest events drop when over cap; `forgotten_through` is the logical floor. Finished **task records** are removed from the session bag after **300 seconds** by default so long-lived workers do not leak metadata.
+
+Override per Agent:
+
+```python
+agent = Agent(
+    ...,
+    max_background_log_events=10_000,
+    max_background_log_bytes=None,  # unlimited bytes
+    background_task_retention_secs=600,
+)
+```
+
+Env: `TIMBAL_BG_LOG_MAX_EVENTS`, `TIMBAL_BG_LOG_MAX_BYTES`, `TIMBAL_BG_TASK_RETENTION_SECS` (`0` / `none` = unlimited / keep forever).
 
 To follow a child live instead of polling, subscribe to its log. `subscribe` replays from `after` and then yields events as they arrive, so you cannot miss one that lands mid-replay.
 

--- a/docs/agents/background-tasks.mdx
+++ b/docs/agents/background-tasks.mdx
@@ -54,7 +54,7 @@ Once this session has at least one background task, the agent automatically gain
 
 ## Completion notifications
 
-When a background child reaches a terminal status (`completed`, `error`, or `cancelled`), the session store queues a one-shot notice. At the **start of the next parent turn** — not mid-turn while the parent is still talking — the agent drains that inbox and injects a synthetic user message into memory so the LLM learns without polling:
+When a background child reaches a terminal status (`completed`, `error`, `cancelled`, or `timed_out`), the session store queues a one-shot notice. At the **start of the next parent turn** — not mid-turn while the parent is still talking — the agent drains that inbox and injects a synthetic user message into memory so the LLM learns without polling:
 
 ```text
 Background task(s) finished since your last turn. ...
@@ -81,7 +81,7 @@ get_background_task("k4d9x2mq7c1a")
 
 ```python
 {
-    "status": "running",           # running | completed | error | cancelled | not_found
+    "status": "running",           # running | completed | error | cancelled | timed_out | not_found
     "task_id": "k4d9x2mq7c1a",
     "name": "build_site",
     "title": "Build the marketing site",
@@ -96,7 +96,21 @@ get_background_task("k4d9x2mq7c1a")
 }
 ```
 
-The summary is deliberately bounded — it's for briefing the user, not for dumping a long build into the context window. When the task finishes, the snapshot also carries `result` (or `error` on failure). Durable child ids seen on the child's events, such as its `run_id`, are lifted onto the snapshot as they arrive.
+The summary is deliberately bounded — it's for briefing the user, not for dumping a long build into the context window. When the task finishes, the snapshot also carries `result` (or `error` on failure / timeout). Durable child ids seen on the child's events, such as its `run_id`, are lifted onto the snapshot as they arrive.
+
+## Timeouts
+
+Set `background_timeout` (seconds) on a tool to hard-cap how long a detached child may run. When the deadline hits, the child is cancelled like a user cancel (Task cancel + handler `aclose` + `on_background_cancel`) but reports status `timed_out` so the next-turn completion notice is unambiguous.
+
+```python
+long_running_tool = Tool(
+    handler=slow_operation,
+    background_mode="always",
+    background_timeout=600.0,  # 10 minutes
+)
+```
+
+`None` (default) or a non-positive value means no deadline.
 
 ## Reading the Raw Transcript
 

--- a/docs/agents/background-tasks.mdx
+++ b/docs/agents/background-tasks.mdx
@@ -112,6 +112,25 @@ long_running_tool = Tool(
 
 `None` (default) or a non-positive value means no deadline.
 
+## Concurrency and depth caps
+
+Each session bag bounds fan-out so one turn cannot detach unbounded work:
+
+- **Concurrent** — max children whose asyncio.Task is still running (default **20**). Override per Agent with `max_background_concurrent=...` or env `TIMBAL_MAX_CONCURRENT_BACKGROUND` (`0` / `none` / `unlimited` = no cap).
+- **Depth** — max nesting of background spawns (default **unlimited**). `max_background_depth=1` means only top-level code may detach; a background child cannot spawn further background work. Env: `TIMBAL_MAX_BACKGROUND_DEPTH`.
+
+Hitting a cap raises `BackgroundLimitError` (surfaced as a tool error to the LLM) instead of spawning.
+
+```python
+agent = Agent(
+    name="orchestrator",
+    model="...",
+    tools=[Bash("*")],
+    max_background_concurrent=4,
+    max_background_depth=1,
+)
+```
+
 ## Reading the Raw Transcript
 
 For the full event stream, read from a cursor. This does not drain either — the same `after` returns the same events, so it's safe to call from more than one place.

--- a/docs/agents/background-tasks.mdx
+++ b/docs/agents/background-tasks.mdx
@@ -166,6 +166,24 @@ page = read_background_transcript("k4d9x2mq7c1a")
 page = read_background_transcript("k4d9x2mq7c1a", after=page["cursor"])
 ```
 
+## Waiting for completion
+
+For app code or frontends that want to block instead of polling the agent loop, use `wait_for_background`. It returns the same snapshot as `get_background_task` and does **not** ack completion notices.
+
+```python
+from timbal.state import wait_for_background
+
+# Block until terminal (or timeout)
+snap = await wait_for_background("k4d9x2mq7c1a", timeout=30.0)
+if snap["status"] == "running":
+    ...  # timeout — poll again
+
+# Long-poll until new events land past a cursor (or terminal / timeout)
+snap = await wait_for_background("k4d9x2mq7c1a", after=cursor, timeout=5.0)
+```
+
+Without `after`, the wait is tied to the child's asyncio task finishing. With `after`, it wakes when the append-only log advances, the log closes on completion, or the timeout hits — useful for streaming UIs that already have a `transcript_cursor`.
+
 ## Log retention
 
 Each child's event log is a **ring buffer** (defaults: 50k events / 32 MiB — same idea as HTTP `JobStore`). Oldest events drop when over cap; `forgotten_through` is the logical floor. Finished **task records** are removed from the session bag after **300 seconds** by default so long-lived workers do not leak metadata.

--- a/docs/agents/background-tasks.mdx
+++ b/docs/agents/background-tasks.mdx
@@ -89,7 +89,10 @@ get_background_task("k4d9x2mq7c1a")
     "started_at": 1755385200000,   # Unix ms
     "summary": {
         "text": "...",             # trailing assistant text, capped at 1000 chars
-        "tools_in_flight": ["write_file", "bash"],
+        "phase": "processing",     # last stage label, heuristic phase, or terminal status
+        "pct": 50,                 # 0–100 when the child reports progress (else null)
+        "last_tool": "write_file", # most recent tool_use name, if any
+        "tools_in_flight": ["write_file", "bash"],  # open tool calls not yet finished
         "event_count": 42,
     },
     "transcript_cursor": 42,       # pass as `after` to read raw events
@@ -97,6 +100,10 @@ get_background_task("k4d9x2mq7c1a")
 ```
 
 The summary is deliberately bounded — it's for briefing the user, not for dumping a long build into the context window. When the task finishes, the snapshot also carries `result` (or `error` on failure / timeout). Durable child ids seen on the child's events, such as its `run_id`, are lifted onto the snapshot as they arrive.
+
+### Structured progress
+
+Handlers that yield progress dicts (e.g. `{"stage": "processing", "progress": 50}`) surface as `summary.phase` and `summary.pct`. Agent children also expose `summary.last_tool` and `summary.tools_in_flight` (open tool calls inferred from the event log — a tool drops off when its `OutputEvent` arrives). While running with no explicit stage, `phase` falls back to `streaming`, `tool:{name}`, or `running`; on terminal success `phase` becomes `completed` and `pct` is `100`.
 
 ## Timeouts
 

--- a/docs/agents/background-tasks.mdx
+++ b/docs/agents/background-tasks.mdx
@@ -54,7 +54,7 @@ Once this session has at least one background task, the agent automatically gain
 
 ## Completion notifications
 
-When a background child reaches a terminal status (`completed`, `error`, `cancelled`, or `timed_out`), the session store queues a one-shot notice. At the **start of the next parent turn** — not mid-turn while the parent is still talking — the agent drains that inbox and injects a synthetic user message into memory so the LLM learns without polling:
+When a background child reaches a terminal status (`completed`, `error`, `cancelled`, `timed_out`, or `stalled`), the session store queues a one-shot notice. At the **start of the next parent turn** — not mid-turn while the parent is still talking — the agent drains that inbox and injects a synthetic user message into memory so the LLM learns without polling:
 
 ```text
 Background task(s) finished since your last turn. ...
@@ -81,7 +81,7 @@ get_background_task("k4d9x2mq7c1a")
 
 ```python
 {
-    "status": "running",           # running | completed | error | cancelled | timed_out | not_found
+    "status": "running",           # running | completed | error | cancelled | timed_out | stalled | not_found
     "task_id": "k4d9x2mq7c1a",
     "name": "build_site",
     "title": "Build the marketing site",
@@ -118,6 +118,20 @@ long_running_tool = Tool(
 ```
 
 `None` (default) or a non-positive value means no deadline.
+
+## Stall detection
+
+Set `background_stall_timeout` (seconds) to cancel a child that stops emitting log events — distinct from wall-clock `background_timeout`. The idle timer **resets on every event** (streaming chunks, tool calls, progress dicts), so a long but chatty build stays alive while a hung subprocess does not.
+
+```python
+long_running_tool = Tool(
+    handler=slow_operation,
+    background_mode="always",
+    background_stall_timeout=120.0,  # no events for 2 minutes → stalled
+)
+```
+
+Terminal status is `stalled`. While still running, snapshots expose `summary.seconds_since_event` and `stall_timeout` for UI warnings before the watchdog fires.
 
 ## Concurrency and depth caps
 

--- a/docs/agents/background-tasks.mdx
+++ b/docs/agents/background-tasks.mdx
@@ -48,7 +48,7 @@ Background tools return immediately with a task handle:
 {"task_id": "k4d9x2mq7c1a", "status": "running"}
 ```
 
-Once this session has at least one background task, the agent automatically gains three tools — `get_background_task`, `list_background_tasks`, and `cancel_background_task` — so it can brief the user or stop a child on a follow-up turn without you wiring anything.
+Once this session has at least one background task, the agent automatically gains three tools — `get_background_task`, `list_background_tasks`, and `cancel_background_task` — so it can brief the user or stop a child on a follow-up turn without you wiring anything. Set `background_transcript_tool=True` on the Agent to also expose `read_background_transcript` for paged raw event replay (off by default).
 
 `get_background_task` **peeks**; it does not drain. Calling it twice returns the same thing, so the agent polling a child never steals events from a frontend streaming the same child.
 
@@ -141,6 +141,17 @@ agent = Agent(
 ## Reading the Raw Transcript
 
 For the full event stream, read from a logical cursor. This does not drain either — the same `after` returns the same events while they remain in the ring, so it's safe to call from more than one place.
+
+**Python / app code** — always available via `timbal.state.read_background_transcript`. **LLM tool** — opt in with `background_transcript_tool=True` on the Agent (registered alongside the other session background tools once a child exists).
+
+```python
+agent = Agent(
+    name="debugger",
+    model="...",
+    tools=[...],
+    background_transcript_tool=True,
+)
+```
 
 When the ring has dropped older events, `gapped` is `true` and `after` is behind `forgotten_through` — treat that like an expired reconnect, not a silent skip to the new head.
 

--- a/docs/agents/background-tasks.mdx
+++ b/docs/agents/background-tasks.mdx
@@ -52,6 +52,27 @@ Once this session has at least one background task, the agent automatically gain
 
 `get_background_task` **peeks**; it does not drain. Calling it twice returns the same thing, so the agent polling a child never steals events from a frontend streaming the same child.
 
+## Completion notifications
+
+When a background child reaches a terminal status (`completed`, `error`, or `cancelled`), the session store queues a one-shot notice. At the **start of the next parent turn** — not mid-turn while the parent is still talking — the agent drains that inbox and injects a synthetic user message into memory so the LLM learns without polling:
+
+```text
+Background task(s) finished since your last turn. ...
+
+<background_task_completed>
+task_id: k4d9x2mq7c1a
+name: build_site
+title: Build the marketing site
+status: completed
+result: ...
+summary: ...
+</background_task_completed>
+```
+
+Notices are lean (short summary / result preview, error string if any) — not full transcripts. After drain they are not re-injected; `get_background_task` still peeks the full snapshot. Concurrent parent runs without a shared `parent_id` keep isolated inboxes.
+
+If the model already polls via the auto-registered `get_background_task` / `list_background_tasks` tools and sees a terminal status, that peek **acks** the notice — the next turn will not fire a duplicate `<background_task_completed>` for a completion the agent already handled. App/Python peeks (`timbal.state.get_background_task`) do not ack by default, so UIs can inspect without stealing the LLM inbox.
+
 ```python
 from timbal.state import get_background_task
 

--- a/python/tests/core/test_background_tasks.py
+++ b/python/tests/core/test_background_tasks.py
@@ -20,6 +20,7 @@ from timbal.state import (
 )
 from timbal.state.background import BackgroundEventLog
 from timbal.types.content import ToolUseContent
+from timbal.types.events import ApprovalEvent
 from timbal.types.events.delta import DeltaEvent, TextDelta
 from timbal.types.events.output import OutputEvent
 from timbal.types.events.start import StartEvent
@@ -1381,6 +1382,205 @@ class TestBackgroundCompletionNotify:
         assert len(notices) == 1
         assert task_id in notices[0]
 
+    @pytest.mark.asyncio
+    async def test_stalled_injected_on_next_turn(self):
+        hang = asyncio.Event()
+
+        async def emit_once_then_hang(prompt: str) -> AsyncGenerator[TextDelta, None]:
+            yield TextDelta(id="s", text_delta=f"{prompt} start")
+            await hang.wait()
+
+        memories: list[list[Message]] = []
+        agent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("builder", {"prompt": "x"}, run_in_background=True),
+                    "Started.",
+                    "Saw the stall.",
+                ]
+            ),
+            tools=[
+                Tool(
+                    name="builder",
+                    handler=emit_once_then_hang,
+                    background_mode="auto",
+                    background_stall_timeout=0.15,
+                )
+            ],
+            post_hook=_capture_memory_hook(memories),
+        )
+
+        await agent(prompt="go").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        await _wait_for_first_event(task_id)
+        await _wait_until_terminal(task_id)
+
+        await agent(prompt="status?").collect()
+        notices = _completion_notices_in_memory(memories[-1])
+        assert len(notices) == 1
+        assert task_id in notices[0]
+        assert "status: stalled" in notices[0]
+        assert "No events for" in notices[0]
+
+    @pytest.mark.asyncio
+    async def test_list_background_tasks_acks_completion(self):
+        async def quick(tag: str) -> str:
+            await asyncio.sleep(0.05)
+            return f"done:{tag}"
+
+        memories: list[list[Message]] = []
+        agent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("quick", {"tag": "ok"}, run_in_background=True),
+                    "Started.",
+                    "Listed.",
+                    "No duplicate.",
+                ]
+            ),
+            tools=[Tool(name="quick", handler=quick, background_mode="auto")],
+            post_hook=_capture_memory_hook(memories),
+        )
+
+        await agent(prompt="start").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        await _wait_until_terminal(task_id)
+
+        from timbal.state.background import current_background_store
+
+        store = current_background_store()
+        assert store.pending_completions()
+        listed = agent.list_background_tasks()
+        assert any(item["task_id"] == task_id and item["status"] == "completed" for item in listed)
+        assert store.pending_completions() == []
+
+        await agent(prompt="list check").collect()
+        assert not _completion_notices_in_memory(memories[-1])
+
+        await agent(prompt="again").collect()
+        assert not _completion_notices_in_memory(memories[-1])
+
+    @pytest.mark.asyncio
+    async def test_subagent_skips_completion_inject(self):
+        gate = asyncio.Event()
+        release = asyncio.Event()
+
+        async def gated(tag: str) -> str:
+            await gate.wait()
+            return f"done:{tag}"
+
+        child_memories: list[list[Message]] = []
+
+        def _child_pre_hook() -> None:
+            release.set()
+
+        child = Agent(
+            name="specialist",
+            model=TestModel(responses=["sub done."]),
+            pre_hook=_child_pre_hook,
+            post_hook=_capture_memory_hook(child_memories),
+        )
+
+        parent_memories: list[list[Message]] = []
+        parent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("gated", {"tag": "x"}, run_in_background=True),
+                    "Started.",
+                    _tool_call("specialist", {"prompt": "hi"}),
+                    "Delegated.",
+                    "Got notice.",
+                ]
+            ),
+            tools=[
+                Tool(name="gated", handler=gated, background_mode="auto"),
+                child,
+            ],
+            post_hook=_capture_memory_hook(parent_memories),
+        )
+
+        await parent(prompt="start bg").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+
+        from timbal.state.background import current_background_store
+
+        delegate = asyncio.create_task(parent(prompt="call sub while bg runs").collect())
+        await release.wait()
+        gate.set()
+        await _wait_until_terminal(task_id)
+        await delegate
+
+        assert current_background_store().pending_completions()
+        if child_memories:
+            assert not _completion_notices_in_memory(child_memories[-1])
+
+        await parent(prompt="parent turn").collect()
+        notices = _completion_notices_in_memory(parent_memories[-1])
+        assert len(notices) == 1
+        assert task_id in notices[0]
+
+    @pytest.mark.asyncio
+    async def test_approval_resume_skips_completion_inject(self):
+        bg_gate = asyncio.Event()
+
+        async def slow_bg(tag: str) -> str:
+            await bg_gate.wait()
+            return f"done:{tag}"
+
+        def gated_action(x: str) -> str:
+            return f"ok:{x}"
+
+        memories: list[list[Message]] = []
+        agent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("slow_bg", {"tag": "bg"}, run_in_background=True),
+                    "Started bg.",
+                    _tool_call("gated_action", {"x": "1"}),
+                    "After resume.",
+                    "Finally.",
+                ]
+            ),
+            tools=[
+                Tool(name="slow_bg", handler=slow_bg, background_mode="auto"),
+                Tool(name="gated_action", handler=gated_action, requires_approval=True),
+            ],
+            post_hook=_capture_memory_hook(memories),
+        )
+
+        r1 = await agent(prompt="start bg").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+
+        events = [event async for event in agent(prompt="gate me", parent_id=r1.run_id)]
+        approval = next(event for event in events if isinstance(event, ApprovalEvent))
+        r2 = next(
+            event for event in events if isinstance(event, OutputEvent) and event.path == "composer"
+        )
+        assert r2.status.reason == "approval_required"
+
+        from timbal.state.background import current_background_store
+
+        bg_gate.set()
+        await _wait_until_terminal(task_id)
+        assert current_background_store().pending_completions()
+
+        await agent(
+            prompt="continue",
+            parent_id=r2.run_id,
+            resume={approval.approval_id: True},
+        ).collect()
+        assert not _completion_notices_in_memory(memories[-1])
+        assert current_background_store().pending_completions()
+
+        await agent(prompt="next").collect()
+        notices = _completion_notices_in_memory(memories[-1])
+        assert len(notices) == 1
+        assert task_id in notices[0]
+
 
 class TestBackgroundTimeout:
     """``background_timeout`` cancels stuck children as ``timed_out``."""
@@ -1637,6 +1837,41 @@ class TestBackgroundStallTimeout:
         assert snap["status"] == "running"
         assert snap["summary"]["seconds_since_event"] >= 0.05
         gate.set()
+
+    @pytest.mark.asyncio
+    async def test_stall_fires_on_cancel_hook(self):
+        cancelled: list[str] = []
+        hang = asyncio.Event()
+
+        async def emit_once_then_hang(prompt: str) -> AsyncGenerator[TextDelta, None]:
+            yield TextDelta(id="s", text_delta=f"{prompt} start")
+            await hang.wait()
+
+        agent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("builder", {"prompt": "x"}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[
+                Tool(
+                    name="builder",
+                    handler=emit_once_then_hang,
+                    background_mode="auto",
+                    background_stall_timeout=0.15,
+                    on_background_cancel=lambda record: cancelled.append(record.task_id),
+                )
+            ],
+        )
+
+        await agent(prompt="go").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        await _wait_for_first_event(task_id)
+        snap = await _wait_until_terminal(task_id)
+        assert snap["status"] == "stalled"
+        assert task_id in cancelled
 
 
 class TestBackgroundLimits:
@@ -1925,6 +2160,46 @@ class TestStructuredProgress:
         assert summary["tools_in_flight"] == ["write_file"]
         assert summary["phase"] == "tool:write_file"
 
+    @pytest.mark.asyncio
+    async def test_agent_tool_returns_progress_fields(self):
+        gate = asyncio.Event()
+
+        async def staged_task() -> AsyncGenerator[dict[str, Any], None]:
+            yield {"stage": "init", "progress": 10}
+            await gate.wait()
+            yield {"stage": "processing", "progress": 55}
+
+        agent = Agent(
+            name="progress_agent",
+            model=TestModel(
+                responses=[
+                    _tool_call("staged_task", {}, run_in_background=True),
+                    "Started.",
+                    _tool_call("get_background_task", {"task_id": "placeholder"}),
+                    "Checked.",
+                ]
+            ),
+            tools=[Tool(name="staged_task", handler=staged_task, background_mode="auto")],
+        )
+        await agent(prompt="go").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        for _ in range(200):
+            if get_background_task(task_id)["summary"].get("phase") == "init":
+                break
+            await asyncio.sleep(0.01)
+
+        agent.model = TestModel(
+            responses=[
+                _tool_call("get_background_task", {"task_id": task_id}),
+                "Done checking.",
+            ]
+        )
+        await agent(prompt="status").collect()
+        snap = agent.get_background_task(task_id)
+        assert snap["summary"]["phase"] == "init"
+        assert snap["summary"]["pct"] == 10
+        gate.set()
+
 
 class TestWaitForBackground:
     @pytest.mark.asyncio
@@ -2008,3 +2283,164 @@ class TestWaitForBackground:
     async def test_wait_not_found(self):
         snap = await wait_for_background("missing_task_id")
         assert snap["status"] == "not_found"
+
+    @pytest.mark.asyncio
+    async def test_wait_until_error(self):
+        async def boom() -> str:
+            await asyncio.sleep(0.05)
+            raise ValueError("wait error test")
+
+        agent = Agent(
+            name="wait_agent",
+            model=TestModel(
+                responses=[
+                    _tool_call("boom", {}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[Tool(name="boom", handler=boom, background_mode="auto")],
+        )
+        await agent(prompt="go").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        snap = await wait_for_background(task_id, timeout=5.0)
+        assert snap["status"] == "error"
+        assert "wait error test" in snap["error"]
+
+    @pytest.mark.asyncio
+    async def test_wait_until_cancelled(self):
+        async def stubborn() -> AsyncGenerator[TextDelta, None]:
+            while True:
+                yield TextDelta(id="s", text_delta=".")
+                await asyncio.sleep(0.05)
+
+        agent = Agent(
+            name="wait_agent",
+            model=TestModel(
+                responses=[
+                    _tool_call("stubborn", {}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[Tool(name="stubborn", handler=stubborn, background_mode="auto")],
+        )
+        await agent(prompt="go").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        await _wait_for_first_event(task_id)
+        cancel_background_task(task_id)
+        snap = await wait_for_background(task_id, timeout=5.0)
+        assert snap["status"] == "cancelled"
+
+    @pytest.mark.asyncio
+    async def test_wait_until_stalled(self):
+        hang = asyncio.Event()
+
+        async def emit_once() -> AsyncGenerator[TextDelta, None]:
+            yield TextDelta(id="s", text_delta="only")
+            await hang.wait()
+
+        agent = Agent(
+            name="wait_agent",
+            model=TestModel(
+                responses=[
+                    _tool_call("emit_once", {}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[
+                Tool(
+                    name="emit_once",
+                    handler=emit_once,
+                    background_mode="auto",
+                    background_stall_timeout=0.15,
+                )
+            ],
+        )
+        await agent(prompt="go").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        await _wait_for_first_event(task_id)
+        snap = await wait_for_background(task_id, timeout=5.0)
+        assert snap["status"] == "stalled"
+
+    @pytest.mark.asyncio
+    async def test_wait_after_until_terminal_on_log_close(self):
+        async def quick() -> str:
+            await asyncio.sleep(0.05)
+            return "done"
+
+        agent = Agent(
+            name="wait_agent",
+            model=TestModel(
+                responses=[
+                    _tool_call("quick", {}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[Tool(name="quick", handler=quick, background_mode="auto")],
+        )
+        await agent(prompt="go").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        snap = await wait_for_background(task_id, after=0, timeout=5.0)
+        assert snap["status"] == "completed"
+        assert snap["result"] == "done"
+
+
+class TestBackgroundEventLogWait:
+    """Unit tests for :meth:`BackgroundEventLog.wait`."""
+
+    @pytest.mark.asyncio
+    async def test_wait_wakes_on_put(self):
+        log = BackgroundEventLog(max_events=10, max_bytes=0)
+
+        async def blocked() -> None:
+            await log.wait(after=0, timeout=2.0)
+
+        task = asyncio.create_task(blocked())
+        await asyncio.sleep(0.02)
+        assert not task.done()
+        log.put_nowait({"type": "event"})
+        await asyncio.wait_for(task, timeout=1.0)
+
+    @pytest.mark.asyncio
+    async def test_wait_returns_when_cursor_already_ahead(self):
+        log = BackgroundEventLog()
+        log.put_nowait("event")
+        await log.wait(after=0, timeout=0.01)
+
+    @pytest.mark.asyncio
+    async def test_wait_wakes_on_close(self):
+        log = BackgroundEventLog()
+        task = asyncio.create_task(log.wait(after=0, timeout=2.0))
+        await asyncio.sleep(0.02)
+        log.close()
+        await asyncio.wait_for(task, timeout=1.0)
+
+
+class TestBackgroundEnvDefaults:
+    """Env-driven defaults for session background stores."""
+
+    def test_max_concurrent_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from timbal.state.background import BackgroundTaskStore, _default_max_concurrent
+
+        monkeypatch.setenv("TIMBAL_MAX_CONCURRENT_BACKGROUND", "3")
+        assert _default_max_concurrent() == 3
+        assert BackgroundTaskStore().max_concurrent == 3
+
+    def test_max_concurrent_unlimited_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from timbal.state.background import _default_max_concurrent
+
+        monkeypatch.setenv("TIMBAL_MAX_CONCURRENT_BACKGROUND", "none")
+        assert _default_max_concurrent() is None
+
+    def test_log_max_events_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from timbal.state.background import BackgroundTaskStore, _default_max_log_events
+
+        monkeypatch.setenv("TIMBAL_BG_LOG_MAX_EVENTS", "100")
+        assert _default_max_log_events() == 100
+        assert BackgroundTaskStore().max_log_events == 100
+
+    def test_task_retention_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from timbal.state.background import BackgroundTaskStore, _default_task_retention_secs
+
+        monkeypatch.setenv("TIMBAL_BG_TASK_RETENTION_SECS", "600")
+        assert _default_task_retention_secs() == 600.0
+        assert BackgroundTaskStore().task_retention_secs == 600.0

--- a/python/tests/core/test_background_tasks.py
+++ b/python/tests/core/test_background_tasks.py
@@ -959,3 +959,379 @@ class TestBackgroundMultitask:
         assert bag.snapshot(task_id)["status"] == "running"
         bag.cancel(task_id)
         await asyncio.sleep(0.1)
+
+
+async def _wait_until_terminal(task_id: str, timeout: float = 5.0) -> dict:
+    """Wait until the child asyncio.Task is done and status is terminal.
+
+    ``status_code()`` can report ``cancelled`` as soon as cancel is requested,
+    before the done-callback has enqueued the completion notice — so we require
+    ``task.done()`` as well.
+    """
+    from timbal.state.background import current_background_store
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        store = current_background_store()
+        record = store.get(task_id) if store is not None else None
+        snap = get_background_task(task_id)
+        if record is not None and record.task.done() and snap["status"] != "running":
+            # Yield once so done-callbacks scheduled on this loop can run.
+            await asyncio.sleep(0)
+            return snap
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"background task {task_id} never reached a terminal status")
+
+
+def _completion_notices_in_memory(memory: list[Message]) -> list[str]:
+    return [
+        msg.collect_text()
+        for msg in memory
+        if msg.role == "user" and "<background_task_completed>" in (msg.collect_text() or "")
+    ]
+
+
+def _capture_memory_hook(bucket: list[list[Message]]):
+    def _hook() -> None:
+        bucket.append(list(get_run_context().current_span().memory))
+
+    return _hook
+
+
+class TestBackgroundCompletionNotify:
+    """Completion inbox → synthetic user message on the next parent turn."""
+
+    @pytest.mark.asyncio
+    async def test_success_injected_on_next_turn(self):
+        async def quick(tag: str) -> str:
+            await asyncio.sleep(0.05)
+            return f"done:{tag}"
+
+        seen_messages: list[list[Message]] = []
+        memories: list[list[Message]] = []
+
+        def _handler(messages: list[Message]):
+            from timbal.types.content import ToolResultContent
+
+            seen_messages.append(list(messages))
+            if any(isinstance(c, ToolResultContent) for m in messages for c in m.content):
+                return "Acknowledged."
+            if any("<background_task_completed>" in (m.collect_text() or "") for m in messages):
+                return "Got the completion."
+            return _tool_call("quick", {"tag": "ok"}, run_in_background=True)
+
+        agent = Agent(
+            name="composer",
+            model=TestModel(handler=_handler),
+            tools=[Tool(name="quick", handler=quick, background_mode="auto")],
+            post_hook=_capture_memory_hook(memories),
+        )
+
+        r1 = await agent(prompt="start").collect()
+        assert_has_output_event(r1)
+        task_id = list_background_tasks()[0]["task_id"]
+        snap = await _wait_until_terminal(task_id)
+        assert snap["status"] == "completed"
+
+        from timbal.state.background import current_background_store
+
+        assert current_background_store().pending_completions()
+        # Spawn turn must not have seen a completion notice (between-turns only).
+        assert not any(
+            "<background_task_completed>" in (m.collect_text() or "") for msgs in seen_messages for m in msgs
+        )
+
+        r2 = await agent(prompt="what happened?").collect()
+        assert_has_output_event(r2)
+        assert get_run_context().parent_id == r1.run_id
+        notices = _completion_notices_in_memory(memories[-1])
+        assert len(notices) == 1
+        assert task_id in notices[0]
+        assert "status: completed" in notices[0]
+        assert "done:ok" in notices[0]
+        # One-shot: inbox empty; peek still works.
+        assert current_background_store().pending_completions() == []
+        assert get_background_task(task_id)["status"] == "completed"
+
+        await agent(prompt="again?").collect()
+        # Historical notice remains in memory, but is not re-injected.
+        notices_again = _completion_notices_in_memory(memories[-1])
+        assert len(notices_again) == 1
+        assert current_background_store().pending_completions() == []
+
+    @pytest.mark.asyncio
+    async def test_error_injected(self):
+        async def boom(should_fail: bool = True) -> str:
+            await asyncio.sleep(0.05)
+            if should_fail:
+                raise ValueError("Intentional failure for testing")
+            return "ok"
+
+        memories: list[list[Message]] = []
+        agent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("boom", {"should_fail": True}, run_in_background=True),
+                    "Started.",
+                    "Saw the error.",
+                ]
+            ),
+            tools=[Tool(name="boom", handler=boom, background_mode="auto")],
+            post_hook=_capture_memory_hook(memories),
+        )
+
+        await agent(prompt="start").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        await _wait_until_terminal(task_id)
+
+        await agent(prompt="status?").collect()
+        notices = _completion_notices_in_memory(memories[-1])
+        assert len(notices) == 1
+        assert "status: error" in notices[0]
+        assert "Intentional failure" in notices[0]
+
+    @pytest.mark.asyncio
+    async def test_cancel_injected(self):
+        async def stubborn(prompt: str) -> AsyncGenerator[TextDelta, None]:
+            try:
+                while True:
+                    yield TextDelta(id="s", text_delta=f"{prompt}...")
+                    await asyncio.sleep(0.05)
+            finally:
+                pass
+
+        memories: list[list[Message]] = []
+        agent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("builder", {"prompt": "loop"}, run_in_background=True),
+                    "Started.",
+                    "Cancelled, noted.",
+                ]
+            ),
+            tools=[Tool(name="builder", handler=stubborn, background_mode="auto")],
+            post_hook=_capture_memory_hook(memories),
+        )
+
+        await agent(prompt="go").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        await _wait_for_first_event(task_id)
+        cancel_background_task(task_id)
+        await _wait_until_terminal(task_id)
+
+        await agent(prompt="what about the builder?").collect()
+        notices = _completion_notices_in_memory(memories[-1])
+        assert len(notices) == 1
+        assert task_id in notices[0]
+        assert "status: cancelled" in notices[0]
+
+    @pytest.mark.asyncio
+    async def test_multi_child_one_notice_block(self):
+        async def quick(tag: str) -> str:
+            await asyncio.sleep(0.05)
+            return f"done:{tag}"
+
+        memories: list[list[Message]] = []
+        agent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_calls(
+                        ("quick", {"tag": "A"}, "c1", True),
+                        ("quick", {"tag": "B"}, "c2", True),
+                    ),
+                    "Both started.",
+                    "Both done.",
+                ]
+            ),
+            tools=[Tool(name="quick", handler=quick, background_mode="auto")],
+            post_hook=_capture_memory_hook(memories),
+        )
+
+        await agent(prompt="start both").collect()
+        ids = [t["task_id"] for t in list_background_tasks()]
+        assert len(ids) == 2
+        for task_id in ids:
+            await _wait_until_terminal(task_id)
+
+        await agent(prompt="update?").collect()
+        notices = _completion_notices_in_memory(memories[-1])
+        assert len(notices) == 1
+        body = notices[0]
+        assert body.count("<background_task_completed>") == 2
+        for task_id in ids:
+            assert task_id in body
+
+    @pytest.mark.asyncio
+    async def test_no_mid_turn_injection(self):
+        """Child completes during the spawn turn; notice waits for the *next* turn."""
+        gate = asyncio.Event()
+        memories: list[list[Message]] = []
+
+        async def gated(tag: str) -> str:
+            await gate.wait()
+            return f"done:{tag}"
+
+        llm_calls = {"n": 0}
+
+        def _handler(messages: list[Message]):
+            from timbal.types.content import ToolResultContent
+
+            llm_calls["n"] += 1
+            has_notice = any("<background_task_completed>" in (m.collect_text() or "") for m in messages)
+            if has_notice:
+                return "noticed"
+            if any(isinstance(c, ToolResultContent) for m in messages for c in m.content):
+                # Still the spawn turn — release the child so it finishes before
+                # we return the final assistant text, proving no mid-turn inject.
+                gate.set()
+                return "Started."
+            return _tool_call("gated", {"tag": "x"}, run_in_background=True)
+
+        agent = Agent(
+            name="composer",
+            model=TestModel(handler=_handler),
+            tools=[Tool(name="gated", handler=gated, background_mode="auto")],
+            post_hook=_capture_memory_hook(memories),
+        )
+
+        r1 = await agent(prompt="start").collect()
+        assert_has_output_event(r1)
+        task_id = list_background_tasks()[0]["task_id"]
+        await _wait_until_terminal(task_id)
+        # Spawn turn LLM calls never saw a completion notice.
+        assert llm_calls["n"] == 2
+        assert not _completion_notices_in_memory(memories[0])
+
+        from timbal.state.background import current_background_store
+
+        assert current_background_store().pending_completions()
+
+        await agent(prompt="now?").collect()
+        notices = _completion_notices_in_memory(memories[-1])
+        assert len(notices) == 1
+        assert task_id in notices[0]
+
+    @pytest.mark.asyncio
+    async def test_isolation_concurrent_sessions(self):
+        async def slow(tag: str) -> str:
+            await asyncio.sleep(0.05)
+            return tag
+
+        def _handler(messages: list[Message]):
+            from timbal.types.content import ToolResultContent
+
+            if any(isinstance(c, ToolResultContent) for m in messages for c in m.content):
+                return "Started."
+            if any("<background_task_completed>" in (m.collect_text() or "") for m in messages):
+                return "Saw mine."
+            prompt = messages[-1].collect_text()
+            tag = "A" if "A" in prompt else "B"
+            return _tool_call("builder", {"tag": tag}, id=tag, run_in_background=True)
+
+        async def run_session(prompt: str) -> tuple[str, list[str]]:
+            memories: list[list[Message]] = []
+            parent = Agent(
+                name="composer",
+                model=TestModel(handler=_handler),
+                tools=[Tool(name="builder", handler=slow, background_mode="auto")],
+                post_hook=_capture_memory_hook(memories),
+            )
+            set_run_context(None)
+            set_call_id(None)
+            set_parent_call_id(None)
+            await parent(prompt=prompt).collect()
+            task_id = list_background_tasks()[0]["task_id"]
+            await _wait_until_terminal(task_id)
+            await parent(prompt=f"check {prompt}").collect()
+            notices = _completion_notices_in_memory(memories[-1])
+            return task_id, notices
+
+        set_run_context(None)
+        set_call_id(None)
+        set_parent_call_id(None)
+        (id_a, notices_a), (id_b, notices_b) = await asyncio.gather(run_session("A"), run_session("B"))
+        assert id_a != id_b
+        assert len(notices_a) == 1 and id_a in notices_a[0] and id_b not in notices_a[0]
+        assert len(notices_b) == 1 and id_b in notices_b[0] and id_a not in notices_b[0]
+
+    @pytest.mark.asyncio
+    async def test_agent_poll_acks_so_next_turn_does_not_reinject(self):
+        """LLM-tool peek (ack_completion=True) must consume the pending notice."""
+        async def quick(tag: str) -> str:
+            await asyncio.sleep(0.05)
+            return f"done:{tag}"
+
+        memories: list[list[Message]] = []
+        agent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("quick", {"tag": "ok"}, run_in_background=True),
+                    "Started.",
+                    "Checked — it's done.",
+                    "Nothing new.",
+                ]
+            ),
+            tools=[Tool(name="quick", handler=quick, background_mode="auto")],
+            post_hook=_capture_memory_hook(memories),
+        )
+
+        await agent(prompt="start").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        await _wait_until_terminal(task_id)
+
+        from timbal.state.background import current_background_store
+
+        store = current_background_store()
+        assert store.pending_completions()
+        # Same path as the auto-registered LLM tool — acks terminal peeks.
+        snap = agent.get_background_task(task_id)
+        assert snap["status"] == "completed"
+        assert store.pending_completions() == []
+        # Module peek still works and does not need to ack again.
+        assert get_background_task(task_id)["status"] == "completed"
+
+        await agent(prompt="status?").collect()
+        assert not _completion_notices_in_memory(memories[-1])
+
+        await agent(prompt="again?").collect()
+        assert not _completion_notices_in_memory(memories[-1])
+
+    @pytest.mark.asyncio
+    async def test_module_peek_does_not_ack(self):
+        """App/UI peeks must not steal the LLM completion inbox."""
+        async def quick(tag: str) -> str:
+            await asyncio.sleep(0.05)
+            return f"done:{tag}"
+
+        memories: list[list[Message]] = []
+        agent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("quick", {"tag": "ok"}, run_in_background=True),
+                    "Started.",
+                    "Got the push notice.",
+                ]
+            ),
+            tools=[Tool(name="quick", handler=quick, background_mode="auto")],
+            post_hook=_capture_memory_hook(memories),
+        )
+
+        await agent(prompt="start").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        await _wait_until_terminal(task_id)
+        # _wait_until_terminal uses module get_background_task (ack=False).
+        from timbal.state.background import current_background_store
+
+        assert current_background_store().pending_completions()
+        assert get_background_task(task_id)["status"] == "completed"
+        assert current_background_store().pending_completions()
+
+        await agent(prompt="what happened?").collect()
+        notices = _completion_notices_in_memory(memories[-1])
+        assert len(notices) == 1
+        assert task_id in notices[0]

--- a/python/tests/core/test_background_tasks.py
+++ b/python/tests/core/test_background_tasks.py
@@ -344,6 +344,9 @@ class TestBackgroundTasks:
         assert status["status"] in ("completed", "running")
         assert "events" not in status
         assert status["summary"]["event_count"] >= 1
+        if status["status"] == "completed":
+            assert status["summary"]["phase"] == "completed"
+            assert status["summary"]["pct"] == 100
 
     @pytest.mark.asyncio
     async def test_multiple_background_tasks_sequential_turns(self):
@@ -1684,3 +1687,93 @@ class TestBackgroundLogRetention:
         store = current_background_store()
         store.reap_finished()
         assert get_background_task(task_id)["status"] == "not_found"
+
+
+class TestStructuredProgress:
+    """Structured phase/pct/last_tool/tools_in_flight in get_background_task snapshots."""
+
+    @pytest.mark.asyncio
+    async def test_mid_flight_custom_progress(self):
+        gate = asyncio.Event()
+
+        async def staged_task() -> AsyncGenerator[dict[str, Any], None]:
+            yield {"stage": "init", "progress": 10}
+            await gate.wait()
+            yield {"stage": "processing", "progress": 55}
+
+        agent = Agent(
+            name="progress_agent",
+            model=TestModel(
+                responses=[
+                    _tool_call("staged_task", {}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[Tool(name="staged_task", handler=staged_task, background_mode="auto")],
+        )
+        await agent(prompt="go").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        for _ in range(200):
+            snap = get_background_task(task_id)
+            if snap["summary"].get("phase") == "init":
+                break
+            await asyncio.sleep(0.01)
+        snap = get_background_task(task_id)
+        assert snap["status"] == "running"
+        assert snap["summary"]["phase"] == "init"
+        assert snap["summary"]["pct"] == 10
+        assert snap["summary"]["last_tool"] is None
+        assert snap["summary"]["tools_in_flight"] == []
+        gate.set()
+        for _ in range(200):
+            if get_background_task(task_id)["status"] == "completed":
+                break
+            await asyncio.sleep(0.01)
+        done = get_background_task(task_id)
+        assert done["summary"]["phase"] == "completed"
+        assert done["summary"]["pct"] == 100
+
+    @pytest.mark.asyncio
+    async def test_streaming_phase_without_custom_progress(self):
+        parent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("builder", {"prompt": "x"}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[Tool(name="builder", handler=_fake_streaming_builder, background_mode="auto")],
+        )
+        await parent(prompt="build").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        await _wait_for_first_event(task_id)
+        snap = get_background_task(task_id)
+        assert snap["status"] == "running"
+        assert snap["summary"]["phase"] == "streaming"
+        assert snap["summary"]["text"]
+        assert snap["summary"]["last_tool"] is None
+
+    def test_tools_in_flight_from_event_log(self):
+        from timbal.state.background import _build_summary_from_events
+        from timbal.types.events.delta import DeltaEvent, ToolUse
+        from timbal.types.events.output import OutputEvent
+        from timbal.types.run_status import RunStatus
+
+        ids = {"run_id": "r1", "call_id": "c1"}
+        events = [
+            DeltaEvent(**ids, path="agent", item=ToolUse(id="t1", name="bash")),
+            DeltaEvent(**ids, path="agent", item=ToolUse(id="t2", name="write_file")),
+            OutputEvent(
+                **ids,
+                path="agent.bash",
+                status=RunStatus(code="success"),
+                t0=0,
+                t1=1,
+                metadata={"tool_call_id": "t1"},
+            ),
+        ]
+        summary = _build_summary_from_events(events)
+        assert summary["last_tool"] == "write_file"
+        assert summary["tools_in_flight"] == ["write_file"]
+        assert summary["phase"] == "tool:write_file"

--- a/python/tests/core/test_background_tasks.py
+++ b/python/tests/core/test_background_tasks.py
@@ -1335,3 +1335,154 @@ class TestBackgroundCompletionNotify:
         notices = _completion_notices_in_memory(memories[-1])
         assert len(notices) == 1
         assert task_id in notices[0]
+
+
+class TestBackgroundTimeout:
+    """``background_timeout`` cancels stuck children as ``timed_out``."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_marks_timed_out_and_fires_on_cancel(self):
+        cancelled: list[str] = []
+
+        async def stubborn(prompt: str) -> AsyncGenerator[TextDelta, None]:
+            try:
+                while True:
+                    yield TextDelta(id="s", text_delta=f"{prompt}...")
+                    await asyncio.sleep(0.05)
+            finally:
+                pass
+
+        agent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("builder", {"prompt": "loop"}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[
+                Tool(
+                    name="builder",
+                    handler=stubborn,
+                    background_mode="auto",
+                    background_timeout=0.15,
+                    on_background_cancel=lambda record: cancelled.append(record.task_id),
+                )
+            ],
+        )
+
+        await agent(prompt="go").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        snap = await _wait_until_terminal(task_id)
+        assert snap["status"] == "timed_out"
+        assert snap["timeout"] == 0.15
+        assert "Timed out after 0.15s" in snap["error"]
+        assert task_id in cancelled
+
+        from timbal.state.background import current_background_store
+
+        pending = current_background_store().pending_completions()
+        assert len(pending) == 1
+        assert pending[0]["status"] == "timed_out"
+        assert "Timed out" in pending[0]["error"]
+
+    @pytest.mark.asyncio
+    async def test_timeout_notice_injected_on_next_turn(self):
+        async def stubborn(prompt: str) -> AsyncGenerator[TextDelta, None]:
+            while True:
+                yield TextDelta(id="s", text_delta=f"{prompt}...")
+                await asyncio.sleep(0.05)
+
+        memories: list[list[Message]] = []
+        agent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("builder", {"prompt": "loop"}, run_in_background=True),
+                    "Started.",
+                    "Saw the timeout.",
+                ]
+            ),
+            tools=[
+                Tool(
+                    name="builder",
+                    handler=stubborn,
+                    background_mode="auto",
+                    background_timeout=0.15,
+                )
+            ],
+            post_hook=_capture_memory_hook(memories),
+        )
+
+        await agent(prompt="go").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        await _wait_until_terminal(task_id)
+
+        await agent(prompt="status?").collect()
+        notices = _completion_notices_in_memory(memories[-1])
+        assert len(notices) == 1
+        assert task_id in notices[0]
+        assert "status: timed_out" in notices[0]
+
+    @pytest.mark.asyncio
+    async def test_completes_before_timeout(self):
+        async def quick(tag: str) -> str:
+            await asyncio.sleep(0.05)
+            return f"done:{tag}"
+
+        agent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("quick", {"tag": "ok"}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[
+                Tool(
+                    name="quick",
+                    handler=quick,
+                    background_mode="auto",
+                    background_timeout=5.0,
+                )
+            ],
+        )
+
+        await agent(prompt="start").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        snap = await _wait_until_terminal(task_id)
+        assert snap["status"] == "completed"
+        assert snap["result"] == "done:ok"
+        assert snap.get("timeout") == 5.0
+
+    @pytest.mark.asyncio
+    async def test_user_cancel_still_cancelled_not_timed_out(self):
+        async def stubborn(prompt: str) -> AsyncGenerator[TextDelta, None]:
+            while True:
+                yield TextDelta(id="s", text_delta=f"{prompt}...")
+                await asyncio.sleep(0.05)
+
+        agent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("builder", {"prompt": "loop"}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[
+                Tool(
+                    name="builder",
+                    handler=stubborn,
+                    background_mode="auto",
+                    background_timeout=30.0,
+                )
+            ],
+        )
+
+        await agent(prompt="go").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        await _wait_for_first_event(task_id)
+        cancel_background_task(task_id)
+        snap = await _wait_until_terminal(task_id)
+        assert snap["status"] == "cancelled"

--- a/python/tests/core/test_background_tasks.py
+++ b/python/tests/core/test_background_tasks.py
@@ -1533,6 +1533,112 @@ class TestBackgroundTimeout:
         assert snap["status"] == "cancelled"
 
 
+class TestBackgroundStallTimeout:
+    """``background_stall_timeout`` cancels idle children as ``stalled``."""
+
+    @pytest.mark.asyncio
+    async def test_stall_after_last_event(self):
+        hang = asyncio.Event()
+
+        async def emit_once_then_hang(prompt: str) -> AsyncGenerator[TextDelta, None]:
+            yield TextDelta(id="s", text_delta=f"{prompt} start")
+            await hang.wait()
+
+        agent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("builder", {"prompt": "x"}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[
+                Tool(
+                    name="builder",
+                    handler=emit_once_then_hang,
+                    background_mode="auto",
+                    background_stall_timeout=0.15,
+                )
+            ],
+        )
+
+        await agent(prompt="go").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        await _wait_for_first_event(task_id)
+        snap = await _wait_until_terminal(task_id)
+        assert snap["status"] == "stalled"
+        assert snap["stall_timeout"] == 0.15
+        assert "No events for 0.15s" in snap["error"]
+
+    @pytest.mark.asyncio
+    async def test_steady_events_do_not_stall_under_wall_timeout(self):
+        """Streaming children reset the idle watchdog on every event."""
+
+        async def chatty(prompt: str) -> AsyncGenerator[TextDelta, None]:
+            while True:
+                yield TextDelta(id="s", text_delta=f"{prompt}.")
+                await asyncio.sleep(0.04)
+
+        agent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("builder", {"prompt": "loop"}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[
+                Tool(
+                    name="builder",
+                    handler=chatty,
+                    background_mode="auto",
+                    background_stall_timeout=0.5,
+                    background_timeout=0.15,
+                )
+            ],
+        )
+
+        await agent(prompt="go").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        snap = await _wait_until_terminal(task_id)
+        assert snap["status"] == "timed_out"
+        assert snap["status"] != "stalled"
+
+    @pytest.mark.asyncio
+    async def test_running_snapshot_exposes_seconds_since_event(self):
+        gate = asyncio.Event()
+
+        async def paused_stream() -> AsyncGenerator[TextDelta, None]:
+            yield TextDelta(id="s", text_delta="one ")
+            await gate.wait()
+
+        agent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("builder", {}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[
+                Tool(
+                    name="builder",
+                    handler=paused_stream,
+                    background_mode="auto",
+                    background_stall_timeout=30.0,
+                )
+            ],
+        )
+        await agent(prompt="go").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        await _wait_for_first_event(task_id)
+        await asyncio.sleep(0.08)
+        snap = get_background_task(task_id)
+        assert snap["status"] == "running"
+        assert snap["summary"]["seconds_since_event"] >= 0.05
+        gate.set()
+
+
 class TestBackgroundLimits:
     """Concurrent + depth caps on the session bag."""
 

--- a/python/tests/core/test_background_tasks.py
+++ b/python/tests/core/test_background_tasks.py
@@ -1486,3 +1486,119 @@ class TestBackgroundTimeout:
         cancel_background_task(task_id)
         snap = await _wait_until_terminal(task_id)
         assert snap["status"] == "cancelled"
+
+
+class TestBackgroundLimits:
+    """Concurrent + depth caps on the session bag."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_cap_rejects_extra_spawn(self):
+        gate = asyncio.Event()
+
+        async def gated(tag: str) -> str:
+            await gate.wait()
+            return tag
+
+        agent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_calls(
+                        ("gated", {"tag": "A"}, "c1", True),
+                        ("gated", {"tag": "B"}, "c2", True),
+                        ("gated", {"tag": "C"}, "c3", True),
+                    ),
+                    "Tried three.",
+                ]
+            ),
+            tools=[Tool(name="gated", handler=gated, background_mode="auto")],
+            max_background_concurrent=2,
+        )
+
+        result = await agent(prompt="start three").collect()
+        assert_has_output_event(result)
+        running = [t for t in list_background_tasks() if t["status"] == "running"]
+        assert len(running) == 2
+        # Third spawn failed — tool error visible in memory / output path.
+        from timbal.state.background import current_background_store
+
+        store = current_background_store()
+        assert store is not None
+        assert store.running_count() == 2
+        assert store.max_concurrent == 2
+
+        gate.set()
+        for t in running:
+            await _wait_until_terminal(t["task_id"])
+
+    @pytest.mark.asyncio
+    async def test_depth_cap_blocks_nested_background_spawn(self):
+        from timbal.state.background import (
+            BackgroundLimitError,
+            BackgroundTaskStore,
+            get_background_depth,
+            reset_background_depth,
+            set_background_depth,
+        )
+
+        store = BackgroundTaskStore(max_concurrent=10, max_depth=1)
+        # Top-level may spawn.
+        store.check_can_spawn(0)
+
+        token = set_background_depth(1)
+        try:
+            assert get_background_depth() == 1
+            with pytest.raises(BackgroundLimitError, match="depth"):
+                store.check_can_spawn()
+            with pytest.raises(BackgroundLimitError, match="depth"):
+                store.begin_spawn()
+        finally:
+            reset_background_depth(token)
+
+        # Agent wires max_background_depth onto the session store.
+        async def quick(tag: str) -> str:
+            return tag
+
+        agent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("quick", {"tag": "A"}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[Tool(name="quick", handler=quick, background_mode="auto")],
+            max_background_depth=1,
+        )
+        await agent(prompt="go").collect()
+        from timbal.state.background import current_background_store
+
+        assert current_background_store().max_depth == 1
+
+    @pytest.mark.asyncio
+    async def test_unlimited_concurrent_when_none(self):
+        async def quick(tag: str) -> str:
+            await asyncio.sleep(0.02)
+            return tag
+
+        agent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_calls(
+                        ("quick", {"tag": "A"}, "c1", True),
+                        ("quick", {"tag": "B"}, "c2", True),
+                        ("quick", {"tag": "C"}, "c3", True),
+                    ),
+                    "All three.",
+                ]
+            ),
+            tools=[Tool(name="quick", handler=quick, background_mode="auto")],
+            max_background_concurrent=None,
+        )
+
+        await agent(prompt="go").collect()
+        assert len(list_background_tasks()) == 3
+        from timbal.state.background import current_background_store
+
+        assert current_background_store().max_concurrent is None

--- a/python/tests/core/test_background_tasks.py
+++ b/python/tests/core/test_background_tasks.py
@@ -209,7 +209,64 @@ class TestBackgroundTasks:
         assert "get_background_task" in tool_names_seen
         assert "list_background_tasks" in tool_names_seen
         assert "cancel_background_task" in tool_names_seen
+        assert "read_background_transcript" not in tool_names_seen
         await asyncio.sleep(0.4)
+
+    @pytest.mark.asyncio
+    async def test_read_background_transcript_tool_opt_in(self):
+        async def slow_task(duration: float) -> str:
+            await asyncio.sleep(duration)
+            return "done"
+
+        agent = Agent(
+            name="bg_agent",
+            model=TestModel(
+                responses=[
+                    _tool_call("slow_task", {"duration": 0.3}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[Tool(name="slow_task", description="Run a slow task", handler=slow_task, background_mode="auto")],
+            background_transcript_tool=True,
+        )
+
+        tool_names_seen = []
+        async for event in agent(prompt="run in background"):
+            if isinstance(event, OutputEvent) and event.path == "bg_agent.llm" and list_background_tasks():
+                tool_names_seen.extend(tool.name for tool in event.input["tools"])
+
+        assert "read_background_transcript" in tool_names_seen
+        await asyncio.sleep(0.4)
+
+    @pytest.mark.asyncio
+    async def test_agent_read_background_transcript_tool_call(self):
+        parent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("builder", {"prompt": "x"}, run_in_background=True),
+                    "Started.",
+                    _tool_call("read_background_transcript", {"task_id": "placeholder", "after": 0}),
+                    "Here is the log.",
+                ]
+            ),
+            tools=[Tool(name="builder", handler=_fake_streaming_builder, background_mode="auto")],
+            background_transcript_tool=True,
+        )
+        await parent(prompt="build").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        await _wait_for_first_event(task_id)
+        parent.model = TestModel(
+            responses=[
+                _tool_call("read_background_transcript", {"task_id": task_id, "after": 0}),
+                "Fetched transcript.",
+            ]
+        )
+        result = await parent(prompt="show me the raw log").collect()
+        assert_has_output_event(result)
+        page = read_background_transcript(task_id, after=0)
+        assert page["cursor"] >= 1
+        assert len(page["events"]) >= 1
 
     @pytest.mark.asyncio
     async def test_background_task_with_events_and_logs(self):

--- a/python/tests/core/test_background_tasks.py
+++ b/python/tests/core/test_background_tasks.py
@@ -17,6 +17,7 @@ from timbal.state import (
     set_parent_call_id,
     set_run_context,
 )
+from timbal.state.background import BackgroundEventLog
 from timbal.types.content import ToolUseContent
 from timbal.types.events.delta import DeltaEvent, TextDelta
 from timbal.types.events.output import OutputEvent
@@ -1602,3 +1603,84 @@ class TestBackgroundLimits:
         from timbal.state.background import current_background_store
 
         assert current_background_store().max_concurrent is None
+
+
+class TestBackgroundLogRetention:
+    """Ring-buffer logs + finished-task retention on the session bag."""
+
+    def test_log_ring_drops_head_and_reports_gapped(self):
+        log = BackgroundEventLog(max_events=2, max_bytes=None)
+        log.put_nowait("a")
+        log.put_nowait("b")
+        log.put_nowait("c")
+        assert log.forgotten_through == 1
+        assert log.qsize() == 2
+        events, cursor, gapped = log.read(after=0)
+        assert gapped is True
+        assert events == []
+        assert cursor == 0
+        events, cursor, gapped = log.read(after=log.forgotten_through)
+        assert gapped is False
+        assert events == ["b", "c"]
+        assert cursor == 3
+
+    @pytest.mark.asyncio
+    async def test_long_stream_respects_store_event_cap(self):
+        async def many_chunks(tag: str) -> AsyncGenerator[TextDelta, None]:
+            for i in range(6):
+                yield TextDelta(id="m", text_delta=f"{i}")
+                await asyncio.sleep(0.01)
+
+        from timbal.state.background import current_background_store
+
+        agent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("many", {"tag": "x"}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[Tool(name="many", handler=many_chunks, background_mode="auto")],
+            max_background_log_events=3,
+            max_background_concurrent=5,
+        )
+        await agent(prompt="go").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        await _wait_until_terminal(task_id)
+        snap = get_background_task(task_id)
+        assert snap["summary"]["event_count"] >= 6
+        assert snap["forgotten_through"] >= 3
+        page = read_background_transcript(task_id, after=0)
+        assert page["gapped"] is True
+        tail = read_background_transcript(task_id, after=page["forgotten_through"])
+        assert tail["gapped"] is False
+        assert len(tail["events"]) <= 3
+
+    @pytest.mark.asyncio
+    async def test_finished_task_reaped_after_retention(self):
+        async def quick(tag: str) -> str:
+            return tag
+
+        agent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("quick", {"tag": "A"}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[Tool(name="quick", handler=quick, background_mode="auto")],
+            background_task_retention_secs=0.05,
+            max_background_concurrent=5,
+        )
+        await agent(prompt="go").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        await _wait_until_terminal(task_id)
+        assert get_background_task(task_id)["status"] == "completed"
+        await asyncio.sleep(0.08)
+        from timbal.state.background import current_background_store
+
+        store = current_background_store()
+        store.reap_finished()
+        assert get_background_task(task_id)["status"] == "not_found"

--- a/python/tests/core/test_background_tasks.py
+++ b/python/tests/core/test_background_tasks.py
@@ -16,6 +16,7 @@ from timbal.state import (
     set_call_id,
     set_parent_call_id,
     set_run_context,
+    wait_for_background,
 )
 from timbal.state.background import BackgroundEventLog
 from timbal.types.content import ToolUseContent
@@ -1023,25 +1024,8 @@ class TestBackgroundMultitask:
 
 
 async def _wait_until_terminal(task_id: str, timeout: float = 5.0) -> dict:
-    """Wait until the child asyncio.Task is done and status is terminal.
-
-    ``status_code()`` can report ``cancelled`` as soon as cancel is requested,
-    before the done-callback has enqueued the completion notice — so we require
-    ``task.done()`` as well.
-    """
-    from timbal.state.background import current_background_store
-
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        store = current_background_store()
-        record = store.get(task_id) if store is not None else None
-        snap = get_background_task(task_id)
-        if record is not None and record.task.done() and snap["status"] != "running":
-            # Yield once so done-callbacks scheduled on this loop can run.
-            await asyncio.sleep(0)
-            return snap
-        await asyncio.sleep(0.01)
-    raise AssertionError(f"background task {task_id} never reached a terminal status")
+    """Wait until the child asyncio.Task is done and status is terminal."""
+    return await wait_for_background(task_id, timeout=timeout)
 
 
 def _completion_notices_in_memory(memory: list[Message]) -> list[str]:
@@ -1834,3 +1818,87 @@ class TestStructuredProgress:
         assert summary["last_tool"] == "write_file"
         assert summary["tools_in_flight"] == ["write_file"]
         assert summary["phase"] == "tool:write_file"
+
+
+class TestWaitForBackground:
+    @pytest.mark.asyncio
+    async def test_wait_until_terminal(self):
+        async def slow_task() -> str:
+            await asyncio.sleep(0.15)
+            return "done"
+
+        agent = Agent(
+            name="wait_agent",
+            model=TestModel(
+                responses=[
+                    _tool_call("slow_task", {}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[Tool(name="slow_task", handler=slow_task, background_mode="auto")],
+        )
+        await agent(prompt="go").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        snap = await wait_for_background(task_id, timeout=5.0)
+        assert snap["status"] == "completed"
+        assert snap["result"] == "done"
+
+    @pytest.mark.asyncio
+    async def test_wait_timeout_returns_running_snapshot(self):
+        async def slow_task() -> str:
+            await asyncio.sleep(2.0)
+            return "done"
+
+        agent = Agent(
+            name="wait_agent",
+            model=TestModel(
+                responses=[
+                    _tool_call("slow_task", {}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[Tool(name="slow_task", handler=slow_task, background_mode="auto")],
+        )
+        await agent(prompt="go").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        snap = await wait_for_background(task_id, timeout=0.05)
+        assert snap["status"] == "running"
+
+    @pytest.mark.asyncio
+    async def test_wait_after_long_polls_on_new_events(self):
+        gate = asyncio.Event()
+
+        async def streaming() -> AsyncGenerator[TextDelta, None]:
+            yield TextDelta(id="a", text_delta="first ")
+            await gate.wait()
+            yield TextDelta(id="a", text_delta="second")
+            await asyncio.Event().wait()
+
+        agent = Agent(
+            name="poll_agent",
+            model=TestModel(
+                responses=[
+                    _tool_call("streaming", {}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[Tool(name="streaming", handler=streaming, background_mode="auto")],
+        )
+        await agent(prompt="go").collect()
+        task_id = list_background_tasks()[0]["task_id"]
+        await _wait_for_first_event(task_id)
+        cursor = read_background_transcript(task_id)["cursor"]
+
+        wait_task = asyncio.create_task(wait_for_background(task_id, timeout=2.0, after=cursor))
+        await asyncio.sleep(0.05)
+        assert not wait_task.done()
+        gate.set()
+        snap = await wait_task
+        assert snap["status"] == "running"
+        assert snap["summary"]["event_count"] > cursor
+        assert "second" in snap["summary"]["text"]
+
+    @pytest.mark.asyncio
+    async def test_wait_not_found(self):
+        snap = await wait_for_background("missing_task_id")
+        assert snap["status"] == "not_found"

--- a/python/timbal/core/agent.py
+++ b/python/timbal/core/agent.py
@@ -45,6 +45,7 @@ from ..state.background import (
     GET_BACKGROUND_TASK_DESCRIPTION,
     LIST_BACKGROUND_TASKS_DESCRIPTION,
     current_background_store,
+    format_background_completion_notice,
 )
 from ..types.content import (
     CustomContent,
@@ -793,6 +794,33 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
             else:
                 await self._compact_on_resume(current_span, prev_usage=previous_span.usage)
 
+    def _inject_background_completions(self, current_span: Any) -> None:
+        """Drain session completion inbox into memory at turn start (Claude-style).
+
+        Delivered between turns only — never mid-loop — so the parent is not
+        interrupted while talking. Skipped for subagents and approval/suspend
+        resumes (must not insert a user message between tool_use and tool_result).
+        Peek APIs are unchanged; notices are one-shot after drain.
+        """
+        if current_span.parent_call_id is not None:
+            return
+        if self._find_pending_tool_uses(current_span.memory):
+            return
+        store = current_background_store()
+        if store is None:
+            return
+        notifications = store.drain_completions()
+        if not notifications:
+            return
+        notice = format_background_completion_notice(notifications)
+        memory = current_span.memory
+        # Sit immediately before the current user prompt so history stays
+        # [...prior turns..., completion notice, user prompt].
+        if memory and memory[-1].role == "user":
+            memory.insert(-1, notice)
+        else:
+            memory.append(notice)
+
     async def _compact_preserving_last_assistant(self, current_span: Any, *, prev_usage: dict | None) -> None:
         """Compact memory while protecting the trailing assistant message (and anything after
         it) from the compactor.
@@ -1311,11 +1339,15 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
             system_prompt = await self._resolve_system_prompt()
 
         await self.resolve_memory()
+        # After memory is assembled (and before the dump): push any background
+        # completions that finished since the last turn into the conversation.
+        self._inject_background_completions(current_span)
 
         prev_dump = getattr(current_span, "_prev_memory_dump", None)
         if prev_dump is not None and "compaction" not in current_span.metadata:
             # Reuse the already-serialized previous messages; only dump new ones
-            # (prompt + any synthetic tool results added by _synthesize_missing_tool_results).
+            # (prompt + any synthetic tool results added by _synthesize_missing_tool_results,
+            # plus background completion notices injected above).
             # If compaction ran it rewrites memory, invalidating the cached dump.
             new_messages = current_span.memory[len(prev_dump) :]
             current_span._memory_dump = prev_dump + await dump(new_messages)

--- a/python/timbal/core/agent.py
+++ b/python/timbal/core/agent.py
@@ -42,6 +42,9 @@ from ..guardrails.types import GuardrailContext, GuardrailStage, Verdict
 from ..state import get_run_context
 from ..state.background import (
     CANCEL_BACKGROUND_TASK_DESCRIPTION,
+    DEFAULT_BG_LOG_MAX_BYTES,
+    DEFAULT_BG_LOG_MAX_EVENTS,
+    DEFAULT_BG_TASK_RETENTION_SECS,
     GET_BACKGROUND_TASK_DESCRIPTION,
     LIST_BACKGROUND_TASKS_DESCRIPTION,
     current_background_store,
@@ -222,6 +225,15 @@ class Agent(Runnable):
     ``1`` allows only top-level (non-background) code to detach children —
     a background child cannot spawn further background work.
     Override with ``TIMBAL_MAX_BACKGROUND_DEPTH``."""
+    max_background_log_events: int | None = DEFAULT_BG_LOG_MAX_EVENTS
+    """Ring-buffer cap on events retained per background child (default 50_000).
+    ``None`` = unlimited. Env: ``TIMBAL_BG_LOG_MAX_EVENTS``."""
+    max_background_log_bytes: int | None = DEFAULT_BG_LOG_MAX_BYTES
+    """Ring-buffer byte cap per background child (default 32 MiB).
+    ``None`` = unlimited. Env: ``TIMBAL_BG_LOG_MAX_BYTES``."""
+    background_task_retention_secs: float = DEFAULT_BG_TASK_RETENTION_SECS
+    """Drop finished task records from the session bag after this many seconds
+    (default 300). ``0`` = keep forever. Env: ``TIMBAL_BG_TASK_RETENTION_SECS``."""
     max_tokens: int | None = None
     """Maximum tokens for the LLM response. Required for Anthropic models."""
     memory_compaction: list[SkipValidation[MemoryCompactor]] | SkipValidation[MemoryCompactor] | None = None
@@ -838,6 +850,9 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
             run_context,
             max_concurrent=self.max_background_concurrent,
             max_depth=self.max_background_depth,
+            max_log_events=self.max_background_log_events,
+            max_log_bytes=self.max_background_log_bytes,
+            task_retention_secs=self.background_task_retention_secs,
         )
 
     async def _compact_preserving_last_assistant(self, current_span: Any, *, prev_usage: dict | None) -> None:

--- a/python/timbal/core/agent.py
+++ b/python/timbal/core/agent.py
@@ -47,6 +47,7 @@ from ..state.background import (
     DEFAULT_BG_TASK_RETENTION_SECS,
     GET_BACKGROUND_TASK_DESCRIPTION,
     LIST_BACKGROUND_TASKS_DESCRIPTION,
+    READ_BACKGROUND_TRANSCRIPT_DESCRIPTION,
     current_background_store,
     format_background_completion_notice,
 )
@@ -234,6 +235,10 @@ class Agent(Runnable):
     background_task_retention_secs: float = DEFAULT_BG_TASK_RETENTION_SECS
     """Drop finished task records from the session bag after this many seconds
     (default 300). ``0`` = keep forever. Env: ``TIMBAL_BG_TASK_RETENTION_SECS``."""
+    background_transcript_tool: bool = False
+    """When True, register ``read_background_transcript`` for the LLM once this
+    session has background tasks. Default off — summaries via
+    ``get_background_task`` are enough for most agents."""
     max_tokens: int | None = None
     """Maximum tokens for the LLM response. Required for Anthropic models."""
     memory_compaction: list[SkipValidation[MemoryCompactor]] | SkipValidation[MemoryCompactor] | None = None
@@ -1051,11 +1056,20 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
 
         store = current_background_store()
         if store is not None and len(store) > 0:
-            for name, description, handler in (
+            bg_tools: list[tuple[str, str, Any]] = [
                 ("get_background_task", GET_BACKGROUND_TASK_DESCRIPTION, self.get_background_task),
                 ("list_background_tasks", LIST_BACKGROUND_TASKS_DESCRIPTION, self.list_background_tasks),
                 ("cancel_background_task", CANCEL_BACKGROUND_TASK_DESCRIPTION, self.cancel_background_task),
-            ):
+            ]
+            if self.background_transcript_tool:
+                bg_tools.append(
+                    (
+                        "read_background_transcript",
+                        READ_BACKGROUND_TRANSCRIPT_DESCRIPTION,
+                        self.read_background_transcript,
+                    )
+                )
+            for name, description, handler in bg_tools:
                 bg_tool = Tool(name=name, description=description, handler=handler)
                 bg_tool.nest(self._path)
                 _register(bg_tool)

--- a/python/timbal/core/agent.py
+++ b/python/timbal/core/agent.py
@@ -213,6 +213,15 @@ class Agent(Runnable):
     Mutually exclusive with skills_include."""
     max_iter: int = 10
     """Maximum number of LLM->tool call iterations before stopping."""
+    max_background_concurrent: int | None = 20
+    """Max in-flight background children for this agent's session bag.
+    ``None`` = unlimited. Applied at turn start; also settable via
+    ``TIMBAL_MAX_CONCURRENT_BACKGROUND`` when no Agent override is active yet."""
+    max_background_depth: int | None = None
+    """Max background spawn nesting depth. ``None`` = unlimited.
+    ``1`` allows only top-level (non-background) code to detach children —
+    a background child cannot spawn further background work.
+    Override with ``TIMBAL_MAX_BACKGROUND_DEPTH``."""
     max_tokens: int | None = None
     """Maximum tokens for the LLM response. Required for Anthropic models."""
     memory_compaction: list[SkipValidation[MemoryCompactor]] | SkipValidation[MemoryCompactor] | None = None
@@ -821,6 +830,16 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
         else:
             memory.append(notice)
 
+    def _apply_background_limits(self, run_context: Any) -> None:
+        """Push Agent concurrent/depth caps onto the session BG store."""
+        from ..state.background import apply_background_limits
+
+        apply_background_limits(
+            run_context,
+            max_concurrent=self.max_background_concurrent,
+            max_depth=self.max_background_depth,
+        )
+
     async def _compact_preserving_last_assistant(self, current_span: Any, *, prev_usage: dict | None) -> None:
         """Compact memory while protecting the trailing assistant message (and anything after
         it) from the compactor.
@@ -1339,6 +1358,8 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
             system_prompt = await self._resolve_system_prompt()
 
         await self.resolve_memory()
+        # Session BG caps (concurrent / depth) before tools can spawn this turn.
+        self._apply_background_limits(run_context)
         # After memory is assembled (and before the dump): push any background
         # completions that finished since the last turn into the conversation.
         self._inject_background_completions(current_span)

--- a/python/timbal/core/runnable.py
+++ b/python/timbal/core/runnable.py
@@ -313,6 +313,11 @@ class Runnable(ABC, BaseModel):
     ``timed_out``. ``None`` / non-positive = no deadline. Only applies when the
     runnable actually detaches (``background_mode`` / ``run_in_background``)."""
 
+    background_stall_timeout: float | None = None
+    """Optional seconds without log events before a background child is
+    cancelled as ``stalled``. Resets on every emitted event. Distinct from
+    ``background_timeout`` (wall-clock). ``None`` / non-positive = disabled."""
+
     on_background_cancel: Callable[..., Any] | None = Field(default=None, exclude=True)
     """Optional hook fired when ``cancel_background_task`` cancels this child.
     Receives the ``BackgroundTask`` record (has ``task_id``, ``metadata`` with
@@ -1605,6 +1610,7 @@ class Runnable(ABC, BaseModel):
                 task=task,
                 on_cancel=self.on_background_cancel,
                 timeout=self.background_timeout,
+                stall_timeout=self.background_stall_timeout,
             )
             registered = True
         except BaseException:

--- a/python/timbal/core/runnable.py
+++ b/python/timbal/core/runnable.py
@@ -1537,14 +1537,26 @@ class Runnable(ABC, BaseModel):
         across sequential turns via ``parent_id``). They are **not** yielded
         back onto the parent stream after detach.
         """
-        from ..state.background import register_background_task
+        from ..state.background import (
+            ensure_background_store,
+            get_background_depth,
+            register_background_task,
+            reset_background_depth,
+            set_background_depth,
+        )
 
         parent_span = run_context.parent_span()
         if not parent_span:
             raise ValueError("Parent span not found. Cannot run in background.")
+
+        store = ensure_background_store(run_context)
+        depth = get_background_depth()
+        # Reserve before create_task so parallel tool spawns cannot overrun the cap.
+        store.begin_spawn(depth)
         record_box: list[Any] = []
 
         async def _bg_handler_execution():
+            token = set_background_depth(depth + 1)
             record = record_box[0]
             output = None
             try:
@@ -1567,17 +1579,28 @@ class Runnable(ABC, BaseModel):
             except asyncio.CancelledError:
                 raise
             finally:
+                reset_background_depth(token)
                 record.log.close()
             return output
 
-        task = asyncio.create_task(_bg_handler_execution(), context=contextvars.copy_context())
-        record = register_background_task(
-            name=self.name,
-            input=input,
-            task=task,
-            on_cancel=self.on_background_cancel,
-            timeout=self.background_timeout,
-        )
+        task: asyncio.Task | None = None
+        registered = False
+        try:
+            task = asyncio.create_task(_bg_handler_execution(), context=contextvars.copy_context())
+            record = register_background_task(
+                name=self.name,
+                input=input,
+                task=task,
+                on_cancel=self.on_background_cancel,
+                timeout=self.background_timeout,
+            )
+            registered = True
+        except BaseException:
+            if not registered:
+                store.abort_spawn()
+                if task is not None:
+                    task.cancel()
+            raise
         record_box.append(record)
         return {"task_id": record.task_id, "status": "running"}
 

--- a/python/timbal/core/runnable.py
+++ b/python/timbal/core/runnable.py
@@ -869,6 +869,18 @@ class Runnable(ABC, BaseModel):
 
         return _read(task_id, after=after)
 
+    async def wait_for_background(
+        self,
+        task_id: str,
+        *,
+        timeout: float | None = None,
+        after: int | None = None,
+    ) -> dict[str, Any]:
+        """Block until a session background child is terminal or new events arrive."""
+        from ..state.background import wait_for_background as _wait
+
+        return await _wait(task_id, timeout=timeout, after=after)
+
     async def _execute_runtime_callable(self, fn: Callable[..., Any], is_coroutine: bool) -> Any:
         """Execute a runtime callable handling async context automatically.
 

--- a/python/timbal/core/runnable.py
+++ b/python/timbal/core/runnable.py
@@ -834,16 +834,23 @@ class Runnable(ABC, BaseModel):
         return self.anthropic_schema
 
     def get_background_task(self, task_id: str) -> dict[str, Any]:
-        """Peek a summary of a session-scoped background task. Does not drain."""
+        """Peek a summary of a session-scoped background task. Does not drain.
+
+        Acks a pending completion notice when the child is already terminal so
+        the next turn does not re-announce a status the model just fetched.
+        """
         from ..state.background import get_background_task as _get
 
-        return _get(task_id)
+        return _get(task_id, ack_completion=True)
 
     def list_background_tasks(self) -> list[dict[str, Any]]:
-        """List background tasks for the current session."""
+        """List background tasks for the current session.
+
+        Acks completion notices for any terminal children returned.
+        """
         from ..state.background import list_background_tasks as _list
 
-        return _list()
+        return _list(ack_completion=True)
 
     def cancel_background_task(self, task_id: str) -> dict[str, Any]:
         """Cancel a running background task in the current session."""

--- a/python/timbal/core/runnable.py
+++ b/python/timbal/core/runnable.py
@@ -308,6 +308,11 @@ class Runnable(ABC, BaseModel):
     background_mode: Literal["auto", "always", "never"] = "never"
     """Background execution mode"""
 
+    background_timeout: float | None = None
+    """Optional wall-clock seconds before a background child is cancelled as
+    ``timed_out``. ``None`` / non-positive = no deadline. Only applies when the
+    runnable actually detaches (``background_mode`` / ``run_in_background``)."""
+
     on_background_cancel: Callable[..., Any] | None = Field(default=None, exclude=True)
     """Optional hook fired when ``cancel_background_task`` cancels this child.
     Receives the ``BackgroundTask`` record (has ``task_id``, ``metadata`` with
@@ -1571,6 +1576,7 @@ class Runnable(ABC, BaseModel):
             input=input,
             task=task,
             on_cancel=self.on_background_cancel,
+            timeout=self.background_timeout,
         )
         record_box.append(record)
         return {"task_id": record.task_id, "status": "running"}

--- a/python/timbal/state/__init__.py
+++ b/python/timbal/state/__init__.py
@@ -7,7 +7,7 @@ Public API:
     - get_run_context(): Retrieves the current run context.
     - get_or_create_run_context(): Retrieves the current run context, creating a new one if necessary.
     - get_background_task / list_background_tasks / cancel_background_task /
-      read_background_transcript: session-scoped background children.
+      read_background_transcript / wait_for_background: session-scoped background children.
 
 The context is typically managed automatically by the framework. Advanced users
 may need to set the context manually when creating custom execution flows.
@@ -31,6 +31,9 @@ from .background import (
 )
 from .background import (
     read_background_transcript as read_background_transcript,
+)
+from .background import (
+    wait_for_background as wait_for_background,
 )
 from .context import RunContext
 

--- a/python/timbal/state/background.py
+++ b/python/timbal/state/background.py
@@ -1153,3 +1153,12 @@ CANCEL_BACKGROUND_TASK_DESCRIPTION = (
     "or list_background_tasks). Stops the child's in-flight work. Use when the "
     "user says to stop/cancel a builder or background task."
 )
+
+READ_BACKGROUND_TRANSCRIPT_DESCRIPTION = (
+    "Read raw events from a background task's append-only log. Use when "
+    "get_background_task's summary is not enough — e.g. to inspect streaming "
+    "output or tool calls mid-build. Pass task_id and optional after (logical "
+    "cursor from a prior read or from get_background_task's transcript_cursor). "
+    "Does not drain — safe to re-read. Page with after on long tasks; when "
+    "gapped is true, events before forgotten_through were dropped from the ring."
+)

--- a/python/timbal/state/background.py
+++ b/python/timbal/state/background.py
@@ -13,6 +13,15 @@ stores.
 The event log is append-only. ``get_background_task`` peeks a summary; it does
 not drain. Raw events are ``read_background_transcript(after=)`` or
 :meth:`BackgroundEventLog.subscribe`.
+
+When a child reaches a terminal status, the store enqueues a one-shot
+completion notice. The parent agent drains that inbox at the **start** of the
+next turn and injects a synthetic user message so the LLM learns without
+polling — never mid-turn while the parent is still talking.
+
+If the parent already learned via the LLM ``get_background_task`` /
+``list_background_tasks`` tools (``ack_completion=True``), the notice is
+dropped so the next turn does not re-announce a completion the model handled.
 """
 
 from __future__ import annotations
@@ -23,8 +32,11 @@ from collections.abc import AsyncIterator, Callable
 from typing import Any
 
 _SUMMARY_TEXT_CHARS = 1_000
+_COMPLETION_SUMMARY_CHARS = 300
+_RESULT_PREVIEW_CHARS = 500
 _TASK_ID_LEN = 12
 _ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"
+_TERMINAL_STATUSES = frozenset({"completed", "error", "cancelled"})
 
 # Process-local: run_id → store. Sequential turns find the bag via parent_id.
 # Concurrent siblings (no parent_id) each create a new store.
@@ -123,6 +135,60 @@ def _title_from_input(name: str, input: dict[str, Any]) -> str:
             if text:
                 return text if len(text) <= 80 else text[:77] + "..."
     return name
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3] + "..."
+
+
+def _preview_value(value: Any, *, limit: int = _RESULT_PREVIEW_CHARS) -> str:
+    """Short, context-safe preview of a terminal result (not a full dump)."""
+    if value is None:
+        return ""
+    collect = getattr(value, "collect_text", None)
+    if callable(collect):
+        try:
+            text = collect() or ""
+        except Exception:
+            text = str(value)
+    elif isinstance(value, str):
+        text = value
+    else:
+        text = str(value)
+    return _truncate(text.strip(), limit)
+
+
+def format_background_completion_notice(notifications: list[dict[str, Any]]) -> Any:
+    """Build the user-role message injected at the start of the next parent turn."""
+    from ..types.content import TextContent
+    from ..types.message import Message
+
+    blocks: list[str] = []
+    for note in notifications:
+        lines = [
+            f"task_id: {note['task_id']}",
+            f"name: {note['name']}",
+            f"status: {note['status']}",
+        ]
+        title = note.get("title")
+        if title:
+            lines.insert(2, f"title: {title}")
+        if note.get("error"):
+            lines.append(f"error: {note['error']}")
+        elif note.get("result"):
+            lines.append(f"result: {note['result']}")
+        summary = note.get("summary")
+        if summary:
+            lines.append(f"summary: {summary}")
+        blocks.append("<background_task_completed>\n" + "\n".join(lines) + "\n</background_task_completed>")
+
+    header = (
+        "Background task(s) finished since your last turn. "
+        "You do not need to poll get_background_task unless you want more detail.\n\n"
+    )
+    return Message(role="user", content=[TextContent(text=header + "\n\n".join(blocks))])
 
 
 class BackgroundEventLog:
@@ -289,10 +355,21 @@ class BackgroundTask:
 
 class BackgroundTaskStore:
     """Per-session bag of background children. Shared across sequential
-    ``RunContext``s in the same parent_id chain; not across concurrent runs."""
+    ``RunContext``s in the same parent_id chain; not across concurrent runs.
+
+    Terminal children enqueue a one-shot completion notice on
+    :attr:`_completion_inbox`. The parent agent drains that inbox at the
+    **start** of the next turn (not mid-turn) so the LLM learns without
+    polling ``get_background_task``. LLM peeks with ``ack_completion=True``
+    suppress the pending notice for that child.
+    """
 
     def __init__(self) -> None:
         self._tasks: dict[str, BackgroundTask] = {}
+        # Ordered, one-shot queue of lean completion payloads for the parent LLM.
+        self._completion_inbox: list[dict[str, Any]] = []
+        # task_ids already enqueued, drained, or acked via peek — never re-inject.
+        self._completion_notified: set[str] = set()
 
     def __len__(self) -> int:
         return len(self._tasks)
@@ -302,18 +379,33 @@ class BackgroundTaskStore:
 
     def add(self, record: BackgroundTask) -> None:
         self._tasks[record.task_id] = record
+        # Enqueue when the asyncio.Task reaches a terminal state. Done callbacks
+        # run on the loop thread; keep this sync and never raise.
+        task = record.task
+        if task.done():
+            self._enqueue_completion(record)
+        else:
+            task.add_done_callback(lambda _t: self._enqueue_completion(record))
 
     def get(self, task_id: str) -> BackgroundTask | None:
         return self._tasks.get(task_id)
 
-    def list(self) -> list[dict[str, Any]]:
-        return [record.listing() for record in self._tasks.values()]
+    def list(self, *, ack_completion: bool = False) -> list[dict[str, Any]]:
+        listings = [record.listing() for record in self._tasks.values()]
+        if ack_completion:
+            for item in listings:
+                if item.get("status") in _TERMINAL_STATUSES:
+                    self.ack_completion(item["task_id"])
+        return listings
 
-    def snapshot(self, task_id: str) -> dict[str, Any]:
+    def snapshot(self, task_id: str, *, ack_completion: bool = False) -> dict[str, Any]:
         record = self._tasks.get(task_id)
         if record is None:
             return {"status": "not_found", "task_id": task_id}
-        return record.summarize()
+        snap = record.summarize()
+        if ack_completion and snap.get("status") in _TERMINAL_STATUSES:
+            self.ack_completion(task_id)
+        return snap
 
     def transcript(self, task_id: str, after: int = 0) -> dict[str, Any]:
         record = self._tasks.get(task_id)
@@ -344,6 +436,56 @@ class BackgroundTaskStore:
             except Exception:
                 pass
         return record.summarize()
+
+    def ack_completion(self, task_id: str) -> None:
+        """Mark ``task_id`` as already delivered to the parent LLM.
+
+        Drops any pending inbox entry and blocks a later done-callback from
+        re-enqueuing. Used when the model polls a terminal child mid-turn.
+        """
+        self._completion_notified.add(task_id)
+        if self._completion_inbox:
+            self._completion_inbox = [n for n in self._completion_inbox if n["task_id"] != task_id]
+
+    def _enqueue_completion(self, record: BackgroundTask) -> None:
+        """Push a lean notice if this child just became terminal (once)."""
+        if record.task_id in self._completion_notified:
+            return
+        # status_code() can report cancelled as soon as cancel is requested,
+        # before the asyncio.Task has actually finished — wait for done.
+        if not record.task.done():
+            return
+        status = record.status_code()
+        if status not in _TERMINAL_STATUSES:
+            return
+        self._completion_notified.add(record.task_id)
+        snap = record.summarize()
+        summary_text = ""
+        summary = snap.get("summary")
+        if isinstance(summary, dict):
+            summary_text = _truncate(str(summary.get("text") or ""), _COMPLETION_SUMMARY_CHARS)
+        note: dict[str, Any] = {
+            "task_id": snap["task_id"],
+            "name": snap["name"],
+            "title": snap.get("title"),
+            "status": status,
+            "summary": summary_text,
+        }
+        if status == "error":
+            note["error"] = str(snap.get("error") or "unknown error")
+        elif status == "completed" and "result" in snap:
+            note["result"] = _preview_value(snap["result"])
+        self._completion_inbox.append(note)
+
+    def pending_completions(self) -> list[dict[str, Any]]:
+        """Peek the completion inbox without draining (tests / UIs)."""
+        return list(self._completion_inbox)
+
+    def drain_completions(self) -> list[dict[str, Any]]:
+        """Take all pending completion notices. Empty after a successful drain."""
+        notices = self._completion_inbox
+        self._completion_inbox = []
+        return notices
 
 
 def bind_background_store(run_context: Any) -> BackgroundTaskStore | None:
@@ -394,7 +536,7 @@ def current_background_store() -> BackgroundTaskStore | None:
     return getattr(run_context, "_bg_store", None)
 
 
-def get_background_task(task_id: str) -> dict[str, Any]:
+def get_background_task(task_id: str, *, ack_completion: bool = False) -> dict[str, Any]:
     """Peek a summary of a background task. Does not drain the event log.
 
     Use this to answer questions about an in-flight or finished background
@@ -402,23 +544,29 @@ def get_background_task(task_id: str) -> dict[str, Any]:
     ``cursor_agent_id``, ``run_id``). You must have a ``task_id`` from a
     previous background-tool result or from ``list_background_tasks``.
     Raw events: ``read_background_transcript``.
+
+    When ``ack_completion`` is true and the child is terminal, any pending
+    completion notice for this task is dropped (LLM tool path).
     """
     store = current_background_store()
     if store is None:
         return {"status": "not_found", "task_id": task_id}
-    return store.snapshot(task_id)
+    return store.snapshot(task_id, ack_completion=ack_completion)
 
 
-def list_background_tasks() -> list[dict[str, Any]]:
+def list_background_tasks(*, ack_completion: bool = False) -> list[dict[str, Any]]:
     """List background tools for this session (not other concurrent runs).
 
     Returns ``[{task_id, name, status, started_at, title}]``. Use a ``task_id``
     with ``get_background_task`` to answer questions about a child.
+
+    When ``ack_completion`` is true, terminal children are treated as already
+    delivered (LLM tool path) so the next turn does not re-inject notices.
     """
     store = current_background_store()
     if store is None:
         return []
-    return store.list()
+    return store.list(ack_completion=ack_completion)
 
 
 def cancel_background_task(task_id: str) -> dict[str, Any]:

--- a/python/timbal/state/background.py
+++ b/python/timbal/state/background.py
@@ -22,6 +22,10 @@ polling — never mid-turn while the parent is still talking.
 Optional ``timeout`` (seconds) on a child cancels it as ``timed_out`` when the
 deadline elapses (Task cancel + handler ``aclose`` + ``on_background_cancel``).
 
+Session caps bound fan-out: ``max_concurrent`` (in-flight) and ``max_depth``
+(nesting). Defaults come from ``TIMBAL_MAX_CONCURRENT_BACKGROUND`` (20) and
+``TIMBAL_MAX_BACKGROUND_DEPTH`` (unlimited); Agents can override per session.
+
 If the parent already learned via the LLM ``get_background_task`` /
 ``list_background_tasks`` tools (``ack_completion=True``), the notice is
 dropped so the next turn does not re-announce a completion the model handled.
@@ -30,6 +34,8 @@ dropped so the next turn does not re-announce a completion the model handled.
 from __future__ import annotations
 
 import asyncio
+import contextvars
+import os
 import time
 from collections.abc import AsyncIterator, Callable
 from typing import Any
@@ -46,6 +52,63 @@ _TERMINAL_STATUSES = frozenset({"completed", "error", "cancelled", "timed_out"})
 _STORES_BY_RUN_ID: dict[str, BackgroundTaskStore] = {}
 
 _DONE = object()
+_UNSET = object()
+
+# Nesting depth of the current coroutine relative to top-level session work.
+# 0 = parent agent/turn; each detached child increments by 1 for its body.
+_background_depth: contextvars.ContextVar[int] = contextvars.ContextVar("timbal_background_depth", default=0)
+
+
+class BackgroundLimitError(RuntimeError):
+    """Raised when a spawn would exceed concurrent or depth caps."""
+
+
+def get_background_depth() -> int:
+    return _background_depth.get()
+
+
+def set_background_depth(depth: int) -> contextvars.Token[int]:
+    return _background_depth.set(depth)
+
+
+def reset_background_depth(token: contextvars.Token[int]) -> None:
+    _background_depth.reset(token)
+
+
+def _default_max_concurrent() -> int | None:
+    """Default in-flight cap. ``TIMBAL_MAX_CONCURRENT_BACKGROUND`` overrides.
+
+    Unset → 20. ``0`` / ``none`` / ``unlimited`` → no cap.
+    """
+    raw = os.environ.get("TIMBAL_MAX_CONCURRENT_BACKGROUND")
+    if raw is None:
+        return 20
+    text = raw.strip().lower()
+    if text in ("", "0", "none", "unlimited"):
+        return None
+    try:
+        value = int(text)
+    except ValueError:
+        return 20
+    return None if value <= 0 else value
+
+
+def _default_max_depth() -> int | None:
+    """Default spawn-depth cap. ``TIMBAL_MAX_BACKGROUND_DEPTH`` overrides.
+
+    Unset / ``none`` / ``unlimited`` → no cap. ``1`` = only top-level may spawn.
+    """
+    raw = os.environ.get("TIMBAL_MAX_BACKGROUND_DEPTH")
+    if raw is None:
+        return None
+    text = raw.strip().lower()
+    if text in ("", "none", "unlimited"):
+        return None
+    try:
+        value = int(text)
+    except ValueError:
+        return None
+    return None if value < 0 else value
 
 
 def _new_task_id() -> str:
@@ -412,12 +475,24 @@ class BackgroundTaskStore:
     suppress the pending notice for that child.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        max_concurrent: int | None | object = _UNSET,
+        max_depth: int | None | object = _UNSET,
+    ) -> None:
         self._tasks: dict[str, BackgroundTask] = {}
         # Ordered, one-shot queue of lean completion payloads for the parent LLM.
         self._completion_inbox: list[dict[str, Any]] = []
         # task_ids already enqueued, drained, or acked via peek — never re-inject.
         self._completion_notified: set[str] = set()
+        self.max_concurrent = (
+            _default_max_concurrent() if max_concurrent is _UNSET else max_concurrent  # type: ignore[assignment]
+        )
+        self.max_depth = _default_max_depth() if max_depth is _UNSET else max_depth  # type: ignore[assignment]
+        # Spawns that passed check_can_spawn but are not yet in ``_tasks``
+        # (between create_task and add). Counts toward the concurrent cap.
+        self._pending_spawns = 0
 
     def __len__(self) -> int:
         return len(self._tasks)
@@ -425,7 +500,43 @@ class BackgroundTaskStore:
     def __contains__(self, task_id: str) -> bool:
         return task_id in self._tasks
 
+    def running_count(self) -> int:
+        """In-flight children + spawns reserved but not yet registered."""
+        live = sum(1 for record in self._tasks.values() if not record.task.done())
+        return live + self._pending_spawns
+
+    def check_can_spawn(self, depth: int | None = None) -> None:
+        """Raise :class:`BackgroundLimitError` if a new spawn is not allowed."""
+        if depth is None:
+            depth = get_background_depth()
+        if self.max_depth is not None and depth >= self.max_depth:
+            raise BackgroundLimitError(
+                f"Background spawn depth limit reached "
+                f"(depth={depth}, max_background_depth={self.max_depth}). "
+                "Nested background spawns are not allowed at this depth."
+            )
+        if self.max_concurrent is not None:
+            running = self.running_count()
+            if running >= self.max_concurrent:
+                raise BackgroundLimitError(
+                    f"Concurrent background limit reached "
+                    f"({running}/{self.max_concurrent}). "
+                    "Wait for a task to finish or cancel one before spawning another."
+                )
+
+    def begin_spawn(self, depth: int | None = None) -> None:
+        """Atomically reserve a concurrent slot (check + pending++)."""
+        self.check_can_spawn(depth)
+        self._pending_spawns += 1
+
+    def abort_spawn(self) -> None:
+        """Release a reservation if registration fails after :meth:`begin_spawn`."""
+        if self._pending_spawns > 0:
+            self._pending_spawns -= 1
+
     def add(self, record: BackgroundTask) -> None:
+        if self._pending_spawns > 0:
+            self._pending_spawns -= 1
         self._tasks[record.task_id] = record
         # Enqueue when the asyncio.Task reaches a terminal state. Done callbacks
         # run on the loop thread; keep this sync and never raise.
@@ -564,6 +675,26 @@ def bind_background_store(run_context: Any) -> BackgroundTaskStore | None:
     return store
 
 
+def apply_background_limits(
+    run_context: Any,
+    *,
+    max_concurrent: int | None | object = _UNSET,
+    max_depth: int | None | object = _UNSET,
+) -> None:
+    """Stash session caps on the RunContext and update an existing store."""
+    if max_concurrent is not _UNSET:
+        run_context._bg_max_concurrent = max_concurrent
+    if max_depth is not _UNSET:
+        run_context._bg_max_depth = max_depth
+    store = getattr(run_context, "_bg_store", None)
+    if store is None:
+        return
+    if max_concurrent is not _UNSET:
+        store.max_concurrent = max_concurrent  # type: ignore[assignment]
+    if max_depth is not _UNSET:
+        store.max_depth = max_depth  # type: ignore[assignment]
+
+
 def ensure_background_store(run_context: Any) -> BackgroundTaskStore:
     """Get (creating if needed) the session bag, and register it for chaining.
 
@@ -572,7 +703,13 @@ def ensure_background_store(run_context: Any) -> BackgroundTaskStore:
     """
     store = run_context._bg_store
     if store is None:
-        store = BackgroundTaskStore()
+        max_concurrent = (
+            run_context._bg_max_concurrent
+            if hasattr(run_context, "_bg_max_concurrent")
+            else _UNSET
+        )
+        max_depth = run_context._bg_max_depth if hasattr(run_context, "_bg_max_depth") else _UNSET
+        store = BackgroundTaskStore(max_concurrent=max_concurrent, max_depth=max_depth)
         run_context._bg_store = store
     _STORES_BY_RUN_ID[run_context.id] = store
     return store
@@ -662,6 +799,7 @@ def register_background_task(
     """Register a running child on the current session bag.
 
     ``timeout`` is seconds until the child is cancelled as ``timed_out``.
+    Raises :class:`BackgroundLimitError` if concurrent/depth caps would be exceeded.
     """
     from . import get_run_context
 
@@ -669,6 +807,10 @@ def register_background_task(
     if run_context is None:
         raise RuntimeError("Cannot register a background task without a RunContext.")
     store = ensure_background_store(run_context)
+    # Slot already reserved by Runnable._spawn_background_task via begin_spawn;
+    # direct callers must begin_spawn (or accept check_can_spawn here without reserve).
+    if store._pending_spawns == 0:
+        store.check_can_spawn()
     record = BackgroundTask(
         _new_task_id(),
         name=name,

--- a/python/timbal/state/background.py
+++ b/python/timbal/state/background.py
@@ -444,6 +444,7 @@ class BackgroundEventLog:
         self._nbytes = 0
         self.forgotten_through = 0
         self._subscribers: list[asyncio.Queue] = []
+        self._waiters: list[asyncio.Future[None]] = []
         self._closed = False
 
     @property
@@ -461,6 +462,39 @@ class BackgroundEventLog:
         self._trim()
         for queue in self._subscribers:
             queue.put_nowait(event)
+        self._wake_waiters()
+
+    def _wake_waiters(self) -> None:
+        for waiter in self._waiters:
+            if not waiter.done():
+                waiter.set_result(None)
+        self._waiters.clear()
+
+    def _discard_waiter(self, waiter: asyncio.Future[None]) -> None:
+        try:
+            self._waiters.remove(waiter)
+        except ValueError:
+            pass
+
+    async def wait(self, after: int = 0, timeout: float | None = None) -> None:
+        """Block until ``cursor_end > after``, the log :meth:`close`s, or timeout.
+
+        Returns (does not raise) on timeout — callers re-read the snapshot.
+        """
+        if after < self.forgotten_through or self.cursor_end > after or self._closed:
+            return
+        loop = asyncio.get_running_loop()
+        waiter = loop.create_future()
+        self._waiters.append(waiter)
+        try:
+            if timeout is None:
+                await waiter
+            elif timeout > 0:
+                await asyncio.wait_for(waiter, timeout)
+        except TimeoutError:
+            pass
+        finally:
+            self._discard_waiter(waiter)
 
     def peek(self, after: int = 0) -> tuple[list[Any], bool]:
         """Return ``(events, gapped)`` from logical cursor ``after``."""
@@ -508,6 +542,7 @@ class BackgroundEventLog:
         self._closed = True
         for queue in self._subscribers:
             queue.put_nowait(_DONE)
+        self._wake_waiters()
 
     def _over_cap(self, n: int, nbytes: int) -> bool:
         return (self._max_events > 0 and n > self._max_events) or (
@@ -1087,6 +1122,72 @@ def read_background_transcript(task_id: str, after: int = 0) -> dict[str, Any]:
             "forgotten_through": 0,
         }
     return store.transcript(task_id, after=after)
+
+
+async def wait_for_background(
+    task_id: str,
+    *,
+    timeout: float | None = None,
+    after: int | None = None,
+) -> dict[str, Any]:
+    """Block until a background child is ready to report, then return its snapshot.
+
+    Without ``after``, waits for a **terminal** status (``completed``,
+    ``error``, ``cancelled``, ``timed_out``). With ``after``, long-polls until
+    the event log advances past that logical cursor, the child finishes, or
+    ``timeout`` elapses — whichever comes first.
+
+    Returns the same dict shape as :func:`get_background_task` (does not ack
+    completion notices). On timeout while still running, returns the current
+    snapshot so callers can poll again.
+    """
+    store = current_background_store()
+    if store is None:
+        return {"status": "not_found", "task_id": task_id}
+
+    record = store.get(task_id)
+    if record is None:
+        return {"status": "not_found", "task_id": task_id}
+
+    def _is_ready(rec: BackgroundTask) -> bool:
+        if after is not None and rec.log.cursor_end > after:
+            return True
+        return rec.task.done() and rec.status_code() in _TERMINAL_STATUSES
+
+    async def _yield_for_callbacks(rec: BackgroundTask) -> None:
+        if rec.task.done():
+            await asyncio.sleep(0)
+
+    if _is_ready(record):
+        await _yield_for_callbacks(record)
+        fresh = store.get(task_id)
+        return fresh.summarize() if fresh is not None else {"status": "not_found", "task_id": task_id}
+
+    if after is None:
+        wait_set = {record.task}
+        if timeout is None:
+            await asyncio.wait(wait_set)
+        else:
+            await asyncio.wait(wait_set, timeout=timeout)
+        await _yield_for_callbacks(record)
+        fresh = store.get(task_id)
+        return fresh.summarize() if fresh is not None else {"status": "not_found", "task_id": task_id}
+
+    deadline = None if timeout is None else time.monotonic() + timeout
+    while True:
+        rec = store.get(task_id)
+        if rec is None:
+            return {"status": "not_found", "task_id": task_id}
+        if _is_ready(rec):
+            await _yield_for_callbacks(rec)
+            return rec.summarize()
+
+        remaining = None if deadline is None else deadline - time.monotonic()
+        if remaining is not None and remaining <= 0:
+            return rec.summarize()
+
+        wait_timeout = remaining if remaining is not None else None
+        await rec.log.wait(after, timeout=wait_timeout)
 
 
 def register_background_task(

--- a/python/timbal/state/background.py
+++ b/python/timbal/state/background.py
@@ -19,6 +19,9 @@ completion notice. The parent agent drains that inbox at the **start** of the
 next turn and injects a synthetic user message so the LLM learns without
 polling — never mid-turn while the parent is still talking.
 
+Optional ``timeout`` (seconds) on a child cancels it as ``timed_out`` when the
+deadline elapses (Task cancel + handler ``aclose`` + ``on_background_cancel``).
+
 If the parent already learned via the LLM ``get_background_task`` /
 ``list_background_tasks`` tools (``ack_completion=True``), the notice is
 dropped so the next turn does not re-announce a completion the model handled.
@@ -36,7 +39,7 @@ _COMPLETION_SUMMARY_CHARS = 300
 _RESULT_PREVIEW_CHARS = 500
 _TASK_ID_LEN = 12
 _ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"
-_TERMINAL_STATUSES = frozenset({"completed", "error", "cancelled"})
+_TERMINAL_STATUSES = frozenset({"completed", "error", "cancelled", "timed_out"})
 
 # Process-local: run_id → store. Sequential turns find the bag via parent_id.
 # Concurrent siblings (no parent_id) each create a new store.
@@ -248,6 +251,7 @@ class BackgroundTask:
         started_at: int,
         title: str | None = None,
         on_cancel: Callable[..., Any] | None = None,
+        timeout: float | None = None,
     ) -> None:
         self.task_id = task_id
         self.name = name
@@ -258,8 +262,45 @@ class BackgroundTask:
         self.log = BackgroundEventLog()
         self.metadata: dict[str, Any] = {}
         self.on_cancel = on_cancel
+        self.timeout = timeout
         self._cancel_requested = False
+        self._timed_out = False
+        self._timeout_handle: asyncio.TimerHandle | None = None
         self._handler_aclose: Callable[..., Any] | None = None
+
+    def schedule_timeout(self) -> None:
+        """Arm a one-shot deadline; no-op when ``timeout`` is unset or non-positive."""
+        if self.timeout is None or self.timeout <= 0:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        self._timeout_handle = loop.call_later(self.timeout, self._on_timeout)
+
+    def clear_timeout(self) -> None:
+        handle = self._timeout_handle
+        self._timeout_handle = None
+        if handle is not None:
+            handle.cancel()
+
+    def _on_timeout(self) -> None:
+        """Cancel the child and mark ``timed_out`` (distinct from user cancel)."""
+        self._timeout_handle = None
+        if self.task.done():
+            return
+        self._timed_out = True
+        self._cancel_requested = True
+        self.task.cancel()
+        try:
+            asyncio.get_running_loop().create_task(self.aclose_handler())
+        except RuntimeError:
+            pass
+        if self.on_cancel is not None:
+            try:
+                self.on_cancel(self)
+            except Exception:
+                pass
 
     async def aclose_handler(self) -> None:
         """Stop the child's handler gen, not just the wrapping asyncio.Task.
@@ -297,6 +338,8 @@ class BackgroundTask:
 
     def status_code(self) -> str:
         task = self.task
+        if self._timed_out:
+            return "timed_out"
         if self._cancel_requested or (task.done() and task.cancelled()):
             return "cancelled"
         if not task.done():
@@ -334,8 +377,13 @@ class BackgroundTask:
             },
             "transcript_cursor": len(events),
         }
+        if self.timeout is not None:
+            snapshot["timeout"] = self.timeout
         snapshot.update(self.metadata)
-        if self.task.done() and not self.task.cancelled():
+        if self._timed_out:
+            timeout = self.timeout
+            snapshot["error"] = f"Timed out after {timeout:g}s" if timeout else "Timed out"
+        elif self.task.done() and not self.task.cancelled():
             exc = self.task.exception()
             if exc is not None:
                 snapshot["error"] = str(exc)
@@ -382,10 +430,17 @@ class BackgroundTaskStore:
         # Enqueue when the asyncio.Task reaches a terminal state. Done callbacks
         # run on the loop thread; keep this sync and never raise.
         task = record.task
+        record.schedule_timeout()
         if task.done():
+            record.clear_timeout()
             self._enqueue_completion(record)
         else:
-            task.add_done_callback(lambda _t: self._enqueue_completion(record))
+
+            def _on_done(_t: asyncio.Task) -> None:
+                record.clear_timeout()
+                self._enqueue_completion(record)
+
+            task.add_done_callback(_on_done)
 
     def get(self, task_id: str) -> BackgroundTask | None:
         return self._tasks.get(task_id)
@@ -423,6 +478,7 @@ class BackgroundTaskStore:
         record = self._tasks.get(task_id)
         if record is None:
             return {"status": "not_found", "task_id": task_id}
+        record.clear_timeout()
         if not record.task.done():
             record._cancel_requested = True
             record.task.cancel()
@@ -471,8 +527,8 @@ class BackgroundTaskStore:
             "status": status,
             "summary": summary_text,
         }
-        if status == "error":
-            note["error"] = str(snap.get("error") or "unknown error")
+        if status in ("error", "timed_out"):
+            note["error"] = str(snap.get("error") or ("Timed out" if status == "timed_out" else "unknown error"))
         elif status == "completed" and "result" in snap:
             note["result"] = _preview_value(snap["result"])
         self._completion_inbox.append(note)
@@ -601,8 +657,12 @@ def register_background_task(
     task: asyncio.Task,
     on_cancel: Callable[..., Any] | None = None,
     started_at: int | None = None,
+    timeout: float | None = None,
 ) -> BackgroundTask:
-    """Register a running child on the current session bag."""
+    """Register a running child on the current session bag.
+
+    ``timeout`` is seconds until the child is cancelled as ``timed_out``.
+    """
     from . import get_run_context
 
     run_context = get_run_context()
@@ -616,6 +676,7 @@ def register_background_task(
         task=task,
         started_at=started_at if started_at is not None else int(time.time() * 1000),
         on_cancel=on_cancel,
+        timeout=timeout,
     )
     store.add(record)
     return record

--- a/python/timbal/state/background.py
+++ b/python/timbal/state/background.py
@@ -21,6 +21,8 @@ polling — never mid-turn while the parent is still talking.
 
 Optional ``timeout`` (seconds) on a child cancels it as ``timed_out`` when the
 deadline elapses (Task cancel + handler ``aclose`` + ``on_background_cancel``).
+Optional ``stall_timeout`` cancels as ``stalled`` when no log events arrive
+within the window (resets on every event).
 
 Session caps bound fan-out: ``max_concurrent`` (in-flight) and ``max_depth``
 (nesting). Defaults come from ``TIMBAL_MAX_CONCURRENT_BACKGROUND`` (20) and
@@ -45,7 +47,7 @@ _COMPLETION_SUMMARY_CHARS = 300
 _RESULT_PREVIEW_CHARS = 500
 _TASK_ID_LEN = 12
 _ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"
-_TERMINAL_STATUSES = frozenset({"completed", "error", "cancelled", "timed_out"})
+_TERMINAL_STATUSES = frozenset({"completed", "error", "cancelled", "timed_out", "stalled"})
 
 # Ring-buffer defaults (mirrors JobStore). ``None`` / 0 = unlimited.
 DEFAULT_BG_LOG_MAX_EVENTS = 50_000
@@ -578,6 +580,7 @@ class BackgroundTask:
         title: str | None = None,
         on_cancel: Callable[..., Any] | None = None,
         timeout: float | None = None,
+        stall_timeout: float | None = None,
         log_max_events: int | None = DEFAULT_BG_LOG_MAX_EVENTS,
         log_max_bytes: int | None = DEFAULT_BG_LOG_MAX_BYTES,
     ) -> None:
@@ -591,11 +594,19 @@ class BackgroundTask:
         self.metadata: dict[str, Any] = {}
         self.on_cancel = on_cancel
         self.timeout = timeout
+        self.stall_timeout = stall_timeout
+        self.last_event_at = time.monotonic()
         self.finished_at: float | None = None
         self._cancel_requested = False
         self._timed_out = False
+        self._stalled = False
         self._timeout_handle: asyncio.TimerHandle | None = None
+        self._stall_handle: asyncio.TimerHandle | None = None
         self._handler_aclose: Callable[..., Any] | None = None
+
+    def clear_watchdogs(self) -> None:
+        self.clear_timeout()
+        self.clear_stall()
 
     def schedule_timeout(self) -> None:
         """Arm a one-shot deadline; no-op when ``timeout`` is unset or non-positive."""
@@ -612,6 +623,41 @@ class BackgroundTask:
         self._timeout_handle = None
         if handle is not None:
             handle.cancel()
+
+    def schedule_stall_watchdog(self) -> None:
+        """Arm a one-shot idle deadline; reset on every :meth:`ingest`."""
+        self.clear_stall()
+        if self.stall_timeout is None or self.stall_timeout <= 0:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        self._stall_handle = loop.call_later(self.stall_timeout, self._on_stall)
+
+    def clear_stall(self) -> None:
+        handle = self._stall_handle
+        self._stall_handle = None
+        if handle is not None:
+            handle.cancel()
+
+    def _on_stall(self) -> None:
+        """Cancel the child when no events arrived within ``stall_timeout``."""
+        self._stall_handle = None
+        if self.task.done():
+            return
+        self._stalled = True
+        self._cancel_requested = True
+        self.task.cancel()
+        try:
+            asyncio.get_running_loop().create_task(self.aclose_handler())
+        except RuntimeError:
+            pass
+        if self.on_cancel is not None:
+            try:
+                self.on_cancel(self)
+            except Exception:
+                pass
 
     def _on_timeout(self) -> None:
         """Cancel the child and mark ``timed_out`` (distinct from user cancel)."""
@@ -659,7 +705,9 @@ class BackgroundTask:
 
     def ingest(self, event: Any) -> None:
         _lift_metadata(event, self.metadata)
+        self.last_event_at = time.monotonic()
         self.log.put_nowait(event)
+        self.schedule_stall_watchdog()
 
     def put_nowait(self, event: Any) -> None:
         """Queue-shaped sink used by ``_execute_handler``."""
@@ -669,6 +717,8 @@ class BackgroundTask:
         task = self.task
         if self._timed_out:
             return "timed_out"
+        if self._stalled:
+            return "stalled"
         if self._cancel_requested or (task.done() and task.cancelled()):
             return "cancelled"
         if not task.done():
@@ -697,10 +747,17 @@ class BackgroundTask:
         }
         if self.timeout is not None:
             snapshot["timeout"] = self.timeout
+        if self.stall_timeout is not None:
+            snapshot["stall_timeout"] = self.stall_timeout
+        if status == "running" and self.stall_timeout is not None:
+            snapshot["summary"]["seconds_since_event"] = round(time.monotonic() - self.last_event_at, 3)
         snapshot.update(self.metadata)
         if self._timed_out:
             timeout = self.timeout
             snapshot["error"] = f"Timed out after {timeout:g}s" if timeout else "Timed out"
+        elif self._stalled:
+            stall = self.stall_timeout
+            snapshot["error"] = f"No events for {stall:g}s" if stall else "Stalled"
         elif self.task.done() and not self.task.cancelled():
             exc = self.task.exception()
             if exc is not None:
@@ -809,15 +866,16 @@ class BackgroundTaskStore:
         # run on the loop thread; keep this sync and never raise.
         task = record.task
         record.schedule_timeout()
+        record.schedule_stall_watchdog()
         if task.done():
-            record.clear_timeout()
+            record.clear_watchdogs()
             if record.finished_at is None:
                 record.finished_at = time.monotonic()
             self._enqueue_completion(record)
         else:
 
             def _on_done(_t: asyncio.Task) -> None:
-                record.clear_timeout()
+                record.clear_watchdogs()
                 if record.finished_at is None:
                     record.finished_at = time.monotonic()
                 self._enqueue_completion(record)
@@ -885,7 +943,7 @@ class BackgroundTaskStore:
         record = self._tasks.get(task_id)
         if record is None:
             return {"status": "not_found", "task_id": task_id}
-        record.clear_timeout()
+        record.clear_watchdogs()
         if not record.task.done():
             record._cancel_requested = True
             record.task.cancel()
@@ -934,8 +992,8 @@ class BackgroundTaskStore:
             "status": status,
             "summary": summary_text,
         }
-        if status in ("error", "timed_out"):
-            note["error"] = str(snap.get("error") or ("Timed out" if status == "timed_out" else "unknown error"))
+        if status in ("error", "timed_out", "stalled"):
+            note["error"] = str(snap.get("error") or ("Timed out" if status == "timed_out" else "Stalled"))
         elif status == "completed" and "result" in snap:
             note["result"] = _preview_value(snap["result"])
         self._completion_inbox.append(note)
@@ -1198,10 +1256,12 @@ def register_background_task(
     on_cancel: Callable[..., Any] | None = None,
     started_at: int | None = None,
     timeout: float | None = None,
+    stall_timeout: float | None = None,
 ) -> BackgroundTask:
     """Register a running child on the current session bag.
 
     ``timeout`` is seconds until the child is cancelled as ``timed_out``.
+    ``stall_timeout`` is seconds without log events until ``stalled``.
     Raises :class:`BackgroundLimitError` if concurrent/depth caps would be exceeded.
     """
     from . import get_run_context
@@ -1222,6 +1282,7 @@ def register_background_task(
         started_at=started_at if started_at is not None else int(time.time() * 1000),
         on_cancel=on_cancel,
         timeout=timeout,
+        stall_timeout=stall_timeout,
         log_max_events=store.max_log_events,
         log_max_bytes=store.max_log_bytes,
     )

--- a/python/timbal/state/background.py
+++ b/python/timbal/state/background.py
@@ -47,6 +47,11 @@ _TASK_ID_LEN = 12
 _ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"
 _TERMINAL_STATUSES = frozenset({"completed", "error", "cancelled", "timed_out"})
 
+# Ring-buffer defaults (mirrors JobStore). ``None`` / 0 = unlimited.
+DEFAULT_BG_LOG_MAX_EVENTS = 50_000
+DEFAULT_BG_LOG_MAX_BYTES = 32 * 1024 * 1024
+DEFAULT_BG_TASK_RETENTION_SECS = 300.0
+
 # Process-local: run_id → store. Sequential turns find the bag via parent_id.
 # Concurrent siblings (no parent_id) each create a new store.
 _STORES_BY_RUN_ID: dict[str, BackgroundTaskStore] = {}
@@ -109,6 +114,51 @@ def _default_max_depth() -> int | None:
     except ValueError:
         return None
     return None if value < 0 else value
+
+
+def _event_nbytes(event: Any) -> int:
+    dump_json = getattr(event, "model_dump_json", None)
+    if callable(dump_json):
+        return len(dump_json())
+    if isinstance(event, str):
+        return len(event)
+    if isinstance(event, (bytes, bytearray)):
+        return len(event)
+    return len(repr(event))
+
+
+def _bg_log_limit(raw: str | None, default: int | None) -> int | None:
+    if raw is None:
+        return default
+    text = raw.strip().lower()
+    if text in ("", "0", "none", "unlimited"):
+        return None
+    try:
+        value = int(text)
+    except ValueError:
+        return default
+    return None if value <= 0 else value
+
+
+def _default_max_log_events() -> int | None:
+    return _bg_log_limit(os.environ.get("TIMBAL_BG_LOG_MAX_EVENTS"), DEFAULT_BG_LOG_MAX_EVENTS)
+
+
+def _default_max_log_bytes() -> int | None:
+    return _bg_log_limit(os.environ.get("TIMBAL_BG_LOG_MAX_BYTES"), DEFAULT_BG_LOG_MAX_BYTES)
+
+
+def _default_task_retention_secs() -> float:
+    raw = os.environ.get("TIMBAL_BG_TASK_RETENTION_SECS")
+    if raw is None:
+        return DEFAULT_BG_TASK_RETENTION_SECS
+    text = raw.strip().lower()
+    if text in ("", "0", "none", "unlimited"):
+        return 0.0
+    try:
+        return max(0.0, float(text))
+    except ValueError:
+        return DEFAULT_BG_TASK_RETENTION_SECS
 
 
 def _new_task_id() -> str:
@@ -258,20 +308,61 @@ def format_background_completion_notice(notifications: list[dict[str, Any]]) -> 
 
 
 class BackgroundEventLog:
-    """Append-only log. ``put_nowait`` matches :class:`asyncio.Queue` so
-    ``_execute_handler`` can treat this as the event sink."""
+    """Append-only ring-buffer log. ``put_nowait`` matches :class:`asyncio.Queue`.
 
-    def __init__(self) -> None:
+    Cursors are **logical** indices: ``after`` is how many events the reader has
+    already seen. When ``max_events`` / ``max_bytes`` is exceeded the oldest
+    entries drop and :attr:`forgotten_through` advances. ``after <
+    forgotten_through`` is a gap — not a silent skip to the new head.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_events: int | None = DEFAULT_BG_LOG_MAX_EVENTS,
+        max_bytes: int | None = DEFAULT_BG_LOG_MAX_BYTES,
+    ) -> None:
+        self._max_events = max_events or 0
+        self._max_bytes = max_bytes or 0
         self._events: list[Any] = []
+        self._sizes: list[int] = []
+        self._nbytes = 0
+        self.forgotten_through = 0
         self._subscribers: list[asyncio.Queue] = []
+        self._closed = False
+
+    @property
+    def cursor_end(self) -> int:
+        """Next logical index to pass as ``after`` (total events appended)."""
+        return self.forgotten_through + len(self._events)
 
     def put_nowait(self, event: Any) -> None:
+        if self._closed:
+            return
+        nbytes = _event_nbytes(event) if self._max_bytes > 0 else 0
         self._events.append(event)
+        self._sizes.append(nbytes)
+        self._nbytes += nbytes
+        self._trim()
         for queue in self._subscribers:
             queue.put_nowait(event)
 
-    def peek(self, after: int = 0) -> list[Any]:
-        return list(self._events[after:])
+    def peek(self, after: int = 0) -> tuple[list[Any], bool]:
+        """Return ``(events, gapped)`` from logical cursor ``after``."""
+        if after < self.forgotten_through:
+            return [], True
+        offset = after - self.forgotten_through
+        return list(self._events[offset:]), False
+
+    def read(self, after: int = 0, limit: int | None = None) -> tuple[list[Any], int, bool]:
+        """``(events, next_cursor, gapped)`` from logical ``after``."""
+        if after < self.forgotten_through:
+            return [], after, True
+        events, _ = self.peek(after)
+        if limit is not None and limit > 0:
+            events = events[:limit]
+        next_cursor = after + len(events)
+        return events, next_cursor, False
 
     def qsize(self) -> int:
         return len(self._events)
@@ -280,12 +371,14 @@ class BackgroundEventLog:
         return not self._events
 
     async def subscribe(self, after: int = 0) -> AsyncIterator[Any]:
-        """Replay from ``after``, then yield live events until :meth:`close`."""
+        """Replay from logical ``after``, then yield live events until :meth:`close`."""
+        if after < self.forgotten_through:
+            return
         queue: asyncio.Queue = asyncio.Queue()
-        # Register before replay so we cannot drop events that arrive mid-replay.
         self._subscribers.append(queue)
         try:
-            for event in self._events[after:]:
+            offset = after - self.forgotten_through
+            for event in self._events[offset:]:
                 yield event
             while True:
                 event = await queue.get()
@@ -297,8 +390,28 @@ class BackgroundEventLog:
                 self._subscribers.remove(queue)
 
     def close(self) -> None:
+        self._closed = True
         for queue in self._subscribers:
             queue.put_nowait(_DONE)
+
+    def _over_cap(self, n: int, nbytes: int) -> bool:
+        return (self._max_events > 0 and n > self._max_events) or (
+            self._max_bytes > 0 and nbytes > self._max_bytes
+        )
+
+    def _trim(self) -> None:
+        """Drop oldest events until the ring fits. Never drops the tip."""
+        drop = 0
+        n = len(self._events)
+        nbytes = self._nbytes
+        while n - drop > 1 and self._over_cap(n - drop, nbytes):
+            nbytes -= self._sizes[drop]
+            drop += 1
+        if drop:
+            del self._events[:drop]
+            del self._sizes[:drop]
+            self._nbytes = nbytes
+            self.forgotten_through += drop
 
 
 class BackgroundTask:
@@ -315,6 +428,8 @@ class BackgroundTask:
         title: str | None = None,
         on_cancel: Callable[..., Any] | None = None,
         timeout: float | None = None,
+        log_max_events: int | None = DEFAULT_BG_LOG_MAX_EVENTS,
+        log_max_bytes: int | None = DEFAULT_BG_LOG_MAX_BYTES,
     ) -> None:
         self.task_id = task_id
         self.name = name
@@ -322,10 +437,11 @@ class BackgroundTask:
         self.task = task
         self.started_at = started_at
         self.title = title or _title_from_input(name, input)
-        self.log = BackgroundEventLog()
+        self.log = BackgroundEventLog(max_events=log_max_events, max_bytes=log_max_bytes)
         self.metadata: dict[str, Any] = {}
         self.on_cancel = on_cancel
         self.timeout = timeout
+        self.finished_at: float | None = None
         self._cancel_requested = False
         self._timed_out = False
         self._timeout_handle: asyncio.TimerHandle | None = None
@@ -412,7 +528,7 @@ class BackgroundTask:
         return "completed"
 
     def summarize(self) -> dict[str, Any]:
-        events = self.log.peek()
+        events, _ = self.log.peek(self.log.forgotten_through)
         classes = _event_classes()
         text_parts: list[str] = []
         tools: list[str] = []
@@ -436,9 +552,10 @@ class BackgroundTask:
             "summary": {
                 "text": text,
                 "tools_in_flight": tools,
-                "event_count": len(events),
+                "event_count": self.log.cursor_end,
             },
-            "transcript_cursor": len(events),
+            "transcript_cursor": self.log.cursor_end,
+            "forgotten_through": self.log.forgotten_through,
         }
         if self.timeout is not None:
             snapshot["timeout"] = self.timeout
@@ -480,6 +597,9 @@ class BackgroundTaskStore:
         *,
         max_concurrent: int | None | object = _UNSET,
         max_depth: int | None | object = _UNSET,
+        max_log_events: int | None | object = _UNSET,
+        max_log_bytes: int | None | object = _UNSET,
+        task_retention_secs: float | object = _UNSET,
     ) -> None:
         self._tasks: dict[str, BackgroundTask] = {}
         # Ordered, one-shot queue of lean completion payloads for the parent LLM.
@@ -490,6 +610,15 @@ class BackgroundTaskStore:
             _default_max_concurrent() if max_concurrent is _UNSET else max_concurrent  # type: ignore[assignment]
         )
         self.max_depth = _default_max_depth() if max_depth is _UNSET else max_depth  # type: ignore[assignment]
+        self.max_log_events = (
+            _default_max_log_events() if max_log_events is _UNSET else max_log_events  # type: ignore[assignment]
+        )
+        self.max_log_bytes = (
+            _default_max_log_bytes() if max_log_bytes is _UNSET else max_log_bytes  # type: ignore[assignment]
+        )
+        self.task_retention_secs = (
+            _default_task_retention_secs() if task_retention_secs is _UNSET else float(task_retention_secs)  # type: ignore[arg-type]
+        )
         # Spawns that passed check_can_spawn but are not yet in ``_tasks``
         # (between create_task and add). Counts toward the concurrent cap.
         self._pending_spawns = 0
@@ -544,14 +673,34 @@ class BackgroundTaskStore:
         record.schedule_timeout()
         if task.done():
             record.clear_timeout()
+            if record.finished_at is None:
+                record.finished_at = time.monotonic()
             self._enqueue_completion(record)
         else:
 
             def _on_done(_t: asyncio.Task) -> None:
                 record.clear_timeout()
+                if record.finished_at is None:
+                    record.finished_at = time.monotonic()
                 self._enqueue_completion(record)
 
             task.add_done_callback(_on_done)
+
+    def reap_finished(self, now: float | None = None) -> None:
+        """Drop terminal tasks whose retention window has lapsed."""
+        secs = self.task_retention_secs
+        if secs <= 0:
+            return
+        now = time.monotonic() if now is None else now
+        expired = [
+            task_id
+            for task_id, record in self._tasks.items()
+            if record.task.done()
+            and record.finished_at is not None
+            and now - record.finished_at >= secs
+        ]
+        for task_id in expired:
+            del self._tasks[task_id]
 
     def get(self, task_id: str) -> BackgroundTask | None:
         return self._tasks.get(task_id)
@@ -576,13 +725,22 @@ class BackgroundTaskStore:
     def transcript(self, task_id: str, after: int = 0) -> dict[str, Any]:
         record = self._tasks.get(task_id)
         if record is None:
-            return {"status": "not_found", "task_id": task_id, "events": [], "cursor": after}
-        events = record.log.peek(after)
+            return {
+                "status": "not_found",
+                "task_id": task_id,
+                "events": [],
+                "cursor": after,
+                "gapped": False,
+                "forgotten_through": 0,
+            }
+        events, cursor, gapped = record.log.read(after)
         return {
             "status": record.status_code(),
             "task_id": task_id,
             "events": [_dump_event(event) for event in events],
-            "cursor": after + len(events),
+            "cursor": cursor,
+            "gapped": gapped,
+            "forgotten_through": record.log.forgotten_through,
         }
 
     def cancel(self, task_id: str) -> dict[str, Any]:
@@ -680,12 +838,21 @@ def apply_background_limits(
     *,
     max_concurrent: int | None | object = _UNSET,
     max_depth: int | None | object = _UNSET,
+    max_log_events: int | None | object = _UNSET,
+    max_log_bytes: int | None | object = _UNSET,
+    task_retention_secs: float | object = _UNSET,
 ) -> None:
     """Stash session caps on the RunContext and update an existing store."""
     if max_concurrent is not _UNSET:
         run_context._bg_max_concurrent = max_concurrent
     if max_depth is not _UNSET:
         run_context._bg_max_depth = max_depth
+    if max_log_events is not _UNSET:
+        run_context._bg_max_log_events = max_log_events
+    if max_log_bytes is not _UNSET:
+        run_context._bg_max_log_bytes = max_log_bytes
+    if task_retention_secs is not _UNSET:
+        run_context._bg_task_retention_secs = task_retention_secs
     store = getattr(run_context, "_bg_store", None)
     if store is None:
         return
@@ -693,6 +860,13 @@ def apply_background_limits(
         store.max_concurrent = max_concurrent  # type: ignore[assignment]
     if max_depth is not _UNSET:
         store.max_depth = max_depth  # type: ignore[assignment]
+    if max_log_events is not _UNSET:
+        store.max_log_events = max_log_events  # type: ignore[assignment]
+    if max_log_bytes is not _UNSET:
+        store.max_log_bytes = max_log_bytes  # type: ignore[assignment]
+    if task_retention_secs is not _UNSET:
+        store.task_retention_secs = float(task_retention_secs)  # type: ignore[arg-type]
+    store.reap_finished()
 
 
 def ensure_background_store(run_context: Any) -> BackgroundTaskStore:
@@ -709,8 +883,24 @@ def ensure_background_store(run_context: Any) -> BackgroundTaskStore:
             else _UNSET
         )
         max_depth = run_context._bg_max_depth if hasattr(run_context, "_bg_max_depth") else _UNSET
-        store = BackgroundTaskStore(max_concurrent=max_concurrent, max_depth=max_depth)
+        max_log_events = (
+            run_context._bg_max_log_events if hasattr(run_context, "_bg_max_log_events") else _UNSET
+        )
+        max_log_bytes = (
+            run_context._bg_max_log_bytes if hasattr(run_context, "_bg_max_log_bytes") else _UNSET
+        )
+        task_retention_secs = (
+            run_context._bg_task_retention_secs if hasattr(run_context, "_bg_task_retention_secs") else _UNSET
+        )
+        store = BackgroundTaskStore(
+            max_concurrent=max_concurrent,
+            max_depth=max_depth,
+            max_log_events=max_log_events,
+            max_log_bytes=max_log_bytes,
+            task_retention_secs=task_retention_secs,
+        )
         run_context._bg_store = store
+    store.reap_finished()
     _STORES_BY_RUN_ID[run_context.id] = store
     return store
 
@@ -776,14 +966,22 @@ def cancel_background_task(task_id: str) -> dict[str, Any]:
 
 
 def read_background_transcript(task_id: str, after: int = 0) -> dict[str, Any]:
-    """Raw events for a background task, from cursor ``after`` (inclusive).
+    """Raw events for a background task, from logical cursor ``after``.
 
-    Does not drain. A second read with the same ``after`` returns the same
-    events. ``cursor`` is the next index to pass.
+    Does not drain. Returns ``gapped=True`` when ``after`` is behind
+    ``forgotten_through`` (events were dropped from the ring). ``cursor`` is
+    the next logical index to pass.
     """
     store = current_background_store()
     if store is None:
-        return {"status": "not_found", "task_id": task_id, "events": [], "cursor": after}
+        return {
+            "status": "not_found",
+            "task_id": task_id,
+            "events": [],
+            "cursor": after,
+            "gapped": False,
+            "forgotten_through": 0,
+        }
     return store.transcript(task_id, after=after)
 
 
@@ -819,6 +1017,8 @@ def register_background_task(
         started_at=started_at if started_at is not None else int(time.time() * 1000),
         on_cancel=on_cancel,
         timeout=timeout,
+        log_max_events=store.max_log_events,
+        log_max_bytes=store.max_log_bytes,
     )
     store.add(record)
     return record

--- a/python/timbal/state/background.py
+++ b/python/timbal/state/background.py
@@ -185,7 +185,7 @@ def _event_classes() -> dict[str, Any]:
     """
     if not _EVENT_CLASSES:
         from ..types.events import OutputEvent
-        from ..types.events.delta import DeltaEvent, Text, TextDelta, ToolUse
+        from ..types.events.delta import Custom, DeltaEvent, Text, TextDelta, ToolUse
 
         _EVENT_CLASSES.update(
             delta_event=DeltaEvent,
@@ -193,6 +193,7 @@ def _event_classes() -> dict[str, Any]:
             text=Text,
             text_delta=TextDelta,
             tool_use=ToolUse,
+            custom=Custom,
         )
     return _EVENT_CLASSES
 
@@ -219,11 +220,125 @@ def _event_text(event: Any, classes: dict[str, Any] | None = None) -> str:
     return ""
 
 
-def _event_tool_name(event: Any, classes: dict[str, Any] | None = None) -> str | None:
-    classes = classes or _event_classes()
-    if isinstance(event, classes["delta_event"]) and isinstance(event.item, classes["tool_use"]):
-        return event.item.name
+def _coerce_pct(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        n = float(value)
+        if 0 <= n <= 1:
+            n *= 100
+        if 0 <= n <= 100:
+            return int(round(n))
     return None
+
+
+def _progress_fields_from_mapping(data: dict[str, Any]) -> tuple[str | None, int | None]:
+    phase: str | None = None
+    for key in ("phase", "stage", "status", "step"):
+        value = data.get(key)
+        if isinstance(value, str) and value.strip():
+            phase = value.strip()
+            break
+    pct: int | None = None
+    for key in ("pct", "progress", "percent", "percentage"):
+        if key in data:
+            pct = _coerce_pct(data[key])
+            if pct is not None:
+                break
+    return phase, pct
+
+
+def _progress_from_payload(payload: Any) -> tuple[str | None, int | None]:
+    if isinstance(payload, dict):
+        return _progress_fields_from_mapping(payload)
+    return None, None
+
+
+def _resolve_inflight_tool(
+    open_tools: dict[str, str],
+    *,
+    tool_call_id: str | None,
+    path: str | None,
+) -> None:
+    if tool_call_id and tool_call_id in open_tools:
+        del open_tools[tool_call_id]
+        return
+    if not path or "." not in path:
+        return
+    segment = path.rsplit(".", 1)[-1]
+    for call_id, name in list(open_tools.items()):
+        if name == segment:
+            del open_tools[call_id]
+            break
+
+
+def _build_summary_from_events(
+    events: list[Any],
+    *,
+    terminal_status: str | None = None,
+) -> dict[str, Any]:
+    """Derive bounded briefing fields from a background child's event log."""
+    classes = _event_classes()
+    text_parts: list[str] = []
+    open_tools: dict[str, str] = {}
+    last_tool: str | None = None
+    phase: str | None = None
+    pct: int | None = None
+
+    for event in events:
+        chunk = _event_text(event, classes)
+        if chunk:
+            text_parts.append(chunk)
+
+        if isinstance(event, classes["delta_event"]):
+            item = event.item
+            if isinstance(item, classes["tool_use"]):
+                open_tools[item.id] = item.name
+                last_tool = item.name
+            elif isinstance(item, classes["custom"]):
+                custom_phase, custom_pct = _progress_from_payload(item.data)
+                if custom_phase is not None:
+                    phase = custom_phase
+                if custom_pct is not None:
+                    pct = custom_pct
+        elif isinstance(event, classes["output_event"]):
+            meta = event.metadata if isinstance(event.metadata, dict) else {}
+            custom_phase, custom_pct = _progress_from_payload(meta)
+            if custom_phase is not None:
+                phase = custom_phase
+            if custom_pct is not None:
+                pct = custom_pct
+            _resolve_inflight_tool(
+                open_tools,
+                tool_call_id=meta.get("tool_call_id") if isinstance(meta.get("tool_call_id"), str) else None,
+                path=getattr(event, "path", None),
+            )
+
+    text = "".join(text_parts)
+    if len(text) > _SUMMARY_TEXT_CHARS:
+        text = text[-_SUMMARY_TEXT_CHARS:]
+
+    tools_in_flight = list(dict.fromkeys(open_tools.values()))
+
+    if terminal_status in _TERMINAL_STATUSES:
+        phase = terminal_status
+        if terminal_status == "completed":
+            pct = 100
+    elif phase is None:
+        if tools_in_flight and last_tool:
+            phase = f"tool:{last_tool}"
+        elif text:
+            phase = "streaming"
+        elif events:
+            phase = "running"
+
+    return {
+        "text": text,
+        "last_tool": last_tool,
+        "tools_in_flight": tools_in_flight,
+        "phase": phase,
+        "pct": pct,
+    }
 
 
 def _lift_metadata(event: Any, metadata: dict[str, Any]) -> None:
@@ -529,29 +644,17 @@ class BackgroundTask:
 
     def summarize(self) -> dict[str, Any]:
         events, _ = self.log.peek(self.log.forgotten_through)
-        classes = _event_classes()
-        text_parts: list[str] = []
-        tools: list[str] = []
-        for event in events:
-            chunk = _event_text(event, classes)
-            if chunk:
-                text_parts.append(chunk)
-            tool_name = _event_tool_name(event, classes)
-            if tool_name:
-                tools.append(tool_name)
-        text = "".join(text_parts)
-        if len(text) > _SUMMARY_TEXT_CHARS:
-            text = text[-_SUMMARY_TEXT_CHARS:]
+        status = self.status_code()
+        briefing = _build_summary_from_events(events, terminal_status=status if status in _TERMINAL_STATUSES else None)
         snapshot: dict[str, Any] = {
-            "status": self.status_code(),
+            "status": status,
             "task_id": self.task_id,
             "name": self.name,
             "input": self.input,
             "title": self.title,
             "started_at": self.started_at,
             "summary": {
-                "text": text,
-                "tools_in_flight": tools,
+                **briefing,
                 "event_count": self.log.cursor_end,
             },
             "transcript_cursor": self.log.cursor_end,
@@ -923,7 +1026,8 @@ def get_background_task(task_id: str, *, ack_completion: bool = False) -> dict[s
     """Peek a summary of a background task. Does not drain the event log.
 
     Use this to answer questions about an in-flight or finished background
-    tool. You get status, a short text summary, and any child ids (e.g.
+    tool. You get status, structured progress (phase, pct, last_tool,
+    tools_in_flight), a short text summary, and any child ids (e.g.
     ``cursor_agent_id``, ``run_id``). You must have a ``task_id`` from a
     previous background-tool result or from ``list_background_tasks``.
     Raw events: ``read_background_transcript``.
@@ -1031,10 +1135,10 @@ def clear_background_stores() -> None:
 
 GET_BACKGROUND_TASK_DESCRIPTION = (
     "Get a summary of an in-flight or finished background tool so you can "
-    "answer questions about it (status, last assistant text, tools it called, "
-    "error). You must have a task_id from a previous background-tool result "
-    "or from list_background_tasks. This does not return the full event log — "
-    "use it to brief the user, not to dump a long build."
+    "answer questions about it (status, phase, pct, last_tool, tools_in_flight, "
+    "last assistant text, error). You must have a task_id from a previous "
+    "background-tool result or from list_background_tasks. This does not return "
+    "the full event log — use it to brief the user, not to dump a long build."
 )
 
 LIST_BACKGROUND_TASKS_DESCRIPTION = (


### PR DESCRIPTION
## Summary
- When a background child reaches a terminal status, enqueue a one-shot notice and inject a lean synthetic user message (`<background_task_completed>`) at the **start of the next parent turn** so the LLM learns without polling.
- LLM `get_background_task` / `list_background_tasks` peeks ack the notice so a mid-turn poll does not get re-announced on the following turn; module/UI peeks do not ack.
- Skips injection for subagents and approval/suspend resumes (no user message between tool_use and tool_result).

## Test plan
- [x] `uv run pytest python/tests/core/test_background_tasks.py` (33 passed)
- [ ] Spot-check: spawn a bg tool → next turn sees notice without `get_background_task`
- [ ] Spot-check: poll terminal status via LLM tool → following turn does **not** re-inject