### PR TITLE
fix(agent): keep subscribe alive after ring-buffer gap

### DIFF
--- a/docs/agents/background-tasks.mdx
+++ b/docs/agents/background-tasks.mdx
@@ -215,7 +215,7 @@ agent = Agent(
 
 Env: `TIMBAL_BG_LOG_MAX_EVENTS`, `TIMBAL_BG_LOG_MAX_BYTES`, `TIMBAL_BG_TASK_RETENTION_SECS` (`0` / `none` = unlimited / keep forever).
 
-To follow a child live instead of polling, subscribe to its log. `subscribe` replays from `after` and then yields events as they arrive, so you cannot miss one that lands mid-replay.
+To follow a child live instead of polling, subscribe to its log. `subscribe` replays from `after` and then yields events as they arrive, so you cannot miss one that lands mid-replay. If `after` is behind `forgotten_through` (ring eviction), the iterator yields `BACKGROUND_LOG_GAPPED` once — same signal as `gapped=True` on `read`/`peek` — then replays from the ring head and continues with live events.
 
 ```python
 from timbal.state.background import current_background_store

--- a/python/tests/core/test_background_tasks.py
+++ b/python/tests/core/test_background_tasks.py
@@ -2384,6 +2384,54 @@ class TestWaitForBackground:
         assert snap["result"] == "done"
 
 
+class TestBackgroundEventLogSubscribe:
+    """Unit tests for :meth:`BackgroundEventLog.subscribe`."""
+
+    @pytest.mark.asyncio
+    async def test_subscribe_gapped_yields_sentinel_and_live_events(self):
+        from timbal.state.background import BACKGROUND_LOG_GAPPED
+
+        log = BackgroundEventLog(max_events=2, max_bytes=None)
+        log.put_nowait("a")
+        log.put_nowait("b")
+        log.put_nowait("c")  # forgotten_through=1, buffer ["b", "c"]
+
+        collected: list[Any] = []
+
+        async def consume() -> None:
+            async for event in log.subscribe(after=0):
+                collected.append(event)
+                if event == "live":
+                    log.close()
+
+        task = asyncio.create_task(consume())
+        await asyncio.sleep(0.02)
+        log.put_nowait("live")
+        await asyncio.wait_for(task, timeout=1.0)
+
+        assert collected[0] is BACKGROUND_LOG_GAPPED
+        assert collected[1:] == ["b", "c", "live"]
+
+    @pytest.mark.asyncio
+    async def test_subscribe_not_gapped_replays_from_after(self):
+        log = BackgroundEventLog(max_events=2, max_bytes=None)
+        log.put_nowait("a")
+        log.put_nowait("b")
+        log.put_nowait("c")
+
+        collected: list[Any] = []
+
+        async def consume() -> None:
+            async for event in log.subscribe(after=2):
+                collected.append(event)
+                log.close()
+
+        task = asyncio.create_task(consume())
+        await asyncio.wait_for(task, timeout=1.0)
+
+        assert collected == ["c"]
+
+
 class TestBackgroundEventLogWait:
     """Unit tests for :meth:`BackgroundEventLog.wait`."""
 

--- a/python/tests/core/test_background_tasks.py
+++ b/python/tests/core/test_background_tasks.py
@@ -2413,6 +2413,31 @@ class TestBackgroundEventLogSubscribe:
         assert collected[1:] == ["b", "c", "live"]
 
     @pytest.mark.asyncio
+    async def test_subscribe_gapped_snapshots_before_sentinel_yield(self):
+        """Ring trim during GAPPED handling must not skew replay offset."""
+        from timbal.state.background import BACKGROUND_LOG_GAPPED
+
+        log = BackgroundEventLog(max_events=2, max_bytes=None)
+        log.put_nowait("a")
+        log.put_nowait("b")
+        log.put_nowait("c")  # forgotten_through=1, buffer ["b", "c"]
+
+        collected: list[Any] = []
+
+        async def consume() -> None:
+            async for event in log.subscribe(after=0):
+                if event is BACKGROUND_LOG_GAPPED:
+                    log.put_nowait("d")  # forgotten_through=2, buffer ["c", "d"]
+                    await asyncio.sleep(0)
+                collected.append(event)
+                if event == "d":
+                    log.close()
+
+        await asyncio.wait_for(consume(), timeout=1.0)
+
+        assert collected == [BACKGROUND_LOG_GAPPED, "b", "c", "d"]
+
+    @pytest.mark.asyncio
     async def test_subscribe_not_gapped_replays_from_after(self):
         log = BackgroundEventLog(max_events=2, max_bytes=None)
         log.put_nowait("a")

--- a/python/timbal/state/__init__.py
+++ b/python/timbal/state/__init__.py
@@ -21,6 +21,9 @@ from contextvars import ContextVar
 from typing import Any
 
 from .background import (
+    BACKGROUND_LOG_GAPPED as BACKGROUND_LOG_GAPPED,
+)
+from .background import (
     cancel_background_task as cancel_background_task,
 )
 from .background import (

--- a/python/timbal/state/background.py
+++ b/python/timbal/state/background.py
@@ -537,11 +537,14 @@ class BackgroundEventLog:
         replay_from = self.forgotten_through if gapped else after
         queue: asyncio.Queue = asyncio.Queue()
         self._subscribers.append(queue)
+        # Snapshot before any yield — the ring may trim while the consumer handles
+        # BACKGROUND_LOG_GAPPED, which would make a post-yield offset negative.
+        offset = replay_from - self.forgotten_through
+        replay = list(self._events[offset:])
         try:
             if gapped:
                 yield _GAPPED
-            offset = replay_from - self.forgotten_through
-            for event in self._events[offset:]:
+            for event in replay:
                 yield event
             while True:
                 event = await queue.get()

--- a/python/timbal/state/background.py
+++ b/python/timbal/state/background.py
@@ -59,7 +59,12 @@ DEFAULT_BG_TASK_RETENTION_SECS = 300.0
 _STORES_BY_RUN_ID: dict[str, BackgroundTaskStore] = {}
 
 _DONE = object()
+_GAPPED = object()
 _UNSET = object()
+
+# Yielded once by :meth:`BackgroundEventLog.subscribe` when ``after`` is behind
+# ``forgotten_through`` (same gap ``read``/``peek`` report via ``gapped=True``).
+BACKGROUND_LOG_GAPPED = _GAPPED
 
 # Nesting depth of the current coroutine relative to top-level session work.
 # 0 = parent agent/turn; each detached child increments by 1 for its body.
@@ -522,13 +527,20 @@ class BackgroundEventLog:
         return not self._events
 
     async def subscribe(self, after: int = 0) -> AsyncIterator[Any]:
-        """Replay from logical ``after``, then yield live events until :meth:`close`."""
-        if after < self.forgotten_through:
-            return
+        """Replay from logical ``after``, then yield live events until :meth:`close`.
+
+        When ``after < forgotten_through``, yields :data:`BACKGROUND_LOG_GAPPED` once
+        (matching ``gapped=True`` on :meth:`read`/``peek``), replays from the ring
+        head, then continues with live events — never returns an empty iterator.
+        """
+        gapped = after < self.forgotten_through
+        replay_from = self.forgotten_through if gapped else after
         queue: asyncio.Queue = asyncio.Queue()
         self._subscribers.append(queue)
         try:
-            offset = after - self.forgotten_through
+            if gapped:
+                yield _GAPPED
+            offset = replay_from - self.forgotten_through
             for event in self._events[offset:]:
                 yield event
             while True:


### PR DESCRIPTION
When after is behind forgotten_through, subscribe now yields BACKGROUND_LOG_GAPPED, replays from the ring head, and continues with live events instead of returning an empty iterator.