### PR TITLE
feat(agent): cooperative mid-flight foreground-to-background handoff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -415,13 +415,13 @@ Tool(name="build", handler=..., background_mode="always",
 # A foreground async-generator tool with background_mode="auto" can be parked
 # cooperatively while its collector keeps being consumed:
 run = agent(prompt="start the build")
-handoff = run.background()  # returns an awaitable request immediately
+handoff = run.background()  # or run.background(call_id=...) if several auto children
 async for event in run:
  ...
 task = await handoff  # {"task_id": "...", "status": "running"}
 ```
 
-- `collector.background()` targets the sole active streaming runnable with `background_mode="auto"`. The handoff happens at its next event; foreground events are not copied into the ring. It fails fast when there is no eligible child or parallel eligible children make the target ambiguous. Continue consuming the collector while the returned future is pending.
+- `collector.background()` parks one in-flight streaming runnable with `background_mode="auto"` at its next event. Foreground events are not copied into the ring. With one eligible child, omit the argument; with several, pass `call_id=` (from that child's `START`/`DELTA`) or it fails fast as ambiguous. Continue consuming the collector while the returned future is pending.
 - Tasks live on a `BackgroundTaskStore` bound to the `RunContext`, inherited across sequential turns via `parent_id`. Concurrent runs of the same Agent get isolated stores (no shared `parent_id`), so a foreign `task_id` is `not_found`. Process-local — does not survive a restart.
 - Once *this session* has a task, the agent auto-gains `get_background_task` / `list_background_tasks` / `cancel_background_task`. Opt in to `read_background_transcript` with `background_transcript_tool=True`.
 - The log is peekable, not consume-once: the parent agent and a frontend can both watch one child. `record.log.subscribe(after=)` replays then streams live.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -411,8 +411,17 @@ from timbal.state import (
 
 Tool(name="build", handler=..., background_mode="always",
  on_background_cancel=lambda record: remote.stop(record.metadata["run_id"]))
+
+# A foreground async-generator tool with background_mode="auto" can be parked
+# cooperatively while its collector keeps being consumed:
+run = agent(prompt="start the build")
+handoff = run.background()  # returns an awaitable request immediately
+async for event in run:
+ ...
+task = await handoff  # {"task_id": "...", "status": "running"}
 ```
 
+- `collector.background()` targets the sole active streaming runnable with `background_mode="auto"`. The handoff happens at its next event; foreground events are not copied into the ring. It fails fast when there is no eligible child or parallel eligible children make the target ambiguous. Continue consuming the collector while the returned future is pending.
 - Tasks live on a `BackgroundTaskStore` bound to the `RunContext`, inherited across sequential turns via `parent_id`. Concurrent runs of the same Agent get isolated stores (no shared `parent_id`), so a foreign `task_id` is `not_found`. Process-local — does not survive a restart.
 - Once *this session* has a task, the agent auto-gains `get_background_task` / `list_background_tasks` / `cancel_background_task`. Opt in to `read_background_transcript` with `background_transcript_tool=True`.
 - The log is peekable, not consume-once: the parent agent and a frontend can both watch one child. `record.log.subscribe(after=)` replays then streams live.

--- a/python/tests/core/test_background_tasks.py
+++ b/python/tests/core/test_background_tasks.py
@@ -2659,6 +2659,84 @@ class TestForegroundBackgroundHandoff:
         assert list_background_tasks() == []
 
     @pytest.mark.asyncio
+    async def test_call_id_selects_one_of_several_eligible_tools(self):
+        both_started = asyncio.Event()
+        release = asyncio.Event()
+        started = 0
+
+        async def streaming(name: str) -> AsyncGenerator[TextDelta, None]:
+            nonlocal started
+            started += 1
+            if started == 2:
+                both_started.set()
+            await both_started.wait()
+            yield TextDelta(id=name, text_delta=f"{name}-fg")
+            await release.wait()
+            yield TextDelta(id=name, text_delta=f"{name}-cut")
+            yield TextDelta(id=name, text_delta=f"{name}-bg")
+
+        agent = Agent(
+            name="targeted_handoff_agent",
+            model=TestModel(
+                responses=[
+                    _tool_calls(
+                        ("streaming", {"name": "a"}, "a", False),
+                        ("streaming", {"name": "b"}, "b", False),
+                    ),
+                    "done",
+                ]
+            ),
+            tools=[Tool(name="streaming", handler=streaming, background_mode="auto")],
+            tracing_provider=None,
+        )
+        stream = agent(prompt="go")
+        handoff = None
+        parked_call_id = None
+        parent_text: list[str] = []
+
+        async for event in stream:
+            if isinstance(event, DeltaEvent) and isinstance(event.item, TextDelta):
+                parent_text.append(event.item.text_delta)
+                if handoff is None:
+                    parked_call_id = event.call_id
+                    handoff = stream.background(call_id=event.call_id)
+                    release.set()
+
+        assert handoff is not None
+        placeholder = await handoff
+        snap = await wait_for_background(placeholder["task_id"], timeout=1.0)
+        transcript = read_background_transcript(placeholder["task_id"])
+        background_text = [
+            event["item"]["text_delta"]
+            for event in transcript["events"]
+            if event.get("type") == "DELTA" and event.get("item", {}).get("type") == "text_delta"
+        ]
+
+        assert parked_call_id is not None
+        assert snap["status"] == "completed"
+        assert any(text.endswith("-bg") for text in background_text)
+        assert any(text.endswith("-fg") for text in parent_text)
+        assert len(list_background_tasks()) == 1
+
+    @pytest.mark.asyncio
+    async def test_unknown_call_id_is_rejected(self):
+        release = asyncio.Event()
+
+        async def streaming() -> AsyncGenerator[TextDelta, None]:
+            yield TextDelta(id="s", text_delta="only")
+            await release.wait()
+
+        stream = Tool(name="streaming", handler=streaming, background_mode="auto", tracing_provider=None)()
+        seen = False
+        async for event in stream:
+            if isinstance(event, DeltaEvent):
+                with pytest.raises(RuntimeError, match="call_id 'nope'"):
+                    stream.background(call_id="nope")
+                seen = True
+                release.set()
+        assert seen
+
+    @pytest.mark.asyncio
     async def test_handler_error_after_handoff_is_background_error_only(self):
         async def streaming() -> AsyncGenerator[TextDelta, None]:
             yield TextDelta(id="s", text_delta="before")

--- a/python/tests/core/test_background_tasks.py
+++ b/python/tests/core/test_background_tasks.py
@@ -1306,6 +1306,7 @@ class TestBackgroundCompletionNotify:
     @pytest.mark.asyncio
     async def test_agent_poll_acks_so_next_turn_does_not_reinject(self):
         """LLM-tool peek (ack_completion=True) must consume the pending notice."""
+
         async def quick(tag: str) -> str:
             await asyncio.sleep(0.05)
             return f"done:{tag}"
@@ -1349,6 +1350,7 @@ class TestBackgroundCompletionNotify:
     @pytest.mark.asyncio
     async def test_module_peek_does_not_ack(self):
         """App/UI peeks must not steal the LLM completion inbox."""
+
         async def quick(tag: str) -> str:
             await asyncio.sleep(0.05)
             return f"done:{tag}"
@@ -1557,9 +1559,7 @@ class TestBackgroundCompletionNotify:
 
         events = [event async for event in agent(prompt="gate me", parent_id=r1.run_id)]
         approval = next(event for event in events if isinstance(event, ApprovalEvent))
-        r2 = next(
-            event for event in events if isinstance(event, OutputEvent) and event.path == "composer"
-        )
+        r2 = next(event for event in events if isinstance(event, OutputEvent) and event.path == "composer")
         assert r2.status.reason == "approval_required"
 
         from timbal.state.background import current_background_store
@@ -2382,6 +2382,613 @@ class TestWaitForBackground:
         snap = await wait_for_background(task_id, after=0, timeout=5.0)
         assert snap["status"] == "completed"
         assert snap["result"] == "done"
+
+
+class TestForegroundBackgroundHandoff:
+    """Cooperative foreground-to-background ownership transfer."""
+
+    @pytest.mark.asyncio
+    async def test_streaming_tool_moves_to_background_without_replaying_foreground_events(self):
+        release = asyncio.Event()
+        post_hook_calls = 0
+
+        async def streaming() -> AsyncGenerator[TextDelta, None]:
+            yield TextDelta(id="s", text_delta="foreground-1")
+            await release.wait()
+            yield TextDelta(id="s", text_delta="foreground-2")
+            yield TextDelta(id="s", text_delta="background")
+
+        def post_hook() -> None:
+            nonlocal post_hook_calls
+            post_hook_calls += 1
+
+        tool = Tool(
+            name="streaming",
+            handler=streaming,
+            background_mode="auto",
+            post_hook=post_hook,
+            tracing_provider=None,
+        )
+        stream = tool()
+        parent_events: list[Any] = []
+        handoff = None
+
+        async for event in stream:
+            parent_events.append(event)
+            if (
+                isinstance(event, DeltaEvent)
+                and isinstance(event.item, TextDelta)
+                and event.item.text_delta == "foreground-1"
+            ):
+                handoff = stream.background()
+                release.set()
+
+        assert handoff is not None
+        placeholder = await handoff
+        task_id = placeholder["task_id"]
+        snap = await wait_for_background(task_id, timeout=1.0)
+
+        parent_text = [
+            event.item.text_delta
+            for event in parent_events
+            if isinstance(event, DeltaEvent) and isinstance(event.item, TextDelta)
+        ]
+        transcript = read_background_transcript(task_id)
+        background_text = [
+            event["item"]["text_delta"]
+            for event in transcript["events"]
+            if event.get("type") == "DELTA" and event.get("item", {}).get("type") == "text_delta"
+        ]
+
+        assert parent_text == ["foreground-1"]
+        assert background_text == ["foreground-2", "background"]
+        assert snap["status"] == "completed"
+        assert post_hook_calls == 1
+        tool_outputs = [
+            event for event in parent_events if isinstance(event, OutputEvent) and event.path == "streaming"
+        ]
+        assert len(tool_outputs) == 1
+        assert tool_outputs[0].output == placeholder
+        assert tool_outputs[0].usage == {}
+        span = get_run_context()._trace[tool_outputs[0].call_id]
+        assert span.status.code == "success"
+        assert span.t1 >= tool_outputs[0].t1
+        assert span.output != placeholder
+
+    @pytest.mark.asyncio
+    async def test_ordinary_foreground_stream_uses_no_queue_or_child_task(self, monkeypatch: pytest.MonkeyPatch):
+        async def streaming() -> AsyncGenerator[TextDelta, None]:
+            for text in ("a", "b", "c"):
+                yield TextDelta(id="s", text_delta=text)
+
+        def unexpected(*args: Any, **kwargs: Any) -> None:
+            raise AssertionError(f"foreground hot path scheduled or queued work: {args!r} {kwargs!r}")
+
+        tool = Tool(name="streaming", handler=streaming, background_mode="auto", tracing_provider=None)
+        monkeypatch.setattr(asyncio, "create_task", unexpected)
+        monkeypatch.setattr(asyncio, "Event", unexpected)
+        monkeypatch.setattr(asyncio, "Queue", unexpected)
+        stream = tool()
+
+        text = [
+            event.item.text_delta
+            async for event in stream
+            if isinstance(event, DeltaEvent) and isinstance(event.item, TextDelta)
+        ]
+
+        assert text == ["a", "b", "c"]
+
+    @pytest.mark.asyncio
+    async def test_single_tool_agent_foreground_path_uses_no_queue_or_child_task(self, monkeypatch: pytest.MonkeyPatch):
+        async def streaming() -> AsyncGenerator[TextDelta, None]:
+            for text in ("a", "b", "c"):
+                yield TextDelta(id="s", text_delta=text)
+
+        def unexpected(*args: Any, **kwargs: Any) -> None:
+            raise AssertionError(f"single-tool hot path scheduled or queued work: {args!r} {kwargs!r}")
+
+        agent = Agent(
+            name="hot_path_agent",
+            model=TestModel(responses=[_tool_call("streaming", {}), "done"]),
+            tools=[Tool(name="streaming", handler=streaming, background_mode="auto")],
+            tracing_provider=None,
+        )
+        monkeypatch.setattr(asyncio, "create_task", unexpected)
+        monkeypatch.setattr(asyncio, "Event", unexpected)
+        monkeypatch.setattr(asyncio, "Queue", unexpected)
+        stream = agent(prompt="go")
+
+        result = await stream.collect()
+
+        assert result.status.code == "success"
+
+    @pytest.mark.asyncio
+    async def test_agent_receives_one_placeholder_tool_result_and_continues(self):
+        release = asyncio.Event()
+
+        async def streaming() -> AsyncGenerator[TextDelta, None]:
+            yield TextDelta(id="s", text_delta="before")
+            await release.wait()
+            yield TextDelta(id="s", text_delta="after")
+
+        model = TestModel(
+            responses=[
+                _tool_call("streaming", {}),
+                "The task is continuing in the background.",
+            ]
+        )
+        agent = Agent(
+            name="handoff_agent",
+            model=model,
+            tools=[Tool(name="streaming", handler=streaming, background_mode="auto")],
+            tracing_provider=None,
+        )
+        stream = agent(prompt="start")
+        events: list[Any] = []
+        handoff = None
+
+        async for event in stream:
+            events.append(event)
+            if (
+                isinstance(event, DeltaEvent)
+                and event.path == "handoff_agent.streaming"
+                and isinstance(event.item, TextDelta)
+            ):
+                handoff = stream.background()
+                release.set()
+
+        assert handoff is not None
+        placeholder = await handoff
+        snap = await wait_for_background(placeholder["task_id"], timeout=1.0)
+        tool_outputs = [
+            event for event in events if isinstance(event, OutputEvent) and event.path == "handoff_agent.streaming"
+        ]
+
+        assert model.call_count == 2
+        assert len(tool_outputs) == 1
+        assert tool_outputs[0].output == placeholder
+        assert snap["status"] == "completed"
+        assert snap["summary"]["text"] == "after"
+
+    @pytest.mark.asyncio
+    async def test_background_cancel_closes_handed_off_handler_and_calls_hook_once(self):
+        blocker = asyncio.Event()
+        closed = asyncio.Event()
+        cancel_calls = 0
+
+        async def streaming() -> AsyncGenerator[TextDelta, None]:
+            try:
+                yield TextDelta(id="s", text_delta="before")
+                await blocker.wait()
+                yield TextDelta(id="s", text_delta="never")
+            finally:
+                closed.set()
+
+        def on_cancel(_record: Any) -> None:
+            nonlocal cancel_calls
+            cancel_calls += 1
+
+        stream = Tool(
+            name="streaming",
+            handler=streaming,
+            background_mode="auto",
+            on_background_cancel=on_cancel,
+            tracing_provider=None,
+        )()
+        handoff = None
+
+        async for event in stream:
+            if isinstance(event, DeltaEvent):
+                handoff = stream.background()
+
+        assert handoff is not None
+        placeholder = await handoff
+        result = cancel_background_task(placeholder["task_id"])
+        await asyncio.wait_for(closed.wait(), timeout=1.0)
+        snap = await wait_for_background(placeholder["task_id"], timeout=1.0)
+
+        assert result["status"] == "cancelled"
+        assert snap["status"] == "cancelled"
+        assert cancel_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_failed_handoff_keeps_foreground_stream_alive(self):
+        from timbal.state.background import ensure_background_store
+
+        async def streaming() -> AsyncGenerator[TextDelta, None]:
+            yield TextDelta(id="s", text_delta="a")
+            yield TextDelta(id="s", text_delta="b")
+
+        stream = Tool(name="streaming", handler=streaming, background_mode="auto", tracing_provider=None)()
+        text: list[str] = []
+        handoff = None
+
+        async for event in stream:
+            if isinstance(event, DeltaEvent) and isinstance(event.item, TextDelta):
+                text.append(event.item.text_delta)
+                if event.item.text_delta == "a":
+                    ensure_background_store(get_run_context()).max_concurrent = 0
+                    handoff = stream.background()
+
+        assert handoff is not None
+        with pytest.raises(RuntimeError, match="Concurrent background limit reached"):
+            await handoff
+        assert text == ["a", "b"]
+        assert list_background_tasks() == []
+
+    @pytest.mark.asyncio
+    async def test_parallel_eligible_tools_are_rejected_as_ambiguous(self):
+        both_started = asyncio.Event()
+        release = asyncio.Event()
+        started = 0
+
+        async def streaming(name: str) -> AsyncGenerator[TextDelta, None]:
+            nonlocal started
+            started += 1
+            if started == 2:
+                both_started.set()
+            await both_started.wait()
+            yield TextDelta(id=name, text_delta=name)
+            await release.wait()
+
+        agent = Agent(
+            name="parallel_handoff_agent",
+            model=TestModel(
+                responses=[
+                    _tool_calls(
+                        ("streaming", {"name": "a"}, "a", False),
+                        ("streaming", {"name": "b"}, "b", False),
+                    ),
+                    "done",
+                ]
+            ),
+            tools=[Tool(name="streaming", handler=streaming, background_mode="auto")],
+            tracing_provider=None,
+        )
+        stream = agent(prompt="go")
+        checked = False
+
+        async for event in stream:
+            if not checked and isinstance(event, DeltaEvent) and event.path == "parallel_handoff_agent.streaming":
+                with pytest.raises(RuntimeError, match="2 eligible runnables"):
+                    stream.background()
+                checked = True
+                release.set()
+
+        assert checked
+        assert list_background_tasks() == []
+
+    @pytest.mark.asyncio
+    async def test_handler_error_after_handoff_is_background_error_only(self):
+        async def streaming() -> AsyncGenerator[TextDelta, None]:
+            yield TextDelta(id="s", text_delta="before")
+            raise ValueError("background boom")
+
+        stream = Tool(name="streaming", handler=streaming, background_mode="auto", tracing_provider=None)()
+        parent_outputs: list[OutputEvent] = []
+        handoff = None
+
+        async for event in stream:
+            if isinstance(event, DeltaEvent):
+                handoff = stream.background()
+            elif isinstance(event, OutputEvent):
+                parent_outputs.append(event)
+
+        assert handoff is not None
+        placeholder = await handoff
+        snap = await wait_for_background(placeholder["task_id"], timeout=1.0)
+
+        assert len(parent_outputs) == 1
+        assert parent_outputs[0].status.code == "success"
+        assert parent_outputs[0].output == placeholder
+        assert snap["status"] == "error"
+        assert snap["error"] == "background boom"
+        span = get_run_context()._trace[parent_outputs[0].call_id]
+        assert span.status.code == "error"
+        assert span.error["message"] == "background boom"
+
+    @pytest.mark.asyncio
+    async def test_post_hook_error_after_handoff_finalizes_error_span(self):
+        async def streaming() -> AsyncGenerator[TextDelta, None]:
+            yield TextDelta(id="s", text_delta="before")
+            yield TextDelta(id="s", text_delta="after")
+
+        def fail_post_hook() -> None:
+            raise ValueError("post-hook boom")
+
+        stream = Tool(
+            name="streaming",
+            handler=streaming,
+            background_mode="auto",
+            post_hook=fail_post_hook,
+            tracing_provider=None,
+        )()
+        handoff = None
+        parent_output = None
+
+        async for event in stream:
+            if isinstance(event, DeltaEvent):
+                handoff = stream.background()
+            elif isinstance(event, OutputEvent):
+                parent_output = event
+
+        assert handoff is not None
+        placeholder = await handoff
+        snap = await wait_for_background(placeholder["task_id"], timeout=1.0)
+        span = get_run_context()._trace[parent_output.call_id]
+
+        assert snap["status"] == "error"
+        assert snap["error"] == "post-hook boom"
+        assert span.status.code == "error"
+        assert span.error["message"] == "post-hook boom"
+        assert span.t1 is not None
+
+    @pytest.mark.asyncio
+    async def test_background_request_on_start_event_is_accepted(self):
+        async def streaming() -> AsyncGenerator[TextDelta, None]:
+            yield TextDelta(id="s", text_delta="first")
+            yield TextDelta(id="s", text_delta="second")
+
+        stream = Tool(name="streaming", handler=streaming, background_mode="auto", tracing_provider=None)()
+        handoff = None
+        parent_text: list[str] = []
+
+        async for event in stream:
+            if isinstance(event, StartEvent):
+                handoff = stream.background()
+            elif isinstance(event, DeltaEvent) and isinstance(event.item, TextDelta):
+                parent_text.append(event.item.text_delta)
+
+        assert handoff is not None
+        placeholder = await handoff
+        snap = await wait_for_background(placeholder["task_id"], timeout=1.0)
+
+        assert parent_text == ["first"]
+        assert snap["summary"]["text"] == "second"
+
+    @pytest.mark.asyncio
+    async def test_inline_await_fails_fast_without_cancelling_request(self):
+        async def streaming() -> AsyncGenerator[TextDelta, None]:
+            yield TextDelta(id="s", text_delta="first")
+            yield TextDelta(id="s", text_delta="second")
+
+        stream = Tool(name="streaming", handler=streaming, background_mode="auto", tracing_provider=None)()
+        handoff = None
+
+        async for event in stream:
+            if isinstance(event, DeltaEvent):
+                handoff = stream.background()
+                with pytest.raises(RuntimeError, match="task consuming this stream"):
+                    await handoff
+
+        assert handoff is not None
+        placeholder = await handoff
+        snap = await wait_for_background(placeholder["task_id"], timeout=1.0)
+        assert snap["status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_cross_task_request_hands_off_blocked_before_first_event(self):
+        from timbal.state.background import store_for_run
+
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        async def streaming() -> AsyncGenerator[TextDelta, None]:
+            entered.set()
+            await release.wait()
+            yield TextDelta(id="s", text_delta="first")
+            yield TextDelta(id="s", text_delta="second")
+
+        stream = Tool(name="streaming", handler=streaming, background_mode="auto", tracing_provider=None)()
+        parent_events: list[Any] = []
+
+        async def consume() -> None:
+            async for event in stream:
+                parent_events.append(event)
+
+        consumer = asyncio.create_task(consume())
+        await entered.wait()
+        handoff = stream.background()
+        release.set()
+        placeholder = await asyncio.wait_for(handoff, timeout=1.0)
+        await asyncio.wait_for(consumer, timeout=1.0)
+        store = store_for_run(parent_events[0].run_id)
+        record = store.get(placeholder["task_id"])
+        await asyncio.wait_for(record.task, timeout=1.0)
+        snap = record.summarize()
+
+        parent_text = [
+            event.item.text_delta
+            for event in parent_events
+            if isinstance(event, DeltaEvent) and isinstance(event.item, TextDelta)
+        ]
+        assert parent_text == ["first"]
+        assert snap["summary"]["text"] == "second"
+
+    @pytest.mark.asyncio
+    async def test_approval_event_rejects_pending_handoff(self):
+        async def streaming() -> AsyncGenerator[TextDelta, None]:
+            yield TextDelta(id="s", text_delta="never")
+
+        stream = Tool(
+            name="streaming",
+            handler=streaming,
+            background_mode="auto",
+            requires_approval=True,
+            tracing_provider=None,
+        )()
+        handoff = None
+        saw_approval = False
+
+        async for event in stream:
+            if isinstance(event, ApprovalEvent):
+                saw_approval = True
+                handoff = stream.background()
+
+        assert saw_approval
+        assert handoff is not None
+        with pytest.raises(RuntimeError, match="waiting for approval"):
+            await handoff
+        assert list_background_tasks() == []
+
+    @pytest.mark.asyncio
+    async def test_stall_watchdog_starts_after_foreground_snapshot(self, monkeypatch: pytest.MonkeyPatch):
+        from timbal.state.context import RunContext
+
+        save_entered = asyncio.Event()
+        release_save = asyncio.Event()
+        delta_seen = asyncio.Event()
+        resume_consumer = asyncio.Event()
+        blocker = asyncio.Event()
+        closed = asyncio.Event()
+        context: list[Any] = []
+        original_save = RunContext._save_trace
+
+        async def delayed_save(self: Any) -> None:
+            if self is context[0] and not release_save.is_set():
+                save_entered.set()
+                await release_save.wait()
+            await original_save(self)
+
+        monkeypatch.setattr(RunContext, "_save_trace", delayed_save)
+
+        async def streaming() -> AsyncGenerator[TextDelta, None]:
+            context.append(get_run_context())
+            try:
+                yield TextDelta(id="s", text_delta="before")
+                await blocker.wait()
+            finally:
+                closed.set()
+
+        stream = Tool(
+            name="streaming",
+            handler=streaming,
+            background_mode="auto",
+            background_stall_timeout=0.01,
+            tracing_provider=None,
+        )()
+
+        async def consume() -> None:
+            async for event in stream:
+                if isinstance(event, DeltaEvent):
+                    delta_seen.set()
+                    await resume_consumer.wait()
+
+        consumer = asyncio.create_task(consume())
+        await delta_seen.wait()
+        handoff = stream.background()
+        resume_consumer.set()
+        await save_entered.wait()
+        record = next(iter(context[0]._bg_store._tasks.values()))
+
+        await asyncio.sleep(0.03)
+        assert record.status_code() == "running"
+        assert not handoff.done()
+
+        release_save.set()
+        await asyncio.wait_for(handoff, timeout=1.0)
+        await asyncio.wait_for(consumer, timeout=1.0)
+        await asyncio.gather(record.task, return_exceptions=True)
+        await asyncio.wait_for(closed.wait(), timeout=1.0)
+
+        assert record.status_code() == "stalled"
+
+    @pytest.mark.asyncio
+    async def test_cancel_during_snapshot_fails_handoff_and_finalizes_span(self, monkeypatch: pytest.MonkeyPatch):
+        from timbal.state.context import RunContext
+
+        save_entered = asyncio.Event()
+        release_save = asyncio.Event()
+        delta_seen = asyncio.Event()
+        resume_consumer = asyncio.Event()
+        blocker = asyncio.Event()
+        closed = asyncio.Event()
+        context: list[Any] = []
+        parent_outputs: list[OutputEvent] = []
+        original_save = RunContext._save_trace
+
+        async def delayed_save(self: Any) -> None:
+            if self is context[0] and not release_save.is_set():
+                save_entered.set()
+                await release_save.wait()
+            await original_save(self)
+
+        monkeypatch.setattr(RunContext, "_save_trace", delayed_save)
+
+        async def streaming() -> AsyncGenerator[TextDelta, None]:
+            context.append(get_run_context())
+            try:
+                yield TextDelta(id="s", text_delta="before")
+                await blocker.wait()
+            finally:
+                closed.set()
+
+        stream = Tool(name="streaming", handler=streaming, background_mode="auto", tracing_provider=None)()
+
+        async def consume() -> None:
+            async for event in stream:
+                if isinstance(event, DeltaEvent):
+                    delta_seen.set()
+                    await resume_consumer.wait()
+                elif isinstance(event, OutputEvent):
+                    parent_outputs.append(event)
+
+        consumer = asyncio.create_task(consume())
+        await delta_seen.wait()
+        handoff = stream.background()
+        resume_consumer.set()
+        await save_entered.wait()
+        record = next(iter(context[0]._bg_store._tasks.values()))
+        context[0]._bg_store.cancel(record.task_id)
+        release_save.set()
+
+        await asyncio.wait_for(consumer, timeout=1.0)
+        with pytest.raises(RuntimeError, match="ended before cutover: cancelled"):
+            await handoff
+        await asyncio.gather(record.task, return_exceptions=True)
+        await asyncio.wait_for(closed.wait(), timeout=1.0)
+
+        span = context[0]._trace[parent_outputs[0].call_id]
+        assert record.status_code() == "cancelled"
+        assert parent_outputs[0].output["status"] == "cancelled"
+        assert span.status.code == "cancelled"
+        assert span.t1 is not None
+
+    @pytest.mark.asyncio
+    async def test_duplicate_pending_request_is_rejected(self):
+        async def streaming() -> AsyncGenerator[TextDelta, None]:
+            yield TextDelta(id="s", text_delta="first")
+            yield TextDelta(id="s", text_delta="second")
+
+        stream = Tool(name="streaming", handler=streaming, background_mode="auto", tracing_provider=None)()
+        handoff = None
+
+        async for event in stream:
+            if isinstance(event, StartEvent):
+                handoff = stream.background()
+                with pytest.raises(RuntimeError, match="already pending"):
+                    stream.background()
+
+        assert handoff is not None
+        await handoff
+
+    def test_background_request_fails_without_active_eligible_runnable(self):
+        async def streaming() -> AsyncGenerator[TextDelta, None]:
+            yield TextDelta(id="s", text_delta="x")
+
+        stream = Tool(name="streaming", handler=streaming, background_mode="auto")()
+
+        with pytest.raises(RuntimeError, match="No active foreground runnable"):
+            stream.background()
+
+    def test_never_mode_collector_rejects_background_request(self):
+        async def streaming() -> AsyncGenerator[TextDelta, None]:
+            yield TextDelta(id="s", text_delta="x")
+
+        stream = Tool(name="streaming", handler=streaming, background_mode="never")()
+
+        with pytest.raises(RuntimeError, match="does not support"):
+            stream.background()
 
 
 class TestBackgroundEventLogSubscribe:

--- a/python/timbal/collectors/base.py
+++ b/python/timbal/collectors/base.py
@@ -5,12 +5,47 @@ from functools import wraps
 from typing import Any
 
 
+class BackgroundRequest:
+    """Awaitable result of a cooperative foreground-to-background request."""
+
+    def __init__(self, future: asyncio.Future[dict[str, Any]], consumer_task: asyncio.Task | None) -> None:
+        self._future = future
+        self._consumer_task = consumer_task
+        future.add_done_callback(self._consume_unretrieved_exception)
+
+    @staticmethod
+    def _consume_unretrieved_exception(future: asyncio.Future[dict[str, Any]]) -> None:
+        if not future.cancelled():
+            future.exception()
+
+    def __await__(self):
+        if not self._future.done() and asyncio.current_task() is self._consumer_task:
+            raise RuntimeError(
+                "Cannot await background() from the task consuming this stream. "
+                "Keep consuming, then await the request after the placeholder is emitted."
+            )
+        return self._future.__await__()
+
+    def done(self) -> bool:
+        return self._future.done()
+
+    def result(self) -> dict[str, Any]:
+        return self._future.result()
+
+
 class BaseCollector(ABC):
     """Base abstract class for all event collectors with internal state management."""
     
-    def __init__(self, async_gen: AsyncGenerator[Any, None], **kwargs: Any): # noqa: ARG002
+    def __init__(
+        self,
+        async_gen: AsyncGenerator[Any, None],
+        background_handoff: Any = None,
+        **kwargs: Any,  # noqa: ARG002
+    ):
         self._async_gen = async_gen
         self._collected = False
+        self._background_handoff = background_handoff
+        self._consumer_task: asyncio.Task | None = None
 
     def __aiter__(self):
         """Return the async iterator object (self).
@@ -26,6 +61,7 @@ class BaseCollector(ABC):
         Returns:
             Self as the async iterator
         """
+        self._consumer_task = asyncio.current_task()
         return self
 
     async def __anext__(self):
@@ -64,6 +100,23 @@ class BaseCollector(ABC):
         """
         await self._async_gen.aclose()
         self._collected = True
+
+    def background(self) -> BackgroundRequest:
+        """Move the sole active eligible foreground child to the background.
+
+        This is a cooperative handoff: a streaming child switches ownership at
+        its next emitted event. The returned request resolves to the usual
+        ``{"task_id", "status": "running"}`` placeholder after cutover.
+        Keep consuming this collector while awaiting the future from another
+        task; awaiting it inline pauses the producer and therefore the handoff.
+        """
+        if self._collected:
+            raise RuntimeError("This run has already finished.")
+        if self._background_handoff is None:
+            raise RuntimeError("This collector does not support foreground-to-background handoff.")
+        future = self._background_handoff.request()
+        consumer_task = self._consumer_task or asyncio.current_task()
+        return BackgroundRequest(future, consumer_task)
     
     async def collect(self) -> Any:
         """Collect the final result by consuming the entire stream.

--- a/python/timbal/collectors/base.py
+++ b/python/timbal/collectors/base.py
@@ -101,20 +101,23 @@ class BaseCollector(ABC):
         await self._async_gen.aclose()
         self._collected = True
 
-    def background(self) -> BackgroundRequest:
-        """Move the sole active eligible foreground child to the background.
+    def background(self, call_id: str | None = None) -> BackgroundRequest:
+        """Move one active eligible foreground child to the background.
 
         This is a cooperative handoff: a streaming child switches ownership at
         its next emitted event. The returned request resolves to the usual
         ``{"task_id", "status": "running"}`` placeholder after cutover.
-        Keep consuming this collector while awaiting the future from another
-        task; awaiting it inline pauses the producer and therefore the handoff.
+        Omit ``call_id`` when exactly one ``background_mode="auto"`` child is
+        in flight; pass it (from that child's ``START`` / ``DELTA``) when
+        several are. Keep consuming this collector while awaiting the future
+        from another task; awaiting it inline pauses the producer and
+        therefore the handoff.
         """
         if self._collected:
             raise RuntimeError("This run has already finished.")
         if self._background_handoff is None:
             raise RuntimeError("This collector does not support foreground-to-background handoff.")
-        future = self._background_handoff.request()
+        future = self._background_handoff.request(call_id=call_id)
         consumer_task = self._consumer_task or asyncio.current_task()
         return BackgroundRequest(future, consumer_task)
     

--- a/python/timbal/core/runnable.py
+++ b/python/timbal/core/runnable.py
@@ -1622,6 +1622,114 @@ class Runnable(ABC, BaseModel):
         record_box.append(record)
         return {"task_id": record.task_id, "status": "running"}
 
+    def _handoff_background_task(
+        self,
+        handler_events: AsyncGenerator[tuple[Event | None, Any, Any], None],
+        input: dict[str, Any],
+        run_context: Any,
+        span: Any,
+        collector: Any,
+    ) -> tuple[dict[str, Any], asyncio.Event, Any]:
+        """Transfer exclusive ownership of a live handler iterator to a child task."""
+        from ..state.background import (
+            ensure_background_store,
+            get_background_depth,
+            register_background_task,
+            reset_background_depth,
+            set_background_depth,
+        )
+
+        store = ensure_background_store(run_context)
+        depth = get_background_depth()
+        store.begin_spawn(depth)
+        start = asyncio.Event()
+        record_box: list[Any] = []
+
+        async def _continue_in_background() -> Any:
+            token = set_background_depth(depth + 1)
+            output = None
+            try:
+                await start.wait()
+                record = record_box[0]
+                record.schedule_stall_watchdog()
+                async for event, final_output, _handler_collector in handler_events:
+                    if event is not None:
+                        record.ingest(event)
+                    if final_output is not None:
+                        output = final_output
+
+                if isinstance(output, OutputEvent):
+                    if output.status.code in {"cancelled", "error"}:
+                        span.status = output.status
+                        span.error = output.error
+                    output = output.output
+                span.output = output
+                if span.status is None:
+                    _emit_default_tool_usage(self)
+
+                set_parent_call_id(span.parent_call_id)
+                set_call_id(span.call_id)
+                if self.post_hook is not None:
+                    await self._execute_runtime_callable(self.post_hook, self._post_hook_is_coroutine)
+                    invalidate_message_dump_caches(span.output)
+                span._output_dump = await dump(span.output)
+                if span.status is None:
+                    stop_reason = output.stop_reason if isinstance(output, Message) else None
+                    span.status = RunStatus(code="success", reason=stop_reason, message=None)
+                return output
+            except asyncio.CancelledError:
+                span.status = RunStatus(code="cancelled", reason="interrupted", message="")
+                raise
+            except Exception as err:
+                span.status = RunStatus(code="error", reason=None, message=None)
+                span.error = {
+                    "type": type(err).__name__,
+                    "message": str(err),
+                    "traceback": traceback.format_exc(),
+                }
+                raise
+            finally:
+                span.t1 = int(time.time() * 1000)
+                try:
+                    await run_context._save_trace()
+                finally:
+                    reset_background_depth(token)
+                    if record_box:
+                        record_box[0].log.close()
+
+        task: asyncio.Task | None = None
+        registered = False
+        try:
+            task = asyncio.create_task(_continue_in_background(), context=contextvars.copy_context())
+            record = register_background_task(
+                name=self.name,
+                input=input,
+                task=task,
+                on_cancel=self.on_background_cancel,
+                timeout=self.background_timeout,
+                stall_timeout=self.background_stall_timeout,
+            )
+            # Stall time starts when the continuation owns the iterator. Keep
+            # the wall-clock timeout armed so a stuck trace snapshot is bounded.
+            record.clear_watchdogs()
+            record.schedule_timeout()
+
+            async def _close_handler() -> None:
+                await handler_events.aclose()
+                if collector is not None:
+                    await collector.aclose()
+
+            record._handler_aclose = _close_handler
+            registered = True
+        except BaseException:
+            if not registered:
+                store.abort_spawn()
+                if task is not None:
+                    task.cancel()
+            raise
+        record_box.append(record)
+        return {"task_id": record.task_id, "status": "running"}, start, record
+
     def __call__(self, **kwargs: Any) -> Any:
         """Execute the runnable, returning a TimbalCollector over its event stream.
 
@@ -1646,9 +1754,17 @@ class Runnable(ABC, BaseModel):
             from ..collectors.impl.timbal import TimbalCollector
 
             _TimbalCollector = TimbalCollector
-        return _TimbalCollector(async_gen=self._stream(**kwargs))
+        background_handoff = None
+        if self.background_mode == "auto" or self._is_orchestrator:
+            from ..state.background import BackgroundHandoff
 
-    async def _stream(self, **kwargs: Any) -> AsyncGenerator[Event, None]:
+            background_handoff = BackgroundHandoff()
+        return _TimbalCollector(
+            async_gen=self._stream(_background_handoff_control=background_handoff, **kwargs),
+            background_handoff=background_handoff,
+        )
+
+    async def _stream(self, _background_handoff_control: Any = None, **kwargs: Any) -> AsyncGenerator[Event, None]:
         """Raw event stream for one runnable execution (internal entry point).
 
         Handles:
@@ -1716,6 +1832,9 @@ class Runnable(ABC, BaseModel):
         # Session data is loaded once per run; nested calls see it already set.
         if run_context._session_data is None:
             await run_context.get_session()
+        previous_handoff_control = getattr(run_context, "_background_handoff_control", None)
+        if _background_handoff_control is not None:
+            run_context._background_handoff_control = _background_handoff_control
         previous_resume_values = dict(run_context._resume_values)
         run_context._resume_values.update(resume_values)
         set_run_context(run_context)
@@ -1759,6 +1878,17 @@ class Runnable(ABC, BaseModel):
         collector = None
         suspend_signal: Suspend | None = None
         _generator_closed = False
+        handed_off = False
+        handoff_start: asyncio.Event | None = None
+        handoff_result: dict[str, Any] | None = None
+        handoff_record = None
+        handoff_control = (
+            getattr(run_context, "_background_handoff_control", None)
+            if self.background_mode == "auto" and self._is_async_gen and not self._is_orchestrator
+            else None
+        )
+        if handoff_control is not None:
+            handoff_control.register(span.call_id, self.name)
         try:
             start_event = StartEvent(
                 run_id=run_context.id,
@@ -1821,6 +1951,10 @@ class Runnable(ABC, BaseModel):
                             _get_logger().info(approval_event.type, **approval_event.model_dump())
                         yield approval_event
                         _restore_context()
+                        if handoff_control is not None and handoff_control.target_call_id == span.call_id:
+                            handoff_control.fail(
+                                RuntimeError("A runnable waiting for approval cannot move to the background.")
+                            )
                     if not proceed:
                         return
 
@@ -1844,10 +1978,9 @@ class Runnable(ABC, BaseModel):
                     suspend_signal = susp
             else:
                 # Iterate over events from handler and yield them
+                handler_events = self._execute_handler(validated_input, run_context, span)
                 try:
-                    async for event, final_output, handler_collector in self._execute_handler(
-                        validated_input, run_context, span
-                    ):
+                    async for event, final_output, handler_collector in handler_events:
                         # Update collector immediately so it's available for interruption handling
                         if handler_collector is not None:
                             collector = handler_collector
@@ -1866,6 +1999,28 @@ class Runnable(ABC, BaseModel):
                                 span.status = RunStatus(code="cancelled", reason=reason, message=message)
                             yield event
                             _restore_context()
+                            if handoff_control is not None and handoff_control.target_call_id == span.call_id:
+                                if isinstance(event, ApprovalEvent | InteractionEvent):
+                                    handoff_control.fail(
+                                        RuntimeError(
+                                            "A runnable waiting for approval or input cannot move to the background."
+                                        )
+                                    )
+                                else:
+                                    try:
+                                        output, handoff_start, handoff_record = self._handoff_background_task(
+                                            handler_events,
+                                            input,
+                                            run_context,
+                                            span,
+                                            collector,
+                                        )
+                                    except Exception as exc:
+                                        handoff_control.fail(exc)
+                                    else:
+                                        handed_off = True
+                                        handoff_result = output
+                                        break
                         if final_output is not None:
                             output = final_output
                 except Suspend as susp:
@@ -1875,7 +2030,9 @@ class Runnable(ABC, BaseModel):
                     # re-fire the handler with the supplied value on resume.
                     suspend_signal = susp
 
-            if suspend_signal is not None:
+            if handed_off:
+                pass
+            elif suspend_signal is not None:
                 interaction_event = await self._finalize_suspend(suspend_signal, span, run_context)
                 if interaction_event.type in self._log_events and _events_logging_enabled():
                     _get_logger().info(interaction_event.type, **interaction_event.model_dump())
@@ -1900,12 +2057,12 @@ class Runnable(ABC, BaseModel):
 
                 span.output = output
 
-                if not run_in_background and span.status.code == "success":
+                if not run_in_background and not handed_off and span.status.code == "success":
                     _emit_default_tool_usage(self)
 
                 set_parent_call_id(_new_parent_call_id)
                 set_call_id(_new_call_id)
-                if self.post_hook is not None and not run_in_background:
+                if self.post_hook is not None and not run_in_background and not handed_off:
                     await self._execute_runtime_callable(self.post_hook, self._post_hook_is_coroutine)
                     # Hooks may mutate message content in place; drop any cached
                     # dumps on the output so the re-dump below sees the changes.
@@ -2053,26 +2210,66 @@ class Runnable(ABC, BaseModel):
             raise
 
         finally:
+            if handoff_control is not None and not handed_off:
+                handoff_control.unregister(span.call_id)
             t1 = int(time.time() * 1000)
-            span.t1 = t1
-            output_event = OutputEvent(
-                run_id=run_context.id,
-                parent_run_id=run_context.parent_id,
-                path=span.path,
-                call_id=span.call_id,
-                parent_call_id=span.parent_call_id,
-                input=span.input,
-                status=span.status,
-                output=span.output,
-                error=span.error,
-                t0=span.t0,
-                t1=span.t1,
-                usage=span.usage,
-                metadata=span.metadata,
-            )
+            if handed_off:
+                output_event = OutputEvent(
+                    run_id=run_context.id,
+                    parent_run_id=run_context.parent_id,
+                    path=span.path,
+                    call_id=span.call_id,
+                    parent_call_id=span.parent_call_id,
+                    input=span.input,
+                    status=RunStatus(code="success", reason=None, message=None),
+                    output=handoff_result,
+                    error=None,
+                    t0=span.t0,
+                    t1=t1,
+                    usage=dict(span.usage),
+                    metadata={**span.metadata, "background_handoff": True},
+                )
+            else:
+                span.t1 = t1
+                output_event = OutputEvent(
+                    run_id=run_context.id,
+                    parent_run_id=run_context.parent_id,
+                    path=span.path,
+                    call_id=span.call_id,
+                    parent_call_id=span.parent_call_id,
+                    input=span.input,
+                    status=span.status,
+                    output=span.output,
+                    error=span.error,
+                    t0=span.t0,
+                    t1=span.t1,
+                    usage=dict(span.usage),
+                    metadata=span.metadata,
+                )
             output_event._input_dump = span._input_dump
-            output_event._output_dump = span._output_dump
-            await run_context._save_trace()
+            output_event._output_dump = await dump(handoff_result) if handed_off else span._output_dump
+            if handoff_start is None:
+                await run_context._save_trace()
+            else:
+                # The continuation must not mutate the shared span until the
+                # foreground placeholder has been snapshotted for tracing.
+                try:
+                    await run_context._save_trace()
+                finally:
+                    handoff_start.set()
+                    if handoff_control is not None and handoff_result is not None:
+                        if handoff_record is not None and (
+                            handoff_record.task.done() or handoff_record.task.cancelling()
+                        ):
+                            status = handoff_record.status_code()
+                            output_event.output = {**handoff_result, "status": status}
+                            output_event._output_dump = await dump(output_event.output)
+                            handoff_control.fail(
+                                RuntimeError(f"Foreground-to-background handoff ended before cutover: {status}.")
+                            )
+                            handoff_control.unregister(span.call_id)
+                        else:
+                            handoff_control.complete(span.call_id, handoff_result)
             # Warn about resume values that didn't match any gate or suspend()
             # so callers find typos / stale IDs instead of silently dropping
             # them. Only check the IDs introduced by THIS call; nested children
@@ -2087,6 +2284,13 @@ class Runnable(ABC, BaseModel):
                         runnable_path=self._path,
                     )
             run_context._resume_values = previous_resume_values
+            if _background_handoff_control is not None:
+                _background_handoff_control.close()
+                if previous_handoff_control is None:
+                    if getattr(run_context, "_background_handoff_control", None) is _background_handoff_control:
+                        del run_context._background_handoff_control
+                else:
+                    run_context._background_handoff_control = previous_handoff_control
             set_parent_call_id(_parent_call_id)
             set_call_id(_call_id)
             if _entry_call_id is not None:

--- a/python/timbal/state/background.py
+++ b/python/timbal/state/background.py
@@ -98,12 +98,14 @@ class BackgroundHandoff:
         if self.target_call_id == call_id:
             self.fail(RuntimeError(f"'{name}' completed before it could move to the background."))
 
-    def request(self) -> asyncio.Future[dict[str, Any]]:
-        """Target the sole active eligible foreground runnable.
+    def request(self, call_id: str | None = None) -> asyncio.Future[dict[str, Any]]:
+        """Target one active eligible foreground runnable.
 
-        Requests are deliberately explicit and fail fast when there is no
-        unambiguous target. The returned future resolves after the foreground
-        snapshot is saved and the background continuation owns the iterator.
+        Omit ``call_id`` only when a single child is active — that fails fast
+        if the target would be ambiguous. Pass ``call_id`` (from the child's
+        ``START`` / ``DELTA``) to pick among several. The returned future
+        resolves after the foreground snapshot is saved and the background
+        continuation owns the iterator.
         """
         if self._closed:
             raise RuntimeError("This run has already finished.")
@@ -114,12 +116,21 @@ class BackgroundHandoff:
                 "No active foreground runnable can move to the background. "
                 "Only streaming runnables with background_mode='auto' are eligible."
             )
-        if len(self._active) != 1:
-            names = ", ".join(sorted(self._active.values()))
-            raise RuntimeError(
-                f"Cannot choose a background target while {len(self._active)} eligible runnables are active: {names}."
-            )
-        self.target_call_id = next(iter(self._active))
+        if call_id is not None:
+            if call_id not in self._active:
+                names = ", ".join(sorted(self._active.values())) or "none"
+                raise RuntimeError(
+                    f"No active foreground runnable with call_id {call_id!r}. "
+                    f"Eligible: {names}."
+                )
+            self.target_call_id = call_id
+        else:
+            if len(self._active) != 1:
+                names = ", ".join(sorted(self._active.values()))
+                raise RuntimeError(
+                    f"Cannot choose a background target while {len(self._active)} eligible runnables are active: {names}."
+                )
+            self.target_call_id = next(iter(self._active))
         loop = asyncio.get_running_loop()
         self._result = loop.create_future()
         return self._result

--- a/python/timbal/state/background.py
+++ b/python/timbal/state/background.py
@@ -75,6 +75,77 @@ class BackgroundLimitError(RuntimeError):
     """Raised when a spawn would exceed concurrent or depth caps."""
 
 
+class BackgroundHandoff:
+    """Loop-local control plane for cooperatively parking one foreground child.
+
+    The producer remains a direct async-generator ``yield`` until a caller asks
+    to background the currently active eligible runnable. No queue, task, or
+    event is allocated on the ordinary foreground event path.
+    """
+
+    def __init__(self) -> None:
+        self._active: dict[str, str] = {}
+        self.target_call_id: str | None = None
+        self._result: asyncio.Future[dict[str, Any]] | None = None
+        self._closed = False
+
+    def register(self, call_id: str, name: str) -> None:
+        if not self._closed:
+            self._active[call_id] = name
+
+    def unregister(self, call_id: str) -> None:
+        name = self._active.pop(call_id, call_id)
+        if self.target_call_id == call_id:
+            self.fail(RuntimeError(f"'{name}' completed before it could move to the background."))
+
+    def request(self) -> asyncio.Future[dict[str, Any]]:
+        """Target the sole active eligible foreground runnable.
+
+        Requests are deliberately explicit and fail fast when there is no
+        unambiguous target. The returned future resolves after the foreground
+        snapshot is saved and the background continuation owns the iterator.
+        """
+        if self._closed:
+            raise RuntimeError("This run has already finished.")
+        if self._result is not None and not self._result.done():
+            raise RuntimeError("A foreground-to-background handoff is already pending.")
+        if not self._active:
+            raise RuntimeError(
+                "No active foreground runnable can move to the background. "
+                "Only streaming runnables with background_mode='auto' are eligible."
+            )
+        if len(self._active) != 1:
+            names = ", ".join(sorted(self._active.values()))
+            raise RuntimeError(
+                f"Cannot choose a background target while {len(self._active)} eligible runnables are active: {names}."
+            )
+        self.target_call_id = next(iter(self._active))
+        loop = asyncio.get_running_loop()
+        self._result = loop.create_future()
+        return self._result
+
+    def complete(self, call_id: str, result: dict[str, Any]) -> None:
+        if self.target_call_id != call_id:
+            return
+        self._active.pop(call_id, None)
+        self.target_call_id = None
+        future = self._result
+        if future is not None and not future.done():
+            future.set_result(result)
+
+    def fail(self, error: Exception) -> None:
+        self.target_call_id = None
+        future = self._result
+        if future is not None and not future.done():
+            future.set_exception(error)
+
+    def close(self) -> None:
+        self._closed = True
+        self._active.clear()
+        if self.target_call_id is not None:
+            self.fail(RuntimeError("The run finished before the foreground task could move to the background."))
+
+
 def get_background_depth() -> int:
     return _background_depth.get()
 
@@ -562,9 +633,7 @@ class BackgroundEventLog:
         self._wake_waiters()
 
     def _over_cap(self, n: int, nbytes: int) -> bool:
-        return (self._max_events > 0 and n > self._max_events) or (
-            self._max_bytes > 0 and nbytes > self._max_bytes
-        )
+        return (self._max_events > 0 and n > self._max_events) or (self._max_bytes > 0 and nbytes > self._max_bytes)
 
     def _trim(self) -> None:
         """Drop oldest events until the ring fits. Never drops the tip."""
@@ -906,9 +975,7 @@ class BackgroundTaskStore:
         expired = [
             task_id
             for task_id, record in self._tasks.items()
-            if record.task.done()
-            and record.finished_at is not None
-            and now - record.finished_at >= secs
+            if record.task.done() and record.finished_at is not None and now - record.finished_at >= secs
         ]
         for task_id in expired:
             del self._tasks[task_id]
@@ -1088,18 +1155,10 @@ def ensure_background_store(run_context: Any) -> BackgroundTaskStore:
     """
     store = run_context._bg_store
     if store is None:
-        max_concurrent = (
-            run_context._bg_max_concurrent
-            if hasattr(run_context, "_bg_max_concurrent")
-            else _UNSET
-        )
+        max_concurrent = run_context._bg_max_concurrent if hasattr(run_context, "_bg_max_concurrent") else _UNSET
         max_depth = run_context._bg_max_depth if hasattr(run_context, "_bg_max_depth") else _UNSET
-        max_log_events = (
-            run_context._bg_max_log_events if hasattr(run_context, "_bg_max_log_events") else _UNSET
-        )
-        max_log_bytes = (
-            run_context._bg_max_log_bytes if hasattr(run_context, "_bg_max_log_bytes") else _UNSET
-        )
+        max_log_events = run_context._bg_max_log_events if hasattr(run_context, "_bg_max_log_events") else _UNSET
+        max_log_bytes = run_context._bg_max_log_bytes if hasattr(run_context, "_bg_max_log_bytes") else _UNSET
         task_retention_secs = (
             run_context._bg_task_retention_secs if hasattr(run_context, "_bg_task_retention_secs") else _UNSET
         )


### PR DESCRIPTION
## Summary
- Add one-way cooperative `run.background()` handoff that steals an in-flight `background_mode="auto"` streaming tool onto a background task at its next event
- Keep the ordinary single-tool foreground hot path free of Queue/Event/create_task allocation; background ownership starts only after cutover
- Cover lifecycle races (cancel, approval, stalls, ambiguous targets, inline-await deadlock, post-hook failures) plus structural hot-path guards

## Test plan
- [x] `pytest python/tests/core/test_background_tasks.py python/tests/core/test_runnable.py`
- [x] `pytest python/tests/core/test_agent.py`
- [x] ruff format/check on touched files
- [ ] Spot-check: stream an `auto` tool, call `run.background()` from another task, confirm parent gets `{task_id, status}` and later events only appear in `read_background_transcript`
- [ ] Spot-check: cancel / stall / approval after handoff still terminate through the existing background paths