### PR TITLE
feat(types): tag runtime control messages for transcript filtering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -554,6 +554,9 @@ msg = Message(
 msg.collect_text()   # concatenate all TextContent.text
 msg.to_anthropic_input()
 msg.to_openai_chat_completions_input()
+# Optional metadata (not sent to providers). Runtime control messages use:
+# metadata={"source": "runtime", "kind": "background_task_completed"}
+# Filter with msg.is_runtime() when painting human transcripts.
 ```
 
 ### File

--- a/docs/agents/background-tasks.mdx
+++ b/docs/agents/background-tasks.mdx
@@ -69,6 +69,14 @@ summary: ...
 </background_task_completed>
 ```
 
+The notice stays `role="user"` (provider wire formats require it mid-history) but is tagged:
+
+```json
+{"source": "runtime", "kind": "background_task_completed"}
+```
+
+Transcript UIs should filter `metadata.source == "runtime"` (or `Message.is_runtime()`) — do not sniff the XML tag. The model still sees the message; humans should not.
+
 Notices are lean (short summary / result preview, error string if any) — not full transcripts. After drain they are not re-injected; `get_background_task` still peeks the full snapshot. Concurrent parent runs without a shared `parent_id` keep isolated inboxes.
 
 If the model already polls via the auto-registered `get_background_task` / `list_background_tasks` tools and sees a terminal status, that peek **acks** the notice — the next turn will not fire a duplicate `<background_task_completed>` for a completion the agent already handled. App/Python peeks (`timbal.state.get_background_task`) do not ack by default, so UIs can inspect without stealing the LLM inbox.

--- a/python/tests/core/test_background_tasks.py
+++ b/python/tests/core/test_background_tasks.py
@@ -1030,11 +1030,7 @@ async def _wait_until_terminal(task_id: str, timeout: float = 5.0) -> dict:
 
 
 def _completion_notices_in_memory(memory: list[Message]) -> list[str]:
-    return [
-        msg.collect_text()
-        for msg in memory
-        if msg.role == "user" and "<background_task_completed>" in (msg.collect_text() or "")
-    ]
+    return [msg.collect_text() for msg in memory if msg.is_runtime()]
 
 
 def _capture_memory_hook(bucket: list[list[Message]]):
@@ -1095,6 +1091,9 @@ class TestBackgroundCompletionNotify:
         assert task_id in notices[0]
         assert "status: completed" in notices[0]
         assert "done:ok" in notices[0]
+        tagged = [m for m in memories[-1] if m.is_runtime()]
+        assert len(tagged) == 1
+        assert tagged[0].metadata == {"source": "runtime", "kind": "background_task_completed"}
         # One-shot: inbox empty; peek still works.
         assert current_background_store().pending_completions() == []
         assert get_background_task(task_id)["status"] == "completed"

--- a/python/tests/core/test_memory_compaction.py
+++ b/python/tests/core/test_memory_compaction.py
@@ -19,6 +19,14 @@ def _msg_user(text: str) -> Message:
     return Message(role="user", content=[TextContent(text=text)])
 
 
+def _msg_runtime(text: str, *, kind: str = "background_task_completed") -> Message:
+    return Message(
+        role="user",
+        content=[TextContent(text=text)],
+        metadata={"source": "runtime", "kind": kind},
+    )
+
+
 def _msg_system(text: str) -> Message:
     return Message(role="system", content=[TextContent(text=text)])
 
@@ -473,6 +481,25 @@ class TestKeepLastNTurns:
         result = compactor(memory)
         assert len(result) == 1
 
+    def test_runtime_notice_does_not_count_as_turn_but_stays_with_user(self) -> None:
+        memory = [
+            _msg_user("turn1"),
+            _msg_assistant_text("reply1"),
+            _msg_user("turn2"),
+            _msg_assistant_text("reply2"),
+            _msg_runtime("<background_task_completed>\ntask_id: t1\nstatus: completed\n</background_task_completed>"),
+            _msg_user("turn3"),
+            _msg_assistant_text("reply3"),
+        ]
+        compactor = keep_last_n_turns(1)
+        result = compactor(memory)
+        assert [m.collect_text() for m in result] == [
+            "<background_task_completed>\ntask_id: t1\nstatus: completed\n</background_task_completed>",
+            "turn3",
+            "reply3",
+        ]
+        assert result[0].is_runtime()
+
 
 # ---------------------------------------------------------------------------
 # summarize
@@ -500,7 +527,9 @@ class TestSummarizeOldMessages:
     async def test_above_threshold_summarizes(self) -> None:
         """When above threshold, older messages are summarized."""
         memory = [_msg_user(f"Message {i}") for i in range(20)]
-        compactor = summarize(threshold=5, keep_last_n=2, model=TestModel(responses=["The user discussed topics 0 through 17."]))
+        compactor = summarize(
+            threshold=5, keep_last_n=2, model=TestModel(responses=["The user discussed topics 0 through 17."])
+        )
         result = await compactor(memory)
 
         assert len(result) < 20
@@ -610,9 +639,7 @@ class TestSummarizeOldMessages:
     async def test_previous_summary_nothing_new_returns_unchanged(self) -> None:
         """Existing summary + keep_last_n covers all remaining messages — no new call."""
         test_model = TestModel(responses=["Should not be called."])
-        summary_msg = Message.validate(
-            {"role": "user", "content": f"{_SUMMARY_MARKER}\nExisting summary."}
-        )
+        summary_msg = Message.validate({"role": "user", "content": f"{_SUMMARY_MARKER}\nExisting summary."})
         # summary + 2 new messages; keep_last_n=2 covers exactly those 2
         memory = [summary_msg, _msg_user("a"), _msg_user("b")]
         compactor = summarize(threshold=2, keep_last_n=2, model=test_model)
@@ -665,14 +692,17 @@ class TestSummarizeOldMessages:
         """to_keep[0] is assistant: summary(user) → assistant is valid alternation, no ack inserted."""
         # 6 alternating messages ending with assistant; keep_last_n=1 → to_keep=[a3]
         memory = [
-            _msg_user("u1"), _msg_assistant_text("a1"),
-            _msg_user("u2"), _msg_assistant_text("a2"),
-            _msg_user("u3"), _msg_assistant_text("a3"),
+            _msg_user("u1"),
+            _msg_assistant_text("a1"),
+            _msg_user("u2"),
+            _msg_assistant_text("a2"),
+            _msg_user("u3"),
+            _msg_assistant_text("a3"),
         ]
         compactor = summarize(threshold=3, keep_last_n=1, model=TestModel(responses=["Summary."]))
         result = await compactor(memory)
 
-        assert result[0].role == "user"       # summary
+        assert result[0].role == "user"  # summary
         assert result[1].role == "assistant"  # to_keep[0] — no ack in between
         # Verify no "Understood." message inserted
         roles = [m.role for m in result]
@@ -683,16 +713,18 @@ class TestSummarizeOldMessages:
         """to_keep[0] is user: summary(user) + user would be consecutive — ack inserted."""
         # 5 alternating messages ending with user; keep_last_n=1 → to_keep=[u3(current)]
         memory = [
-            _msg_user("u1"), _msg_assistant_text("a1"),
-            _msg_user("u2"), _msg_assistant_text("a2"),
+            _msg_user("u1"),
+            _msg_assistant_text("a1"),
+            _msg_user("u2"),
+            _msg_assistant_text("a2"),
             _msg_user("u3"),
         ]
         compactor = summarize(threshold=3, keep_last_n=1, model=TestModel(responses=["Summary."]))
         result = await compactor(memory)
 
-        assert result[0].role == "user"       # summary
+        assert result[0].role == "user"  # summary
         assert result[1].role == "assistant"  # ack
-        assert result[2].role == "user"       # to_keep[0]
+        assert result[2].role == "user"  # to_keep[0]
         # No consecutive same-role messages anywhere
         for prev, cur in zip(result, result[1:]):
             assert prev.role != cur.role, f"Consecutive {prev.role!r} messages"
@@ -756,9 +788,9 @@ class TestSummarizeOldMessages:
         result = await compactor(memory)
 
         # After orphan cleanup to_keep = [a2, u2] → starts with assistant → no ack
-        assert result[0].role == "user"       # summary
+        assert result[0].role == "user"  # summary
         assert result[1].role == "assistant"  # a2 (not an orphaned tool result)
-        assert result[2].role == "user"       # u2
+        assert result[2].role == "user"  # u2
         # No tool messages in result
         assert all(m.role != "tool" for m in result)
         # No consecutive same-role messages
@@ -861,9 +893,7 @@ class TestCompactToolResultsMultipleToolCalls:
         compactor = compact_tool_results()
         result = compactor(memory)
         assert all(m.role != "tool" for m in result)
-        assert all(
-            not any(isinstance(c, ToolUseContent) for c in m.content) for m in result
-        )
+        assert all(not any(isinstance(c, ToolUseContent) for c in m.content) for m in result)
 
     def test_keep_last_n_one_keeps_entire_last_batch(self) -> None:
         """With keep_last_n=1, the entire last batch (all parallel calls in one assistant message) is kept."""
@@ -881,12 +911,7 @@ class TestCompactToolResultsMultipleToolCalls:
         compactor = compact_tool_results(keep_last_n=1)
         result = compactor(memory)
         # t1 and t2 are in the same batch — both should survive
-        tool_ids = {
-            c.id
-            for m in result
-            for c in m.content
-            if isinstance(c, (ToolUseContent, ToolResultContent))
-        }
+        tool_ids = {c.id for m in result for c in m.content if isinstance(c, (ToolUseContent, ToolResultContent))}
         assert "t1" in tool_ids
         assert "t2" in tool_ids
 
@@ -931,9 +956,7 @@ class TestCompactToolResultsKeepLastNZero:
         compactor = compact_tool_results(keep_last_n=0)
         result = compactor(memory)
         assert all(m.role != "tool" for m in result)
-        assert all(
-            not any(isinstance(c, ToolUseContent) for c in m.content) for m in result
-        )
+        assert all(not any(isinstance(c, ToolUseContent) for c in m.content) for m in result)
 
     def test_replace_mode_zero_replaces_all(self) -> None:
         memory = [
@@ -1150,10 +1173,7 @@ class TestCompactionMetadata:
 
 
 def _has_id(memory: list[Message], uid: str, role: str, content_type: type) -> bool:
-    return any(
-        m.role == role and any(isinstance(c, content_type) and c.id == uid for c in m.content)
-        for m in memory
-    )
+    return any(m.role == role and any(isinstance(c, content_type) and c.id == uid for c in m.content) for m in memory)
 
 
 class TestPinnedResults:
@@ -1181,8 +1201,7 @@ class TestPinnedResults:
         assert _has_id(result, "P", "assistant", ToolUseContent), "pinned tool_use orphaned/dropped"
         # The pinned body must be verbatim, never replaced/truncated.
         pinned = next(
-            c for m in result if m.role == "tool" for c in m.content
-            if isinstance(c, ToolResultContent) and c.id == "P"
+            c for m in result if m.role == "tool" for c in m.content if isinstance(c, ToolResultContent) and c.id == "P"
         )
         assert pinned.content[0].text == "SKILL DOC BODY"
         assert pinned.pinned is True
@@ -1199,8 +1218,7 @@ class TestPinnedResults:
         self._assert_pinned_pair_intact(result)
         # Unpinned results are replaced (not verbatim).
         a = next(
-            c for m in result if m.role == "tool" for c in m.content
-            if isinstance(c, ToolResultContent) and c.id == "A"
+            c for m in result if m.role == "tool" for c in m.content if isinstance(c, ToolResultContent) and c.id == "A"
         )
         assert "chars]" in a.content[0].text
 
@@ -1216,10 +1234,16 @@ class TestPinnedResults:
         result = keep_last_n_messages(2)(self._memory())
         self._assert_pinned_pair_intact(result)
         # Order preserved: pinned tool_use precedes its result.
-        idx_use = next(i for i, m in enumerate(result) if m.role == "assistant"
-                       and any(isinstance(c, ToolUseContent) and c.id == "P" for c in m.content))
-        idx_res = next(i for i, m in enumerate(result) if m.role == "tool"
-                       and any(isinstance(c, ToolResultContent) and c.id == "P" for c in m.content))
+        idx_use = next(
+            i
+            for i, m in enumerate(result)
+            if m.role == "assistant" and any(isinstance(c, ToolUseContent) and c.id == "P" for c in m.content)
+        )
+        idx_res = next(
+            i
+            for i, m in enumerate(result)
+            if m.role == "tool" and any(isinstance(c, ToolResultContent) and c.id == "P" for c in m.content)
+        )
         assert idx_use < idx_res
         # No consecutive same-role messages.
         for prev, cur in zip(result, result[1:], strict=False):
@@ -1811,6 +1835,7 @@ class TestCompactionIntegrationLowRatio:
 # Integration test: Anthropic — alternation fix
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.integration
 class TestCompactionIntegrationAnthropic:
     """Integration tests against the real Anthropic API.
@@ -2047,11 +2072,11 @@ class TestServerToolUse:
         compactor = compact_tool_results(keep_last_n=1)
         result = compactor(memory)
 
-        tool_ids_kept = {
-            c.id for m in result for c in m.content if isinstance(c, ToolUseContent)
-        }
+        tool_ids_kept = {c.id for m in result for c in m.content if isinstance(c, ToolUseContent)}
         custom_ids_kept = {
-            c.value.get("tool_use_id") for m in result for c in m.content
+            c.value.get("tool_use_id")
+            for m in result
+            for c in m.content
             if isinstance(c, CustomContent) and isinstance(c.value, dict)
         }
         assert "srvtoolu_1" not in tool_ids_kept
@@ -2088,9 +2113,9 @@ class TestServerToolUse:
         result = _remove_orphaned_tool_parts(memory)
 
         cleaned = next(
-            m for m in result
-            if m.role == "assistant"
-            and any(isinstance(c, TextContent) and c.text == "Some text." for c in m.content)
+            m
+            for m in result
+            if m.role == "assistant" and any(isinstance(c, TextContent) and c.text == "Some text." for c in m.content)
         )
         assert not any(isinstance(c, CustomContent) for c in cleaned.content)
 
@@ -2238,6 +2263,31 @@ class TestSummarizeV2:
         )
         result = await compactor(memory)
         assert _VERBATIM_MARKER not in result[0].collect_text()
+
+    @pytest.mark.asyncio
+    async def test_verbatim_skips_runtime_notices(self) -> None:
+        """Runtime control messages must not land in the Verbatim User Messages section."""
+        from timbal.core.memory_compaction import _VERBATIM_MARKER
+
+        notice = (
+            "Background task(s) finished since your last turn.\n\n"
+            "<background_task_completed>\ntask_id: abc\nstatus: completed\n</background_task_completed>"
+        )
+        memory = [
+            _msg_runtime(notice),
+            _msg_user("Deploy to staging only."),
+            _msg_assistant_text("ok"),
+            *[_msg_user(f"filler {i}") for i in range(8)],
+        ]
+        compactor = summarize(threshold=3, keep_last_n=2, model=TestModel(responses=["Summary text."]))
+        result = await compactor(memory)
+
+        text = result[0].collect_text()
+        assert _VERBATIM_MARKER in text
+        verbatim_section = text.split(_VERBATIM_MARKER, 1)[1]
+        assert "Deploy to staging only." in verbatim_section
+        assert "background_task_completed" not in verbatim_section
+        assert "Background task(s) finished" not in verbatim_section
 
     @pytest.mark.asyncio
     async def test_verbatim_carried_forward_incrementally(self) -> None:
@@ -2531,7 +2581,9 @@ class TestSummarizeV2:
 
         # A second pass re-parses the (now hostile) summary message — must not raise,
         # and must still produce a well-formed summary message with the note last-ish.
-        twice = await compactor([*once, _msg_user("new instruction"), *[_msg_assistant_text(f"more {i}") for i in range(5)]])
+        twice = await compactor(
+            [*once, _msg_user("new instruction"), *[_msg_assistant_text(f"more {i}") for i in range(5)]]
+        )
         text_twice = twice[0].collect_text()
         assert text_twice.startswith(_SUMMARY_MARKER)
         assert "new instruction" in text_twice

--- a/python/tests/types/test_message.py
+++ b/python/tests/types/test_message.py
@@ -1,4 +1,3 @@
-import base64
 import pathlib
 
 import pytest
@@ -54,9 +53,38 @@ def test_message_full_envelope_dict_is_parsed() -> None:
     assert message.content == [TextContent(text="hi")]
 
 
+def test_message_metadata_roundtrip() -> None:
+    from timbal.types.message import BACKGROUND_TASK_COMPLETED_KIND, RUNTIME_SOURCE
+
+    message = Message(
+        role="user",
+        content=[TextContent(text="notice")],
+        metadata={"source": RUNTIME_SOURCE, "kind": BACKGROUND_TASK_COMPLETED_KIND},
+    )
+    assert message.is_runtime()
+    dumped = Message.serialize(message)
+    assert dumped["metadata"] == {"source": "runtime", "kind": "background_task_completed"}
+    restored = Message.validate(dumped)
+    assert restored.is_runtime()
+    assert restored.metadata == message.metadata
+    # Provider wire formats omit metadata.
+    assert "metadata" not in message.to_anthropic_input()
+    assert "metadata" not in message.to_openai_chat_completions_input()
+
+
+def test_message_metadata_omitted_when_empty() -> None:
+    message = Message(role="user", content=[TextContent(text="hi")])
+    assert message.metadata == {}
+    assert not message.is_runtime()
+    assert "metadata" not in Message.serialize(message)
+
+
 def test_message_text_to_openai_chat_completions_input() -> None:
     message = Message(role="assistant", content=[TextContent(text="Hello, World!")])
-    assert message.to_openai_chat_completions_input() == {"role": "assistant", "content": [{"type": "text", "text": "Hello, World!"}]}
+    assert message.to_openai_chat_completions_input() == {
+        "role": "assistant",
+        "content": [{"type": "text", "text": "Hello, World!"}],
+    }
 
 
 def test_message_thinking_omitted_by_default() -> None:
@@ -115,7 +143,7 @@ def test_message_to_anthropic_input_omits_empty_text() -> None:
 def test_message_file_validation(tmp_path: pathlib.Path) -> None:
     test_file = tmp_path / "image.png"
     png_content = bytes.fromhex(
-        '89504e470d0a1a0a'  # PNG signature
+        "89504e470d0a1a0a"  # PNG signature
     )
     test_file.write_bytes(png_content)
     file_content = FileContent(file=File.validate(str(test_file)))
@@ -130,27 +158,46 @@ def test_message_file_validation(tmp_path: pathlib.Path) -> None:
 
 
 def test_message_tool_use_validation() -> None:
-    message = Message(role="assistant", content=[ToolUseContent(id="123", name="get_weather", input={"city": "London"})])
+    message = Message(
+        role="assistant", content=[ToolUseContent(id="123", name="get_weather", input={"city": "London"})]
+    )
     assert isinstance(message, Message)
     assert message.role == "assistant"
     assert message.content == [ToolUseContent(id="123", name="get_weather", input={"city": "London"})]
 
     with pytest.raises(ValidationError):
-        Message.validate({"role": "assistant", "content": [{"type": "tool_use", "id": "123", "name": "get_weather", "input": "not a dict"}]})
+        Message.validate(
+            {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "123", "name": "get_weather", "input": "not a dict"}],
+            }
+        )
 
 
 def test_message_with_tool_use_to_openai_chat_completions_input() -> None:
-    message = Message(role="assistant", content=[ToolUseContent(id="123", name="get_weather", input={"city": "London"})])
-    assert message.to_openai_chat_completions_input() == {"role": "assistant", "tool_calls": [{"id": "123", "type": "function", "function": {"arguments": '{"city": "London"}', "name": "get_weather"}}]}
+    message = Message(
+        role="assistant", content=[ToolUseContent(id="123", name="get_weather", input={"city": "London"})]
+    )
+    assert message.to_openai_chat_completions_input() == {
+        "role": "assistant",
+        "tool_calls": [
+            {"id": "123", "type": "function", "function": {"arguments": '{"city": "London"}', "name": "get_weather"}}
+        ],
+    }
 
 
 def test_message_with_tool_use_to_anthropic_input() -> None:
     message = Message(role="user", content=[ToolUseContent(id="123", name="get_weather", input={"city": "London"})])
-    assert message.to_anthropic_input() == {"role": "user", "content": [{"type": "tool_use", "id": "123", "name": "get_weather", "input": {"city": "London"}}]}
+    assert message.to_anthropic_input() == {
+        "role": "user",
+        "content": [{"type": "tool_use", "id": "123", "name": "get_weather", "input": {"city": "London"}}],
+    }
 
 
 def test_message_tool_result_validation() -> None:
-    message = Message(role="assistant", content=[ToolResultContent(id="123", content=[TextContent(text="Hello, World!")])])
+    message = Message(
+        role="assistant", content=[ToolResultContent(id="123", content=[TextContent(text="Hello, World!")])]
+    )
     assert isinstance(message, Message)
     assert message.role == "assistant"
     assert message.content == [ToolResultContent(id="123", content=[TextContent(text="Hello, World!")])]
@@ -160,12 +207,21 @@ def test_message_tool_result_validation() -> None:
 
 def test_message_with_tool_result_to_openai_chat_completions_input() -> None:
     message = Message(role="user", content=[ToolResultContent(id="123", content=[TextContent(text="Hello, World!")])])
-    assert message.to_openai_chat_completions_input() == {"role": "tool", "tool_call_id": "123", "content": [{"type": "text", "text": "Hello, World!"}]}
+    assert message.to_openai_chat_completions_input() == {
+        "role": "tool",
+        "tool_call_id": "123",
+        "content": [{"type": "text", "text": "Hello, World!"}],
+    }
 
 
 def test_message_with_tool_result_to_anthropic_input() -> None:
     message = Message(role="user", content=[ToolResultContent(id="123", content=[TextContent(text="Hello, World!")])])
-    assert message.to_anthropic_input() == {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "123", "content": [{"type": "text", "text": "Hello, World!"}]}]}
+    assert message.to_anthropic_input() == {
+        "role": "user",
+        "content": [
+            {"type": "tool_result", "tool_use_id": "123", "content": [{"type": "text", "text": "Hello, World!"}]}
+        ],
+    }
 
 
 # --- Cross-provider replay of server-side tool blocks -----------------------
@@ -191,7 +247,10 @@ def _anthropic_server_tool_message() -> Message:
 def test_server_tool_blocks_skipped_in_openai_responses_input() -> None:
     inputs = _anthropic_server_tool_message().to_openai_responses_input()
     assert inputs == [
-        {"role": "assistant", "content": [{"type": "output_text", "text": "It is sunny. [[weather.com](https://weather.com)]"}]}
+        {
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "It is sunny. [[weather.com](https://weather.com)]"}],
+        }
     ]
 
 

--- a/python/tests/types/test_message.py
+++ b/python/tests/types/test_message.py
@@ -89,12 +89,28 @@ async def test_message_metadata_survives_trace_dump() -> None:
 
 
 def test_message_metadata_omitted_when_empty() -> None:
+    from copy import deepcopy
+
     message = Message(role="user", content=[TextContent(text="hi")])
     assert message.metadata == {}
     assert not message.is_runtime()
     assert "metadata" not in Message.serialize(message)
     with pytest.raises(TypeError):
         message.metadata["source"] = "runtime"
+    # Tracing providers deepcopy live Message graphs — empty metadata must
+    # not store a MappingProxyType on the instance.
+    cloned = deepcopy(message)
+    assert cloned.metadata == {}
+    assert not cloned.is_runtime()
+    tagged = Message(
+        role="user",
+        content=[TextContent(text="notice")],
+        metadata={"source": "runtime", "kind": "background_task_completed"},
+    )
+    cloned_tagged = deepcopy(tagged)
+    assert cloned_tagged.is_runtime()
+    assert cloned_tagged.metadata == tagged.metadata
+    assert cloned_tagged.metadata is not tagged.metadata
 
 
 def test_message_text_to_openai_chat_completions_input() -> None:

--- a/python/tests/types/test_message.py
+++ b/python/tests/types/test_message.py
@@ -72,11 +72,29 @@ def test_message_metadata_roundtrip() -> None:
     assert "metadata" not in message.to_openai_chat_completions_input()
 
 
+@pytest.mark.asyncio
+async def test_message_metadata_survives_trace_dump() -> None:
+    from timbal.utils import dump
+
+    message = Message(
+        role="user",
+        content=[TextContent(text="notice")],
+        metadata={"source": "runtime", "kind": "background_task_completed"},
+    )
+    dumped = await dump(message)
+    assert dumped["metadata"] == {"source": "runtime", "kind": "background_task_completed"}
+    ordinary = Message(role="user", content=[TextContent(text="hi")])
+    ordinary_dump = await dump(ordinary)
+    assert "metadata" not in ordinary_dump
+
+
 def test_message_metadata_omitted_when_empty() -> None:
     message = Message(role="user", content=[TextContent(text="hi")])
     assert message.metadata == {}
     assert not message.is_runtime()
     assert "metadata" not in Message.serialize(message)
+    with pytest.raises(TypeError):
+        message.metadata["source"] = "runtime"
 
 
 def test_message_text_to_openai_chat_completions_input() -> None:

--- a/python/tests/types/test_message.py
+++ b/python/tests/types/test_message.py
@@ -64,9 +64,12 @@ def test_message_metadata_roundtrip() -> None:
     assert message.is_runtime()
     dumped = Message.serialize(message)
     assert dumped["metadata"] == {"source": "runtime", "kind": "background_task_completed"}
+    assert dumped["metadata"] is not message.metadata
+    dumped["metadata"]["source"] = "forged"
+    assert message.is_runtime()
     restored = Message.validate(dumped)
-    assert restored.is_runtime()
-    assert restored.metadata == message.metadata
+    assert not restored.is_runtime()
+    assert message.metadata["source"] == RUNTIME_SOURCE
     # Provider wire formats omit metadata.
     assert "metadata" not in message.to_anthropic_input()
     assert "metadata" not in message.to_openai_chat_completions_input()
@@ -83,6 +86,9 @@ async def test_message_metadata_survives_trace_dump() -> None:
     )
     dumped = await dump(message)
     assert dumped["metadata"] == {"source": "runtime", "kind": "background_task_completed"}
+    assert dumped["metadata"] is not message.metadata
+    dumped["metadata"]["source"] = "forged"
+    assert message.is_runtime()
     ordinary = Message(role="user", content=[TextContent(text="hi")])
     ordinary_dump = await dump(ordinary)
     assert "metadata" not in ordinary_dump

--- a/python/timbal/core/agent.py
+++ b/python/timbal/core/agent.py
@@ -1305,13 +1305,18 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
                 break
 
     def _trailing_user_messages(self, memory: list[Message]) -> list[Message]:
-        """The user messages of the current turn: everything after the last assistant/tool message."""
+        """The human user messages of the current turn.
+
+        Everything after the last assistant/tool message, excluding runtime
+        control messages (e.g. background completion notices) so input
+        guardrails do not treat them as user content.
+        """
         start = 0
         for idx in range(len(memory) - 1, -1, -1):
             if memory[idx].role != "user":
                 start = idx + 1
                 break
-        return [m for m in memory[start:] if m.role == "user"]
+        return [m for m in memory[start:] if m.role == "user" and not m.is_runtime()]
 
     async def _run_input_guardrails(
         self,

--- a/python/timbal/core/memory_compaction.py
+++ b/python/timbal/core/memory_compaction.py
@@ -38,7 +38,9 @@ _REHYDRATED_MARKER = "[Rehydrated Context]"
 _SECTION_MARKERS = (_SUMMARY_MARKER, _VERBATIM_MARKER, _TRANSCRIPT_MARKER, _NOTE_MARKER, _REHYDRATED_MARKER)
 _VERBATIM_SEPARATOR = "\n----8<----\n"
 _VERBATIM_HEADER = "The user's own messages from the compacted region, verbatim, oldest first:"
-_VERBATIM_TRIMMED_NOTE = "[Earlier user messages were dropped from this section; they are covered by the summary above.]"
+_VERBATIM_TRIMMED_NOTE = (
+    "[Earlier user messages were dropped from this section; they are covered by the summary above.]"
+)
 _MAX_TRANSCRIPT_HANDLES = 5
 
 # The continuation guidance is deliberately conservative: post-compaction "continue without
@@ -106,25 +108,24 @@ def _remove_orphaned_tool_parts(memory: list[Message]) -> list[Message]:
             kept = [c for c in msg.content if isinstance(c, ToolResultContent) and c.id in valid_tool_ids]
             if not kept:
                 continue
-            result.append(Message(role=msg.role, content=kept, stop_reason=msg.stop_reason))
+            result.append(
+                Message(role=msg.role, content=kept, stop_reason=msg.stop_reason, metadata=msg.metadata or None)
+            )
         elif msg.role == "assistant":
             # Server tool use blocks (e.g. web search) are self-contained: both the
             # server_tool_use ToolUseContent and its paired result CustomContent live in
             # the same assistant message with no separate tool-role message — never treat
             # them as orphans. Conversely, drop any CustomContent whose tool_use_id has
             # no matching server_tool_use in this message.
-            server_tool_ids = {
-                c.id for c in msg.content
-                if isinstance(c, ToolUseContent) and c.is_server_tool_use
-            }
+            server_tool_ids = {c.id for c in msg.content if isinstance(c, ToolUseContent) and c.is_server_tool_use}
             kept = [
-                c for c in msg.content
-                if not isinstance(c, ToolUseContent)
-                or c.id in valid_tool_ids
-                or c.is_server_tool_use
+                c
+                for c in msg.content
+                if not isinstance(c, ToolUseContent) or c.id in valid_tool_ids or c.is_server_tool_use
             ]
             kept = [
-                c for c in kept
+                c
+                for c in kept
                 if not (
                     isinstance(c, CustomContent)
                     and isinstance(c.value, dict)
@@ -134,7 +135,9 @@ def _remove_orphaned_tool_parts(memory: list[Message]) -> list[Message]:
             ]
             if not kept:
                 continue
-            result.append(Message(role=msg.role, content=kept, stop_reason=msg.stop_reason))
+            result.append(
+                Message(role=msg.role, content=kept, stop_reason=msg.stop_reason, metadata=msg.metadata or None)
+            )
         else:
             result.append(msg)
     return result
@@ -473,9 +476,7 @@ def compact_tool_results(
                         else:
                             # Replace content
                             tool_name = call_id_to_name.get(c.id, "unknown")
-                            result_text = "".join(
-                                item.text for item in c.content if isinstance(item, TextContent)
-                            )
+                            result_text = "".join(item.text for item in c.content if isinstance(item, TextContent))
                             if callable(replacement):
                                 placeholder = replacement(tool_name, c.id, result_text)
                             else:
@@ -499,7 +500,14 @@ def compact_tool_results(
                         new_content.append(c)
                 if not new_content:
                     continue
-                result.append(Message(role=msg.role, content=new_content, stop_reason=msg.stop_reason))
+                result.append(
+                    Message(
+                        role=msg.role,
+                        content=new_content,
+                        stop_reason=msg.stop_reason,
+                        metadata=msg.metadata or None,
+                    )
+                )
             elif msg.role == "assistant":
                 if drop_mode:
                     # Collect IDs of server tool use blocks that are being dropped so we
@@ -507,13 +515,15 @@ def compact_tool_results(
                     # matching tool_use_id). Both live in the same assistant message and
                     # must always travel together, regardless of the result block type.
                     dropped_server_ids = {
-                        c.id for c in msg.content
+                        c.id
+                        for c in msg.content
                         if isinstance(c, ToolUseContent) and c.is_server_tool_use and c.id not in kept_ids
                     }
                     kept = [c for c in msg.content if not isinstance(c, ToolUseContent) or c.id in kept_ids]
                     if dropped_server_ids:
                         kept = [
-                            c for c in kept
+                            c
+                            for c in kept
                             if not (
                                 isinstance(c, CustomContent)
                                 and isinstance(c.value, dict)
@@ -522,7 +532,14 @@ def compact_tool_results(
                         ]
                     if not kept:
                         continue
-                    result.append(Message(role=msg.role, content=kept, stop_reason=msg.stop_reason))
+                    result.append(
+                        Message(
+                            role=msg.role,
+                            content=kept,
+                            stop_reason=msg.stop_reason,
+                            metadata=msg.metadata or None,
+                        )
+                    )
                 else:
                     result.append(msg)
             else:
@@ -573,10 +590,16 @@ def keep_last_n_turns(n: int) -> Callable[[list[Message]], list[Message]]:
     def _compact(memory: list[Message]) -> list[Message]:
         if not memory:
             return memory
-        user_indices = [i for i, m in enumerate(memory) if m.role == "user"]
+        # Runtime control messages (e.g. background completion notices) are role=user
+        # for the LLM wire but must not count as turn boundaries.
+        user_indices = [i for i, m in enumerate(memory) if m.role == "user" and not m.is_runtime()]
         if len(user_indices) <= n:
             return _remove_orphaned_tool_parts(memory)
         start = user_indices[-n]
+        # Pull contiguous runtime notices that sit immediately before the first kept
+        # human user message so [...notice, user...] stays intact.
+        while start > 0 and memory[start - 1].is_runtime():
+            start -= 1
         # Keep the last n turns, plus any pinned messages (and their paired tool_use) from
         # earlier turns. Order is preserved.
         keep = set(range(start, len(memory))) | _pinned_protected_indices(memory)
@@ -633,7 +656,8 @@ def summarize(
         keep_last_n: Number of recent messages to keep unsummarized.
         max_summary_tokens: Maximum tokens for the summary response.
         preserve_user_messages: Carry the user's messages from the summarized region
-            verbatim in the summary message (default True).
+            verbatim in the summary message (default True). Runtime control messages
+            (``Message.is_runtime()``) are excluded — they are not human utterances.
         max_verbatim_chars: Budget for the verbatim section; oldest entries are
             dropped first when exceeded.
         store: OffloadStore for the canonical record. Defaults to None, which uses
@@ -722,7 +746,7 @@ def summarize(
         # Mechanical sections — assembled by us, never trusted to the summarizer.
         if preserve_user_messages:
             for msg in to_summarize:
-                if msg.role != "user":
+                if msg.role != "user" or msg.is_runtime():
                     continue
                 text = msg.collect_text().strip()
                 if text and not text.startswith(_SUMMARY_MARKER):

--- a/python/timbal/state/background.py
+++ b/python/timbal/state/background.py
@@ -481,9 +481,14 @@ def _preview_value(value: Any, *, limit: int = _RESULT_PREVIEW_CHARS) -> str:
 
 
 def format_background_completion_notice(notifications: list[dict[str, Any]]) -> Any:
-    """Build the user-role message injected at the start of the next parent turn."""
+    """Build the user-role message injected at the start of the next parent turn.
+
+    Stays ``role="user"`` so provider wire formats accept it mid-history, but is
+    tagged ``metadata.source="runtime"`` so transcript UIs can drop it without
+    sniffing the XML body.
+    """
     from ..types.content import TextContent
-    from ..types.message import Message
+    from ..types.message import BACKGROUND_TASK_COMPLETED_KIND, RUNTIME_SOURCE, Message
 
     blocks: list[str] = []
     for note in notifications:
@@ -508,7 +513,11 @@ def format_background_completion_notice(notifications: list[dict[str, Any]]) -> 
         "Background task(s) finished since your last turn. "
         "You do not need to poll get_background_task unless you want more detail.\n\n"
     )
-    return Message(role="user", content=[TextContent(text=header + "\n\n".join(blocks))])
+    return Message(
+        role="user",
+        content=[TextContent(text=header + "\n\n".join(blocks))],
+        metadata={"source": RUNTIME_SOURCE, "kind": BACKGROUND_TASK_COMPLETED_KIND},
+    )
 
 
 class BackgroundEventLog:

--- a/python/timbal/types/__init__.py
+++ b/python/timbal/types/__init__.py
@@ -1,4 +1,4 @@
 # ruff: noqa: F401
 from .approval import ApprovalPolicyDecision, ApprovalResolution, Cancel
 from .file import File
-from .message import Message
+from .message import BACKGROUND_TASK_COMPLETED_KIND, RUNTIME_SOURCE, Message

--- a/python/timbal/types/message.py
+++ b/python/timbal/types/message.py
@@ -1,3 +1,4 @@
+from types import MappingProxyType
 from typing import Any, Literal
 
 from pydantic import (
@@ -11,6 +12,10 @@ from pydantic import (
 from pydantic_core import CoreSchema, core_schema
 
 from .content import TextContent, ThinkingContent, ToolResultContent, ToolUseContent, content_factory
+
+# Shared empty mapping for the common case (no runtime annotations). Mutating it
+# is a TypeError — Message is immutable after construction aside from content appends.
+_EMPTY_METADATA: MappingProxyType[str, Any] = MappingProxyType({})
 
 # Runtime-injected control messages (not human utterances). Consumers that paint
 # chat transcripts should filter ``source == "runtime"`` rather than sniffing text.
@@ -69,7 +74,7 @@ class Message:
         object.__setattr__(self, "role", role)
         object.__setattr__(self, "content", content)
         object.__setattr__(self, "stop_reason", stop_reason)
-        object.__setattr__(self, "metadata", dict(metadata) if metadata else {})
+        object.__setattr__(self, "metadata", dict(metadata) if metadata else _EMPTY_METADATA)
         # Serialized-form cache (see timbal.utils.serialization). Long
         # conversations re-dump the same Message objects on every turn
         # (span input dump, memory dump, LLM input dump); messages are
@@ -223,7 +228,7 @@ class Message:
             role=self.role,
             content=kept,
             stop_reason=self.stop_reason,
-            metadata=self.metadata or None,
+            metadata=dict(self.metadata) if self.metadata else None,
         )
 
     @classmethod

--- a/python/timbal/types/message.py
+++ b/python/timbal/types/message.py
@@ -12,8 +12,15 @@ from pydantic_core import CoreSchema, core_schema
 
 from .content import TextContent, ThinkingContent, ToolResultContent, ToolUseContent, content_factory
 
+# Runtime-injected control messages (not human utterances). Consumers that paint
+# chat transcripts should filter ``source == "runtime"`` rather than sniffing text.
+RUNTIME_SOURCE = "runtime"
+BACKGROUND_TASK_COMPLETED_KIND = "background_task_completed"
 
-def _append_anthropic_content_blocks(target: list[dict[str, Any]], anthropic_input: dict[str, Any] | list[dict[str, Any]]) -> None:
+
+def _append_anthropic_content_blocks(
+    target: list[dict[str, Any]], anthropic_input: dict[str, Any] | list[dict[str, Any]]
+) -> None:
     """Append Anthropic content blocks, dropping empty text (API rejects text: '')."""
     if isinstance(anthropic_input, list):
         for block in anthropic_input:
@@ -38,21 +45,31 @@ class Message:
             - Anthropic: 'end_turn', 'max_tokens', 'stop_sequence', 'tool_use', 'pause_turn', 'refusal'
             - OpenAI Chat Completions: 'stop', 'length', 'tool_calls', 'content_filter', 'function_call'
             - OpenAI Responses: 'completed', 'max_output_tokens', 'content_filter', etc.
+        metadata: Optional bag for runtime annotations (not sent to LLM providers).
+            Background completion notices use ``{"source": "runtime", "kind": "..."}``.
     """
 
-    __slots__ = ("role", "content", "stop_reason", "_cached_dump", "_cached_dump_len")
+    __slots__ = ("role", "content", "stop_reason", "metadata", "_cached_dump", "_cached_dump_len")
 
-    def __init__(self, role: Any, content: Any, stop_reason: str | None = None) -> None:
+    def __init__(
+        self,
+        role: Any,
+        content: Any,
+        stop_reason: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
         """Initialize a Message instance.
 
         Args:
             role: The role of the message sender
             content: The content of the message
             stop_reason: The reason the LLM stopped generating (optional, only for assistant messages)
+            metadata: Optional runtime annotations (omitted from provider wire formats)
         """
         object.__setattr__(self, "role", role)
         object.__setattr__(self, "content", content)
         object.__setattr__(self, "stop_reason", stop_reason)
+        object.__setattr__(self, "metadata", dict(metadata) if metadata else {})
         # Serialized-form cache (see timbal.utils.serialization). Long
         # conversations re-dump the same Message objects on every turn
         # (span input dump, memory dump, LLM input dump); messages are
@@ -63,11 +80,18 @@ class Message:
         object.__setattr__(self, "_cached_dump_len", -1)
 
     def __str__(self) -> str:
+        parts = [f"role={self.role}", f"content={self.content}"]
         if self.stop_reason:
-            return f"Message(role={self.role}, content={self.content}, stop_reason={self.stop_reason})"
-        return f"Message(role={self.role}, content={self.content})"
+            parts.append(f"stop_reason={self.stop_reason}")
+        if self.metadata:
+            parts.append(f"metadata={self.metadata}")
+        return f"Message({', '.join(parts)})"
 
     __repr__ = __str__
+
+    def is_runtime(self) -> bool:
+        """True when this message is a runtime control signal, not a human utterance."""
+        return self.metadata.get("source") == RUNTIME_SOURCE
 
     def to_openai_responses_input(self) -> list[dict[str, Any]]:
         """Convert the message to OpenAI's responses api expected input format."""
@@ -166,7 +190,8 @@ class Message:
         from .content import FileContent
 
         unloaded = [
-            c.file for c in self.content
+            c.file
+            for c in self.content
             if isinstance(c, FileContent) and object.__getattribute__(c.file, "__fileobj__") is None
         ]
         if not unloaded:
@@ -175,6 +200,7 @@ class Message:
             await asyncio.gather(*(f.load(client=client) for f in unloaded))
         else:
             import httpx
+
             async with httpx.AsyncClient(timeout=httpx.Timeout(30.0)) as own_client:
                 await asyncio.gather(*(f.load(client=own_client) for f in unloaded))
 
@@ -193,7 +219,12 @@ class Message:
             return None
         if len(kept) == len(self.content):
             return self
-        return Message(role=self.role, content=kept, stop_reason=self.stop_reason)
+        return Message(
+            role=self.role,
+            content=kept,
+            stop_reason=self.stop_reason,
+            metadata=self.metadata or None,
+        )
 
     @classmethod
     def validate(cls, value: ValidatorFunctionWrapHandler, _info: dict | ValidationInfo | None = None) -> "Message":
@@ -210,10 +241,13 @@ class Message:
                 role = value.get("role", "user")
                 content = value.get("content", None)
                 stop_reason = value.get("stop_reason", None)
+                metadata = value.get("metadata", None)
                 if not isinstance(content, list):
                     content = [content]
                 content = [content_factory(item) for item in content]
-                return cls(role=role, content=content, stop_reason=stop_reason)
+                if metadata is not None and not isinstance(metadata, dict):
+                    metadata = None
+                return cls(role=role, content=content, stop_reason=stop_reason, metadata=metadata)
             # Arbitrary payload (e.g. a tool's dict output wired straight into a prompt):
             # stringify the whole dict via content_factory instead of silently dropping
             # it to the literal "None" (which is what the envelope path used to produce).
@@ -238,9 +272,11 @@ class Message:
             "role": value.role,
             "content": value.content,
         }
-        # Only include stop_reason if it's set (to avoid breaking existing serialization)
+        # Only include optional fields when set (avoid breaking existing serialization)
         if value.stop_reason is not None:
             result["stop_reason"] = value.stop_reason
+        if value.metadata:
+            result["metadata"] = value.metadata
         return result
 
     @classmethod
@@ -258,6 +294,10 @@ class Message:
                 "content": {
                     "type": "array",
                     "items": {},  # Keep it open/generic for now.
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": True,
                 },
             },
         }

--- a/python/timbal/types/message.py
+++ b/python/timbal/types/message.py
@@ -13,8 +13,9 @@ from pydantic_core import CoreSchema, core_schema
 
 from .content import TextContent, ThinkingContent, ToolResultContent, ToolUseContent, content_factory
 
-# Shared empty mapping for the common case (no runtime annotations). Mutating it
-# is a TypeError — Message is immutable after construction aside from content appends.
+# Shared empty view returned by the ``metadata`` property when unset. Never
+# stored on the instance — MappingProxyType is not deepcopy/pickle-safe, and
+# voice/tracing deepcopy live Message graphs in memory.
 _EMPTY_METADATA: MappingProxyType[str, Any] = MappingProxyType({})
 
 # Runtime-injected control messages (not human utterances). Consumers that paint
@@ -54,7 +55,7 @@ class Message:
             Background completion notices use ``{"source": "runtime", "kind": "..."}``.
     """
 
-    __slots__ = ("role", "content", "stop_reason", "metadata", "_cached_dump", "_cached_dump_len")
+    __slots__ = ("role", "content", "stop_reason", "_metadata", "_cached_dump", "_cached_dump_len")
 
     def __init__(
         self,
@@ -74,7 +75,9 @@ class Message:
         object.__setattr__(self, "role", role)
         object.__setattr__(self, "content", content)
         object.__setattr__(self, "stop_reason", stop_reason)
-        object.__setattr__(self, "metadata", dict(metadata) if metadata else _EMPTY_METADATA)
+        # Store None (not MappingProxyType) when empty so deepcopy/pickle of
+        # Message graphs used by tracing providers keeps working.
+        object.__setattr__(self, "_metadata", dict(metadata) if metadata else None)
         # Serialized-form cache (see timbal.utils.serialization). Long
         # conversations re-dump the same Message objects on every turn
         # (span input dump, memory dump, LLM input dump); messages are
@@ -84,19 +87,25 @@ class Message:
         object.__setattr__(self, "_cached_dump", None)
         object.__setattr__(self, "_cached_dump_len", -1)
 
+    @property
+    def metadata(self) -> MappingProxyType[str, Any] | dict[str, Any]:
+        """Runtime annotations. Empty messages share a read-only view (no alloc)."""
+        return self._metadata if self._metadata is not None else _EMPTY_METADATA
+
     def __str__(self) -> str:
         parts = [f"role={self.role}", f"content={self.content}"]
         if self.stop_reason:
             parts.append(f"stop_reason={self.stop_reason}")
-        if self.metadata:
-            parts.append(f"metadata={self.metadata}")
+        if self._metadata:
+            parts.append(f"metadata={self._metadata}")
         return f"Message({', '.join(parts)})"
 
     __repr__ = __str__
 
     def is_runtime(self) -> bool:
         """True when this message is a runtime control signal, not a human utterance."""
-        return self.metadata.get("source") == RUNTIME_SOURCE
+        md = self._metadata
+        return md is not None and md.get("source") == RUNTIME_SOURCE
 
     def to_openai_responses_input(self) -> list[dict[str, Any]]:
         """Convert the message to OpenAI's responses api expected input format."""

--- a/python/timbal/types/message.py
+++ b/python/timbal/types/message.py
@@ -290,7 +290,9 @@ class Message:
         if value.stop_reason is not None:
             result["stop_reason"] = value.stop_reason
         if value.metadata:
-            result["metadata"] = value.metadata
+            # Copy so mutating the envelope cannot change the live Message
+            # (dump() already copies; serialize must match).
+            result["metadata"] = dict(value.metadata)
         return result
 
     @classmethod

--- a/python/timbal/utils/serialization.py
+++ b/python/timbal/utils/serialization.py
@@ -104,6 +104,9 @@ def _dump_sync(value: Any) -> Any:
         }
         if value.stop_reason is not None:
             result["stop_reason"] = value.stop_reason
+        metadata = value.metadata
+        if metadata:
+            result["metadata"] = dict(metadata)
         object.__setattr__(value, "_cached_dump", result)
         object.__setattr__(value, "_cached_dump_len", len(content))
         return result
@@ -140,6 +143,7 @@ def _dump_sync(value: Any) -> Any:
 # ---------------------------------------------------------------------------
 # Async path — only entered when a File object exists in the value tree
 # ---------------------------------------------------------------------------
+
 
 async def _dump_async(value: Any) -> Any:
     _ensure_types()
@@ -187,6 +191,9 @@ async def _dump_async(value: Any) -> Any:
         }
         if value.stop_reason is not None:
             result["stop_reason"] = value.stop_reason
+        metadata = value.metadata
+        if metadata:
+            result["metadata"] = dict(metadata)
         object.__setattr__(value, "_cached_dump", result)
         object.__setattr__(value, "_cached_dump_len", len(content))
         return result
@@ -217,6 +224,7 @@ async def _dump_async(value: Any) -> Any:
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
 
 def invalidate_message_dump_caches(value: Any) -> None:
     """Reset the cached dump on any Message reachable in *value* (shallow containers).


### PR DESCRIPTION
## Summary
- Add optional `Message.metadata` (round-trips through serialize/validate; omitted from provider wire formats)
- Stamp background completion notices with `{"source": "runtime", "kind": "background_task_completed"}` so UIs can filter via `msg.is_runtime()` instead of sniffing `<background_task_completed>`
- Skip runtime messages in `summarize` verbatim preservation, `keep_last_n_turns` boundaries (while keeping notices attached to the following human turn), and input-guardrail trailing-user selection

## Test plan
- [x] `pytest python/tests/types/test_message.py`
- [x] `pytest` keep-last-n-turns + summarize verbatim runtime cases
- [x] `pytest TestBackgroundCompletionNotify::test_success_injected_on_next_turn`
- [ ] After merge: Studio/monolith can switch hydrate filter from XML sniff to `metadata.source == "runtime"`