### PR TITLE
feat(tools): Power BI user-delegated OAuth + service principal

### DIFF
--- a/python/tests/tools/test_powerbi.py
+++ b/python/tests/tools/test_powerbi.py
@@ -1,0 +1,161 @@
+"""Tests for Power BI auth (user-delegated OAuth + app-delegated service principal)."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import SecretStr
+from timbal.errors import CredentialNotAvailable
+from timbal.platform.integrations import Integration
+from timbal.tools.powerbi import (
+    PowerBIListWorkspaces,
+    _raise_for_execute_queries,
+    _resolve_token,
+    _service_principal_parts,
+)
+
+
+def _tool(**kwargs: object) -> SimpleNamespace:
+    defaults = {
+        "integration": None,
+        "api_key": None,
+        "token": None,
+        "tenant_id": None,
+        "client_id": None,
+        "client_secret": None,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.fixture(autouse=True)
+def _clear_powerbi_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "POWERBI_API_KEY",
+        "POWERBI_ACCESS_TOKEN",
+        "POWERBI_TENANT_ID",
+        "POWERBI_CLIENT_ID",
+        "POWERBI_CLIENT_SECRET",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.mark.asyncio
+async def test_explicit_api_key_still_works() -> None:
+    tool = _tool(api_key=SecretStr("app-bearer"))
+    assert await _resolve_token(tool) == "app-bearer"
+
+
+@pytest.mark.asyncio
+async def test_explicit_oauth_token() -> None:
+    tool = _tool(token=SecretStr("user-oauth"))
+    assert await _resolve_token(tool) == "user-oauth"
+
+
+@pytest.mark.asyncio
+async def test_explicit_api_key_beats_explicit_token() -> None:
+    tool = _tool(api_key=SecretStr("app-bearer"), token=SecretStr("user-oauth"))
+    assert await _resolve_token(tool) == "app-bearer"
+
+
+@pytest.mark.asyncio
+async def test_oauth_token_from_integration() -> None:
+    integration = MagicMock(spec=Integration)
+    integration.resolve = AsyncMock(return_value={"token": "platform-user-token"})
+    assert await _resolve_token(_tool(integration=integration)) == "platform-user-token"
+
+
+@pytest.mark.asyncio
+async def test_oauth_access_token_alias_from_integration() -> None:
+    integration = MagicMock(spec=Integration)
+    integration.resolve = AsyncMock(return_value={"access_token": "platform-user-access"})
+    assert await _resolve_token(_tool(integration=integration)) == "platform-user-access"
+
+
+@pytest.mark.asyncio
+async def test_api_key_from_integration_still_works() -> None:
+    integration = MagicMock(spec=Integration)
+    integration.resolve = AsyncMock(return_value={"api_key": "platform-app-key"})
+    assert await _resolve_token(_tool(integration=integration)) == "platform-app-key"
+
+
+@pytest.mark.asyncio
+async def test_integration_oauth_beats_api_key_when_both_present() -> None:
+    integration = MagicMock(spec=Integration)
+    integration.resolve = AsyncMock(return_value={"token": "user-oauth", "api_key": "app-key"})
+    assert await _resolve_token(_tool(integration=integration)) == "user-oauth"
+
+
+@pytest.mark.asyncio
+async def test_service_principal_from_integration(monkeypatch: pytest.MonkeyPatch) -> None:
+    integration = MagicMock(spec=Integration)
+    integration.resolve = AsyncMock(
+        return_value={"tenant_id": "tid", "client_id": "cid", "client_secret": "csecret"},
+    )
+    monkeypatch.setattr(
+        "timbal.tools.powerbi._get_token_from_client_credentials",
+        AsyncMock(return_value="sp-access-token"),
+    )
+    assert await _resolve_token(_tool(integration=integration)) == "sp-access-token"
+
+
+@pytest.mark.asyncio
+async def test_service_principal_from_tool_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "timbal.tools.powerbi._get_token_from_client_credentials",
+        AsyncMock(return_value="sp-access-token"),
+    )
+    tool = _tool(tenant_id="tid", client_id="cid", client_secret=SecretStr("csecret"))
+    assert await _resolve_token(tool) == "sp-access-token"
+
+
+@pytest.mark.asyncio
+async def test_env_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POWERBI_API_KEY", "env-app-key")
+    assert await _resolve_token(_tool()) == "env-app-key"
+
+
+@pytest.mark.asyncio
+async def test_env_access_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POWERBI_ACCESS_TOKEN", "env-user-token")
+    assert await _resolve_token(_tool()) == "env-user-token"
+
+
+@pytest.mark.asyncio
+async def test_env_api_key_beats_env_access_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POWERBI_API_KEY", "env-app-key")
+    monkeypatch.setenv("POWERBI_ACCESS_TOKEN", "env-user-token")
+    assert await _resolve_token(_tool()) == "env-app-key"
+
+
+def test_service_principal_parts_incomplete() -> None:
+    assert _service_principal_parts(_tool(tenant_id="tid", client_id="cid"), {}) is None
+
+
+@pytest.mark.asyncio
+async def test_missing_credentials_raises() -> None:
+    with pytest.raises(CredentialNotAvailable) as exc_info:
+        await _resolve_token(_tool())
+    assert exc_info.value.provider_name == "PowerBI"
+
+
+def test_list_workspaces_config_exposes_both_auth_fields() -> None:
+    config = PowerBIListWorkspaces().get_config()
+    assert "api_key" in config
+    assert "token" in config
+    assert "tenant_id" in config
+    assert "client_id" in config
+    assert "client_secret" in config
+    assert "integration" in config
+
+
+def test_execute_queries_401_names_rls_limitation() -> None:
+    response = SimpleNamespace(
+        status_code=401,
+        text='{"error":{"code":"PowerBINotAuthorizedException"}}',
+        raise_for_status=lambda: None,
+    )
+    with pytest.raises(ValueError, match="user-delegated OAuth") as exc_info:
+        _raise_for_execute_queries(response)
+    assert "PowerBINotAuthorizedException" in str(exc_info.value)
+    assert "impersonatedUserName" in str(exc_info.value)

--- a/python/timbal/tools/powerbi.py
+++ b/python/timbal/tools/powerbi.py
@@ -1,12 +1,39 @@
+"""Power BI REST API tools.
+
+Auth (first match wins):
+
+- **User delegated (OAuth)**: ``token`` / ``access_token`` from
+  ``Integration("powerbi")``, tool field ``token``, or env ``POWERBI_ACCESS_TOKEN``.
+- **App delegated (service principal)**: ``api_key`` as a Bearer token (existing),
+  or Azure AD client credentials (``tenant_id`` + ``client_id`` + ``client_secret``)
+  with scope ``https://analysis.windows.net/powerbi/api/.default``.
+  Also accepts ``POWERBI_API_KEY`` or ``POWERBI_TENANT_ID`` / ``POWERBI_CLIENT_ID`` /
+  ``POWERBI_CLIENT_SECRET``.
+"""
+
+from __future__ import annotations
+
+import os
 from typing import Annotated, Any
 
 from pydantic import Field, SecretStr
 
 from ..core.tool import Tool
+from ..errors import CredentialNotAvailable
 from ..platform.integrations import Integration
-from ._creds import resolve_api_key
 
 _BASE_URL = "https://api.powerbi.com/v1.0/myorg"
+_POWERBI_SCOPE = "https://analysis.windows.net/powerbi/api/.default"
+_TOKEN_URL = "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+
+
+def _secret_value(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, SecretStr):
+        value = value.get_secret_value()
+    text = str(value).strip()
+    return text or None
 
 
 def _datasets_url(workspace_id: str | None, suffix: str = "") -> str:
@@ -21,18 +48,140 @@ def _reports_url(workspace_id: str | None, suffix: str = "") -> str:
     return f"{_BASE_URL}/reports{suffix}"
 
 
-class PowerBIListWorkspaces(Tool):
-    name: str = "powerbi_list_workspaces"
-    description: str | None = "List all Power BI workspaces (groups) the authenticated user has access to."
+async def _get_token_from_client_credentials(tenant_id: str, client_id: str, client_secret: str) -> str:
+    """Obtain an app-only token via the Azure AD client-credentials flow."""
+    import httpx
+
+    token_url = _TOKEN_URL.format(tenant_id=tenant_id)
+    async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
+        response = await client.post(
+            token_url,
+            data={
+                "grant_type": "client_credentials",
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "scope": _POWERBI_SCOPE,
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        response.raise_for_status()
+        token = response.json().get("access_token")
+        if not token:
+            raise ValueError("Power BI service principal token response did not include access_token.")
+        return str(token)
+
+
+def _service_principal_parts(tool: Any, creds: dict[str, Any]) -> tuple[str, str, str] | None:
+    tenant_id = (
+        _secret_value(creds.get("tenant_id"))
+        or _secret_value(getattr(tool, "tenant_id", None))
+        or _secret_value(os.getenv("POWERBI_TENANT_ID"))
+    )
+    client_id = (
+        _secret_value(creds.get("client_id"))
+        or _secret_value(getattr(tool, "client_id", None))
+        or _secret_value(os.getenv("POWERBI_CLIENT_ID"))
+    )
+    client_secret = (
+        _secret_value(creds.get("client_secret"))
+        or _secret_value(getattr(tool, "client_secret", None))
+        or _secret_value(os.getenv("POWERBI_CLIENT_SECRET"))
+    )
+    if tenant_id and client_id and client_secret:
+        return tenant_id, client_id, client_secret
+    return None
+
+
+async def _resolve_token(tool: Any) -> str:
+    """Return a Power BI REST Bearer token (user-delegated OAuth or app-delegated)."""
+    explicit_key = _secret_value(getattr(tool, "api_key", None))
+    if explicit_key:
+        return explicit_key
+    explicit_token = _secret_value(getattr(tool, "token", None))
+    if explicit_token:
+        return explicit_token
+
+    creds: dict[str, Any] = {}
+    if isinstance(getattr(tool, "integration", None), Integration):
+        creds = await tool.integration.resolve()
+
+    oauth = _secret_value(creds.get("token")) or _secret_value(creds.get("access_token"))
+    if oauth:
+        return oauth
+
+    api_key = _secret_value(creds.get("api_key"))
+    if api_key:
+        return api_key
+
+    sp = _service_principal_parts(tool, creds)
+    if sp:
+        return await _get_token_from_client_credentials(*sp)
+
+    env_key = _secret_value(os.getenv("POWERBI_API_KEY"))
+    if env_key:
+        return env_key
+    env_oauth = _secret_value(os.getenv("POWERBI_ACCESS_TOKEN"))
+    if env_oauth:
+        return env_oauth
+
+    raise CredentialNotAvailable(
+        "PowerBI",
+        missing=["token", "api_key"],
+        env_vars=[
+            "POWERBI_ACCESS_TOKEN",
+            "POWERBI_API_KEY",
+            "POWERBI_TENANT_ID",
+            "POWERBI_CLIENT_ID",
+            "POWERBI_CLIENT_SECRET",
+        ],
+    )
+
+
+def _raise_for_execute_queries(response: Any) -> None:
+    """Map the documented SP + RLS 401 to a message the agent can act on."""
+    if getattr(response, "status_code", None) != 401:
+        response.raise_for_status()
+        return
+    snippet = (getattr(response, "text", None) or "")[:200]
+    hint = (
+        "Power BI executeQueries returned 401. Service principals cannot query "
+        "semantic models with RLS (PowerBINotAuthorizedException); impersonatedUserName "
+        "does not bypass that. Use a user-delegated OAuth integration "
+        "(Dataset.Read.All + Workspace.Read.All)."
+    )
+    raise ValueError(f"{hint} Upstream: {snippet}" if snippet else hint)
+
+
+class _PowerBITool(Tool):
+    """Shared auth fields for Power BI tools (OAuth user-delegated + service principal)."""
+
     integration: Annotated[str, Integration("powerbi")] | None = None
     api_key: SecretStr | None = None
+    token: SecretStr | None = None
+    tenant_id: str | None = None
+    client_id: str | None = None
+    client_secret: SecretStr | None = None
 
     def get_config(self) -> dict[str, Any]:
         """See base class."""
         return {
             **super().get_config(),
-            **self._annotate_config({"integration": self.integration, "api_key": self.api_key}),
+            **self._annotate_config(
+                {
+                    "integration": self.integration,
+                    "api_key": self.api_key,
+                    "token": self.token,
+                    "tenant_id": self.tenant_id,
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                }
+            ),
         }
+
+
+class PowerBIListWorkspaces(_PowerBITool):
+    name: str = "powerbi_list_workspaces"
+    description: str | None = "List all Power BI workspaces (groups) the authenticated user has access to."
 
     def __init__(self, **kwargs: Any) -> None:
         async def _list_workspaces(
@@ -40,7 +189,7 @@ class PowerBIListWorkspaces(Tool):
             skip: int = Field(0, description="Number of workspaces to skip for pagination."),
             filter: str | None = Field(None, description="OData $filter expression, e.g. 'type eq 'Workspace''."),
         ) -> Any:
-            api_key = await resolve_api_key(tool=self, provider_name="PowerBI", env_var="POWERBI_API_KEY")
+            token = await _resolve_token(self)
             import httpx
 
             params: dict[str, Any] = {"$top": top, "$skip": skip}
@@ -50,7 +199,7 @@ class PowerBIListWorkspaces(Tool):
             async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     f"{_BASE_URL}/groups",
-                    headers={"Authorization": f"Bearer {api_key}"},
+                    headers={"Authorization": f"Bearer {token}"},
                     params=params,
                 )
                 response.raise_for_status()
@@ -59,30 +208,23 @@ class PowerBIListWorkspaces(Tool):
         super().__init__(handler=_list_workspaces, **kwargs)
 
 
-class PowerBIListDatasets(Tool):
+class PowerBIListDatasets(_PowerBITool):
     name: str = "powerbi_list_datasets"
     description: str | None = "List Power BI datasets in a workspace or in My Workspace."
-    integration: Annotated[str, Integration("powerbi")] | None = None
-    api_key: SecretStr | None = None
-
-    def get_config(self) -> dict[str, Any]:
-        """See base class."""
-        return {
-            **super().get_config(),
-            **self._annotate_config({"integration": self.integration, "api_key": self.api_key}),
-        }
 
     def __init__(self, **kwargs: Any) -> None:
         async def _list_datasets(
-            workspace_id: str | None = Field(None, description="Power BI workspace (group) ID. If omitted, lists datasets in My Workspace.")
+            workspace_id: str | None = Field(
+                None, description="Power BI workspace (group) ID. If omitted, lists datasets in My Workspace."
+            ),
         ) -> Any:
-            api_key = await resolve_api_key(tool=self, provider_name="PowerBI", env_var="POWERBI_API_KEY")
+            token = await _resolve_token(self)
             import httpx
 
             async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     _datasets_url(workspace_id),
-                    headers={"Authorization": f"Bearer {api_key}"},
+                    headers={"Authorization": f"Bearer {token}"},
                 )
                 response.raise_for_status()
                 return response.json()
@@ -90,31 +232,24 @@ class PowerBIListDatasets(Tool):
         super().__init__(handler=_list_datasets, **kwargs)
 
 
-class PowerBIGetDataset(Tool):
+class PowerBIGetDataset(_PowerBITool):
     name: str = "powerbi_get_dataset"
     description: str | None = "Get metadata for a specific Power BI dataset."
-    integration: Annotated[str, Integration("powerbi")] | None = None
-    api_key: SecretStr | None = None
-
-    def get_config(self) -> dict[str, Any]:
-        """See base class."""
-        return {
-            **super().get_config(),
-            **self._annotate_config({"integration": self.integration, "api_key": self.api_key}),
-        }
 
     def __init__(self, **kwargs: Any) -> None:
         async def _get_dataset(
             dataset_id: str = Field(..., description="Power BI dataset ID"),
-            workspace_id: str | None = Field(None, description="Power BI workspace (group) ID. If omitted, lists datasets in My Workspace."),
+            workspace_id: str | None = Field(
+                None, description="Power BI workspace (group) ID. If omitted, lists datasets in My Workspace."
+            ),
         ) -> Any:
-            api_key = await resolve_api_key(tool=self, provider_name="PowerBI", env_var="POWERBI_API_KEY")
+            token = await _resolve_token(self)
             import httpx
 
             async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     _datasets_url(workspace_id, f"/{dataset_id}"),
-                    headers={"Authorization": f"Bearer {api_key}"},
+                    headers={"Authorization": f"Bearer {token}"},
                 )
                 response.raise_for_status()
                 return response.json()
@@ -122,27 +257,32 @@ class PowerBIGetDataset(Tool):
         super().__init__(handler=_get_dataset, **kwargs)
 
 
-class PowerBIQueryDataset(Tool):
+class PowerBIQueryDataset(_PowerBITool):
     name: str = "powerbi_query_dataset"
-    description: str | None = "Execute a DAX query against a Power BI dataset and return the results."
-    integration: Annotated[str, Integration("powerbi")] | None = None
-    api_key: SecretStr | None = None
-
-    def get_config(self) -> dict[str, Any]:
-        """See base class."""
-        return {
-            **super().get_config(),
-            **self._annotate_config({"integration": self.integration, "api_key": self.api_key}),
-        }
+    description: str | None = (
+        "Execute a DAX query against a Power BI dataset and return the results. "
+        "Datasets with RLS require user-delegated OAuth; service principal always 401s."
+    )
 
     def __init__(self, **kwargs: Any) -> None:
         async def _query_dataset(
             dataset_id: str = Field(..., description="Power BI dataset ID"),
-            query: str = Field(..., description="DAX query string, e.g. EVALUATE SUMMARIZECOLUMNS('Sales'[Region], \"Total\",[Total Sales])"),
-            workspace_id: str | None = Field(None, description="Power BI workspace (group) ID. If omitted, uses My Workspace."),
-            impersonated_user_name: str | None = Field(None, description="UPN of a user to impersonate for row-level security (RLS)."),
+            query: str = Field(
+                ...,
+                description="DAX query string, e.g. EVALUATE SUMMARIZECOLUMNS('Sales'[Region], \"Total\",[Total Sales])",
+            ),
+            workspace_id: str | None = Field(
+                None, description="Power BI workspace (group) ID. If omitted, uses My Workspace."
+            ),
+            impersonated_user_name: str | None = Field(
+                None,
+                description=(
+                    "UPN to impersonate. Ignored on models without RLS. Does not work with a "
+                    "service principal on RLS models (API returns 401); use user-delegated OAuth instead."
+                ),
+            ),
         ) -> Any:
-            api_key = await resolve_api_key(tool=self, provider_name="PowerBI", env_var="POWERBI_API_KEY")
+            token = await _resolve_token(self)
             import httpx
 
             body: dict[str, Any] = {"queries": [{"query": query}]}
@@ -152,37 +292,32 @@ class PowerBIQueryDataset(Tool):
             async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.post(
                     _datasets_url(workspace_id, f"/{dataset_id}/executeQueries"),
-                    headers={"Authorization": f"Bearer {api_key}"},
+                    headers={"Authorization": f"Bearer {token}"},
                     json=body,
                 )
-                response.raise_for_status()
+                _raise_for_execute_queries(response)
                 return response.json()
 
         super().__init__(handler=_query_dataset, **kwargs)
 
 
-class PowerBIListReports(Tool):
+class PowerBIListReports(_PowerBITool):
     name: str = "powerbi_list_reports"
     description: str | None = "List Power BI reports in a workspace or in My Workspace."
-    integration: Annotated[str, Integration("powerbi")] | None = None
-    api_key: SecretStr | None = None
-
-    def get_config(self) -> dict[str, Any]:
-        """See base class."""
-        return {
-            **super().get_config(),
-            **self._annotate_config({"integration": self.integration, "api_key": self.api_key}),
-        }
 
     def __init__(self, **kwargs: Any) -> None:
-        async def _list_reports(workspace_id: str | None = Field(None, description="Power BI workspace (group) ID. If omitted, lists reports in My Workspace.")) -> Any:
-            api_key = await resolve_api_key(tool=self, provider_name="PowerBI", env_var="POWERBI_API_KEY")
+        async def _list_reports(
+            workspace_id: str | None = Field(
+                None, description="Power BI workspace (group) ID. If omitted, lists reports in My Workspace."
+            ),
+        ) -> Any:
+            token = await _resolve_token(self)
             import httpx
 
             async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     _reports_url(workspace_id),
-                    headers={"Authorization": f"Bearer {api_key}"},
+                    headers={"Authorization": f"Bearer {token}"},
                 )
                 response.raise_for_status()
                 return response.json()
@@ -190,31 +325,24 @@ class PowerBIListReports(Tool):
         super().__init__(handler=_list_reports, **kwargs)
 
 
-class PowerBIGetReport(Tool):
+class PowerBIGetReport(_PowerBITool):
     name: str = "powerbi_get_report"
     description: str | None = "Get metadata for a specific Power BI report, including its embed URL."
-    integration: Annotated[str, Integration("powerbi")] | None = None
-    api_key: SecretStr | None = None
-
-    def get_config(self) -> dict[str, Any]:
-        """See base class."""
-        return {
-            **super().get_config(),
-            **self._annotate_config({"integration": self.integration, "api_key": self.api_key}),
-        }
 
     def __init__(self, **kwargs: Any) -> None:
         async def _get_report(
             report_id: str = Field(..., description="Power BI report ID"),
-            workspace_id: str | None = Field(None, description="Power BI workspace (group) ID. If omitted, uses My Workspace."),
+            workspace_id: str | None = Field(
+                None, description="Power BI workspace (group) ID. If omitted, uses My Workspace."
+            ),
         ) -> Any:
-            api_key = await resolve_api_key(tool=self, provider_name="PowerBI", env_var="POWERBI_API_KEY")
+            token = await _resolve_token(self)
             import httpx
 
             async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
                 response = await client.get(
                     _reports_url(workspace_id, f"/{report_id}"),
-                    headers={"Authorization": f"Bearer {api_key}"},
+                    headers={"Authorization": f"Bearer {token}"},
                 )
                 response.raise_for_status()
                 return response.json()


### PR DESCRIPTION
## Summary
- Add user-delegated auth for Power BI tools via integration `token` / `access_token`, tool `token`, or `POWERBI_ACCESS_TOKEN` (same pattern as Outlook/Excel).
- Keep app-delegated paths: `api_key` / `POWERBI_API_KEY` and Azure AD client credentials (`tenant_id`, `client_id`, `client_secret`).
- Clarify `powerbi_query_dataset` for RLS: service principal + `executeQueries` returns 401; `impersonatedUserName` does not bypass that — user-delegated OAuth is required (La Tramuntana / BBDD-TPV).
- Add unit tests for auth resolution and the RLS 401 error message.

## Test plan
- [x] `uv run python -m pytest python/tests/tools/test_powerbi.py -q --no-cov` (16 passed)
- [ ] Platform: wire Power BI OAuth connector in Integrations (Sign in with Microsoft) so `integration.resolve()` returns a refreshed bearer token
- [ ] La Tramuntana: copilot uses OAuth integration (not client secret) and `executeQueries` on BBDD-TPV returns 200


Made with [Cursor](https://cursor.com)