### PR TITLE
fix(llm): forward x-timbal-project-id for per-project cost attribution

### DIFF
--- a/python/tests/core/llm/test_llm_router_dispatch.py
+++ b/python/tests/core/llm/test_llm_router_dispatch.py
@@ -851,24 +851,25 @@ class TestLlmRouterTestModelPath:
 class TestLlmRouterPlatformHeaders:
     """Test that platform config subject fields are forwarded as request headers."""
 
-    def _make_platform_context(self, app_id=None):
+    def _make_platform_context(self, app_id=None, project_id=None):
         from timbal.state.config import PlatformConfig
 
         platform_config = MagicMock(spec=PlatformConfig)
         platform_config.subject = MagicMock()
         platform_config.subject.org_id = "org_999"
+        # Explicit None — MagicMock attributes are truthy by default and would
+        # otherwise leak a mock object into the header value.
         platform_config.subject.app_id = app_id
+        platform_config.subject.project_id = project_id
         platform_config.host = "api.timbal.ai"
         platform_config.auth = MagicMock()
         platform_config.auth.header_value = "Bearer tok"
         return _make_run_context(platform_config=platform_config)
 
-    @pytest.mark.asyncio
-    async def test_app_id_added_to_headers(self):
+    async def _capture_headers(self, **platform_kwargs):
         from timbal.core.llm import _llm_router
 
-        self._make_platform_context(app_id="app_123")
-
+        self._make_platform_context(**platform_kwargs)
         captured_kwargs = {}
 
         async def fake_create(**kwargs):
@@ -888,38 +889,38 @@ class TestLlmRouterPlatformHeaders:
             except (RuntimeError, StopAsyncIteration):
                 pass
 
-        headers = captured_kwargs.get("extra_headers", {})
+        return captured_kwargs.get("extra_headers", {})
+
+    @pytest.mark.asyncio
+    async def test_app_id_added_to_headers(self):
+        headers = await self._capture_headers(app_id="app_123")
         assert headers.get("x-timbal-app-id") == "app_123"
+        assert "x-timbal-project-id" not in headers
         assert "x-timbal-version-id" not in headers
 
     @pytest.mark.asyncio
     async def test_app_id_absent_omits_header(self):
-        from timbal.core.llm import _llm_router
-
-        self._make_platform_context(app_id=None)
-
-        captured_kwargs = {}
-
-        async def fake_create(**kwargs):
-            captured_kwargs.update(kwargs)
-            return _empty_async_stream()
-
-        mock_client = MagicMock()
-        mock_client.messages.create = fake_create
-
-        with patch("timbal.core.llm.clients._get_client", return_value=mock_client):
-            try:
-                async for _ in _llm_router(
-                    model="anthropic/claude-sonnet-4-6",
-                    max_tokens=100,
-                ):
-                    pass
-            except (RuntimeError, StopAsyncIteration):
-                pass
-
-        headers = captured_kwargs.get("extra_headers", {})
+        headers = await self._capture_headers(app_id=None)
         assert "x-timbal-app-id" not in headers
+        assert "x-timbal-project-id" not in headers
         assert "x-timbal-version-id" not in headers
+
+    @pytest.mark.asyncio
+    async def test_project_id_added_to_headers(self):
+        headers = await self._capture_headers(project_id="proj_456")
+        assert headers.get("x-timbal-project-id") == "proj_456"
+        assert "x-timbal-app-id" not in headers
+
+    @pytest.mark.asyncio
+    async def test_project_id_absent_omits_header(self):
+        headers = await self._capture_headers(project_id=None)
+        assert "x-timbal-project-id" not in headers
+
+    @pytest.mark.asyncio
+    async def test_app_and_project_id_both_forwarded(self):
+        headers = await self._capture_headers(app_id="app_123", project_id="proj_456")
+        assert headers.get("x-timbal-app-id") == "app_123"
+        assert headers.get("x-timbal-project-id") == "proj_456"
 
 
 class TestLlmRouterAnthropicStructuredOutput:

--- a/python/tests/types/test_message.py
+++ b/python/tests/types/test_message.py
@@ -119,6 +119,54 @@ def test_message_metadata_omitted_when_empty() -> None:
     assert cloned_tagged.metadata is not tagged.metadata
 
 
+def test_message_collect_text() -> None:
+    message = Message(
+        role="assistant",
+        content=[
+            TextContent(text="Hello"),
+            ToolUseContent(id="1", name="edit", input={}),
+            TextContent(text="World"),
+        ],
+    )
+    assert message.collect_text() == "Hello\n\nWorld"
+
+
+def test_message_closing_text_is_trailing_contiguous_run() -> None:
+    message = Message(
+        role="assistant",
+        content=[
+            TextContent(text="narration before tools"),
+            ToolUseContent(id="1", name="write", input={"path": "a.py"}),
+            ToolUseContent(id="2", name="bash", input={"cmd": "ls"}),
+            TextContent(text="Contract: /api/users"),
+            TextContent(text="Done."),
+        ],
+    )
+    assert message.closing_text() == "Contract: /api/users\n\nDone."
+    assert message.collect_text() == "narration before tools\n\nContract: /api/users\n\nDone."
+
+
+def test_message_closing_text_still_reports_when_turn_ends_on_tool_call() -> None:
+    """Trailing tool_use (token limit / cancel) must not erase the closing prose."""
+    message = Message(
+        role="assistant",
+        content=[
+            TextContent(text="Wrote the route contract."),
+            ToolUseContent(id="1", name="edit", input={"path": "routes.ts"}),
+            ToolUseContent(id="2", name="bash", input={"cmd": "pytest"}),
+        ],
+    )
+    assert message.closing_text() == "Wrote the route contract."
+
+
+def test_message_closing_text_empty_without_trailing_text() -> None:
+    message = Message(
+        role="assistant",
+        content=[ToolUseContent(id="1", name="edit", input={})],
+    )
+    assert message.closing_text() == ""
+
+
 def test_message_text_to_openai_chat_completions_input() -> None:
     message = Message(role="assistant", content=[TextContent(text="Hello, World!")])
     assert message.to_openai_chat_completions_input() == {

--- a/python/timbal/core/llm/router.py
+++ b/python/timbal/core/llm/router.py
@@ -96,6 +96,8 @@ async def _llm_router(
     if run_context.platform_config and run_context.platform_config.subject:
         if run_context.platform_config.subject.app_id:
             request_headers["x-timbal-app-id"] = run_context.platform_config.subject.app_id
+        if run_context.platform_config.subject.project_id:
+            request_headers["x-timbal-project-id"] = run_context.platform_config.subject.project_id
 
     client, base_url = _resolve_client(provider, config, api_key, base_url, run_context)
 

--- a/python/timbal/types/message.py
+++ b/python/timbal/types/message.py
@@ -226,6 +226,25 @@ class Message:
                 message_text += content.text + "\n\n"
         return message_text.strip()
 
+    def closing_text(self) -> str:
+        """Return the trailing contiguous run of text blocks (the closing report).
+
+        Scans content backwards and keeps the last contiguous sequence of
+        ``TextContent``. Stops at a ``ToolUseContent`` only after at least one
+        text block has been collected — so a turn that ends mid-edit (trailing
+        tool calls from token limit / cancellation) still yields its prose.
+        Non-text, non-tool blocks (thinking, tool results, files, etc.) are
+        skipped without breaking the run.
+        """
+        parts: list[str] = []
+        for content in reversed(self.content):
+            if isinstance(content, TextContent):
+                parts.append(content.text)
+            elif isinstance(content, ToolUseContent) and parts:
+                break
+        parts.reverse()
+        return "\n\n".join(p for p in parts if p).strip()
+
     def without_empty_text_blocks(self) -> "Message | None":
         """Drop ``TextContent`` with empty text (invalid for Anthropic; see DEBUG2)."""
         kept = [c for c in self.content if not (isinstance(c, TextContent) and c.text == "")]


### PR DESCRIPTION
## Summary
- `_llm_router` now sends `x-timbal-project-id` from `PlatformSubject` **in addition to** `x-timbal-app-id`. Tool proxy already did this; the LLM path did not, so composer/org-scoped calls (no `app_id`) billed with `OrgsCosts.project_id = NULL`.
- `Message.closing_text()` returns the last contiguous run of text blocks, stopping at `tool_use` only after text has been collected — so a turn that ends mid-edit still yields its closing report.

Needs a **2.7.x** release so composer (`timbal>=2.7.3,<2.8`) can pick it up. Monolith proxy readers (`resolve_billing_context_from_headers`) are a separate follow-up and should land **after** this ships.

## Test plan
- [x] `uv run pytest python/tests/core/llm/test_llm_router_dispatch.py::TestLlmRouterPlatformHeaders`
- [x] `uv run pytest python/tests/types/test_message.py`
- [ ] Confirm a 2.7.x cut, then replay the monolith header reader on responses/completions/anthropic proxies