### PR TITLE
feat(state): RunContext.emit() — ambient fire-and-forget custom DELTA events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -537,6 +537,24 @@ get_run_context().update_usage("my_api:calls", 1)
 
 Propagates up the call stack. Usage accumulates in `OutputEvent.usage`.
 
+### `emit(data)` — fire-and-forget custom DELTA events
+
+```python
+from timbal.state import emit  # no-op without a run context (unit tests)
+
+get_run_context().emit({"kind": "ui-event", "event": "preview_ready", "url": "..."})
+emit({"kind": "progress", "pct": 50})  # module-level convenience
+```
+
+Out-of-band event channel from anywhere inside a handler (including helpers deep in the call stack): wraps `data` in a `Custom` delta item (`item.type == "custom"`, `item.id` = current call id) and interleaves it with the current call's processed events. Foreground calls surface emissions on the parent event stream; detached background children surface them in their background log/transcript. Always ordered before that call's OUTPUT.
+
+- Never passes through the collector — unlike a generator `yield`, it cannot alter the call's output or the persisted span.
+- Thread-safe from `offload_blocking` / sync-generator executor threads (marshalled onto the owning loop).
+- Fire-and-forget: no await, no backpressure, never raises; outside a run it's a silent no-op (`emit` module function) or log-and-drop (`RunContext.emit`).
+- Zero cost when unused: the per-call sink is allocated on first `emit()`, not on every runnable invocation.
+- Generator handlers: emits between yields surface at the next chunk boundary (or at completion, still before OUTPUT).
+- Plain (non-generator) handlers: emits flush when the handler returns, still before OUTPUT. Not raced against the handler — Task-wrapping every tool/step would show up in the framework-overhead benches.
+
 ---
 
 ## Types

--- a/python/tests/core/test_emit.py
+++ b/python/tests/core/test_emit.py
@@ -292,6 +292,68 @@ class TestEmitBackground:
         assert emitted[0]["item"]["data"] == {"kind": "bg-progress", "pct": 50}
         await asyncio.sleep(0.1)
 
+    @pytest.mark.asyncio
+    async def test_emit_after_spawn_placeholder_reaches_transcript(self):
+        """Spawn-at-birth must not close the forwarding sink in the launcher's finally.
+
+        The launching span yields a placeholder OUTPUT and exits while the child
+        is still running. Emits after that cutover have to keep reaching the
+        background log — not walk to a parent or drop because the sink was
+        closed / t1 was set.
+        """
+        released = asyncio.Event()
+
+        async def bg_task() -> str:
+            await released.wait()
+            emit({"kind": "late-bg-progress", "pct": 100})
+            return "bg done"
+
+        agent = Agent(
+            name="late_bg_emit_agent",
+            model=TestModel(
+                responses=[
+                    _tool_call("bg_task", {}, run_in_background=True),
+                    "Started in the background.",
+                ]
+            ),
+            tools=[
+                Tool(
+                    name="bg_task",
+                    description="Emit late from background",
+                    handler=bg_task,
+                    background_mode="auto",
+                )
+            ],
+        )
+
+        parent_events = [event async for event in agent(prompt="run it")]
+        assert_has_output_event(parent_events[-1])
+        assert _custom_deltas(parent_events, "kind") == []
+
+        listed = list_background_tasks()
+        assert len(listed) == 1
+        task_id = listed[0]["task_id"]
+        # Parent stream is fully drained — launcher _stream finally has run.
+        released.set()
+
+        deadline = time.monotonic() + 5
+        emitted = []
+        while time.monotonic() < deadline and not emitted:
+            transcript = read_background_transcript(task_id)
+            emitted = [
+                event
+                for event in transcript["events"]
+                if isinstance(event, dict)
+                and event.get("type") == "DELTA"
+                and event.get("item", {}).get("type") == "custom"
+                and isinstance(event["item"].get("data"), dict)
+                and event["item"]["data"].get("kind") == "late-bg-progress"
+            ]
+            if not emitted:
+                await asyncio.sleep(0.01)
+        assert len(emitted) == 1
+        assert emitted[0]["item"]["data"] == {"kind": "late-bg-progress", "pct": 100}
+
 
 class TestEmitNoContext:
     """No-op outside a run: tools stay unit-testable without a context harness."""

--- a/python/tests/core/test_emit.py
+++ b/python/tests/core/test_emit.py
@@ -1,0 +1,314 @@
+"""Tests for RunContext.emit() — ambient, fire-and-forget custom DELTA events.
+
+emit() gives any handler code (plain coroutines, sync handlers, helpers deep in
+the call stack) an out-of-band channel to the current call's event stream:
+
+- foreground calls surface emissions on the parent event stream;
+- detached background children surface them in their background log/transcript;
+- emissions are always ordered before that call's OUTPUT event;
+- emissions never pass through the collector, so they cannot alter the output.
+"""
+
+import asyncio
+import time
+
+import pytest
+from timbal import Agent, Tool
+from timbal.core.test_model import TestModel
+from timbal.state import (
+    emit,
+    get_run_context,
+    list_background_tasks,
+    read_background_transcript,
+)
+from timbal.types.content import ToolUseContent
+from timbal.types.events import OutputEvent
+from timbal.types.events.delta import DeltaEvent
+from timbal.types.message import Message
+
+from ..conftest import assert_has_output_event
+
+
+def _tool_call(tool_name: str, input: dict, *, id: str = "c1", run_in_background: bool = False) -> Message:
+    """Return a TestModel response that calls one tool."""
+    actual_input = {**input, **({"run_in_background": True} if run_in_background else {})}
+    return Message(
+        role="assistant",
+        content=[ToolUseContent(id=id, name=tool_name, input=actual_input)],
+        stop_reason="tool_use",
+    )
+
+
+def _custom_deltas(events: list, payload_key: str | None = None) -> list[DeltaEvent]:
+    """Filter DELTA events with item.type == 'custom' (optionally by payload key)."""
+    found = []
+    for event in events:
+        if isinstance(event, DeltaEvent) and event.item.type == "custom":
+            if payload_key is None or (isinstance(event.item.data, dict) and payload_key in event.item.data):
+                found.append(event)
+    return found
+
+
+class TestEmitForeground:
+    """Foreground delivery: emissions ride the parent event stream."""
+
+    @pytest.mark.asyncio
+    async def test_plain_handler_emit_shape_and_ordering(self):
+        """A plain coroutine handler's emits arrive as custom DELTAs before OUTPUT."""
+
+        async def handler() -> dict:
+            get_run_context().emit({"kind": "ui-event", "step": 1})
+            get_run_context().emit({"kind": "ui-event", "step": 2})
+            return {"ok": True}
+
+        tool = Tool(name="emitter", handler=handler)
+        events = [event async for event in tool()]
+
+        output_events = [e for e in events if isinstance(e, OutputEvent)]
+        assert len(output_events) == 1
+        output_event = output_events[0]
+        assert output_event.status.code == "success"
+        # Requirement: emissions never touch the output.
+        assert output_event.output == {"ok": True}
+
+        customs = _custom_deltas(events, "kind")
+        assert [c.item.data["step"] for c in customs] == [1, 2]
+        # Emissions are ordered before the call's OUTPUT.
+        assert all(events.index(c) < events.index(output_event) for c in customs)
+        # Ambient ids: the event is attributed to the emitting call.
+        for custom in customs:
+            assert custom.call_id == output_event.call_id
+            assert custom.path == output_event.path == "emitter"
+            assert custom.run_id == output_event.run_id
+            assert custom.item.id == custom.call_id
+
+    @pytest.mark.asyncio
+    async def test_plain_handler_emit_flushed_before_output(self):
+        """Plain handlers are not Task-wrapped (bench hot path). Emits flush at completion, still before OUTPUT."""
+
+        async def handler() -> str:
+            get_run_context().emit({"kind": "progress", "phase": "started"})
+            await asyncio.sleep(0)
+            return "done"
+
+        tool = Tool(name="midrun", handler=handler)
+        events = [event async for event in tool()]
+
+        output_event = events[-1]
+        assert isinstance(output_event, OutputEvent)
+        assert output_event.status.code == "success"
+        assert output_event.output == "done"
+        customs = _custom_deltas(events, "kind")
+        assert len(customs) == 1
+        assert events.index(customs[0]) < events.index(output_event)
+
+    @pytest.mark.asyncio
+    async def test_emit_visible_on_agent_stream(self):
+        """Emissions from a tool handler surface on the owning agent's stream."""
+
+        async def resolve_resource() -> dict:
+            emit({"kind": "compose-ui-event", "event": "trace_ref", "resource": "res-42"})
+            return {"resource_id": "res-42"}
+
+        agent = Agent(
+            name="emit_agent",
+            model=TestModel(responses=[_tool_call("resolve_resource", {}), "All done."]),
+            tools=[Tool(name="resolve_resource", handler=resolve_resource)],
+        )
+
+        events = [event async for event in agent(prompt="resolve it")]
+        customs = _custom_deltas(events, "kind")
+        assert len(customs) == 1
+        custom = customs[0]
+        assert custom.path == "emit_agent.resolve_resource"
+        assert custom.item.data["event"] == "trace_ref"
+
+        tool_output = next(
+            e
+            for e in events
+            if isinstance(e, OutputEvent) and e.path == "emit_agent.resolve_resource"
+        )
+        # Attributed to the tool call, ordered before the tool's OUTPUT, and
+        # absent from the tool's output itself.
+        assert custom.call_id == tool_output.call_id
+        assert events.index(custom) < events.index(tool_output)
+        assert tool_output.output == {"resource_id": "res-42"}
+
+    @pytest.mark.asyncio
+    async def test_emit_from_async_gen_handler_does_not_pollute_output(self):
+        """Generator handlers: emit() bypasses the collector, unlike yields."""
+
+        async def gen_handler():
+            yield "a"
+            get_run_context().emit({"kind": "side-channel", "n": 1})
+            yield "b"
+
+        tool = Tool(name="gen_emitter", handler=gen_handler)
+        events = [event async for event in tool()]
+
+        output_event = next(e for e in events if isinstance(e, OutputEvent))
+        # String yields concatenate via the string collector — the emitted
+        # dict must not have passed through it.
+        assert output_event.output == "ab"
+        emitted = _custom_deltas(events, "kind")
+        assert len(emitted) == 1
+        assert emitted[0].item.data == {"kind": "side-channel", "n": 1}
+        assert events.index(emitted[0]) < events.index(output_event)
+
+    @pytest.mark.asyncio
+    async def test_emit_from_offloaded_sync_handler(self):
+        """Thread safety: emit from a sync handler running in an executor thread."""
+
+        def blocking_handler() -> str:
+            emit({"kind": "from-thread"})
+            time.sleep(0.05)
+            return "done"
+
+        tool = Tool(name="offloaded", handler=blocking_handler, offload_blocking=True)
+        events = [event async for event in tool()]
+
+        output_event = next(e for e in events if isinstance(e, OutputEvent))
+        assert output_event.status.code == "success"
+        assert output_event.output == "done"
+        emitted = _custom_deltas(events, "kind")
+        assert len(emitted) == 1
+        assert events.index(emitted[0]) < events.index(output_event)
+
+    @pytest.mark.asyncio
+    async def test_emit_from_sync_gen_handler(self):
+        """Thread safety: sync generators run via sync_to_async_gen off-loop."""
+
+        def sync_gen():
+            yield 1
+            emit({"kind": "from-sync-gen"})
+            yield 2
+
+        tool = Tool(name="sync_gen_emitter", handler=sync_gen)
+        events = [event async for event in tool()]
+
+        output_event = next(e for e in events if isinstance(e, OutputEvent))
+        assert output_event.output == [1, 2]
+        emitted = _custom_deltas(events, "kind")
+        assert len(emitted) == 1
+        assert events.index(emitted[0]) < events.index(output_event)
+
+    @pytest.mark.asyncio
+    async def test_emit_kept_out_of_default_collector_output(self):
+        """Non-string yields collect into a list — emissions must not join it."""
+
+        async def gen_handler():
+            yield {"chunk": 1}
+            get_run_context().emit({"kind": "side-channel"})
+            yield {"chunk": 2}
+
+        tool = Tool(name="dict_gen_emitter", handler=gen_handler)
+        events = [event async for event in tool()]
+
+        output_event = next(e for e in events if isinstance(e, OutputEvent))
+        assert output_event.output == [{"chunk": 1}, {"chunk": 2}]
+        assert len(_custom_deltas(events, "kind")) == 1
+
+    @pytest.mark.asyncio
+    async def test_child_emit_does_not_steal_parent_sink(self):
+        """A parent that already emitted must not swallow the child's first emit."""
+
+        def pre_hook():
+            emit({"kind": "parent"})
+
+        async def child() -> str:
+            emit({"kind": "child"})
+            span = get_run_context().current_span()
+            assert span.path == "a.child"
+            assert span._emit_sink is not None
+            assert span._emit_sink.has_pending()
+            return "ok"
+
+        agent = Agent(
+            name="a",
+            model=TestModel(responses=[_tool_call("child", {}), "done"]),
+            tools=[Tool(name="child", handler=child)],
+            pre_hook=pre_hook,
+        )
+        events = [event async for event in agent(prompt="go")]
+
+        parent_events = [e for e in _custom_deltas(events, "kind") if e.item.data["kind"] == "parent"]
+        child_events = [e for e in _custom_deltas(events, "kind") if e.item.data["kind"] == "child"]
+        assert len(parent_events) == 1
+        assert parent_events[0].path == "a"
+        assert len(child_events) == 1
+        child_output = next(e for e in events if isinstance(e, OutputEvent) and e.path == "a.child")
+        assert child_events[0].path == "a.child"
+        assert child_events[0].call_id == child_output.call_id
+        assert events.index(child_events[0]) < events.index(child_output)
+
+
+class TestEmitBackground:
+    """Detached background children: emissions land in the background log."""
+
+    @pytest.mark.asyncio
+    async def test_emit_lands_in_background_transcript(self):
+        async def bg_task() -> str:
+            emit({"kind": "bg-progress", "pct": 50})
+            await asyncio.sleep(0.05)
+            return "bg done"
+
+        agent = Agent(
+            name="bg_emit_agent",
+            model=TestModel(
+                responses=[
+                    _tool_call("bg_task", {}, run_in_background=True),
+                    "Started in the background.",
+                ]
+            ),
+            tools=[Tool(name="bg_task", description="Emit from background", handler=bg_task, background_mode="auto")],
+        )
+
+        parent_events = [event async for event in agent(prompt="run it")]
+        assert_has_output_event(parent_events[-1])
+        # The emission belongs to the detached child, not the parent stream.
+        assert _custom_deltas(parent_events, "kind") == []
+
+        listed = list_background_tasks()
+        assert len(listed) == 1
+        task_id = listed[0]["task_id"]
+
+        # The transcript serializes events to dicts.
+        deadline = time.monotonic() + 5
+        emitted = []
+        while time.monotonic() < deadline and not emitted:
+            transcript = read_background_transcript(task_id)
+            emitted = [
+                event
+                for event in transcript["events"]
+                if isinstance(event, dict)
+                and event.get("type") == "DELTA"
+                and event.get("item", {}).get("type") == "custom"
+                and isinstance(event["item"].get("data"), dict)
+                and "kind" in event["item"]["data"]
+            ]
+            if not emitted:
+                await asyncio.sleep(0.01)
+        assert len(emitted) == 1
+        assert emitted[0]["item"]["data"] == {"kind": "bg-progress", "pct": 50}
+        await asyncio.sleep(0.1)
+
+
+class TestEmitNoContext:
+    """No-op outside a run: tools stay unit-testable without a context harness."""
+
+    def test_module_emit_without_context_is_noop(self):
+        emit({"kind": "nobody-listening"})  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_handler_calling_emit_is_directly_invocable(self):
+        async def handler() -> str:
+            emit({"kind": "ui-event"})
+            return "ok"
+
+        # Direct invocation, no framework, no run context.
+        assert await handler() == "ok"
+
+    def test_run_context_emit_without_active_call_is_noop(self):
+        from timbal.state.context import RunContext
+
+        RunContext().emit({"kind": "no-span"})  # must not raise

--- a/python/tests/core/test_emit.py
+++ b/python/tests/core/test_emit.py
@@ -123,11 +123,7 @@ class TestEmitForeground:
         assert custom.path == "emit_agent.resolve_resource"
         assert custom.item.data["event"] == "trace_ref"
 
-        tool_output = next(
-            e
-            for e in events
-            if isinstance(e, OutputEvent) and e.path == "emit_agent.resolve_resource"
-        )
+        tool_output = next(e for e in events if isinstance(e, OutputEvent) and e.path == "emit_agent.resolve_resource")
         # Attributed to the tool call, ordered before the tool's OUTPUT, and
         # absent from the tool's output itself.
         assert custom.call_id == tool_output.call_id
@@ -353,6 +349,60 @@ class TestEmitBackground:
                 await asyncio.sleep(0.01)
         assert len(emitted) == 1
         assert emitted[0]["item"]["data"] == {"kind": "late-bg-progress", "pct": 100}
+
+    @pytest.mark.asyncio
+    async def test_pre_hook_emit_flushed_when_spawn_never_runs(self):
+        """run_in_background is set at _stream entry; spawn is later.
+
+        A raise from pre_hook (or an early return from approval / guardrails /
+        param resolution) must still flush buffered emits before OUTPUT. The
+        launcher finally must snapshot span._emit_sink unless spawn actually
+        rebound it.
+        """
+
+        def boom():
+            emit({"kind": "pre-spawn-fail"})
+            raise RuntimeError("pre_hook boom")
+
+        tool = Tool(
+            name="bg_prehook_fail",
+            handler=lambda: "never",
+            background_mode="always",
+            pre_hook=boom,
+        )
+        events = [event async for event in tool()]
+
+        output_event = events[-1]
+        assert isinstance(output_event, OutputEvent)
+        assert output_event.status.code == "error"
+        customs = _custom_deltas(events, "kind")
+        assert [c.item.data["kind"] for c in customs] == ["pre-spawn-fail"]
+        assert events.index(customs[0]) < events.index(output_event)
+
+    @pytest.mark.asyncio
+    async def test_approval_early_return_flushes_emit_when_background(self):
+        """Approval gate returns before spawn; buffered emits still flush."""
+
+        def announce() -> str:
+            emit({"kind": "pre-approval"})
+            return "x"
+
+        async def handler(note: str) -> str:
+            return note
+
+        tool = Tool(
+            name="bg_gated",
+            handler=handler,
+            requires_approval=True,
+            background_mode="always",
+            default_params={"note": announce},
+        )
+        events = [event async for event in tool()]
+
+        output_event = next(e for e in events if isinstance(e, OutputEvent))
+        customs = _custom_deltas(events, "kind")
+        assert [c.item.data["kind"] for c in customs] == ["pre-approval"]
+        assert events.index(customs[0]) < events.index(output_event)
 
 
 class TestEmitNoContext:

--- a/python/timbal/core/runnable.py
+++ b/python/timbal/core/runnable.py
@@ -1903,6 +1903,10 @@ class Runnable(ABC, BaseModel):
         handoff_start: asyncio.Event | None = None
         handoff_result: dict[str, Any] | None = None
         handoff_record = None
+        # Foreground sink this _stream owns. Spawn-at-birth rebinds
+        # span._emit_sink to a forwarding sink on the same span; we snapshot
+        # first so finally closes *this* object, not the child's.
+        emit_sink = None
         handoff_control = (
             getattr(run_context, "_background_handoff_control", None)
             if self.background_mode == "auto" and self._is_async_gen and not self._is_orchestrator
@@ -1989,6 +1993,7 @@ class Runnable(ABC, BaseModel):
 
             # Background task
             if run_in_background:
+                emit_sink = span._emit_sink
                 output = self._spawn_background_task(validated_input, input, run_context, span)
             elif not self._is_async_gen and not self._is_gen:
                 # Fast path: plain sync/coroutine handlers cannot yield events,
@@ -2245,9 +2250,12 @@ class Runnable(ABC, BaseModel):
             raise
 
         finally:
-            # Snapshot before handoff_start.set(): the continuation may rebind
-            # span._emit_sink to a forwarding sink. Close/drain *this* object.
-            emit_sink = span._emit_sink
+            # Spawn-at-birth already snapshotted the foreground sink above;
+            # do not pick up the forwarding sink the child just installed.
+            # Handoff snapshots here, before handoff_start.set(), for the
+            # same reason: the continuation rebinds span._emit_sink after.
+            if not run_in_background:
+                emit_sink = span._emit_sink
             if handoff_control is not None and not handed_off:
                 handoff_control.unregister(span.call_id)
             t1 = int(time.time() * 1000)

--- a/python/timbal/core/runnable.py
+++ b/python/timbal/core/runnable.py
@@ -1907,6 +1907,7 @@ class Runnable(ABC, BaseModel):
         # span._emit_sink to a forwarding sink on the same span; we snapshot
         # first so finally closes *this* object, not the child's.
         emit_sink = None
+        spawned_background = False
         handoff_control = (
             getattr(run_context, "_background_handoff_control", None)
             if self.background_mode == "auto" and self._is_async_gen and not self._is_orchestrator
@@ -1994,6 +1995,7 @@ class Runnable(ABC, BaseModel):
             # Background task
             if run_in_background:
                 emit_sink = span._emit_sink
+                spawned_background = True
                 output = self._spawn_background_task(validated_input, input, run_context, span)
             elif not self._is_async_gen and not self._is_gen:
                 # Fast path: plain sync/coroutine handlers cannot yield events,
@@ -2250,11 +2252,14 @@ class Runnable(ABC, BaseModel):
             raise
 
         finally:
-            # Spawn-at-birth already snapshotted the foreground sink above;
-            # do not pick up the forwarding sink the child just installed.
-            # Handoff snapshots here, before handoff_start.set(), for the
-            # same reason: the continuation rebinds span._emit_sink after.
-            if not run_in_background:
+            # Only skip the snapshot when spawn actually rebound the sink.
+            # run_in_background is set at _stream entry; a raise / early
+            # return from pre_hook, approval, guardrails, or param
+            # resolution never reaches spawn — those buffered emits still
+            # live on span._emit_sink and must flush before OUTPUT.
+            # Handoff snapshots here, before handoff_start.set(), so the
+            # continuation can rebind after.
+            if not spawned_background:
                 emit_sink = span._emit_sink
             if handoff_control is not None and not handed_off:
                 handoff_control.unregister(span.call_id)

--- a/python/timbal/core/runnable.py
+++ b/python/timbal/core/runnable.py
@@ -43,7 +43,7 @@ from ..state import (
     set_parent_call_id,
     set_run_context,
 )
-from ..state.context import RunContext
+from ..state.context import RunContext, _EmitSink
 from ..state.dependency_analyzer import RunContextDependencyAnalyzer
 from ..state.tracing.providers import TRACING_UNSET
 from ..state.tracing.span import Span
@@ -1575,6 +1575,13 @@ class Runnable(ABC, BaseModel):
         async def _bg_handler_execution():
             token = set_background_depth(depth + 1)
             record = record_box[0]
+            # Ambient emits from the detached child must reach its background
+            # log — after detach the only copy of its stream — not the finished
+            # foreground call. Nested runnables inside the child attach their
+            # own per-call sinks whose drained events reach the record via
+            # process_event; only this root frame needs the forwarding sink.
+            bg_emit_sink = _EmitSink(asyncio.get_running_loop(), forward=record.put_nowait)
+            span._emit_sink = bg_emit_sink
             output = None
             try:
                 async for _, final_output, _handler_collector in self._execute_handler(
@@ -1596,6 +1603,7 @@ class Runnable(ABC, BaseModel):
             except asyncio.CancelledError:
                 raise
             finally:
+                bg_emit_sink.close()
                 reset_background_depth(token)
                 record.log.close()
             return output
@@ -1648,9 +1656,15 @@ class Runnable(ABC, BaseModel):
         async def _continue_in_background() -> Any:
             token = set_background_depth(depth + 1)
             output = None
+            bg_emit_sink = None
             try:
                 await start.wait()
                 record = record_box[0]
+                # After cutover the record log is the only copy of the child's
+                # stream: rebind ambient RunContext.emit() delivery to it (the
+                # foreground sink was drained and closed by _stream's finally).
+                bg_emit_sink = _EmitSink(asyncio.get_running_loop(), forward=record.put_nowait)
+                span._emit_sink = bg_emit_sink
                 record.schedule_stall_watchdog()
                 async for event, final_output, _handler_collector in handler_events:
                     if event is not None:
@@ -1689,6 +1703,8 @@ class Runnable(ABC, BaseModel):
                 }
                 raise
             finally:
+                if bg_emit_sink is not None:
+                    bg_emit_sink.close()
                 span.t1 = int(time.time() * 1000)
                 try:
                     await run_context._save_trace()
@@ -1854,6 +1870,11 @@ class Runnable(ABC, BaseModel):
             runnable=self,
         )
         run_context._trace[_new_call_id] = span
+        # Capture the loop once per run so off-thread emit() can marshal onto
+        # it. The per-call sink itself is allocated lazily on first emit() —
+        # benches never emit, so this is a pointer compare, not an object.
+        if run_context._loop is None:
+            run_context._loop = asyncio.get_running_loop()
 
         def _restore_context():
             """Restore this invocation's context vars.
@@ -1972,6 +1993,10 @@ class Runnable(ABC, BaseModel):
             elif not self._is_async_gen and not self._is_gen:
                 # Fast path: plain sync/coroutine handlers cannot yield events,
                 # so skip the async-generator/tuple protocol entirely.
+                # RunContext.emit() during the handler is buffered on the span
+                # and flushed in finally, still before OUTPUT. We deliberately
+                # do NOT Task-wrap this await: that extra schedule hop shows up
+                # in the framework-overhead benches (trivial `return a + b`).
                 try:
                     output = await self._execute_simple(validated_input)
                 except Suspend as susp:
@@ -1984,6 +2009,16 @@ class Runnable(ABC, BaseModel):
                         # Update collector immediately so it's available for interruption handling
                         if handler_collector is not None:
                             collector = handler_collector
+                        # Interleave ambient RunContext.emit() events at chunk
+                        # boundaries. The sink is None until the first emit —
+                        # the `is not None` check is a slot load, not an alloc.
+                        emit_sink = span._emit_sink
+                        if emit_sink is not None and emit_sink.has_pending():
+                            for emitted in emit_sink.drain():
+                                if emitted.type in self._log_events and _events_logging_enabled():
+                                    _get_logger().info(emitted.type, **emitted.model_dump())
+                                yield emitted
+                                _restore_context()
                         if event is not None:
                             # If a child gates/suspends, set our own status BEFORE the
                             # yield so that a consumer breaking the stream right after
@@ -2210,6 +2245,9 @@ class Runnable(ABC, BaseModel):
             raise
 
         finally:
+            # Snapshot before handoff_start.set(): the continuation may rebind
+            # span._emit_sink to a forwarding sink. Close/drain *this* object.
+            emit_sink = span._emit_sink
             if handoff_control is not None and not handed_off:
                 handoff_control.unregister(span.call_id)
             t1 = int(time.time() * 1000)
@@ -2302,6 +2340,17 @@ class Runnable(ABC, BaseModel):
                 # (entry call id None) deliberately leave their context set so
                 # sequential same-task runs chain sessions implicitly.
                 set_run_context(_entry_run_context)
+            # Flush any still-buffered RunContext.emit() events (post_hook,
+            # error paths, plain handlers) so every emission is ordered
+            # before this call's OUTPUT. Close first: a racing off-loop emit
+            # either lands in this drain or is dropped, never stranded.
+            if emit_sink is not None:
+                emit_sink.close()
+                if not _generator_closed:
+                    for emitted in emit_sink.drain():
+                        if emitted.type in self._log_events and _events_logging_enabled():
+                            _get_logger().info(emitted.type, **emitted.model_dump())
+                        yield emitted
             if output_event.type in self._log_events and _events_logging_enabled():
                 _get_logger().info(output_event.type, **output_event.model_dump())
             if not _generator_closed:

--- a/python/timbal/state/__init__.py
+++ b/python/timbal/state/__init__.py
@@ -6,6 +6,7 @@ Public API:
     - RunContext: The data model for the run context.
     - get_run_context(): Retrieves the current run context.
     - get_or_create_run_context(): Retrieves the current run context, creating a new one if necessary.
+    - emit(): Fire-and-forget custom DELTA event on the current call's stream.
     - get_background_task / list_background_tasks / cancel_background_task /
       read_background_transcript / wait_for_background: session-scoped background children.
 
@@ -66,6 +67,20 @@ def set_run_context(context: RunContext | None) -> None:
     context can lead to unexpected behavior if not handled correctly.
     """
     _run_context_var.set(context)
+
+
+def emit(data: Any) -> None:
+    """Fire-and-forget: broadcast a custom DELTA event on the current call's stream.
+
+    Convenience wrapper over :meth:`RunContext.emit` that swallows the call
+    when no run context is active, so handlers (and helpers deep inside them)
+    stay unit-testable without a context harness. See :meth:`RunContext.emit`
+    for delivery and ordering semantics.
+    """
+    run_context = get_run_context()
+    if run_context is None:
+        return
+    run_context.emit(data)
 
 
 # INTERNAL: This variables hold the call ids. Do not access directly.

--- a/python/timbal/state/context.py
+++ b/python/timbal/state/context.py
@@ -1,4 +1,7 @@
+import asyncio
 import os
+from collections import deque
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -32,6 +35,101 @@ class _NoDefault:
 
 
 _NO_DEFAULT = _NoDefault()
+
+
+def _emit_sink_unpickle() -> None:
+    """Unpickle target for :class:`_EmitSink` — a sink never survives serialization."""
+    return None
+
+
+class _EmitSink:
+    """INTERNAL: per-call delivery channel for :meth:`RunContext.emit`.
+
+    Attached to a span (``span._emit_sink``) for the duration of one runnable
+    invocation, pointing wherever that call's processed handler events go:
+
+    - Buffered (foreground): emitted events accumulate here and the owning
+      ``Runnable._stream`` drains them at yield boundaries, interleaving them
+      with the handler's own events. They never pass through the collector, so
+      they cannot alter the call's output.
+    - Forwarding (detached background child): events go straight to the
+      child's background record log, which after detach is the only copy of
+      its stream.
+
+    Thread-safe: handlers may run off-loop (``offload_blocking`` /
+    ``sync_to_async_gen`` executor threads). The owning loop is captured at
+    creation; off-loop puts are marshalled with ``call_soon_threadsafe``.
+    Fire-and-forget: no backpressure, no await, never raises — the same
+    durability contract as the background ``put_nowait`` path.
+    """
+
+    __slots__ = ("_loop", "_forward", "_buffer", "closed")
+
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        forward: Callable[[Any], None] | None = None,
+    ) -> None:
+        self._loop = loop
+        self._forward = forward
+        # Lazily allocated on first emit — most calls never emit.
+        self._buffer: deque[Any] | None = None
+        self.closed = False
+
+    def put(self, event: Any) -> None:
+        """Deliver one event. Safe to call from any thread; never raises."""
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+        if running is self._loop:
+            self._put_on_loop(event)
+            return
+        try:
+            self._loop.call_soon_threadsafe(self._put_on_loop, event)
+        except RuntimeError:
+            # Owning loop already closed — accepted fire-and-forget loss.
+            _get_logger().debug("emit() after the owning event loop closed; event dropped.")
+
+    def _put_on_loop(self, event: Any) -> None:
+        if self.closed:
+            _get_logger().debug("emit() after the call's stream closed; event dropped.", path=event.path)
+            return
+        if self._forward is not None:
+            self._forward(event)
+            return
+        if self._buffer is None:
+            self._buffer = deque()
+        self._buffer.append(event)
+
+    def has_pending(self) -> bool:
+        return bool(self._buffer)
+
+    def drain(self) -> list[Any]:
+        """Take all buffered events. Loop-thread only; atomic (no await points)."""
+        buffer = self._buffer
+        if not buffer:
+            return []
+        drained = list(buffer)
+        buffer.clear()
+        return drained
+
+    def close(self) -> None:
+        """Stop accepting events. Already-buffered events remain drainable."""
+        self.closed = True
+
+    # A sink lives on its span (``span._emit_sink``) and holds the event loop
+    # and possibly futures. Serializing providers snapshot traces via
+    # deepcopy/pickle; the copy has no live stream to deliver to, so the sink
+    # collapses to None instead of dragging asyncio internals along.
+    def __copy__(self) -> None:
+        return None
+
+    def __deepcopy__(self, memo: dict) -> None:
+        return None
+
+    def __reduce__(self) -> tuple:
+        return (_emit_sink_unpickle, ())
 
 
 class RunContext(BaseModel):
@@ -195,6 +293,9 @@ class RunContext(BaseModel):
         # Plain instance attributes (see NOTE above).
         self._base_path: Path | None = None
         self._session_data: dict[str, Any] | None = None
+        # Captured once per run so off-loop emit() can marshal onto it.
+        # None until the first Runnable._stream on this context.
+        self._loop: asyncio.AbstractEventLoop | None = None
         self._resume_values: dict[str, Any] = {}
         self._used_resume_ids: set[str] = set()
         self._trace = Trace()
@@ -397,6 +498,90 @@ class RunContext(BaseModel):
         if isinstance(default, _NoDefault):
             raise SpanNotFound(name)
         return default
+
+    def emit(self, data: Any) -> None:
+        """Broadcast a custom DELTA event on the current call's event stream.
+
+        Fire-and-forget, ambient, out-of-band: the event is interleaved with
+        the current call's processed handler events — on the parent event
+        stream for a foreground call, or in the background log/transcript for
+        a detached background child — always ordered before that call's
+        OUTPUT. It never passes through the handler's collector, so unlike a
+        generator ``yield`` it cannot alter the call's output or the persisted
+        span. The per-call sink is created on first emit, not on every
+        invocation (the no-emit path is a slot check). Plain handlers flush
+        at completion; generator handlers drain at chunk boundaries.
+
+        Works from any handler shape (plain sync/coroutine, sync/async
+        generator) and from any thread the framework runs handlers on
+        (``offload_blocking``, ``sync_to_async_gen``). Never raises and never
+        blocks: when the current call cannot be resolved or no live stream
+        exists, the event is logged and dropped.
+
+        Args:
+            data: JSON-serializable payload. Wrapped in a
+                :class:`~timbal.types.events.delta.Custom` item
+                (``item.type == "custom"``) whose ``id`` is the current call id.
+        """
+        from ..types.events.delta import Custom, DeltaEvent
+        from . import get_call_id
+
+        call_id = get_call_id()
+        span = self._trace.get(call_id) if call_id else None
+        if span is None:
+            _get_logger().debug("emit() outside an active call; event dropped.", run_id=self.id)
+            return
+        event = DeltaEvent(
+            run_id=self.id,
+            parent_run_id=self.parent_id,
+            path=span.path,
+            call_id=span.call_id,
+            parent_call_id=span.parent_call_id,
+            item=Custom(id=span.call_id, data=data),
+        )
+        # 1. This span already has a live sink — use it even if t1 is set.
+        #    Background spawn finalizes the launching span, then rebinds
+        #    ``_emit_sink`` to a forwarding sink; those emits must not drop.
+        # 2. Still in-flight, no sink yet — create on THIS span. Do not walk
+        #    parents here: a parent that already emitted would steal the
+        #    child's first emit (ids would be the child's, drain would not).
+        # 3. Finished, no live sink — walk parents (stale call id / hooks).
+        sink = span._emit_sink
+        if sink is not None and not sink.closed:
+            sink.put(event)
+            return
+        if span.t1 is None:
+            sink = self._ensure_emit_sink(span)
+            if sink is not None:
+                sink.put(event)
+                return
+        parent_id = span.parent_call_id
+        while parent_id:
+            parent = self._trace.get(parent_id)
+            if parent is None:
+                break
+            sink = parent._emit_sink
+            if sink is not None and not sink.closed:
+                sink.put(event)
+                return
+            parent_id = parent.parent_call_id
+        _get_logger().debug("emit() found no live event stream; event dropped.", run_id=self.id, path=event.path)
+
+    def _ensure_emit_sink(self, span: Any) -> Any:
+        """INTERNAL: attach a buffered sink to ``span`` if it does not have a live one."""
+        sink = span._emit_sink
+        if sink is not None and not sink.closed:
+            return sink
+        loop = self._loop
+        if loop is None:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                return None
+            self._loop = loop
+        sink = _EmitSink(loop)
+        span._emit_sink = sink
+        return sink
 
     def update_usage(self, key: str, value: int) -> None:
         """Update usage statistics for the current call and all parent calls.

--- a/python/timbal/state/tracing/span.py
+++ b/python/timbal/state/tracing/span.py
@@ -39,6 +39,7 @@ class Span(SlotModel):
         "_memory_dump",
         "_prev_memory_dump",
         "_session_dump",
+        "_emit_sink",
         "_extra",
     )
 
@@ -101,6 +102,10 @@ class Span(SlotModel):
         # INTERNAL: accepted on construction for deserialization support.
         # Do not access directly; use RunContext.get_session() instead.
         self.session = session
+        # Per-call emit sink. None until the first RunContext.emit() (or a
+        # background spawn rebinds it). Must be initialized so the streaming
+        # hot path can do `span._emit_sink is not None` without AttributeError.
+        self._emit_sink = None
 
     @property
     def elapsed(self) -> int | None:


### PR DESCRIPTION
## Summary

- Adds `get_run_context().emit(data)` plus a module-level `timbal.state.emit()` convenience: an out-of-band channel from anywhere inside a handler (including helpers deep in the call stack) that wraps the payload in a `Custom` delta item attributed to the current call and interleaves it with that call's processed events — always ordered before the call's OUTPUT.
- `yield` was doing three jobs at once (collector input / native-event passthrough / custom emission), and plain non-generator handlers had no emission path at all. `emit()` gives custom emission its own channel: it never passes through the collector, so it cannot alter the call's output or the persisted span.
- Foreground calls surface emissions on the parent event stream; detached background children surface them in their background log/transcript (both the spawn-at-birth and `collector.background()` handoff paths rebind the sink to the record log).

## Design notes

- **Zero cost when unused**: the per-call `_EmitSink` is allocated lazily on first `emit()`, not per invocation. The plain-handler fast path keeps its in-place `await` (no Task wrapping — verified against the framework-overhead benches), and the streaming hot path adds one slot load per chunk.
- **Thread-safe**: emits from `offload_blocking` / sync-generator executor threads are marshalled onto the owning loop via `call_soon_threadsafe`.
- **Fire-and-forget**: no await, no backpressure, never raises. Outside a run context the module-level `emit()` is a silent no-op, so tools stay unit-testable bare.
- **Attribution**: delivery walks up from the emitting call's span to the nearest live sink, so a child's emissions can't be swallowed by a parent that also emitted.
- Sinks collapse to `None` on copy/deepcopy/pickle so async internals never leak into serialized traces.

## Known limitation (deliberate)

Plain (non-generator) handlers flush their emits when the handler returns — still before OUTPUT, but not mid-run. Surfacing them mid-run would require Task-wrapping every tool/step call, which regresses the framework-overhead benchmarks for a niche case. Generator handlers and background children already surface emits live at chunk boundaries. An opt-in `live_emit=True` flag is a possible follow-up if a concrete need shows up.

## Test plan

- [x] `python/tests/core/test_emit.py`: ordering before OUTPUT, attribution, mid-run visibility for generator handlers, background transcript delivery (spawn + handoff), thread-safety from executor threads, no-context no-op, output/collector purity, parent-walk attribution.
- [x] Full suite `uv run pytest` green; `uv run ruff check` clean.