### PR TITLE
feat(voice): Munsit streaming STT + provider-native EOU generalization

### DIFF
--- a/python/tests/server/test_capacity.py
+++ b/python/tests/server/test_capacity.py
@@ -275,10 +275,10 @@ class TestProfiles:
         capacity.configure_capacity(self._config(turn_detector=unknown))
         assert capacity._profile.name == "audio_eou"
 
-    @pytest.mark.parametrize("stt", ["deepgram", "deepgram-flux"])
-    def test_flux_stt_is_cheap_whatever_the_detector_says(self, stt: str) -> None:
-        """Flux does its own endpointing, so `select_turn_detector_spec` forces
-        the provider detector and will not let a client escalate back."""
+    @pytest.mark.parametrize("stt", ["deepgram", "deepgram-flux", "munsit", "faseeh"])
+    def test_native_eou_stt_is_cheap_whatever_the_detector_says(self, stt: str) -> None:
+        """Flux/Munsit do their own endpointing, so `select_turn_detector_spec`
+        forces the provider detector and will not let a client escalate back."""
         capacity.configure_capacity(self._config(stt_provider=stt, turn_detector="local"))
         assert capacity._profile.name == "no_eou"
 

--- a/python/tests/server/test_voice_detector_choice.py
+++ b/python/tests/server/test_voice_detector_choice.py
@@ -27,26 +27,40 @@ def _with_extra(monkeypatch, *, available: bool) -> None:
     )
 
 
-class TestFluxOwnsEndpointing:
+class TestNativeEouOwnsEndpointing:
+    """``stt_native_eou=True`` — Deepgram Flux and Munsit deployments."""
+
     def test_nothing_chosen_gets_provider(self):
-        assert select_turn_detector_spec(None, None, stt_is_flux=True) == "provider"
+        assert select_turn_detector_spec(None, None, stt_native_eou=True) == "provider"
+
+    def test_the_capability_flag_is_set_where_expected(self):
+        # The server derives stt_native_eou from this attribute; if a provider
+        # loses it, every rule in this class silently stops applying to it.
+        from timbal.voice.deepgram import DeepgramFluxSTT, DeepgramNovaSTT
+        from timbal.voice.elevenlabs import ElevenLabsRealtimeSTT
+        from timbal.voice.munsit import MunsitStreamSTT
+
+        assert DeepgramFluxSTT.native_eou is True
+        assert MunsitStreamSTT.native_eou is True
+        assert DeepgramNovaSTT.native_eou is False
+        assert ElevenLabsRealtimeSTT.native_eou is False
 
     def test_local_is_overridden(self):
-        assert select_turn_detector_spec("local", None, stt_is_flux=True) == "provider"
+        assert select_turn_detector_spec("local", None, stt_native_eou=True) == "provider"
 
     def test_lexical_is_overridden(self):
-        assert select_turn_detector_spec("lexical", None, stt_is_flux=True) == "provider"
+        assert select_turn_detector_spec("lexical", None, stt_native_eou=True) == "provider"
 
     def test_an_instance_is_overridden_too(self):
         # Documents current behaviour: Flux wins even over an explicit instance
         # from voice_config, which is why the override is logged.
-        assert select_turn_detector_spec(LocalAudioTurnDetector(), None, stt_is_flux=True) == "provider"
+        assert select_turn_detector_spec(LocalAudioTurnDetector(), None, stt_native_eou=True) == "provider"
 
     def test_explicit_heuristic_is_respected(self):
-        assert select_turn_detector_spec("heuristic", None, stt_is_flux=True) == "heuristic"
+        assert select_turn_detector_spec("heuristic", None, stt_native_eou=True) == "heuristic"
 
     def test_explicit_raw_is_respected(self):
-        assert select_turn_detector_spec("raw", None, stt_is_flux=True) == "raw"
+        assert select_turn_detector_spec("raw", None, stt_native_eou=True) == "raw"
 
 
 class TestSilenceEndpointingDefault:
@@ -62,46 +76,46 @@ class TestSilenceEndpointingDefault:
 
     def test_defaults_to_local_with_the_extra(self, monkeypatch):
         _with_extra(monkeypatch, available=True)
-        assert select_turn_detector_spec(None, None, stt_is_flux=False) == "local"
+        assert select_turn_detector_spec(None, None, stt_native_eou=False) == "local"
 
     def test_falls_back_to_lexical_without_the_extra(self, monkeypatch):
         # `local` without an audio EOU model returns the heuristic decision
         # verbatim, so it would not hold; `lexical` does, with no extra deps.
         _with_extra(monkeypatch, available=False)
-        assert select_turn_detector_spec(None, None, stt_is_flux=False) == "lexical"
+        assert select_turn_detector_spec(None, None, stt_native_eou=False) == "lexical"
 
     def test_never_defaults_to_the_holdless_heuristic(self, monkeypatch):
         for available in (True, False):
             _with_extra(monkeypatch, available=available)
-            assert select_turn_detector_spec(None, None, stt_is_flux=False) != "heuristic"
+            assert select_turn_detector_spec(None, None, stt_native_eou=False) != "heuristic"
 
     def test_explicit_heuristic_is_still_honoured(self):
-        assert select_turn_detector_spec("heuristic", None, stt_is_flux=False) == "heuristic"
+        assert select_turn_detector_spec("heuristic", None, stt_native_eou=False) == "heuristic"
 
     def test_an_instance_is_passed_through(self):
         detector = HeuristicTurnDetector()
-        assert select_turn_detector_spec(detector, None, stt_is_flux=False) is detector
+        assert select_turn_detector_spec(detector, None, stt_native_eou=False) is detector
 
     def test_a_factory_is_passed_through(self):
         def factory() -> HeuristicTurnDetector:
             return HeuristicTurnDetector()
 
-        assert select_turn_detector_spec(factory, None, stt_is_flux=False) is factory
+        assert select_turn_detector_spec(factory, None, stt_native_eou=False) is factory
 
 
 class TestClientOverride:
     def test_client_mode_beats_the_server_spec(self):
-        assert select_turn_detector_spec("local", "heuristic", stt_is_flux=False) == "heuristic"
+        assert select_turn_detector_spec("local", "heuristic", stt_native_eou=False) == "heuristic"
 
     def test_client_mode_beats_a_server_instance(self):
-        assert select_turn_detector_spec(LocalAudioTurnDetector(), "lexical", stt_is_flux=False) == "lexical"
+        assert select_turn_detector_spec(LocalAudioTurnDetector(), "lexical", stt_native_eou=False) == "lexical"
 
     def test_blank_client_mode_is_ignored(self):
-        assert select_turn_detector_spec("lexical", "   ", stt_is_flux=False) == "lexical"
+        assert select_turn_detector_spec("lexical", "   ", stt_native_eou=False) == "lexical"
 
     def test_non_string_client_spec_is_refused(self):
         # A browser must not be able to hand the server a callable.
-        assert select_turn_detector_spec("lexical", {"mode": "local"}, stt_is_flux=False) == "lexical"
+        assert select_turn_detector_spec("lexical", {"mode": "local"}, stt_native_eou=False) == "lexical"
 
     def test_client_cannot_escape_the_flux_override(self):
-        assert select_turn_detector_spec(None, "local", stt_is_flux=True) == "provider"
+        assert select_turn_detector_spec(None, "local", stt_native_eou=True) == "provider"

--- a/python/tests/voice/test_deepgram.py
+++ b/python/tests/voice/test_deepgram.py
@@ -24,6 +24,7 @@ from timbal.voice.deepgram import (
     stt_provider_id,
 )
 from timbal.voice.elevenlabs import ElevenLabsRealtimeSTT
+from timbal.voice.munsit import MunsitStreamSTT
 
 
 def _drain(stt) -> list:
@@ -305,6 +306,10 @@ class TestResolveStt:
         assert isinstance(resolve_stt("deepgram", model="flux-general-en"), DeepgramFluxSTT)
         # Leftover Scribe model + bare deepgram must NOT silently become Nova.
         assert isinstance(resolve_stt("deepgram", model="scribe_v2_realtime"), DeepgramFluxSTT)
+        assert isinstance(resolve_stt("munsit"), MunsitStreamSTT)
+        assert isinstance(resolve_stt("faseeh"), MunsitStreamSTT)
+        # Label wins over a stale model id from env defaults.
+        assert isinstance(resolve_stt("munsit", model="scribe_v2_realtime"), MunsitStreamSTT)
 
     def test_ui_labels(self) -> None:
         assert isinstance(resolve_stt("deepgram-flux"), DeepgramFluxSTT)
@@ -316,6 +321,8 @@ class TestResolveStt:
     def test_inference_from_model(self) -> None:
         assert isinstance(resolve_stt(None, model="flux-general-multi"), DeepgramFluxSTT)
         assert isinstance(resolve_stt(None, model="nova-3"), DeepgramNovaSTT)
+        assert isinstance(resolve_stt(None, model="munsit-en-ar"), MunsitStreamSTT)
+        assert isinstance(resolve_stt(None, model="munsit"), MunsitStreamSTT)
         assert isinstance(resolve_stt(None, model="scribe_v2_realtime"), ElevenLabsRealtimeSTT)
         assert isinstance(resolve_stt(None, model=None), ElevenLabsRealtimeSTT)
 
@@ -324,9 +331,14 @@ class TestResolveStt:
         assert effective_stt_model(DeepgramFluxSTT(), "flux-general-en") == "flux-general-en"
         assert effective_stt_model(DeepgramNovaSTT(), "scribe_v2_realtime") == DEFAULT_NOVA_MODEL
         assert effective_stt_model(DeepgramNovaSTT(), "nova-3-general") == "nova-3-general"
-        # Unknown-provider fallback → ElevenLabs must not keep a Flux/Nova id.
+        assert effective_stt_model(DeepgramNovaSTT(), "munsit-en-ar") == DEFAULT_NOVA_MODEL
+        assert effective_stt_model(MunsitStreamSTT(), "scribe_v2_realtime") == "munsit-en-ar"
+        assert effective_stt_model(MunsitStreamSTT(), "flux-general-multi") == "munsit-en-ar"
+        assert effective_stt_model(MunsitStreamSTT(), "munsit") == "munsit"
+        # Unknown-provider fallback → ElevenLabs must not keep a foreign id.
         assert effective_stt_model(ElevenLabsRealtimeSTT(), "flux-general-multi") is None
         assert effective_stt_model(ElevenLabsRealtimeSTT(), "nova-3") is None
+        assert effective_stt_model(ElevenLabsRealtimeSTT(), "munsit-en-ar") is None
         assert effective_stt_model(ElevenLabsRealtimeSTT(), "scribe_v2_realtime") == "scribe_v2_realtime"
         assert effective_stt_model(ElevenLabsRealtimeSTT(), None) is None
 
@@ -337,6 +349,7 @@ class TestResolveStt:
     def test_stt_provider_id(self) -> None:
         assert stt_provider_id(DeepgramFluxSTT()) == "deepgram-flux"
         assert stt_provider_id(DeepgramNovaSTT()) == "deepgram-nova"
+        assert stt_provider_id(MunsitStreamSTT()) == "munsit"
         assert stt_provider_id(ElevenLabsRealtimeSTT()) == "elevenlabs"
 
     def test_is_flux_model(self) -> None:

--- a/python/tests/voice/test_munsit.py
+++ b/python/tests/voice/test_munsit.py
@@ -1,18 +1,23 @@
+import json
 from contextlib import asynccontextmanager
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from pydantic import SecretStr
 from timbal.voice.config import DEFAULT_VOICE_ID
 from timbal.voice.munsit import (
     DEFAULT_MUNSIT_VOICE_ID,
+    DEFAULT_STT_MODEL,
     DEFAULT_TTS_MODEL,
+    MunsitStreamSTT,
     MunsitStreamTTS,
     _resolve_api_key,
     effective_sample_rate,
+    effective_stt_model,
     effective_tts_model,
     effective_voice_id,
 )
-from timbal.voice.providers import AudioOutputConfig
+from timbal.voice.providers import AudioInputConfig, AudioOutputConfig
 
 
 def _cfg(**kwargs) -> AudioOutputConfig:
@@ -96,7 +101,9 @@ class FakeClient:
         self.closed = True
 
 
-async def _connected(response: FakeResponse, config: AudioOutputConfig, monkeypatch) -> tuple[MunsitStreamTTS, FakeClient]:
+async def _connected(
+    response: FakeResponse, config: AudioOutputConfig, monkeypatch
+) -> tuple[MunsitStreamTTS, FakeClient]:
     monkeypatch.setenv("MUNSIT_API_KEY", "test-key")
     tts = MunsitStreamTTS()
     await tts.connect(config)
@@ -180,3 +187,229 @@ def test_default_voice_settings_are_overridable():
     # tts_extra flows into AudioOutputConfig.extra; stability/speed ride there.
     cfg = _cfg(voice="ar-najdi-male-2", extra={"stability": 0.8, "speed": 1.1})
     assert cfg.extra["stability"] == 0.8
+
+
+# ---------------------------------------------------------------------------
+# Streaming STT (WSS /api/v1/listen)
+# ---------------------------------------------------------------------------
+
+
+def _stt_cfg(**kwargs) -> AudioInputConfig:
+    return AudioInputConfig(**kwargs)
+
+
+def _drain(stt: MunsitStreamSTT) -> list:
+    events = []
+    while not stt._queue.empty():
+        events.append(stt._queue.get_nowait())
+    return events
+
+
+def _results(text: str, *, is_final: bool, speech_final: bool = False, **kw) -> dict:
+    return {
+        "type": "Results",
+        "channel": 0,
+        "turn_id": 1,
+        "transcript": text,
+        "is_final": is_final,
+        "speech_final": speech_final,
+        **kw,
+    }
+
+
+class _FakeWs:
+    def __init__(self) -> None:
+        self.sent: list = []
+        self.closed = False
+
+    async def send(self, payload) -> None:
+        self.sent.append(payload)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class TestMunsitSttUri:
+    def _parse(self, config: AudioInputConfig) -> dict:
+        uri = MunsitStreamSTT()._build_uri(config)
+        parsed = urlparse(uri)
+        assert parsed.scheme == "wss"
+        assert parsed.path == "/api/v1/listen"
+        return parse_qs(parsed.query)
+
+    def test_defaults(self) -> None:
+        q = self._parse(_stt_cfg())
+        assert q["model"] == [DEFAULT_STT_MODEL]
+        assert q["encoding"] == ["linear16"]
+        assert q["sample_rate"] == ["16000"]
+        assert "language" not in q
+
+    def test_foreign_model_replaced(self) -> None:
+        # Only stt_provider switched; env stt_model still Scribe's / Flux's.
+        assert self._parse(_stt_cfg(model="scribe_v2_realtime"))["model"] == [DEFAULT_STT_MODEL]
+        assert self._parse(_stt_cfg(model="flux-general-multi"))["model"] == [DEFAULT_STT_MODEL]
+
+    def test_munsit_models_kept(self) -> None:
+        assert self._parse(_stt_cfg(model="munsit"))["model"] == ["munsit"]
+        assert self._parse(_stt_cfg(model="munsit-en-ar"))["model"] == ["munsit-en-ar"]
+
+    def test_language_ar_passes_others_dropped(self) -> None:
+        # `ar` is the only supported value in v1; invalid params are fatal 4002.
+        assert self._parse(_stt_cfg(language="ar"))["language"] == ["ar"]
+        assert self._parse(_stt_cfg(language="ar-AE"))["language"] == ["ar"]
+        assert "language" not in self._parse(_stt_cfg(language="en"))
+
+    def test_extra_passthrough_filtered(self) -> None:
+        q = self._parse(
+            _stt_cfg(
+                extra={
+                    "endpointing": 300,
+                    "smart_turn": True,
+                    "hotwords": "فصيح,منصت",
+                    # Scribe-only knob must not leak into the query (fatal 4002).
+                    "commit_strategy": "vad",
+                    "vad_silence_threshold_secs": 1.2,
+                }
+            )
+        )
+        assert q["endpointing"] == ["300"]
+        assert q["smart_turn"] == ["true"]
+        assert q["hotwords"] == ["فصيح,منصت"]
+        assert "commit_strategy" not in q
+        assert "vad_silence_threshold_secs" not in q
+
+    def test_host_override(self) -> None:
+        uri = MunsitStreamSTT()._build_uri(_stt_cfg(extra={"stt_host": "munsit.internal"}))
+        assert uri.startswith("wss://munsit.internal/api/v1/listen?")
+
+    def test_unsupported_sample_rate_raises(self) -> None:
+        # /listen accepts only 8000/16000 — fail at session start, not with a
+        # fatal 4002 mid-connect.
+        with pytest.raises(ValueError, match="8000 or 16000"):
+            MunsitStreamSTT()._build_uri(_stt_cfg(sample_rate=48_000))
+
+
+@pytest.mark.asyncio
+async def test_stt_connect_requires_api_key(monkeypatch):
+    monkeypatch.delenv("MUNSIT_API_KEY", raising=False)
+    stt = MunsitStreamSTT()
+    with pytest.raises(ValueError, match="MUNSIT_API_KEY"):
+        await stt.connect(_stt_cfg())
+
+
+class TestMunsitSttEventMapping:
+    async def test_interim_is_partial(self) -> None:
+        stt = MunsitStreamSTT()
+        await stt._handle_message(_results("مرحبا", is_final=False))
+        events = _drain(stt)
+        assert [(e.type, e.text) for e in events] == [("partial", "مرحبا")]
+
+    async def test_speech_final_commits(self) -> None:
+        stt = MunsitStreamSTT()
+        await stt._handle_message(_results("لا تتكلم هكذا", is_final=True, speech_final=True))
+        events = _drain(stt)
+        assert [(e.type, e.text) for e in events] == [("committed", "لا تتكلم هكذا")]
+
+    async def test_forced_split_does_not_commit(self) -> None:
+        """is_final without speech_final is the ~60s forced split — the text is
+        stable but the speaker is still talking. Committing it would answer a
+        user mid-sentence."""
+        stt = MunsitStreamSTT()
+        await stt._handle_message(_results("first sixty seconds", is_final=True, speech_final=False))
+        assert _drain(stt) == []
+        assert stt._segments == ["first sixty seconds"]
+
+    async def test_forced_split_then_speech_final_commits_joined(self) -> None:
+        stt = MunsitStreamSTT()
+        await stt._handle_message(_results("first sixty seconds", is_final=True, speech_final=False))
+        await stt._handle_message(_results("and the ending", is_final=True, speech_final=True, turn_id=2))
+        events = _drain(stt)
+        assert [(e.type, e.text) for e in events] == [("committed", "first sixty seconds and the ending")]
+        assert stt._segments == []
+
+    async def test_partial_includes_buffered_segments(self) -> None:
+        stt = MunsitStreamSTT()
+        await stt._handle_message(_results("first sixty seconds", is_final=True, speech_final=False))
+        await stt._handle_message(_results("and the", is_final=False, turn_id=2))
+        events = _drain(stt)
+        assert [(e.type, e.text) for e in events] == [("partial", "first sixty seconds and the")]
+
+    async def test_utterance_end_after_speech_final_does_not_double_commit(self) -> None:
+        """UtteranceEnd fires right after the final Results of a completed turn;
+        the speech_final frame already committed, so it must be a no-op."""
+        stt = MunsitStreamSTT()
+        await stt._handle_message(_results("نعم", is_final=True, speech_final=True))
+        await stt._handle_message({"type": "UtteranceEnd", "channel": 0, "turn_id": 1, "last_word_end": 1.2})
+        events = _drain(stt)
+        assert [(e.type, e.text) for e in events] == [("committed", "نعم")]
+
+    async def test_utterance_end_flushes_leftover_segments(self) -> None:
+        stt = MunsitStreamSTT()
+        await stt._handle_message(_results("hello there", is_final=True, speech_final=False))
+        await stt._handle_message({"type": "UtteranceEnd", "channel": 0, "turn_id": 1})
+        events = _drain(stt)
+        assert [(e.type, e.text) for e in events] == [("committed", "hello there")]
+
+    async def test_empty_transcripts_skipped(self) -> None:
+        stt = MunsitStreamSTT()
+        await stt._handle_message(_results("", is_final=False))
+        await stt._handle_message(_results("  ", is_final=True, speech_final=True))
+        assert _drain(stt) == []
+
+    async def test_enrichment_and_speech_started_emit_nothing(self) -> None:
+        stt = MunsitStreamSTT()
+        await stt._handle_message({"type": "SpeechStarted", "channel": 0, "ts": 4.31})
+        await stt._handle_message({"type": "Gender", "channel": 0, "turn_id": 1, "label": "female", "score": 0.99})
+        await stt._handle_message({"type": "Sentiment", "channel": 0, "turn_id": 1, "label": "negative", "score": 0.87})
+        assert _drain(stt) == []
+
+    async def test_metadata_emits_nothing(self) -> None:
+        stt = MunsitStreamSTT()
+        await stt._handle_message({"type": "Metadata", "session_id": "s1", "model": "munsit-v2"})
+        await stt._handle_message(
+            {"type": "Metadata", "session_id": "s1", "audio_seconds_billed": 12.4, "turn_count": 3}
+        )
+        assert _drain(stt) == []
+
+    async def test_recoverable_error_logged_fatal_surfaces(self) -> None:
+        stt = MunsitStreamSTT()
+        await stt._handle_message({"type": "Error", "code": 4002, "message": "bad Configure", "recoverable": True})
+        assert _drain(stt) == []
+        await stt._handle_message(
+            {"type": "Error", "code": 1008, "message": "insufficient balance", "recoverable": False}
+        )
+        events = _drain(stt)
+        assert len(events) == 1
+        assert events[0].type == "error"
+        assert "insufficient balance" in events[0].text
+
+    async def test_commit_is_noop(self) -> None:
+        """Munsit's turn machine owns endpointing — no client force-commit."""
+        stt = MunsitStreamSTT()
+        stt._ws = _FakeWs()
+        await stt.commit()
+        assert stt._ws.sent == []
+
+
+@pytest.mark.asyncio
+async def test_stt_close_sends_close_stream_and_closes_ws():
+    stt = MunsitStreamSTT()
+    ws = _FakeWs()
+    stt._ws = ws
+    await stt.close()
+    assert [json.loads(m) for m in ws.sent if isinstance(m, str)] == [{"type": "CloseStream"}]
+    assert ws.closed
+    assert stt._ws is None
+
+
+def test_stt_effective_model_helper():
+    assert effective_stt_model(None) == DEFAULT_STT_MODEL
+    assert effective_stt_model("scribe_v2_realtime") == DEFAULT_STT_MODEL
+    assert effective_stt_model("flux-general-multi") == DEFAULT_STT_MODEL
+    assert effective_stt_model("munsit") == "munsit"
+    assert effective_stt_model("munsit-en-ar") == "munsit-en-ar"
+
+
+def test_stt_native_eou_capability():
+    # The server keys turn-detector forcing and VAD-endpointing disable off this.
+    assert MunsitStreamSTT.native_eou is True

--- a/python/tests/voice/test_munsit.py
+++ b/python/tests/voice/test_munsit.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from contextlib import asynccontextmanager
 from urllib.parse import parse_qs, urlparse
@@ -282,11 +283,18 @@ class TestMunsitSttUri:
         uri = MunsitStreamSTT()._build_uri(_stt_cfg(extra={"stt_host": "munsit.internal"}))
         assert uri.startswith("wss://munsit.internal/api/v1/listen?")
 
-    def test_unsupported_sample_rate_raises(self) -> None:
-        # /listen accepts only 8000/16000 — fail at session start, not with a
-        # fatal 4002 mid-connect.
-        with pytest.raises(ValueError, match="8000 or 16000"):
-            MunsitStreamSTT()._build_uri(_stt_cfg(sample_rate=48_000))
+    def test_unsupported_sample_rate_negotiates_16k_wire(self) -> None:
+        # The session applies one sample_rate to both STT and TTS, and 48 kHz
+        # is the documented rate for engine-native Munsit TTS — the STT leg
+        # must negotiate a legal wire rate and resample, not refuse to start.
+        assert self._parse(_stt_cfg(sample_rate=48_000))["sample_rate"] == ["16000"]
+        assert self._parse(_stt_cfg(sample_rate=8_000))["sample_rate"] == ["8000"]
+
+    def test_unsupported_rate_with_compressed_encoding_raises(self) -> None:
+        # Can't resample a non-PCM16 stream client-side — fail at session
+        # start, not with a fatal 4002 mid-connect.
+        with pytest.raises(ValueError, match="cannot resample"):
+            MunsitStreamSTT()._build_uri(_stt_cfg(sample_rate=48_000, encoding="mulaw"))
 
 
 @pytest.mark.asyncio
@@ -400,6 +408,80 @@ async def test_stt_close_sends_close_stream_and_closes_ws():
     assert [json.loads(m) for m in ws.sent if isinstance(m, str)] == [{"type": "CloseStream"}]
     assert ws.closed
     assert stt._ws is None
+
+
+@pytest.mark.asyncio
+async def test_stt_connect_48k_session_resamples_to_16k_wire(monkeypatch):
+    """A 48 kHz session (the rate engine-native Munsit TTS wants, shared with
+    STT by the session config) must connect and downsample the mic leg
+    client-side instead of failing before the socket opens."""
+    pytest.importorskip("av")
+    monkeypatch.setenv("MUNSIT_API_KEY", "k")
+
+    class _IterFakeWs(_FakeWs):
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            # Behave like the real server: stay open until CloseStream.
+            while not any(isinstance(m, str) and "CloseStream" in m for m in self.sent):
+                await asyncio.sleep(0.005)
+            raise StopAsyncIteration
+
+    ws = _IterFakeWs()
+    captured: dict = {}
+
+    async def fake_connect(uri, **_kwargs):
+        captured["uri"] = uri
+        return ws
+
+    import websockets.asyncio.client as ws_client
+
+    monkeypatch.setattr(ws_client, "connect", fake_connect)
+
+    stt = MunsitStreamSTT()
+    await stt.connect(_stt_cfg(sample_rate=48_000))
+    try:
+        assert "sample_rate=16000" in captured["uri"]
+        assert stt._resampler is not None
+        # Flush cadence sized for the 16 kHz wire, not the 48 kHz session.
+        assert stt._flush_bytes == int(16_000 * 0.08 * 2)
+        for _ in range(10):
+            await stt.push_audio(b"\x00\x00" * 4_800)  # 100ms @ 48 kHz
+    finally:
+        await stt.close()
+    wire = sum(len(m) for m in ws.sent if isinstance(m, (bytes, bytearray)))
+    expected = 10 * 9_600 // 3  # 1s of audio at the 16 kHz wire rate
+    # Tolerance: sub-threshold tail not flushed at close + FIR filter delay.
+    assert expected - 4_096 <= wire <= expected
+
+
+@pytest.mark.asyncio
+async def test_stt_connect_16k_session_has_no_resampler(monkeypatch):
+    monkeypatch.setenv("MUNSIT_API_KEY", "k")
+
+    class _IterFakeWs(_FakeWs):
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            while not any(isinstance(m, str) and "CloseStream" in m for m in self.sent):
+                await asyncio.sleep(0.005)
+            raise StopAsyncIteration
+
+    async def fake_connect(_uri, **_kwargs):
+        return _IterFakeWs()
+
+    import websockets.asyncio.client as ws_client
+
+    monkeypatch.setattr(ws_client, "connect", fake_connect)
+
+    stt = MunsitStreamSTT()
+    await stt.connect(_stt_cfg(sample_rate=16_000))
+    try:
+        assert stt._resampler is None
+    finally:
+        await stt.close()
 
 
 def test_stt_effective_model_helper():

--- a/python/tests/voice/test_session_stt_refinement.py
+++ b/python/tests/voice/test_session_stt_refinement.py
@@ -128,6 +128,38 @@ def test_flush_segment_inverted_question_not_clause_end():
     assert final_remainder == "¿"
 
 
+def test_flush_segment_arabic_question_mark_is_clause_end():
+    """Short Arabic questions ending in ؟ (U+061F) flush immediately, like Latin ?."""
+    for tail in ("هل تريد؟", " كيف حالك؟"):
+        assert len(tail) < 24  # MIN_FLUSH_CHARS
+        assert _flush_segment(tail, first_segment=False) == tail
+
+
+def test_flush_segment_arabic_sentence_boundary_splits():
+    """A ؟-terminated sentence mid-buffer is a split point — the trailing clause stays buffered."""
+    text = "هل تريد حجز موعد؟ يمكنني مساعدتك في اختيار الوقت المناسب"
+    result = _flush_segment(text, first_segment=False)
+    assert result is not None
+    assert result.rstrip().endswith("موعد؟")
+    assert "يمكنني" not in result
+
+
+def test_flush_segment_arabic_semicolon_is_boundary():
+    """Arabic semicolon ؛ (U+061B) behaves like the Latin one for flush heuristics."""
+    text = "أهلاً وسهلاً بك في عيادتنا؛ يسعدني أن أساعدك اليوم في حجز موعدك"
+    result = _flush_segment(text, first_segment=False)
+    assert result is not None
+    assert result.rstrip().endswith("عيادتنا؛")
+
+
+def test_flush_segment_arabic_first_segment():
+    """First segment of an Arabic reply splits at the earliest qualifying ؟ boundary."""
+    text = "كيف حالك؟ أنا هنا لمساعدتك في كل ما تحتاجه اليوم"
+    result = _flush_segment(text, first_segment=True)
+    assert result is not None
+    assert result.rstrip() == "كيف حالك؟"
+
+
 def test_reconcile_final_assistant_empty_stream():
     merged, suffix = _reconcile_final_assistant_text("", "Hello world")
     assert merged == "Hello world"

--- a/python/timbal/server/capacity.py
+++ b/python/timbal/server/capacity.py
@@ -148,11 +148,11 @@ _DETECTOR_PROFILES = {
     "off": "no_eou",
 }
 
-# `resolve_stt` sends both of these to DeepgramFluxSTT, and Flux does its own
-# endpointing: `select_turn_detector_spec` then forces the provider detector and
-# will not let a client escalate back to `local`. So a Flux deployment is in the
-# cheap class no matter what its detector field says.
-_FLUX_STT_PROVIDERS = frozenset({"deepgram", "deepgram-flux"})
+# Provider ids `resolve_stt` sends to a native-EOU STT (Flux; Munsit), which
+# does its own endpointing: `select_turn_detector_spec` then forces the provider
+# detector and will not let a client escalate back to `local`. So such a
+# deployment is in the cheap class no matter what its detector field says.
+_NATIVE_EOU_STT_PROVIDERS = frozenset({"deepgram", "deepgram-flux", "munsit", "faseeh"})
 
 # Below this a cap does more harm than good: one session must always be
 # admissible, and a second lets a caller reconnect before the first has
@@ -238,7 +238,9 @@ def _profile_for(voice_config: Any) -> _Profile:
         return _DEFAULT_PROFILE
     stt = str(getattr(voice_config, "stt_provider", "") or "").strip().lower()
     name = (
-        "no_eou" if stt in _FLUX_STT_PROVIDERS else _detector_profile_name(getattr(voice_config, "turn_detector", None))
+        "no_eou"
+        if stt in _NATIVE_EOU_STT_PROVIDERS
+        else _detector_profile_name(getattr(voice_config, "turn_detector", None))
     )
     profile = _PROFILES.get(name or "", _DEFAULT_PROFILE)
     recording = getattr(voice_config, "recording", None)
@@ -265,9 +267,9 @@ def configure_capacity(voice_config: Any) -> None:
 
     The consequence is worth stating: on a deployment whose *default* detector
     is cheap, a client that asks for ``local`` gets a session costing ~30x what
-    the cap was sized for. Flux STT can't be escalated that way, but the others
-    can — pin the detector server-side, or set the env var explicitly, if that
-    matters to you.
+    the cap was sized for. Native-EOU STT (Flux, Munsit) can't be escalated
+    that way, but the others can — pin the detector server-side, or set the
+    env var explicitly, if that matters to you.
     """
     global _profile
     _profile = _profile_for(voice_config)

--- a/python/timbal/server/voice.py
+++ b/python/timbal/server/voice.py
@@ -394,15 +394,15 @@ def voice_onnx_warmup_intended(voice_config: VoiceConfig) -> bool:
     """Whether boot should pre-load Smart Turn / Namo / Silero.
 
     Same detector choice the session will make
-    (:func:`select_turn_detector_spec`). Flux forces the provider turn
-    detector, so those ONNX models never run — loading them anyway races
-    the first turn with HuggingFace downloads on a cold box.
+    (:func:`select_turn_detector_spec`). Native-EOU STT (Flux, Munsit) forces
+    the provider turn detector, so those ONNX models never run — loading them
+    anyway races the first turn with HuggingFace downloads on a cold box.
 
     Can be *heavy*: with ``turn_detector=None`` the spec resolution builds the
     default detector, importing onnxruntime/transformers. Call it off the
     event loop (``warmup_voice_stack`` runs it in the import executor).
     """
-    from ..voice.deepgram import DeepgramFluxSTT, resolve_stt
+    from ..voice.deepgram import resolve_stt
     from ..voice.turn_detection import LocalAudioTurnDetector
 
     try:
@@ -412,7 +412,7 @@ def voice_onnx_warmup_intended(voice_config: VoiceConfig) -> bool:
     spec = select_turn_detector_spec(
         voice_config.turn_detector,
         None,
-        stt_is_flux=isinstance(stt, DeepgramFluxSTT),
+        stt_native_eou=bool(getattr(stt, "native_eou", False)),
     )
     if isinstance(spec, LocalAudioTurnDetector):
         return True
@@ -565,7 +565,7 @@ async def _ambient_path(source: str) -> Path:
         raise HTTPException(status_code=502, detail=f"Ambience source unavailable: {e}") from e
 
 
-def select_turn_detector_spec(server_spec: Any, client_spec: Any, *, stt_is_flux: bool) -> Any:
+def select_turn_detector_spec(server_spec: Any, client_spec: Any, *, stt_native_eou: bool) -> Any:
     """Choose the turn detector for a session: a mode name, instance, or factory.
 
     ``server_spec`` comes from ``runnable.voice_config`` and may be any of those
@@ -577,6 +577,10 @@ def select_turn_detector_spec(server_spec: Any, client_spec: Any, *, stt_is_flux
     :func:`~timbal.voice.turn_detection.resolve_turn_detector` because it turns
     on the STT: whichever mode is best depends on how well the provider
     endpoints, and only the session setup knows which provider is in play.
+
+    ``stt_native_eou`` is the provider's
+    :attr:`~timbal.voice.providers.SpeechToText.native_eou` capability —
+    Deepgram Flux and Munsit today.
     """
     spec = server_spec
     if isinstance(client_spec, str) and client_spec.strip():
@@ -585,15 +589,17 @@ def select_turn_detector_spec(server_spec: Any, client_spec: Any, *, stt_is_flux
         logger.warning("voice_ws_bad_turn_detector", error="client turn_detector must be a mode name string")
 
     mode = spec.strip().lower() if isinstance(spec, str) else None
-    if stt_is_flux:
-        # Flux owns EOU (~260ms). Local/lexical run *after* EndOfTurn and add a
-        # second HOLD tax; they also disable the useful Provider path. Force
-        # provider unless the caller explicitly picked heuristic/raw/provider.
+    if stt_native_eou:
+        # The provider owns EOU (Flux TurnInfo ~260ms; Munsit endpointing +
+        # smart_turn). Local/lexical run *after* the provider's turn end and
+        # add a second HOLD tax; they also disable the useful Provider path.
+        # Force provider unless the caller explicitly picked heuristic/raw/
+        # provider.
         if mode is None or mode in ("local", "audio", "smart_turn", "lexical"):
             if spec is not None:
                 # Includes an instance or factory from voice_config, which this
                 # overrides too — worth saying so rather than silently ignoring.
-                logger.info("voice_ws_flux_overrides_turn_detector", requested=str(spec), using="provider")
+                logger.info("voice_ws_native_eou_overrides_turn_detector", requested=str(spec), using="provider")
             return "provider"
         return spec
     if spec is not None:
@@ -635,7 +641,6 @@ def build_voice_session(
     """
     from ..voice import VoiceSession
     from ..voice.deepgram import (
-        DeepgramFluxSTT,
         effective_stt_model,
         resolve_stt,
         stt_provider_id,
@@ -656,11 +661,12 @@ def build_voice_session(
             requested_provider=stt_provider,
             requested_model=stt_model_requested,
         )
-        # Fallback must not keep a Flux/Nova model id on the ElevenLabs wire,
-        # or the client/config log will claim Deepgram while Scribe runs.
+        # Fallback must not keep a Flux/Nova/Munsit model id on the ElevenLabs
+        # wire, or the client/config log will claim another provider while
+        # Scribe runs.
         stt = resolve_stt("elevenlabs")
         stt_model_requested = None
-    stt_is_flux = isinstance(stt, DeepgramFluxSTT)
+    stt_native_eou = bool(getattr(stt, "native_eou", False))
     # Config id for clients/logs (``deepgram-flux``), not the class name.
     stt_provider = stt_provider_id(stt)
     stt_model = effective_stt_model(stt, stt_model_requested)
@@ -685,8 +691,9 @@ def build_voice_session(
     # non-dict rather than 500-ing the socket.
     stt_extra = dict(merged.stt_extra) if isinstance(merged.stt_extra, dict) else {}
     tts_extra = dict(merged.tts_extra) if isinstance(merged.tts_extra, dict) else {}
-    if stt_is_flux:
-        # Scribe-tuned VAD knobs don't apply to Flux's turn machine.
+    if stt_native_eou:
+        # Scribe-tuned VAD knobs don't apply to a provider-side turn machine
+        # (Flux, Munsit).
         for k in ("commit_strategy", "min_speech_duration_ms", "vad_silence_threshold_secs", "vad_threshold"):
             stt_extra.pop(k, None)
     audio_in = AudioInputConfig(
@@ -709,12 +716,12 @@ def build_voice_session(
     # may additionally select a *mode name* (string only — useful for A/B
     # testing detectors from the playground); instances and factories can never
     # come over the wire. When neither picks one, the server chooses by STT
-    # (Flux → provider; else the resolver default — local / lexical).
+    # (native EOU → provider; else the resolver default — local / lexical).
     turn_detector = None
     raw_td = select_turn_detector_spec(
         defaults.turn_detector,
         client_config.get("turn_detector"),
-        stt_is_flux=stt_is_flux,
+        stt_native_eou=stt_native_eou,
     )
     try:
         # voice_config is process-wide; VoiceSession clones the resolved
@@ -732,21 +739,15 @@ def build_voice_session(
     vad_endpointing = merged.vad_endpointing
     if not isinstance(vad_endpointing, bool):
         vad_endpointing = None
-    if stt_is_flux:
-        # Flux has no force-commit (commit() is a no-op); the Silero fast path
-        # would just burn CPU scoring audio it can never act on.
+    if stt_native_eou:
+        # Flux/Munsit have no force-commit (commit() is a no-op); the Silero
+        # fast path would just burn CPU scoring audio it can never act on.
         vad_endpointing = False
 
     # Playground / client may override the Agent's LLM for this session only.
     raw_model = merged.model
-    model_override = (
-        raw_model.strip()
-        if isinstance(raw_model, str) and "/" in raw_model.strip()
-        else None
-    )
-    llm_model = model_override or (
-        str(runnable.model) if isinstance(getattr(runnable, "model", None), str) else None
-    )
+    model_override = raw_model.strip() if isinstance(raw_model, str) and "/" in raw_model.strip() else None
+    llm_model = model_override or (str(runnable.model) if isinstance(getattr(runnable, "model", None), str) else None)
     logger.info(
         "voice_session_config",
         stt=type(stt).__name__,
@@ -758,11 +759,7 @@ def build_voice_session(
         model=llm_model,
         turn_detector=turn_detector_label,
         vad_endpointing="auto" if vad_endpointing is None else vad_endpointing,
-        greeting=(
-            None
-            if merged.greeting is None
-            else ((merged.greeting.text or "")[:80] or "<generated>")
-        ),
+        greeting=(None if merged.greeting is None else ((merged.greeting.text or "")[:80] or "<generated>")),
     )
 
     session_kwargs: dict[str, Any] = {}
@@ -842,8 +839,9 @@ def build_voice_session(
         "turn_detector": turn_detector_label,
         # Server config, not client-settable. Phase 1: the browser mixes this
         # locally (fetch /voice/ambience/current); nothing is mixed server-side.
-        "ambient": ({"source": defaults.ambient.source, "volume": defaults.ambient.volume}
-                    if defaults.ambient else None),
+        "ambient": (
+            {"source": defaults.ambient.source, "volume": defaults.ambient.volume} if defaults.ambient else None
+        ),
     }
     if session.parent_run_id:
         # Lets the client confirm which conversation this call joined.

--- a/python/timbal/voice/__init__.py
+++ b/python/timbal/voice/__init__.py
@@ -84,10 +84,10 @@ def __getattr__(name: str):
         from .elevenlabs import ElevenLabsRealtimeSTT
 
         return ElevenLabsRealtimeSTT
-    if name == "MunsitStreamTTS":
-        from .munsit import MunsitStreamTTS
+    if name in ("MunsitStreamSTT", "MunsitStreamTTS"):
+        from . import munsit
 
-        return MunsitStreamTTS
+        return getattr(munsit, name)
     if name == "FishAudioStreamTTS":
         from .fish_audio import FishAudioStreamTTS
 
@@ -132,6 +132,7 @@ __all__ = [
     "HeuristicTurnDetector",
     "LexicalTurnDetector",
     "LocalAudioTurnDetector",
+    "MunsitStreamSTT",
     "MunsitStreamTTS",
     "NamoTextEouPredictor",
     "PartialDecision",

--- a/python/timbal/voice/deepgram.py
+++ b/python/timbal/voice/deepgram.py
@@ -251,6 +251,8 @@ class DeepgramFluxSTT(_DeepgramSTTBase):
     VAD endpointing off (the server wires both automatically).
     """
 
+    native_eou = True
+
     def _build_uri(self, config: AudioInputConfig) -> str:
         extra = dict(config.extra)
         host = str(extra.pop("stt_host", _DG_HOST))
@@ -436,17 +438,23 @@ def is_flux_model(model: str | None) -> bool:
 
 def effective_stt_model(provider_instance: SpeechToText, requested: str | None) -> str | None:
     """Model id actually sent to the provider (foreign leftovers swapped out)."""
+    from .munsit import MunsitStreamSTT
+    from .munsit import effective_stt_model as munsit_effective_stt_model
+
     if isinstance(provider_instance, DeepgramFluxSTT):
         return requested if is_flux_model(requested) else DEFAULT_FLUX_MODEL
     if isinstance(provider_instance, DeepgramNovaSTT):
         m = requested or ""
-        if not m or is_flux_model(m) or m.startswith(("scribe", "eleven")):
+        if not m or is_flux_model(m) or m.startswith(("scribe", "eleven", "munsit")):
             return DEFAULT_NOVA_MODEL
         return requested
-    # ElevenLabs (and any non-Deepgram STT): never pass flux/nova ids through —
-    # e.g. unknown-provider fallback keeps the merged model string otherwise.
+    if isinstance(provider_instance, MunsitStreamSTT):
+        return munsit_effective_stt_model(requested)
+    # ElevenLabs (and any non-Deepgram STT): never pass flux/nova/munsit ids
+    # through — e.g. unknown-provider fallback keeps the merged model string
+    # otherwise.
     m = (requested or "").strip().lower()
-    if not m or is_flux_model(m) or m.startswith("nova"):
+    if not m or is_flux_model(m) or m.startswith(("nova", "munsit")):
         return None
     return requested
 
@@ -455,12 +463,17 @@ def stt_provider_id(provider_instance: SpeechToText) -> str:
     """Config-style provider id for the running STT instance.
 
     Matches playground / ``voice_config`` values (``elevenlabs``,
-    ``deepgram-flux``, ``deepgram-nova``) — not the Python class name.
+    ``deepgram-flux``, ``deepgram-nova``, ``munsit``) — not the Python class
+    name.
     """
+    from .munsit import MunsitStreamSTT
+
     if isinstance(provider_instance, DeepgramFluxSTT):
         return "deepgram-flux"
     if isinstance(provider_instance, DeepgramNovaSTT):
         return "deepgram-nova"
+    if isinstance(provider_instance, MunsitStreamSTT):
+        return "munsit"
     return "elevenlabs"
 
 
@@ -472,9 +485,10 @@ def resolve_stt(
 ) -> SpeechToText:
     """STT factory for the voice server.
 
-    ``provider`` is ``"elevenlabs"`` / ``"deepgram"`` (case-insensitive; also
-    accepts UI labels like ``"deepgram-flux"`` / ``"deepgram-nova"``). When
-    ``None``, inferred from the model id: ``flux-*`` / ``nova-*`` → Deepgram,
+    ``provider`` is ``"elevenlabs"`` / ``"deepgram"`` / ``"munsit"`` (alias
+    ``"faseeh"``; case-insensitive; also accepts UI labels like
+    ``"deepgram-flux"`` / ``"deepgram-nova"``). When ``None``, inferred from
+    the model id: ``flux-*`` / ``nova-*`` → Deepgram, ``munsit*`` → Munsit,
     anything else (including ``scribe_*``) → ElevenLabs.
 
     Bare ``"deepgram"`` defaults to Flux (voice-agent native EOU). Only an
@@ -484,11 +498,20 @@ def resolve_stt(
     p = (provider or "").strip().lower()
     m = (model or "").strip().lower()
     if not p:
-        p = "deepgram" if (m.startswith("flux") or m.startswith("nova")) else "elevenlabs"
+        if m.startswith(("flux", "nova")):
+            p = "deepgram"
+        elif m.startswith("munsit"):
+            p = "munsit"
+        else:
+            p = "elevenlabs"
     if p in ("elevenlabs", "el", "11labs"):
         from .elevenlabs import ElevenLabsRealtimeSTT
 
         return ElevenLabsRealtimeSTT(api_key=api_key)
+    if p in ("munsit", "faseeh"):
+        from .munsit import MunsitStreamSTT
+
+        return MunsitStreamSTT(api_key=api_key)
     if p.startswith("deepgram") or p == "dg":
         # UI labels win. Bare "deepgram"/"dg" → Flux unless model is clearly nova-*.
         if "nova" in p:

--- a/python/timbal/voice/munsit.py
+++ b/python/timbal/voice/munsit.py
@@ -84,8 +84,15 @@ def _resolve_api_key(explicit: str | SecretStr | None) -> str:
 # Streaming STT — WSS /api/v1/listen
 # ---------------------------------------------------------------------------
 
-# The /listen socket accepts exactly these rates (anything else is a fatal 4002).
+# The /listen socket accepts exactly these rates (anything else is a fatal
+# 4002). The session applies one sample_rate to both STT and TTS, and Munsit
+# TTS is engine-native at 48 kHz — so PCM16 sessions at any other rate are
+# resampled client-side down to _STT_WIRE_RATE instead of rejected (same
+# approach as Munsit's own LiveKit plugin, whose 48 kHz tracks feed a 16 kHz
+# wire).
 _STT_SAMPLE_RATES = frozenset({8_000, 16_000})
+_STT_WIRE_RATE = 16_000
+_PCM16_ENCODINGS = ("pcm_s16le", "linear16", "")
 # Munsit is happy with 20-200ms frames; 80ms matches the Deepgram adapters so
 # the session's mic cadence behaves identically across providers.
 _STT_AUDIO_FLUSH_INTERVAL = 0.08
@@ -128,6 +135,24 @@ def effective_stt_model(requested: str | None) -> str:
     return requested.strip() if is_munsit_stt_model(requested) else DEFAULT_STT_MODEL
 
 
+def _stt_wire_rate(config: AudioInputConfig) -> int:
+    """Sample rate actually negotiated on the ``/listen`` socket.
+
+    Rates the socket accepts pass through; any other PCM16 rate resamples
+    client-side to 16 kHz (see :data:`_STT_SAMPLE_RATES`). Compressed
+    encodings can't be resampled here, so those fail at session start rather
+    than let the server kill the socket with a fatal 4002 on the first frame.
+    """
+    if config.sample_rate in _STT_SAMPLE_RATES:
+        return config.sample_rate
+    if config.encoding not in _PCM16_ENCODINGS:
+        raise ValueError(
+            f"Munsit streaming STT accepts 8000/16000 Hz and cannot resample "
+            f"{config.encoding!r} audio client-side; got {config.sample_rate} Hz."
+        )
+    return _STT_WIRE_RATE
+
+
 class MunsitStreamSTT(SpeechToText):
     """Munsit live streaming STT (``WSS /api/v1/listen``) with native EOU.
 
@@ -154,6 +179,12 @@ class MunsitStreamSTT(SpeechToText):
     :attr:`native_eou`, and disables the VAD endpointing fast path the same
     way it does for Deepgram Flux.
 
+    The socket accepts only 8/16 kHz, but the session applies one
+    ``sample_rate`` to both STT and TTS and Munsit TTS is engine-native at
+    48 kHz — so PCM16 sessions at other rates get the mic leg resampled
+    client-side to 16 kHz (stateful ``PcmResampler``; no per-chunk edge
+    artifacts) instead of failing at ``connect``.
+
     ``stt_extra`` passthrough: ``endpointing`` (ms, 100-5000), ``smart_turn``,
     ``hotwords`` (ignored by ``munsit-en-ar``), ``channels``,
     ``correlation_id``, ``metadata``, ``interim_results``; plus ``stt_host``
@@ -167,6 +198,8 @@ class MunsitStreamSTT(SpeechToText):
         self._api_key: str | None = None
         self._ws: Any = None
         self._buf = bytearray()
+        # Set by connect() when the session rate isn't wire-legal (e.g. 48 kHz).
+        self._resampler: Any = None
         # Single lock over buffer mutation *and* ws.send — same rationale as
         # the Deepgram adapters: threshold pushes, the flush loop and control
         # frames must never interleave frames on the socket.
@@ -182,15 +215,11 @@ class MunsitStreamSTT(SpeechToText):
     def _build_uri(self, config: AudioInputConfig) -> str:
         extra = dict(config.extra)
         host = str(extra.pop("stt_host", _DEFAULT_HOST))
-        if config.sample_rate not in _STT_SAMPLE_RATES:
-            # Fail at session start rather than let the server kill the socket
-            # with a fatal 4002 on the first frame.
-            raise ValueError(f"Munsit streaming STT supports 8000 or 16000 Hz; got {config.sample_rate}.")
-        encoding = "linear16" if config.encoding in ("pcm_s16le", "linear16", "") else config.encoding
+        encoding = "linear16" if config.encoding in _PCM16_ENCODINGS else config.encoding
         params: list[tuple[str, str]] = [
             ("model", effective_stt_model(config.model)),
             ("encoding", encoding),
-            ("sample_rate", str(config.sample_rate)),
+            ("sample_rate", str(_stt_wire_rate(config))),
         ]
         # `ar` is the only supported value in v1 and invalid connection params
         # are fatal — drop foreign language leftovers rather than 4002 the
@@ -209,7 +238,15 @@ class MunsitStreamSTT(SpeechToText):
     async def connect(self, config: AudioInputConfig) -> None:
         self._api_key = _resolve_api_key(self._api_key_explicit)
         uri = self._build_uri(config)
-        self._flush_bytes = int(config.sample_rate * _STT_AUDIO_FLUSH_INTERVAL * 2)
+        wire_rate = _stt_wire_rate(config)
+        if wire_rate != config.sample_rate:
+            from .telephony import PcmResampler
+
+            self._resampler = PcmResampler(config.sample_rate, wire_rate)
+            logger.debug("munsit_stt_resampling", src_rate=config.sample_rate, wire_rate=wire_rate)
+        else:
+            self._resampler = None
+        self._flush_bytes = int(wire_rate * _STT_AUDIO_FLUSH_INTERVAL * 2)
         logger.debug("munsit_stt_connecting", uri=uri[:160])
         from websockets.asyncio.client import connect as ws_connect
 
@@ -230,6 +267,12 @@ class MunsitStreamSTT(SpeechToText):
         from websockets.exceptions import ConnectionClosed
 
         async with self._wire_lock:
+            # Resample under the lock — the FIR filter carries state across
+            # chunks, so ordering must match the wire.
+            if self._resampler is not None:
+                chunk = self._resampler.process(chunk)
+                if not chunk:
+                    return
             self._buf.extend(chunk)
             if len(self._buf) < self._flush_bytes or self._ws is None:
                 return
@@ -430,7 +473,9 @@ def effective_sample_rate(config: AudioOutputConfig) -> int:
     server-side (a quality cost, not a latency one). The session-wide default
     of 16 kHz is honoured as requested; deployments that want engine-native
     audio should raise the session ``sample_rate`` (e.g. LiveKit/WebRTC
-    transports, which resample to 48 kHz anyway), not this provider.
+    transports, which resample to 48 kHz anyway), not this provider. A 48 kHz
+    session works with Munsit STT too: :class:`MunsitStreamSTT` resamples the
+    mic leg down to its 16 kHz wire client-side.
     """
     sr = config.sample_rate
     if not (_SAMPLE_RATE_MIN <= sr <= _SAMPLE_RATE_MAX):

--- a/python/timbal/voice/munsit.py
+++ b/python/timbal/voice/munsit.py
@@ -1,40 +1,68 @@
-"""Munsit (Faseeh) streaming Arabic TTS for :class:`~timbal.voice.VoiceSession`.
+"""Munsit (Faseeh) Arabic voice providers for :class:`~timbal.voice.VoiceSession`.
 
-Uses the HTTP chunked-streaming endpoint:
+Two providers, both authenticated with ``MUNSIT_API_KEY``:
 
-* ``POST /api/v1/text-to-speech/{model_id}`` with ``streaming: true`` —
+* :class:`MunsitStreamSTT` — live streaming STT over
+  ``WSS /api/v1/listen`` (interim results, word timestamps, and
+  provider-native end-of-turn detection via ``endpointing`` + ``smart_turn``).
+* :class:`MunsitStreamTTS` — TTS over the HTTP chunked-streaming endpoint
+  ``POST /api/v1/text-to-speech/{model_id}`` with ``streaming: true`` —
   raw PCM16 chunks are yielded as they are generated.
 
-Munsit also documents a TTS WebSocket (``/websocket/text-to-speech``), but as
-of 2026-08 it accepts ``initConnection``/``text`` frames and never produces
-audio (verified empirically across auth methods, flush flags and long texts),
-so this provider deliberately uses HTTP streaming — which Munsit itself
-recommends when the text of a segment is available upfront. No ``open_stream``
-capability: the session falls back to per-segment ``synthesize``.
+**Why TTS is HTTP and not the WebSocket** (re-verified 2026-08-31 against
+https://docs.munsit.com/reference/websocket): the documented TTS socket
+(``/api/v1/websocket/text-to-speech``) still accepts ``initConnection`` (and
+answers ``connectionInitialized``) and ``text`` frames, but produces **no
+audio** — probed live on 2026-08-31 across query-param / initConnection auth
+and every ``flush`` / ``try_trigger_generation`` combination; the documented
+header and Bearer auth are additionally rejected with error 40101. Even per
+its docs the socket tops out at ``pcm_24000`` while HTTP serves the
+engine-native 48 kHz, and Munsit itself recommends HTTP when the segment text
+is known upfront (our case: the session flushes complete segments).
 
-Requires ``MUNSIT_API_KEY``.
+Decisively: Munsit's own first-party plugins do not use their TTS socket
+either. ``livekit-plugins-munsit`` 0.4.0 implements its incremental
+``stream()`` as a client-side sentence chunker issuing one HTTP
+``streaming: true`` POST per chunk, and ``pipecat-plugins-munsit`` 0.2.0 does
+the same — zero WebSocket code in either TTS module (verified from the PyPI
+sdists, 2026-08-31). There is no prosody-continuous incremental-feed path in
+this API today, so no ``open_stream`` capability: the session falls back to
+per-segment ``synthesize``, which is exactly the transport the vendor's own
+plugins use.
 """
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import json
 import os
 from collections.abc import AsyncIterator
 from typing import Any
+from urllib.parse import urlencode
 
 import structlog
 from pydantic import SecretStr
 
 from .config import DEFAULT_VOICE_ID as _ELEVENLABS_DEFAULT_VOICE_ID
 from .providers import (
+    AudioInputConfig,
     AudioOutputConfig,
+    SpeechToText,
     TextToSpeech,
+    TranscriptEvent,
 )
 
 logger = structlog.get_logger("timbal.voice.munsit")
 
 DEFAULT_TTS_MODEL = "faseeh-v1-preview"
-# Override with MUNSIT_VOICE_ID (cloned/custom voices are account-specific).
-DEFAULT_MUNSIT_VOICE_ID = "ar-najdi-male-2"
+# Munsit's LiveKit examples use this Emirati voice; the docs' own example voice
+# (ar-najdi-male-2) is Najdi Saudi, which surprised the Emirati deployments this
+# provider was added for. Override with MUNSIT_VOICE_ID (cloned/custom voices
+# are account-specific) or set an explicit voice on the session.
+DEFAULT_MUNSIT_VOICE_ID = "ar-uae-male-1"
+
+DEFAULT_STT_MODEL = "munsit-en-ar"
 
 _DEFAULT_HOST = "api.munsit.com"
 _SAMPLE_RATE_MIN = 8_000
@@ -52,12 +80,357 @@ def _resolve_api_key(explicit: str | SecretStr | None) -> str:
     return key
 
 
+# ---------------------------------------------------------------------------
+# Streaming STT — WSS /api/v1/listen
+# ---------------------------------------------------------------------------
+
+# The /listen socket accepts exactly these rates (anything else is a fatal 4002).
+_STT_SAMPLE_RATES = frozenset({8_000, 16_000})
+# Munsit is happy with 20-200ms frames; 80ms matches the Deepgram adapters so
+# the session's mic cadence behaves identically across providers.
+_STT_AUDIO_FLUSH_INTERVAL = 0.08
+# 12s with neither audio nor KeepAlive closes the socket with 1011; Munsit's
+# docs say to send KeepAlive during pauses — well inside that window.
+_STT_KEEPALIVE_INTERVAL = 5.0
+# After CloseStream the server finalizes the in-flight turn and sends the
+# billing Metadata before closing with 1000. Closing our side first aborts
+# finalization (documented), so close() waits for the server — but bounded.
+_STT_CLOSE_DRAIN_TIMEOUT = 5.0
+
+# Query params /api/v1/listen accepts (used to filter stt_extra passthrough).
+# `model`, `language`, `encoding`, `sample_rate` are owned by the config.
+_STT_QUERY_KEYS = frozenset(
+    {
+        "channels",
+        "endpointing",
+        "smart_turn",
+        "hotwords",
+        "interim_results",
+        "correlation_id",
+        "metadata",
+    }
+)
+
+
+def is_munsit_stt_model(model: str | None) -> bool:
+    return bool(model) and model.strip().lower().startswith("munsit")
+
+
+def effective_stt_model(requested: str | None) -> str:
+    """Model id actually sent to Munsit (foreign leftovers swapped out).
+
+    Same pattern as :func:`effective_tts_model`: a session that only switched
+    ``stt_provider`` must not put ``scribe_v2_realtime`` / ``flux-*`` on the
+    Munsit wire. Defaults to ``munsit-en-ar`` (code-switching) rather than the
+    raw API's ``munsit`` because the deployments pinning Munsit mix Arabic and
+    English mid-utterance — same default as Munsit's own LiveKit plugin.
+    """
+    return requested.strip() if is_munsit_stt_model(requested) else DEFAULT_STT_MODEL
+
+
+class MunsitStreamSTT(SpeechToText):
+    """Munsit live streaming STT (``WSS /api/v1/listen``) with native EOU.
+
+    The wire protocol is Deepgram-flavored. Event mapping:
+
+    * interim ``Results`` → ``partial`` (the transcript is the whole turn so
+      far; buffered forced-split segments are prepended)
+    * ``Results`` with ``speech_final: true`` → ``committed`` — Munsit's own
+      endpointing + smart-turn model decided the speaker finished
+    * ``Results`` with ``is_final: true`` but ``speech_final: false`` is the
+      ~60s forced split during unbroken speech: the text is stable but the
+      speaker is still talking, so it is buffered and **never** committed on
+      its own (no ``UtteranceEnd`` fires for it either)
+    * ``UtteranceEnd`` → backup flush of any buffered segments; normally a
+      no-op because the ``speech_final`` frame already committed the turn
+    * ``Gender`` / ``Sentiment`` enrichment and ``SpeechStarted`` → logged only
+    * ``Error`` with ``recoverable: true`` → logged; ``recoverable: false``
+      always precedes a close and surfaces as a session error
+
+    ``commit()`` is a no-op: the Munsit turn machine owns endpointing —
+    ``Configure`` can retune the silence window mid-session but there is no
+    client force-commit (``CloseStream`` ends the whole session). Pair with
+    ``turn_detector="provider"``; the server wires that automatically via
+    :attr:`native_eou`, and disables the VAD endpointing fast path the same
+    way it does for Deepgram Flux.
+
+    ``stt_extra`` passthrough: ``endpointing`` (ms, 100-5000), ``smart_turn``,
+    ``hotwords`` (ignored by ``munsit-en-ar``), ``channels``,
+    ``correlation_id``, ``metadata``, ``interim_results``; plus ``stt_host``
+    for a self-hosted deployment.
+    """
+
+    native_eou = True
+
+    def __init__(self, api_key: str | SecretStr | None = None) -> None:
+        self._api_key_explicit = api_key
+        self._api_key: str | None = None
+        self._ws: Any = None
+        self._buf = bytearray()
+        # Single lock over buffer mutation *and* ws.send — same rationale as
+        # the Deepgram adapters: threshold pushes, the flush loop and control
+        # frames must never interleave frames on the socket.
+        self._wire_lock = asyncio.Lock()
+        self._stop = asyncio.Event()
+        self._flusher: asyncio.Task[None] | None = None
+        self._keepalive: asyncio.Task[None] | None = None
+        self._receiver: asyncio.Task[None] | None = None
+        self._queue: asyncio.Queue[TranscriptEvent | None] = asyncio.Queue()
+        self._segments: list[str] = []
+        self._flush_bytes = int(16_000 * _STT_AUDIO_FLUSH_INTERVAL * 2)
+
+    def _build_uri(self, config: AudioInputConfig) -> str:
+        extra = dict(config.extra)
+        host = str(extra.pop("stt_host", _DEFAULT_HOST))
+        if config.sample_rate not in _STT_SAMPLE_RATES:
+            # Fail at session start rather than let the server kill the socket
+            # with a fatal 4002 on the first frame.
+            raise ValueError(f"Munsit streaming STT supports 8000 or 16000 Hz; got {config.sample_rate}.")
+        encoding = "linear16" if config.encoding in ("pcm_s16le", "linear16", "") else config.encoding
+        params: list[tuple[str, str]] = [
+            ("model", effective_stt_model(config.model)),
+            ("encoding", encoding),
+            ("sample_rate", str(config.sample_rate)),
+        ]
+        # `ar` is the only supported value in v1 and invalid connection params
+        # are fatal — drop foreign language leftovers rather than 4002 the
+        # socket ("ar-AE" style region tags collapse to "ar").
+        lang = (config.language or "").strip().lower()
+        if lang.startswith("ar"):
+            params.append(("language", "ar"))
+        elif lang:
+            logger.debug("munsit_stt_language_dropped", language=config.language)
+        for k, v in extra.items():
+            if v is None or k.startswith("_") or k not in _STT_QUERY_KEYS:
+                continue
+            params.append((k, str(v).lower() if isinstance(v, bool) else str(v)))
+        return f"wss://{host}/api/v1/listen?{urlencode(params)}"
+
+    async def connect(self, config: AudioInputConfig) -> None:
+        self._api_key = _resolve_api_key(self._api_key_explicit)
+        uri = self._build_uri(config)
+        self._flush_bytes = int(config.sample_rate * _STT_AUDIO_FLUSH_INTERVAL * 2)
+        logger.debug("munsit_stt_connecting", uri=uri[:160])
+        from websockets.asyncio.client import connect as ws_connect
+
+        self._ws = await ws_connect(
+            uri,
+            # Server-side x-api-key header — never the api_key query param,
+            # which puts the key in any log that records the URI.
+            additional_headers={"x-api-key": self._api_key},
+        )
+        self._stop.clear()
+        self._flusher = asyncio.create_task(self._flush_loop())
+        self._keepalive = asyncio.create_task(self._keepalive_loop())
+        self._receiver = asyncio.create_task(self._receive_loop())
+
+    async def push_audio(self, chunk: bytes) -> None:
+        if not chunk:
+            return
+        from websockets.exceptions import ConnectionClosed
+
+        async with self._wire_lock:
+            self._buf.extend(chunk)
+            if len(self._buf) < self._flush_bytes or self._ws is None:
+                return
+            raw = bytes(self._buf)
+            self._buf.clear()
+            try:
+                await self._ws.send(raw)
+            except ConnectionClosed:
+                pass
+
+    async def _flush_audio(self) -> None:
+        from websockets.exceptions import ConnectionClosed
+
+        async with self._wire_lock:
+            if self._ws is None:
+                return
+            raw = bytes(self._buf)
+            self._buf.clear()
+            if not raw:
+                return
+            try:
+                await self._ws.send(raw)
+            except ConnectionClosed:
+                pass
+
+    async def _flush_loop(self) -> None:
+        from websockets.exceptions import ConnectionClosed
+
+        try:
+            while not self._stop.is_set():
+                await asyncio.sleep(_STT_AUDIO_FLUSH_INTERVAL)
+                await self._flush_audio()
+        except asyncio.CancelledError:
+            raise
+        except ConnectionClosed:
+            pass
+
+    async def _keepalive_loop(self) -> None:
+        try:
+            while not self._stop.is_set():
+                await asyncio.sleep(_STT_KEEPALIVE_INTERVAL)
+                await self._send_json({"type": "KeepAlive"})
+        except asyncio.CancelledError:
+            raise
+
+    async def commit(self) -> None:
+        """No-op: Munsit's turn machine owns endpointing (no force-commit API)."""
+
+    async def _handle_message(self, msg: dict[str, Any]) -> None:
+        mt = msg.get("type", "")
+        if mt == "Results":
+            text = (msg.get("transcript") or "").strip()
+            is_final = bool(msg.get("is_final"))
+            speech_final = bool(msg.get("speech_final"))
+            if not is_final:
+                if text:
+                    partial = " ".join((*self._segments, text)) if self._segments else text
+                    await self._queue.put(TranscriptEvent(type="partial", text=partial))
+                return
+            if not speech_final:
+                # Forced ~60s split: stable text, speaker still talking under
+                # the next turn_id. Buffer; committing here would answer a
+                # user who is mid-sentence.
+                if text:
+                    self._segments.append(text)
+                logger.debug("munsit_stt_forced_split", turn_id=msg.get("turn_id"), text_preview=text[:80])
+                return
+            if text:
+                self._segments.append(text)
+            if self._segments:
+                utterance = " ".join(self._segments)
+                self._segments = []
+                await self._queue.put(TranscriptEvent(type="committed", text=utterance))
+            return
+        if mt == "UtteranceEnd":
+            # Fires right after the final Results of a completed turn, so the
+            # speech_final frame has normally already flushed — this is the
+            # backup for a final that carried speech_final: false variants.
+            if self._segments:
+                utterance = " ".join(self._segments)
+                self._segments = []
+                await self._queue.put(TranscriptEvent(type="committed", text=utterance))
+            return
+        if mt == "SpeechStarted":
+            logger.debug("munsit_stt_speech_started", ts=msg.get("ts"))
+            return
+        if mt in ("Gender", "Sentiment"):
+            # Enrichment is out of scope for the voice session; visibility only.
+            logger.debug("munsit_stt_enrichment", enrichment=mt, label=msg.get("label"), score=msg.get("score"))
+            return
+        if mt == "Metadata":
+            if "audio_seconds_billed" in msg:
+                logger.info(
+                    "munsit_stt_session_closed",
+                    session_id=msg.get("session_id"),
+                    audio_seconds_billed=msg.get("audio_seconds_billed"),
+                    turn_count=msg.get("turn_count"),
+                )
+            else:
+                logger.info("munsit_stt_session_started", session_id=msg.get("session_id"), model=msg.get("model"))
+                if msg.get("dropped_hotwords"):
+                    logger.warning("munsit_stt_dropped_hotwords", dropped=msg["dropped_hotwords"])
+            return
+        if mt == "Error":
+            err = msg.get("message") or "Unknown Munsit error"
+            if msg.get("recoverable"):
+                logger.warning("munsit_stt_recoverable_error", error=err, code=msg.get("code"))
+                return
+            logger.error("munsit_stt_fatal", error=err, code=msg.get("code"))
+            await self._queue.put(TranscriptEvent(type="error", text=f"STT fatal: {err}"))
+
+    async def _receive_loop(self) -> None:
+        from websockets.exceptions import ConnectionClosed
+
+        assert self._ws is not None
+        try:
+            async for raw_msg in self._ws:
+                if isinstance(raw_msg, bytes):
+                    continue
+                try:
+                    msg = json.loads(raw_msg)
+                except ValueError:
+                    continue
+                await self._handle_message(msg)
+        except ConnectionClosed as e:
+            if self._stop.is_set():
+                logger.debug("munsit_stt_ws_closed", error=str(e))
+            else:
+                # Provider-initiated hangup is not the user hanging up — same
+                # rule as the Deepgram adapters.
+                logger.warning("munsit_stt_ws_closed_unrequested", error=str(e))
+                await self._queue.put(TranscriptEvent(type="error", text=f"STT connection closed: {e}"))
+        except Exception as e:
+            logger.error("munsit_stt_receive_error", error=str(e), exc_info=True)
+            await self._queue.put(TranscriptEvent(type="error", text=f"STT receive error: {e}"))
+        finally:
+            await self._queue.put(None)
+
+    async def events(self) -> AsyncIterator[TranscriptEvent]:
+        while True:
+            item = await self._queue.get()
+            if item is None:
+                break
+            if item.type == "error":
+                raise RuntimeError(item.text)
+            if item.text:
+                yield item
+
+    async def _send_json(self, payload: dict[str, Any]) -> None:
+        async with self._wire_lock:
+            if self._ws is None:
+                return
+            with contextlib.suppress(Exception):
+                await self._ws.send(json.dumps(payload))
+
+    async def close(self) -> None:
+        self._stop.set()
+        for task in (self._flusher, self._keepalive):
+            if task and not task.done():
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+        self._flusher = None
+        self._keepalive = None
+        with contextlib.suppress(Exception):
+            await self._flush_audio()
+        await self._send_json({"type": "CloseStream"})
+        # Wait for the server to finalize and close (1000) — closing our side
+        # first aborts finalization and loses the final Results + billing
+        # Metadata (documented). Bounded so a wedged server can't hang teardown.
+        if self._receiver and not self._receiver.done():
+            with contextlib.suppress(TimeoutError, asyncio.TimeoutError, asyncio.CancelledError, Exception):
+                await asyncio.wait_for(asyncio.shield(self._receiver), timeout=_STT_CLOSE_DRAIN_TIMEOUT)
+        if self._ws is not None:
+            with contextlib.suppress(Exception):
+                await self._ws.close()
+            self._ws = None
+        if self._receiver and not self._receiver.done():
+            self._receiver.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._receiver
+        self._receiver = None
+
+
+# ---------------------------------------------------------------------------
+# Streaming TTS — POST /api/v1/text-to-speech/{model_id} (streaming: true)
+# ---------------------------------------------------------------------------
+
+
 def effective_sample_rate(config: AudioOutputConfig) -> int:
     """Sample rate actually requested (endpoint accepts 8000–48000 Hz).
 
     Out-of-range rates raise instead of remapping: the session clocks playback
     at ``config.sample_rate``, so silently requesting a different rate would
     desync audio (chipmunk/slow-motion speech).
+
+    Munsit's engine-native rate is 48000 — lower rates are downsampled
+    server-side (a quality cost, not a latency one). The session-wide default
+    of 16 kHz is honoured as requested; deployments that want engine-native
+    audio should raise the session ``sample_rate`` (e.g. LiveKit/WebRTC
+    transports, which resample to 48 kHz anyway), not this provider.
     """
     sr = config.sample_rate
     if not (_SAMPLE_RATE_MIN <= sr <= _SAMPLE_RATE_MAX):
@@ -95,6 +468,11 @@ class MunsitStreamTTS(TextToSpeech):
 
     A persistent ``httpx.AsyncClient`` keeps connections pooled across
     segments, so per-segment requests skip the TCP+TLS handshake.
+
+    ``tts_extra`` passthrough: ``stability`` (default 0.5), ``speed`` (default
+    1.0), ``dialect`` (``auto`` | ``emirati`` | ``fusha`` — pronunciation hint,
+    unset means the API's ``auto``), and ``tts_host``. An Emirati deployment
+    sets ``tts_extra={"dialect": "emirati"}`` with no code change here.
     """
 
     provider_id = "munsit"

--- a/python/timbal/voice/providers.py
+++ b/python/timbal/voice/providers.py
@@ -50,6 +50,18 @@ class SpeechToText(ABC):
     Lifecycle: ``connect`` → push audio / consume ``events`` → ``close``.
     """
 
+    native_eou: bool = False
+    """Provider-native end-of-utterance detection.
+
+    ``True`` when committed transcripts are real turn boundaries decided
+    server-side (Deepgram Flux ``EndOfTurn``, Munsit ``speech_final`` /
+    ``UtteranceEnd``). The voice server then forces the ``provider`` turn
+    detector and disables the local VAD endpointing fast path — stacking
+    Smart Turn HOLD on top of provider EOU is a second turn policy fighting
+    the first, and these providers have no force-commit for the fast path
+    to trigger anyway.
+    """
+
     @abstractmethod
     async def connect(self, config: AudioInputConfig) -> None: ...
 

--- a/python/timbal/voice/session.py
+++ b/python/timbal/voice/session.py
@@ -135,7 +135,7 @@ def _strip_markdown(text: str) -> str:
 # TTS flush: send text to ElevenLabs when we have a clause boundary so audio tracks the LLM
 # without waiting for huge buffers. ``first_segment`` uses a low threshold so the first
 # sentence (e.g. "Hello!") reaches TTS quickly even if the model omits a space after "!".
-SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?\n;:])\s+")
+SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?\n;:\u061f\u061b])\s+")
 # Minimum chars before flushing to TTS.  Bigger segments = better prosody (ElevenLabs
 # multi-context has no cross-context continuity, so each segment's intonation is
 # independent).  Too small → choppy "final" intonation at every boundary.
@@ -145,8 +145,9 @@ MIN_FLUSH_CHARS = 24
 FIRST_SEGMENT_MIN_CHARS = 6
 MAX_TTS_BUFFER_CHARS = 200
 
-# Clause-ending chars for flush heuristics (ASCII + common Spanish + fullwidth variants).
-_CLAUSE_END_CHARS = frozenset(".!?;\n:\uff1f\uff01")
+# Clause-ending chars for flush heuristics (ASCII + common Spanish + fullwidth variants +
+# Arabic ؟/؛ — Arabic uses the Latin period for full stops, so "." already covers those).
+_CLAUSE_END_CHARS = frozenset(".!?;\n:\uff1f\uff01\u061f\u061b")
 
 
 def _nfc(s: str) -> str:


### PR DESCRIPTION
## Summary

- **New `MunsitStreamSTT`** over Munsit's `/api/v1/listen` WebSocket — interim/final event mapping, `speech_final` vs forced-split buffering (a final with `speech_final=false` is a mid-speech split, not a turn end), 5s keepalive, `CloseStream` drain, billing metadata on close, and Sentiment/Gender enrichment passthrough. Arabic and ar-en code-switch voice sessions no longer need double-vendor routing (Munsit TTS + ElevenLabs Scribe STT).
- **Provider-native EOU generalized**: the Flux-specific `stt_is_flux` gate becomes a `native_eou` capability flag on `SpeechToText`. Any native-EOU provider (Flux, Munsit) forces the `provider` turn detector and strips Scribe-tuned VAD knobs. Capacity profiles class `munsit`/`faseeh` sessions as cheap native-EOU (`_FLUX_STT_PROVIDERS` → `_NATIVE_EOU_STT_PROVIDERS`).
- **Munsit TTS stays on HTTP chunked streaming.** Live WS probes and the vendor's own livekit/pipecat plugins confirm the TTS WebSocket accepts frames but never emits audio; evidence and rationale recorded in the `munsit.py` docstring. Default voice moved to Emirati `ar-uae-male-1`.
- **Arabic-aware TTS flush**: session flush heuristics learn `؟` (U+061F) and `؛` (U+061B). Previously a question-form Arabic reply never hit the clause-complete fast path and buffered to the 200-char cap before first audio.
- `resolve_stt` accepts `munsit`/`faseeh` aliases and infers the provider from `munsit-*` model names.

## Test plan

- [x] `uv run pytest python/tests/voice python/tests/server` — 1061 passed, 4 skipped
- [x] `uv run ruff check` clean on touched files
- [x] Live smoke test: Munsit TTS HTTP → PCM16 → `MunsitStreamSTT` round-trip with real API key (partials, committed transcript, enrichment, billing metadata on close)
- [ ] Staging voice session with an org pinned to `stt=munsit` + `tts=munsit`