### PR TITLE
perf(voice): cut LiveKit first-call cold start (FFI warmup + hello window anchoring)

### DIFF
--- a/python/tests/server/test_livekit_session.py
+++ b/python/tests/server/test_livekit_session.py
@@ -413,6 +413,64 @@ class TestGuardLifetimeAroundSessionBuild:
         assert guard.on_abandon() is None  # no session yet — closure is a no-op
         await asyncio.wait({task}, timeout=2.0)
 
+    async def test_hello_window_is_anchored_at_caller_connect_not_mic(
+        self,
+        driver_env: tuple[_FakeRoom, _FakeGuard, _LogRecorder, object],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The window opens when the caller *connects*; their mic setup time
+        counts against it. A hello-less caller whose mic lands after the window
+        closed must not pay the full wait again on top (that flat tax on every
+        hello-less call is what this anchoring removed)."""
+        room, _guard, _log, app = driver_env
+        monkeypatch.setattr("timbal.server.livekit_session._HELLO_WAIT_SECS", 0.5)
+
+        def _stop(*_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("stop at build")
+
+        monkeypatch.setattr("timbal.server.livekit_session.build_voice_session", _stop)
+        task = asyncio.create_task(_run_livekit_session(app))
+        await asyncio.wait_for(room.connected.wait(), timeout=1.0)
+        await asyncio.sleep(0)
+        participant = SimpleNamespace(
+            identity="playground",
+            kind="PARTICIPANT_KIND_STANDARD",
+            attributes={},
+            disconnect_reason=None,
+        )
+        room.handlers["participant_connected"](participant)
+        # No hello ever, and the mic takes longer than the whole window.
+        await asyncio.sleep(0.6)
+        room.handlers["track_subscribed"](SimpleNamespace(kind=1), None, participant)
+        # Build follows the subscribe immediately — the window was already spent.
+        done, _ = await asyncio.wait({task}, timeout=0.25)
+        assert task in done
+        assert isinstance(task.exception(), RuntimeError)
+
+    async def test_hello_after_mic_within_the_window_still_applies(
+        self,
+        driver_env: tuple[_FakeRoom, _FakeGuard, _LogRecorder, object],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A prompt mic must not shrink the window to nothing: a hello arriving
+        after the subscribe but inside the window is still merged."""
+        room, _guard, _log, app = driver_env
+        seen: dict = {}
+
+        def _capture(runnable: object, defaults: object, config: dict, **kwargs: object):
+            seen["config"] = config
+            raise RuntimeError("stop after capture")
+
+        monkeypatch.setattr("timbal.server.livekit_session.build_voice_session", _capture)
+        task = asyncio.create_task(_run_livekit_session(app))
+        await asyncio.wait_for(room.connected.wait(), timeout=1.0)
+        await asyncio.sleep(0)
+        _subscribe_caller(room)
+        await asyncio.sleep(0.1)
+        _deliver_hello(room, {"sample_rate": 16000, "stt_provider": "deepgram-flux"})
+        await asyncio.wait({task}, timeout=2.0)
+        assert seen["config"]["stt_provider"] == "deepgram-flux"
+
     async def test_hello_before_subscribe_is_applied_to_the_session(
         self,
         driver_env: tuple[_FakeRoom, _FakeGuard, _LogRecorder, object],

--- a/python/timbal/server/livekit_session.py
+++ b/python/timbal/server/livekit_session.py
@@ -24,8 +24,9 @@ Env contract for the boot-env path (all platform-owned):
 * ``TIMBAL_LIVEKIT_AGENT_IDENTITY`` — this box's identity (exclude from caller resolution)
 * ``TIMBAL_VOICE_CALL_ID`` — platform call id for SIP transfer API paths
 * ``TIMBAL_VOICE_CLIENT_CONFIG`` — JSON, same keys as the WS hello / rtc config.
-  Overlay: after the caller publishes a mic, the driver waits up to 2s for an
-  untyped data-message hello (playground dropdowns) and merges it on top.
+  Overlay: the driver accepts an untyped data-message hello (playground
+  dropdowns) for up to 2s after the caller connects and merges it on top; the
+  session is still built only once their mic is subscribed.
 * ``TIMBAL_VOICE_PARENT_RUN_ID`` — run id this call continues (text → voice).
   Session identity, not a voice knob: it is read here (and off the dial body
   on the per-request path), never off the data-channel hello.
@@ -63,6 +64,7 @@ import base64
 import contextlib
 import json
 import os
+import time
 import uuid
 from contextlib import aclosing
 from dataclasses import dataclass
@@ -78,6 +80,11 @@ logger = structlog.get_logger("timbal.server.livekit_session")
 
 _MAX_RELIABLE_BYTES = 12 * 1024
 _EVENTS_TOPIC = "timbal.events"
+# The hello window opens when the caller *connects* (they can't send data
+# before that), not when their mic track lands. Browsers send the hello
+# immediately after joining, so the window usually elapses while the mic is
+# still being published — anchoring it after the mic subscribe instead would
+# put a flat 2s on top of every hello-less call's setup.
 _HELLO_WAIT_SECS = 2.0
 
 # How long a per-request join may take before the caller gets a 504. The SFU is
@@ -519,6 +526,9 @@ async def _run_livekit_session(
     caller_participant: Any | None = None
     caller_identity: str | None = None
     caller_is_sip = False
+    # When the caller was first seen in the room — the hello window is
+    # measured from here (see _HELLO_WAIT_SECS).
+    caller_seen_at: dict[str, float] = {}
     mic_tracks: asyncio.Queue[Any] = asyncio.Queue()
     caller_ready = asyncio.Event()
     session_aborted = asyncio.Event()
@@ -626,6 +636,7 @@ async def _run_livekit_session(
         caller_participant = participant
         caller_identity = getattr(participant, "identity", "") or ""
         caller_is_sip = is_sip_participant(participant)
+        caller_seen_at["t"] = time.monotonic()
         attrs = dict(getattr(participant, "attributes", None) or {})
         call_control_holder["c"] = LivekitCallControl(
             room=room,
@@ -773,7 +784,17 @@ async def _run_livekit_session(
         if session_aborted.is_set():
             _release_if_never_connected()
             return
-        await _wait_event_or_abort(hello_event, timeout=_HELLO_WAIT_SECS)
+        # Only the part of the hello window the caller's own mic setup didn't
+        # already consume is waited out here — usually nothing, because the
+        # hello rides the data channel the moment the caller connects while
+        # the mic subscribe takes a getUserMedia + publish round trip.
+        seen_at = caller_seen_at.get("t")
+        hello_wait = (
+            max(0.0, _HELLO_WAIT_SECS - (time.monotonic() - seen_at))
+            if seen_at is not None
+            else _HELLO_WAIT_SECS
+        )
+        await _wait_event_or_abort(hello_event, timeout=hello_wait)
         if session_aborted.is_set():
             _release_if_never_connected()
             return

--- a/python/timbal/server/voice.py
+++ b/python/timbal/server/voice.py
@@ -421,18 +421,30 @@ def voice_onnx_warmup_intended(voice_config: VoiceConfig) -> bool:
     return False
 
 
-async def warmup_voice_stack(voice_config: VoiceConfig) -> None:
+async def warmup_voice_stack(voice_config: VoiceConfig, *, livekit: bool | None = None) -> None:
     """Background warmup at server boot so the first voice session starts fast.
 
-    Two tiers, both best-effort:
+    Three tiers, all best-effort:
 
     * **Imports** (always): voice adapters (ElevenLabs + Deepgram). The
       ``timbal[voice]`` extra (numpy/onnxruntime + Smart Turn/Namo/Silero)
       is imported only when those ONNX models will actually run.
+    * **LiveKit FFI**: ``livekit.rtc`` loads a native library on first import,
+      which otherwise lands inside the first dial's join budget (see
+      ``_JOIN_TIMEOUT_SECS`` in :mod:`timbal.server.livekit_session`).
+      ``livekit=None`` auto-detects from the env: ``TIMBAL_VOICE_TRANSPORT``
+      (serverless boot-env dials) or ``TIMBAL_LIVEKIT_URL`` (long-lived
+      servers pin the dialable URL — the composer sidecar gets it from the
+      monolith supervisor). Pass a bool to override either way.
     * **Models**: load Smart Turn + Namo + Silero when the session's turn
       detector is local. Skipped for Flux / ``provider`` EOU — see
       :func:`voice_onnx_warmup_intended`.
     """
+    if livekit is None:
+        livekit = (
+            os.environ.get("TIMBAL_VOICE_TRANSPORT", "").strip().lower() == "livekit"
+            or bool(os.environ.get("TIMBAL_LIVEKIT_URL", "").strip())
+        )
     loop = asyncio.get_running_loop()
 
     def _import_stack() -> bool:
@@ -440,6 +452,11 @@ async def warmup_voice_stack(voice_config: VoiceConfig) -> None:
 
         importlib.import_module("timbal.voice.elevenlabs")
         importlib.import_module("timbal.voice.deepgram")
+        if livekit:
+            try:
+                importlib.import_module("livekit.rtc")
+            except ImportError:
+                pass  # timbal[voice-livekit] not installed — the dial will 501
         # The detector-choice probe can itself import onnxruntime/transformers
         # (default turn_detector resolution) — must stay in this executor, off
         # the event loop and under the caller's except.

--- a/python/timbal/server/voice.py
+++ b/python/timbal/server/voice.py
@@ -455,8 +455,12 @@ async def warmup_voice_stack(voice_config: VoiceConfig, *, livekit: bool | None 
         if livekit:
             try:
                 importlib.import_module("livekit.rtc")
-            except ImportError:
-                pass  # timbal[voice-livekit] not installed — the dial will 501
+            except Exception:  # noqa: BLE001
+                # ImportError: timbal[voice-livekit] not installed — the dial
+                # will 501. Anything else (OSError from a broken native lib):
+                # equally best-effort, and it must not knock out the ONNX
+                # model-warmup tier below.
+                pass
         # The detector-choice probe can itself import onnxruntime/transformers
         # (default turn_detector resolution) — must stay in this executor, off
         # the event loop and under the caller's except.


### PR DESCRIPTION
## Summary

Two independent cuts to voice cold start on the LiveKit transport; together they remove the "always-on server, horrendous first call" gap.

- **Boot warmup now covers the LiveKit FFI.** `warmup_voice_stack` pre-imported the ElevenLabs/Deepgram adapters but not `livekit.rtc`, whose native-lib load landed inside the first dial's join budget (it's what `_JOIN_TIMEOUT_SECS` was sized around). New best-effort tier, auto-detected from `TIMBAL_VOICE_TRANSPORT` / `TIMBAL_LIVEKIT_URL`, so every existing warmup call site (`server/http.py`, long-lived sidecars) gets it with no signature change. Optional `livekit: bool | None` kwarg to force it either way.
- **The hello window is anchored at caller connect, not mic subscribe.** The driver used to wait for the caller's mic track and *then* open the 2s hello window — so any hello-less call paid `mic setup + 2s` flat, every call, forever. But the hello rides the data channel the moment the caller connects, while the mic still needs a getUserMedia + publish round trip. The window is now measured from first sight of the caller (`_note_caller`), and after the mic lands the driver waits out only whatever the caller's own setup didn't already consume — usually nothing. Worst case (no hello ever) drops from `mic + 2s` to `max(mic, 2s)`.

The session is still built strictly after the mic subscribe, so all abort/guard sequencing (SIP BYE before media, short-abandon during the hello window, late media after BYE) is unchanged — the existing tests around those invariants pass untouched.

Not addressed here: SIP callers gain little from the anchoring (phone media lands almost immediately after connect, so the window is still mostly unconsumed). Skipping the window for SIP outright conflicts with the short-abandon-during-hello sequencing; left for a separate change if the 2s matters on telephony.

## Test plan

- [x] `python/tests/server/test_livekit_session.py` — 71 passed, including two new regression tests: a hello-less caller whose mic lands after the window builds immediately (no second flat wait), and a hello arriving after a fast mic but inside the window is still merged.
- [x] Full `python/tests/server` package with `--extra server`: 533 passed (one pre-existing telephony failure requiring the `timbal[voice]` extra, unrelated).
- [x] Downstream check: composer sidecar suite (412 tests) passes against pinned timbal 2.7.6, confirming the no-kwarg call path stays compatible.