### PR TITLE
fix(voice): accept LiveKit proto int participant kinds (browser callers were invisible)

### DIFF
--- a/python/tests/server/test_livekit_sip.py
+++ b/python/tests/server/test_livekit_sip.py
@@ -20,7 +20,7 @@ from timbal.server.livekit_sip import (
 def _p(
     identity: str,
     *,
-    kind: str = "PARTICIPANT_KIND_STANDARD",
+    kind: str | int = "PARTICIPANT_KIND_STANDARD",
     reason: str | None = None,
     attributes: dict[str, str] | None = None,
 ) -> SimpleNamespace:
@@ -60,6 +60,16 @@ class TestEligibleCaller:
             local_identity="agent-1",
             caller_hint="caller-",
         )
+
+    def test_proto_int_kind_is_eligible(self) -> None:
+        """The Python FFI exposes STANDARD=0 / SIP=3, not the enum name."""
+        assert is_eligible_caller(_p("caller-abc", kind=0), local_identity="agent-1")
+        assert is_eligible_caller(_p("+34111", kind=3), local_identity="agent-1")
+
+    def test_proto_int_service_and_agent_are_excluded(self) -> None:
+        assert not is_eligible_caller(_p("rec", kind=2), local_identity="agent-1")  # EGRESS
+        assert not is_eligible_caller(_p("ing", kind=1), local_identity="agent-1")  # INGRESS
+        assert not is_eligible_caller(_p("bot", kind=4), local_identity="agent-1")  # AGENT
 
     def test_first_eligible_wins(self) -> None:
         remotes = [

--- a/python/timbal/server/livekit_sip.py
+++ b/python/timbal/server/livekit_sip.py
@@ -24,6 +24,21 @@ KIND_INGRESS = "PARTICIPANT_KIND_INGRESS"
 SERVICE_KINDS = frozenset({KIND_EGRESS, KIND_INGRESS, "EGRESS", "INGRESS"})
 CALLER_KINDS = frozenset({KIND_STANDARD, KIND_SIP, "STANDARD", "SIP"})
 
+# ``livekit.rtc.ParticipantKind`` is a protobuf enum: the FFI sets
+# ``participant.kind`` to the *number* (STANDARD=0, SIP=3), not the name.
+# ``str(0) == "0"`` is not in ``CALLER_KINDS``, so a browser that joined and
+# published a mic was silently ignored — the driver sat on ``caller_ready``
+# forever. Map the wire numbers here so every kind check sees the name.
+_KIND_BY_NUMBER = {
+    0: KIND_STANDARD,
+    1: KIND_INGRESS,
+    2: KIND_EGRESS,
+    3: KIND_SIP,
+    4: "PARTICIPANT_KIND_AGENT",
+    5: "PARTICIPANT_KIND_CONNECTOR",
+    6: "PARTICIPANT_KIND_BRIDGE",
+}
+
 # §7.1 — definitive inbound BYE / room teardown vs media blip.
 DEFINITIVE_DISCONNECT = frozenset(
     {
@@ -83,6 +98,8 @@ def _kind_label(kind: Any) -> str:
     name = getattr(kind, "name", None)
     if isinstance(name, str) and name:
         return name
+    if isinstance(kind, int) and not isinstance(kind, bool):
+        return _KIND_BY_NUMBER.get(kind, str(kind))
     return str(kind)
 
 


### PR DESCRIPTION
## Summary

The LiveKit Python FFI exposes `participant.kind` as the protobuf **number** (`STANDARD=0`, `SIP=3`), not `PARTICIPANT_KIND_STANDARD`. `is_eligible_caller` compared `str(kind)` against the name set, so `"0"` never matched and **every browser caller was silently ignored**.

That is the composer-voice hang: dial 200, agent in the room, FE `RoomEvent.Connected` + `LocalTrackPublished` `{source: microphone}`, then no `session_started` — the driver parks on `caller_ready` forever. Disconnect is also ignored because we never noted them as the caller.

`_kind_label` now maps the proto wire numbers (0–6) to the names the rest of the module already uses. String kinds (tests, some fakes) are unchanged.

Composer is not on SIP. It shares `livekit_session`, which started using this filter in 2.7.6 (`#147`) to skip egress/ingress. Tests only ever passed string kinds.

## Test plan

- [x] `python/tests/server/test_livekit_sip.py` + `test_livekit_session.py` — 89 passed, including proto-int STANDARD/SIP eligible and EGRESS/INGRESS/AGENT excluded.