### PR TITLE
docs(models): refresh catalog prices against official provider rates

### DIFF
--- a/docs/models/anthropic.mdx
+++ b/docs/models/anthropic.mdx
@@ -47,7 +47,7 @@ description: "Claude Fable 5, Opus 5, Sonnet 5, and Haiku models with specs, pri
 
   Current-generation Sonnet — near-Opus intelligence at Sonnet pricing for coding, agents, and everyday professional work. Drop-in replacement for Sonnet 4.6.
 
-  - &#36;3 / &#36;15 per 1M tokens (input / output; intro &#36;2 / &#36;10 through Aug 31, 2026)
+  - &#36;2 / &#36;10 per 1M tokens (input / output)
   - <Icon icon="window-maximize" size={14} /> 1M context
   - <Icon icon="right-from-bracket" size={14} /> 128K max output
   - <Icon icon="keyboard" size={14} /> Text, Image input

--- a/docs/models/byteplus.mdx
+++ b/docs/models/byteplus.mdx
@@ -17,7 +17,7 @@ description: "Seed 2.0 and Seed 1.8 models with specs, pricing, and capabilities
 
   <Warning>Activation required — enable in the [Ark Console](https://console.byteplus.com/ark/region:ark+ap-southeast-1/models) before first use.</Warning>
 
-  - ~&#36;0.47 / ~&#36;2.37
+  - &#36;0.50 / &#36;3.00 (&#36;1 / &#36;6 above 128K prompt tokens)
   - <Icon icon="window-maximize" size={14} /> 256K context
   - <Icon icon="keyboard" size={14} /> Text, Image, Video input
   - <Icon icon="brain" size={14} /> Deep thinking
@@ -30,7 +30,7 @@ description: "Seed 2.0 and Seed 1.8 models with specs, pricing, and capabilities
 
   Cost-efficient Seed 2.0 variant optimised for high-concurrency and latency-sensitive workloads. Supports multimodal input and tool calling at a fraction of the Pro cost.
 
-  - &#36;0.25 / &#36;1
+  - &#36;0.25 / &#36;2 (&#36;0.50 / &#36;4 above 128K prompt tokens)
   - <Icon icon="window-maximize" size={14} /> 256K context
   - <Icon icon="keyboard" size={14} /> Text, Image, Video input
   </Card>

--- a/docs/models/fireworks.mdx
+++ b/docs/models/fireworks.mdx
@@ -15,7 +15,7 @@ description: "Open-source models via Fireworks serverless inference with specs, 
 
   Official DeepSeek V4 Flash on Fireworks serverless (supersedes the April preview). Fast, cost-efficient MoE with near-Pro reasoning at 1M context.
 
-  - &#36;0.14 / &#36;0.28
+  - &#36;0.22 / &#36;0.66
   - <Icon icon="window-maximize" size={14} /> 1M context
   - <Icon icon="keyboard" size={14} /> Text input
   </Card>

--- a/docs/models/openai.mdx
+++ b/docs/models/openai.mdx
@@ -3,7 +3,7 @@ title: "OpenAI"
 description: "GPT-5, GPT-4, and o-series models with specs, pricing, and capabilities"
 ---
 
-<Note>Source: [OpenAI model docs](https://platform.openai.com/docs/models) · [API pricing](https://openai.com/api/pricing/) (cached input &#36;0.50 / 1M for GPT-5.5)</Note>
+<Note>Source: [OpenAI model docs](https://platform.openai.com/docs/models) · [API pricing](https://developers.openai.com/api/docs/pricing) (GPT-5.6 Sol promo at least through Nov 21, 2026)</Note>
 
 ## GPT-5 Series
 
@@ -57,7 +57,7 @@ description: "GPT-5, GPT-4, and o-series models with specs, pricing, and capabil
 
   GPT-5.6 flagship tier for the hardest coding, agentic, and long-horizon tasks. Supports programmatic tool calling and multi-agent flows in the Responses API.
 
-  - &#36;5 / &#36;30 per 1M tokens (input / output); cached input &#36;0.50 / 1M
+  - &#36;4 / &#36;20 per 1M tokens (input / output; promo at least through Nov 21, 2026); cached input &#36;0.40 / 1M
   - <Icon icon="window-maximize" size={14} /> 1.05M context
   - <Icon icon="right-from-bracket" size={14} /> 128K max output
   - <Icon icon="keyboard" size={14} /> Text, Image input
@@ -72,7 +72,7 @@ description: "GPT-5, GPT-4, and o-series models with specs, pricing, and capabil
 
   GPT-5.6 balanced tier for everyday production work—competitive with GPT-5.5 at roughly half the cost of Sol.
 
-  - &#36;2.50 / &#36;15 per 1M tokens (input / output); cached input &#36;0.25 / 1M
+  - &#36;2 / &#36;12 per 1M tokens (input / output); cached input &#36;0.20 / 1M
   - <Icon icon="window-maximize" size={14} /> 1.05M context
   - <Icon icon="right-from-bracket" size={14} /> 128K max output
   - <Icon icon="keyboard" size={14} /> Text, Image input
@@ -87,7 +87,7 @@ description: "GPT-5, GPT-4, and o-series models with specs, pricing, and capabil
 
   GPT-5.6 fast, cost-efficient tier for high-volume, latency-sensitive, and budget-conscious workloads.
 
-  - &#36;1 / &#36;6 per 1M tokens (input / output); cached input &#36;0.10 / 1M
+  - &#36;0.20 / &#36;1.20 per 1M tokens (input / output); cached input &#36;0.02 / 1M
   - <Icon icon="window-maximize" size={14} /> 1.05M context
   - <Icon icon="right-from-bracket" size={14} /> 128K max output
   - <Icon icon="keyboard" size={14} /> Text, Image input

--- a/docs/models/togetherai.mdx
+++ b/docs/models/togetherai.mdx
@@ -15,7 +15,7 @@ description: "Open-source models via TogetherAI inference with specs, pricing, a
 
   Multilingual instruction-tuned model with 70B parameters, delivering enhanced performance relative to Llama 3.1 70B and matching Llama 3.2 90B on text-only tasks.
 
-  - &#36;0.88 / &#36;0.88
+  - &#36;1.04 / &#36;1.04
   - <Icon icon="window-maximize" size={14} /> 128K context
   - <Icon icon="keyboard" size={14} /> Text input
   - <Icon icon="calendar" size={14} /> Knowledge cutoff Dec 2023

--- a/docs/models/xai.mdx
+++ b/docs/models/xai.mdx
@@ -3,7 +3,7 @@ title: "xAI"
 description: "Grok 4.6, Grok 4.5, and Grok 4.3 models with specs, pricing, and capabilities"
 ---
 
-<Note>Source: [xAI model docs](https://docs.x.ai/docs/models). Search includes Web Search and X Search, priced at &#36;2.50-&#36;5/1K calls. Cached input: &#36;0.05/1M.</Note>
+<Note>Source: [xAI pricing](https://docs.x.ai/developers/pricing). Web Search and X Search are &#36;5/1K calls. Cached input varies by model.</Note>
 
 ## Grok 4.6
 
@@ -15,7 +15,7 @@ description: "Grok 4.6, Grok 4.5, and Grok 4.3 models with specs, pricing, and c
 
   xAI's August 2026 flagship for coding, long-running agents, and ambitious interactive work.
 
-  - &#36;2 / &#36;6 (&#36;4 / &#36;12 above 200K prompt tokens)
+  - &#36;2 / &#36;6 (&#36;4 / &#36;12 above 200K prompt tokens); cached input &#36;0.50 / 1M
   - <Icon icon="window-maximize" size={14} /> 500K context
   - <Icon icon="keyboard" size={14} /> Text, Image input
   - <Icon icon="brain" size={14} /> Configurable reasoning
@@ -35,7 +35,7 @@ description: "Grok 4.6, Grok 4.5, and Grok 4.3 models with specs, pricing, and c
 
   xAI's July 2026 flagship for coding, agentic tool use, and knowledge work. Configurable reasoning effort (low / medium / high).
 
-  - &#36;2 / &#36;6 (&#36;4 / &#36;12 above 200K prompt tokens)
+  - &#36;2 / &#36;6 (&#36;4 / &#36;12 above 200K prompt tokens); cached input &#36;0.30 / 1M
   - <Icon icon="window-maximize" size={14} /> 500K context
   - <Icon icon="keyboard" size={14} /> Text, Image input
   - <Icon icon="brain" size={14} /> Configurable reasoning
@@ -55,7 +55,7 @@ description: "Grok 4.6, Grok 4.5, and Grok 4.3 models with specs, pricing, and c
 
   Production mid-tier for coding, agents, and general workloads. Replacement for the retired Grok 4 Fast / 4.1 Fast slugs (removed May 15, 2026).
 
-  - &#36;1.25 / &#36;2.50
+  - &#36;1.25 / &#36;2.50 (&#36;2.50 / &#36;5.00 above 200K prompt tokens); cached input &#36;0.20 / 1M
   - <Icon icon="window-maximize" size={14} /> 1M context
   - <Icon icon="keyboard" size={14} /> Text, Image input
   - <Icon icon="brain" size={14} /> Reasoning

--- a/python/timbal/models.yaml
+++ b/python/timbal/models.yaml
@@ -44,9 +44,10 @@ models:
   display_name: Claude Sonnet 5
   description: Best combination of speed and intelligence. Drop-in upgrade from Sonnet 4.6 for coding, agents, and professional
     work.
-  notes: Introductory API pricing ($2/$10 per 1M tokens) through August 31, 2026.
-  input_price: 3.0
-  output_price: 15.0
+  notes: Standard API pricing is $2/$10 per 1M tokens. The previously announced increase to $3/$15 on September 1, 2026 did
+    not occur.
+  input_price: 2.0
+  output_price: 10.0
   context_window: 1000000
   capabilities: [vision, tools, reasoning]
 - id: anthropic/claude-opus-4-7
@@ -128,8 +129,10 @@ models:
   provider: openai
   display_name: GPT-5.6 Sol
   description: OpenAI GPT-5.6 flagship tier for the hardest coding, agentic, and long-horizon tasks.
-  input_price: 5.0
-  output_price: 30.0
+  notes: Promotional short-context API pricing ($4/$20 per 1M tokens, cached input $0.40) available at least through November
+    21, 2026. Long-context rates are $8/$30.
+  input_price: 4.0
+  output_price: 20.0
   context_window: 1050000
   capabilities: [vision, tools, reasoning]
 - id: openai/gpt-5.6-terra
@@ -353,8 +356,8 @@ models:
   provider: togetherai
   display_name: Llama 3.3 70B Instruct Turbo
   description: Multilingual 70B model delivering enhanced performance and matching Llama 3.2 90B on text-only tasks.
-  input_price: 0.88
-  output_price: 0.88
+  input_price: 1.04
+  output_price: 1.04
   context_window: 128000
   capabilities: [tools]
 - id: togetherai/Qwen/Qwen3.5-397B-A17B
@@ -699,6 +702,7 @@ models:
   display_name: Grok 4.3
   description: xAI production mid-tier for coding, agents, and general workloads; replacement for retired Grok 4 Fast / 4.1
     Fast slugs.
+  notes: Long-context surcharge applies above 200k tokens ($2.50/$5.00 per 1M).
   input_price: 1.25
   output_price: 2.5
   context_window: 1000000
@@ -731,10 +735,10 @@ models:
 - id: fireworks/accounts/fireworks/models/deepseek-v4-flash-0731
   provider: fireworks
   display_name: DeepSeek V4 Flash 0731 (Fireworks)
-  description: 'Official DeepSeek V4 Flash on Fireworks serverless: supersedes the April preview, same pricing, stronger agentic behavior.'
+  description: 'Official DeepSeek V4 Flash on Fireworks serverless: supersedes the April preview, stronger agentic behavior.'
   notes: Replacement for retired serverless deepseek-v4-flash.
-  input_price: 0.14
-  output_price: 0.28
+  input_price: 0.22
+  output_price: 0.66
   context_window: 1048576
   capabilities: [tools, reasoning]
 - id: fireworks/accounts/fireworks/models/qwen3p7-plus
@@ -806,8 +810,9 @@ models:
   display_name: Seed 2.0 Lite
   description: Cost-efficient Seed 2.0 variant optimised for high-concurrency and latency-sensitive workloads with multimodal
     input.
+  notes: Long-context surcharge applies above 128k tokens ($0.50/$4.00 per 1M).
   input_price: 0.25
-  output_price: 1.0
+  output_price: 2.0
   context_window: 256000
   capabilities: [vision, tools, video]
 - id: byteplus/seed-2-0-mini-260215
@@ -841,10 +846,11 @@ models:
   display_name: Seed 2.0 Pro
   description: BytePlus's flagship Seed 2.0 model excelling at complex reasoning, coding, and agentic tasks with deep thinking
     and multimodal understanding.
-  notes: Activate in the Ark Console before first use — https://console.byteplus.com/ark/region:ark+ap-southeast-1/models
+  notes: Activate in the Ark Console before first use — https://console.byteplus.com/ark/region:ark+ap-southeast-1/models.
+    Long-context surcharge applies above 128k tokens ($1.00/$6.00 per 1M).
   requires_activation: true
-  input_price: 0.47
-  output_price: 2.37
+  input_price: 0.5
+  output_price: 3.0
   context_window: 256000
   capabilities: [vision, tools, reasoning, video]
 - id: byteplus/kimi-k2-250905


### PR DESCRIPTION
## Summary
- Bring model catalog prices in `docs/models/` and `python/timbal/models.yaml` in line with current official API cards (Anthropic, OpenAI, xAI, Fireworks, Together, BytePlus).
- Claude Sonnet 5 is now permanently $2/$10 (the Sep 1 increase did not happen); GPT-5.6 Sol is $4/$20 promotional through at least Nov 21, 2026, with Terra/Luna at $2/$12 and $0.20/$1.20.
- Also corrected xAI search/cache notes, Grok 4.3 long-context surcharge, Fireworks DeepSeek V4 Flash, Together Llama 3.3 70B, and BytePlus Seed 2.0 Pro/Lite (including >128K tiers).

## Test plan
- [ ] Spot-check the updated cards on the docs preview (Anthropic, OpenAI, xAI, Fireworks, Together, BytePlus)
- [ ] Confirm Sonnet 5 no longer mentions intro pricing through Aug 31
- [ ] Confirm GPT-5.6 Sol/Terra/Luna match https://developers.openai.com/api/docs/pricing
- [ ] `uv run python scripts/audit_models.py --offline` (already green: 115 models, yaml + docs in sync)


Made with [Cursor](https://cursor.com)