### PR TITLE
fix(core): never mint a root span with an orphan parent_call_id

### DIFF
--- a/python/tests/core/test_context_swap_hardening.py
+++ b/python/tests/core/test_context_swap_hardening.py
@@ -1,0 +1,226 @@
+"""Regression guards for the T11 incident: orphan ``parent_call_id`` on root spans.
+
+Producer shape (Benito ``email-handler``): a workflow Tool handler calls
+``set_run_context(RunContext(...))`` (platform bootstrap — fresh context, empty
+trace) while the task's ambient call ids still point at the Tool's span in the
+*old* context, then does a nested ``.collect()`` on a top-level runnable.
+Before the fix, the top-level invoke only cleared ambient ids when the ambient
+context had traces (fork branch), so the first span minted in the swapped-in
+context inherited an orphan ``parent_call_id`` — and platform trace validation
+rejected the whole trace ("Parent call ID should be empty for root span").
+
+Two layers under test:
+1. Top-level invoke (no "." in path) clears ambient call ids even when the
+   ambient context's trace is empty, keeping the caller-provided context.
+2. Belt at span minting: an ambient parent id that doesn't resolve within the
+   current context is repaired to the context's current root — ``None`` on an
+   empty trace (the span becomes the root), the existing root otherwise (the
+   trace stays closed and single-rooted). Leaving the orphan in place is not
+   an option: ``RunContext.update_usage`` asserts trace closure on every
+   propagation, so the run would die later with an opaque AssertionError.
+"""
+
+import time
+
+from timbal import Agent, Workflow
+from timbal.core import Tool
+from timbal.core.test_model import TestModel
+from timbal.state import (
+    get_run_context,
+    set_call_id,
+    set_parent_call_id,
+    set_run_context,
+)
+from timbal.state.context import RunContext
+from timbal.state.tracing.providers import InMemoryTracingProvider
+from timbal.state.tracing.span import Span
+
+
+def _assert_trace_closure(ctx: RunContext) -> None:
+    """Every span's parent resolves in-trace and there is exactly one root.
+
+    This is the invariant the platform's trace validation enforces.
+    """
+    roots = [s for s in ctx._trace.values() if s.parent_call_id is None]
+    assert len(roots) == 1, f"expected exactly one root span, got {len(roots)}"
+    assert ctx._trace._root_call_id == roots[0].call_id
+    for span in ctx._trace.values():
+        if span.parent_call_id is not None:
+            assert span.parent_call_id in ctx._trace, (
+                f"span {span.path} has orphan parent_call_id {span.parent_call_id}"
+            )
+
+
+class TestBootstrapContextSwap:
+    async def test_workflow_bootstrap_swap_mints_root_span(self):
+        """Benito-shaped repro: workflow → Tool entry → set_run_context(fresh)
+        → nested .collect(). The inner run's first span must be a root."""
+        captured: dict = {}
+
+        def capture() -> None:
+            captured["inner_ctx"] = get_run_context()
+
+        inner = Agent(
+            name="inner",
+            model=TestModel(responses=["done"]),
+            pre_hook=capture,
+            tracing_provider=InMemoryTracingProvider,
+        )
+
+        async def entry() -> str:
+            swapped = RunContext(tracing_provider=InMemoryTracingProvider)
+            set_run_context(swapped)
+            captured["swapped_ctx"] = swapped
+            result = await inner(prompt="hi").collect()
+            captured["inner_output_event"] = result
+            return result.output.collect_text()
+
+        workflow = Workflow(name="wf").step(Tool(name="entry", handler=entry))
+        result = await workflow().collect()
+        assert result.status.code == "success", result.error
+
+        # The caller-provided (empty-trace) context is kept, not forked away.
+        inner_ctx = captured["inner_ctx"]
+        assert inner_ctx is captured["swapped_ctx"]
+
+        # The stale ambient ids from the outer context did not leak in.
+        root = inner_ctx.root_span()
+        assert root is not None
+        assert root.path == "inner"
+        assert root.parent_call_id is None
+        assert captured["inner_output_event"].parent_call_id is None
+        _assert_trace_closure(inner_ctx)
+
+    async def test_direct_tool_bootstrap_swap_mints_root_span(self):
+        """Same mechanism without the workflow wrapper: a Tool handler swaps
+        in a fresh context and nested-collects a top-level agent."""
+        captured: dict = {}
+
+        def capture() -> None:
+            captured["inner_ctx"] = get_run_context()
+
+        inner = Agent(
+            name="inner",
+            model=TestModel(responses=["done"]),
+            pre_hook=capture,
+            tracing_provider=InMemoryTracingProvider,
+        )
+
+        async def bootstrap() -> str:
+            set_run_context(RunContext(tracing_provider=InMemoryTracingProvider))
+            result = await inner(prompt="hi").collect()
+            return result.output.collect_text()
+
+        tool = Tool(name="bootstrap", handler=bootstrap)
+        result = await tool().collect()
+        assert result.status.code == "success", result.error
+
+        root = captured["inner_ctx"].root_span()
+        assert root is not None
+        assert root.parent_call_id is None
+        _assert_trace_closure(captured["inner_ctx"])
+
+    async def test_healthy_nested_collect_still_forks(self):
+        """Guard against regression of the existing fork branch: a nested
+        .collect() from a handler WITHOUT a context swap (ambient trace
+        non-empty) still forks a fresh context with a clean root."""
+        captured: dict = {}
+
+        def capture() -> None:
+            captured["inner_ctx"] = get_run_context()
+
+        inner = Agent(
+            name="inner",
+            model=TestModel(responses=["done"]),
+            pre_hook=capture,
+            tracing_provider=InMemoryTracingProvider,
+        )
+
+        async def nested_call() -> str:
+            captured["outer_ctx"] = get_run_context()
+            result = await inner(prompt="hi").collect()
+            return result.output.collect_text()
+
+        tool = Tool(name="nested_call", handler=nested_call)
+        result = await tool().collect()
+        assert result.status.code == "success", result.error
+
+        # Fresh context (concurrent-sibling fork), not the outer one.
+        assert captured["inner_ctx"] is not captured["outer_ctx"]
+        assert captured["inner_ctx"].id != captured["outer_ctx"].id
+        root = captured["inner_ctx"].root_span()
+        assert root is not None
+        assert root.parent_call_id is None
+        _assert_trace_closure(captured["inner_ctx"])
+        _assert_trace_closure(captured["outer_ctx"])
+
+    async def test_preset_empty_context_without_stale_ids_is_kept(self):
+        """The legit pattern — set_run_context(RunContext(...)) at the top of
+        a script to inject config — keeps working: context kept, root clean."""
+        ctx = RunContext(tracing_provider=InMemoryTracingProvider)
+        set_run_context(ctx)
+
+        agent = Agent(
+            name="solo",
+            model=TestModel(responses=["done"]),
+            tracing_provider=InMemoryTracingProvider,
+        )
+        result = await agent(prompt="hi").collect()
+        assert result.status.code == "success", result.error
+
+        assert get_run_context() is ctx
+        root = ctx.root_span()
+        assert root is not None
+        assert root.path == "solo"
+        assert root.parent_call_id is None
+        _assert_trace_closure(ctx)
+
+
+class TestOrphanParentBelt:
+    async def test_belt_clears_orphan_parent_on_empty_trace(self):
+        """A dotted-path runnable (bypasses the top-level guard) invoked under
+        a swapped context with stale ambient ids: the orphan parent id is
+        cleared so the first span of the context is a root."""
+        tool = Tool(name="step", handler=lambda: "x")
+        tool.nest("wf")  # path becomes "wf.step" — no top-level clearing
+
+        ctx = RunContext(tracing_provider=InMemoryTracingProvider)
+        set_run_context(ctx)
+        set_parent_call_id("stale_parent_from_old_context")
+        set_call_id("stale_call_from_old_context")
+
+        result = await tool().collect()
+        assert result.status.code == "success", result.error
+
+        assert len(ctx._trace) == 1
+        span = next(iter(ctx._trace.values()))
+        assert span.path == "wf.step"
+        assert span.parent_call_id is None
+        assert ctx._trace._root_call_id == span.call_id
+
+    async def test_belt_reparents_orphan_to_existing_root(self):
+        """With an existing root in the trace, an unresolvable parent id is
+        reparented to that root: the run completes, usage propagation (which
+        asserts trace closure) works, and the trace stays single-rooted."""
+        tool = Tool(name="step", handler=lambda: "x")
+        tool.nest("wf")
+
+        ctx = RunContext(tracing_provider=InMemoryTracingProvider)
+        t0 = int(time.time() * 1000)
+        ctx._trace["existing_root"] = Span(
+            path="wf", call_id="existing_root", parent_call_id=None, t0=t0
+        )
+        set_run_context(ctx)
+        set_parent_call_id(None)
+        set_call_id("stale_call_from_old_context")
+
+        result = await tool().collect()
+        assert result.status.code == "success", result.error
+
+        spans = [s for s in ctx._trace.values() if s.path == "wf.step"]
+        assert len(spans) == 1
+        assert spans[0].parent_call_id == "existing_root"
+        assert ctx._trace._root_call_id == "existing_root"
+        _assert_trace_closure(ctx)
+        # Usage propagated through the repaired chain up to the root.
+        assert ctx._trace["existing_root"].usage.get("step:requests", 0) >= 1

--- a/python/timbal/core/runnable.py
+++ b/python/timbal/core/runnable.py
@@ -1818,31 +1818,39 @@ class Runnable(ABC, BaseModel):
             run_context = RunContext(parent_id=explicit_parent_id, tracing_provider=self.tracing_provider)
             _parent_call_id = None
             _call_id = None
-        elif "." not in self._path and run_context._trace:
-            # Top-level runnable sees an existing context with traces.
-            # If the root span has completed (t1 is set), this is a finished
-            # previous run — chain session data via parent_id.
-            # If the root span is still running (t1 is None), this context
-            # belongs to a concurrent sibling — create a fresh context.
-            # Inherit the parent's platform_config: a forked child run (linked
-            # by parent_id, same process/deployment) shares it. Without this, the
-            # fresh context re-resolves from env only and an explicitly-injected
-            # platform_config is lost — breaking platform API calls (e.g. a
-            # standalone Agent instantiated inside a step body).
-            _inherited_platform_config = run_context.platform_config
-            root = run_context.root_span()
-            if root is not None and root.t1 is not None:
-                run_context = RunContext(
-                    parent_id=explicit_parent_id or run_context.id,
-                    tracing_provider=self.tracing_provider,
-                    platform_config=_inherited_platform_config,
-                )
-            else:
-                run_context = RunContext(
-                    parent_id=explicit_parent_id,
-                    tracing_provider=self.tracing_provider,
-                    platform_config=_inherited_platform_config,
-                )
+        elif "." not in self._path:
+            if run_context._trace:
+                # Top-level runnable sees an existing context with traces.
+                # If the root span has completed (t1 is set), this is a finished
+                # previous run — chain session data via parent_id.
+                # If the root span is still running (t1 is None), this context
+                # belongs to a concurrent sibling — create a fresh context.
+                # Inherit the parent's platform_config: a forked child run (linked
+                # by parent_id, same process/deployment) shares it. Without this, the
+                # fresh context re-resolves from env only and an explicitly-injected
+                # platform_config is lost — breaking platform API calls (e.g. a
+                # standalone Agent instantiated inside a step body).
+                _inherited_platform_config = run_context.platform_config
+                root = run_context.root_span()
+                if root is not None and root.t1 is not None:
+                    run_context = RunContext(
+                        parent_id=explicit_parent_id or run_context.id,
+                        tracing_provider=self.tracing_provider,
+                        platform_config=_inherited_platform_config,
+                    )
+                else:
+                    run_context = RunContext(
+                        parent_id=explicit_parent_id,
+                        tracing_provider=self.tracing_provider,
+                        platform_config=_inherited_platform_config,
+                    )
+            # Whether we forked above or kept a caller-provided context whose
+            # trace is still empty (e.g. `set_run_context(RunContext(...))`
+            # inside a handler, a common platform-bootstrap pattern), the
+            # ambient call ids belong to the *previous* context on this task.
+            # A top-level invoke always mints the first span of its context,
+            # and that span must be a root: carrying the stale ids over would
+            # produce an orphan parent_call_id that trace validation rejects.
             _parent_call_id = None
             _call_id = None
         # Session data is loaded once per run; nested calls see it already set.
@@ -1856,6 +1864,26 @@ class Runnable(ABC, BaseModel):
         set_run_context(run_context)
 
         _new_parent_call_id = _call_id
+        if _new_parent_call_id is not None and _new_parent_call_id not in run_context._trace:
+            # The ambient parent id doesn't resolve within this context: the
+            # call ids leaked from another context (e.g. a caller swapped in a
+            # RunContext mid-handler). An unresolvable parent is fatal — usage
+            # propagation asserts trace closure and platform trace validation
+            # rejects the whole run — so repair to the only in-trace answer:
+            # the current root (None on an empty trace, making this span the
+            # root; the existing root otherwise, keeping the trace closed and
+            # single-rooted).
+            _repaired_parent_call_id = run_context._trace._root_call_id
+            _get_logger().warning(
+                "Ambient parent call id not found in the current run context; reparenting the "
+                "span to the context's root so the trace stays closed. This usually means call "
+                "ids leaked across a manual set_run_context() swap.",
+                runnable_path=self._path,
+                orphan_parent_call_id=_new_parent_call_id,
+                repaired_parent_call_id=_repaired_parent_call_id,
+                run_id=run_context.id,
+            )
+            _new_parent_call_id = _repaired_parent_call_id
         _new_call_id: str = uuid7(as_type="hex")  # type: ignore
         set_parent_call_id(_new_parent_call_id)
         set_call_id(_new_call_id)


### PR DESCRIPTION
## Summary

Framework hardening for the T11 incident (monolith ERROR storm 29 Aug–1 Sep, "Parent call ID should be empty for root span", 74 runs with zero persisted traces).

**Producer shape:** a handler calls `set_run_context(RunContext(...))` (platform bootstrap — fresh context, empty trace) while the task's ambient call ids still point at the old context, then does a nested `.collect()` on a top-level runnable. The old fork-clear branch (`elif "." not in path and run_context._trace`) skipped the empty-trace case, so the first span minted in the swapped-in context inherited an orphan `parent_call_id` and platform trace validation rejected the whole run.

Two layers:

- **Top-level invoke clears ambient call ids even on an empty trace.** The fork branch became `elif "." not in self._path:` with the existing fork/session-chaining logic nested (unchanged) under the trace check. The caller-provided context is kept — only the stale ids are dropped, restoring the invariant that the first span of a context is a root.
- **Belt at span minting:** an ambient parent id that doesn't resolve within the current context is repaired to the context's current root — `None` on an empty trace (span becomes the root), the existing root otherwise (trace stays closed and single-rooted) — with a structured warning carrying the orphan and repaired ids. Warn-only was not an option: `RunContext.update_usage` asserts trace closure on every propagation, so a preserved orphan kills the run later with an opaque `AssertionError`; forcing `None` under an existing root trips `Trace`'s single-root guard.

Healthy nested `.collect()` from tool handlers (ambient trace non-empty → fork) is byte-for-byte unchanged.

Companion server-side change (independent, not in this PR): map the `parse_trace` validation bail to `400 BadRequest` instead of `TimbalError::Any` → 500 in the monolith, stopping client retry amplification.

## Test plan

- [x] New `python/tests/core/test_context_swap_hardening.py` (6 tests): workflow-shaped incident repro, direct-tool variant, healthy-fork regression guard, legit preset-empty-context pattern, belt clear-to-root on empty trace, belt reparent-to-existing-root with usage propagation through the repaired chain
- [x] Full suite: 4224 passed, 6 skipped, 7 xfailed
- [x] `ruff check` clean on changed files (one pre-existing B009 at `runnable.py:591`, untouched)