### PR TITLE
feat(voice): accept interaction_answer from voice clients (tap-to-answer ask_user)

### DIFF
--- a/python/tests/server/test_livekit_session.py
+++ b/python/tests/server/test_livekit_session.py
@@ -24,6 +24,7 @@ from timbal.server.livekit_session import (
     dial_from_body,
     dial_from_env,
     is_config_hello,
+    parse_interaction_answer,
     is_livekit_dial,
     maybe_start_livekit_session,
     merge_client_config,
@@ -175,6 +176,23 @@ class TestConfigHello:
 
     def test_null_type_is_hello(self) -> None:
         assert is_config_hello({"type": None, "sample_rate": 16000})
+
+
+class TestInteractionAnswer:
+    def test_parse_requires_id_and_value(self) -> None:
+        assert parse_interaction_answer({"type": "playback"}) is None
+        assert parse_interaction_answer({"type": "interaction_answer"}) is None
+        assert parse_interaction_answer(
+            {"type": "interaction_answer", "interaction_id": "i1", "value": ""}
+        ) is None
+        assert parse_interaction_answer(
+            {
+                "type": "interaction_answer",
+                "interaction_id": "i1",
+                "run_id": None,
+                "value": "A spreadsheet",
+            }
+        ) == ("i1", "A spreadsheet", None)
 
 
 class _FakeParticipant:

--- a/python/tests/voice/test_suspension.py
+++ b/python/tests/voice/test_suspension.py
@@ -309,6 +309,29 @@ class _HangSTT(SpeechToText):
         self._closed.set()
 
 
+async def _start_hanging_session(agent: Agent) -> tuple[VoiceSession, list[VoiceSessionEvent], asyncio.Task]:
+    """Session whose STT never commits — turns only start via ``submit_user_text``."""
+    session = VoiceSession(agent=agent, stt=_HangSTT(), tts=_TTS(), turn_detector="heuristic")
+    events: list[VoiceSessionEvent] = []
+
+    async def _mic() -> AsyncIterator[bytes]:
+        yield b"\x00" * 320
+        await asyncio.sleep(30)
+
+    async def _collect() -> None:
+        async with aclosing(session.run(_mic())) as stream:
+            async for ev in stream:
+                events.append(ev)
+
+    task = asyncio.create_task(_collect())
+    for _ in range(50):
+        if session.started_at is not None:
+            break
+        await asyncio.sleep(0.02)
+    assert session.started_at is not None
+    return session, events, task
+
+
 class TestSubmitUserText:
     async def test_tap_starts_the_same_turn_speech_would(self) -> None:
         queued: dict = {}
@@ -318,27 +341,7 @@ class TestSubmitUserText:
                 queued.update(interaction_id=interaction_id, value=value, run_id=run_id)
 
         agent = _Agent(name="plain", model=TestModel(responses=["Heard you."]), tools=[])
-        session = VoiceSession(
-            agent=agent, stt=_HangSTT(), tts=_TTS(), turn_detector="heuristic"
-        )
-
-        async def _mic() -> AsyncIterator[bytes]:
-            yield b"\x00" * 320
-            await asyncio.sleep(30)
-
-        events: list[VoiceSessionEvent] = []
-
-        async def _collect() -> None:
-            async with aclosing(session.run(_mic())) as stream:
-                async for ev in stream:
-                    events.append(ev)
-
-        task = asyncio.create_task(_collect())
-        for _ in range(50):
-            if session.started_at is not None:
-                break
-            await asyncio.sleep(0.02)
-        assert session.started_at is not None
+        session, events, task = await _start_hanging_session(agent)
 
         assert await session.submit_user_text(
             "A spreadsheet", interaction_id="i1", run_id="r1"
@@ -355,6 +358,58 @@ class TestSubmitUserText:
             isinstance(e, TranscriptCommitted) and e.text == "A spreadsheet" for e in events
         )
         assert any(isinstance(e, AgentTextDone) for e in events)
+
+    async def test_tap_disarms_pending_hold(self) -> None:
+        """A leftover STT HOLD must not expire into a second turn after a tap."""
+        agent = Agent(name="plain", model=TestModel(responses=["ok", "ghost"]), tools=[])
+        session, events, task = await _start_hanging_session(agent)
+
+        await session._arm_hold("leftover fragment", 0.05)
+        assert session._held_user_text == "leftover fragment"
+        assert await session.submit_user_text("A spreadsheet", interaction_id="i1")
+        assert session._held_user_text is None
+        assert session._hold_task is None or session._hold_task.done()
+
+        await asyncio.sleep(0.15)
+        user_texts = [e.text for e in session.transcript if e.role == "user"]
+        await session.close()
+        await task
+
+        assert user_texts == ["A spreadsheet"]
+        assert not any(
+            isinstance(e, TranscriptCommitted) and e.text == "leftover fragment" for e in events
+        )
+
+    async def test_overlapping_taps_do_not_orphan_a_turn(self) -> None:
+        """Two fire-and-forget taps must serialize interrupt + begin."""
+        agent = Agent(name="plain", model=TestModel(responses=["one", "two"]), tools=[])
+        session, _events, task = await _start_hanging_session(agent)
+
+        in_flight = 0
+        max_in_flight = 0
+        orig = session._begin_user_turn
+
+        async def _gated(final_text: str, **kwargs) -> None:
+            nonlocal in_flight, max_in_flight
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+            await asyncio.sleep(0.05)
+            try:
+                await orig(final_text, **kwargs)
+            finally:
+                in_flight -= 1
+
+        session._begin_user_turn = _gated  # type: ignore[method-assign]
+
+        first, second = await asyncio.gather(
+            session.submit_user_text("first", interaction_id="i1"),
+            session.submit_user_text("second", interaction_id="i2"),
+        )
+        await session.close()
+        await task
+
+        assert first is True and second is True
+        assert max_in_flight == 1
 
     async def test_empty_or_unstarted_is_a_no_op(self) -> None:
         agent = Agent(name="plain", model=TestModel(responses=["x"]), tools=[])

--- a/python/tests/voice/test_suspension.py
+++ b/python/tests/voice/test_suspension.py
@@ -10,6 +10,7 @@ over HTTP.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import AsyncIterator
 from contextlib import aclosing
@@ -24,6 +25,7 @@ from timbal.voice import (
     AgentApproval,
     AgentInteraction,
     AgentTextDone,
+    TranscriptCommitted,
     AudioInputConfig,
     AudioOutputConfig,
     SpeechToText,
@@ -281,3 +283,83 @@ class TestSuspensionsOverAFullTurn:
             "session_transcript",
             "session_ended",
         }
+
+
+class _HangSTT(SpeechToText):
+    """Never commits — turns only start via ``submit_user_text``."""
+
+    def __init__(self) -> None:
+        self._closed = asyncio.Event()
+
+    async def connect(self, config: AudioInputConfig) -> None:
+        pass
+
+    async def push_audio(self, chunk: bytes) -> None:
+        pass
+
+    async def commit(self) -> None:
+        pass
+
+    async def events(self) -> AsyncIterator[TranscriptEvent]:
+        await self._closed.wait()
+        return
+        yield
+
+    async def close(self) -> None:
+        self._closed.set()
+
+
+class TestSubmitUserText:
+    async def test_tap_starts_the_same_turn_speech_would(self) -> None:
+        queued: dict = {}
+
+        class _Agent(Agent):
+            def answer_interaction(self, *, interaction_id, value, run_id=None):
+                queued.update(interaction_id=interaction_id, value=value, run_id=run_id)
+
+        agent = _Agent(name="plain", model=TestModel(responses=["Heard you."]), tools=[])
+        session = VoiceSession(
+            agent=agent, stt=_HangSTT(), tts=_TTS(), turn_detector="heuristic"
+        )
+
+        async def _mic() -> AsyncIterator[bytes]:
+            yield b"\x00" * 320
+            await asyncio.sleep(30)
+
+        events: list[VoiceSessionEvent] = []
+
+        async def _collect() -> None:
+            async with aclosing(session.run(_mic())) as stream:
+                async for ev in stream:
+                    events.append(ev)
+
+        task = asyncio.create_task(_collect())
+        for _ in range(50):
+            if session.started_at is not None:
+                break
+            await asyncio.sleep(0.02)
+        assert session.started_at is not None
+
+        assert await session.submit_user_text(
+            "A spreadsheet", interaction_id="i1", run_id="r1"
+        )
+        for _ in range(50):
+            if any(isinstance(e, AgentTextDone) for e in events):
+                break
+            await asyncio.sleep(0.05)
+        await session.close()
+        await task
+
+        assert queued == {"interaction_id": "i1", "value": "A spreadsheet", "run_id": "r1"}
+        assert any(
+            isinstance(e, TranscriptCommitted) and e.text == "A spreadsheet" for e in events
+        )
+        assert any(isinstance(e, AgentTextDone) for e in events)
+
+    async def test_empty_or_unstarted_is_a_no_op(self) -> None:
+        agent = Agent(name="plain", model=TestModel(responses=["x"]), tools=[])
+        session = VoiceSession(
+            agent=agent, stt=_HangSTT(), tts=_TTS(), turn_detector="heuristic"
+        )
+        assert await session.submit_user_text("") is False
+        assert await session.submit_user_text("hi") is False

--- a/python/timbal/server/livekit_session.py
+++ b/python/timbal/server/livekit_session.py
@@ -412,6 +412,24 @@ def is_config_hello(data: dict[str, Any]) -> bool:
     return data.get("type") is None
 
 
+def parse_interaction_answer(data: dict[str, Any]) -> tuple[str, str, str | None] | None:
+    """Client tap on a parked ``ask_user`` (``timbal.events`` / ``interaction_answer``).
+
+    Returns ``(interaction_id, value, run_id)`` or ``None`` when the frame is
+    not this event or is missing the fields a resume needs. ``run_id`` may
+    be ``None`` — the parked run on the session is the source of truth.
+    """
+    if data.get("type") != "interaction_answer":
+        return None
+    interaction_id = str(data.get("interaction_id") or "").strip()
+    value = str(data.get("value") or "").strip()
+    if not interaction_id or not value:
+        return None
+    raw_run = data.get("run_id")
+    run_id = str(raw_run).strip() if raw_run else ""
+    return interaction_id, value, run_id or None
+
+
 def merge_client_config(env_raw: str, hello: dict[str, Any] | None) -> dict[str, Any]:
     """Env JSON is the base; the data-message hello overlays it."""
     config: dict[str, Any] = {}
@@ -733,6 +751,33 @@ async def _run_livekit_session(
                 sess.playback.on_playback_ack(float(data["played_ms"]))
             except (KeyError, TypeError, ValueError):
                 logger.debug("voice_livekit_bad_playback_ack", data=str(data)[:120])
+            return
+        parsed = parse_interaction_answer(data)
+        if parsed is not None:
+            interaction_id, value, run_id = parsed
+            if caller_identity:
+                ident = getattr(getattr(pkt, "participant", None), "identity", "") or ""
+                if ident and ident != caller_identity:
+                    logger.debug("voice_livekit_interaction_answer_ignored", reason="not_caller")
+                    return
+            if sess is None:
+                logger.info("voice_livekit_interaction_answer_dropped", reason="no_session")
+                return
+
+            async def _submit_tap() -> None:
+                try:
+                    ok = await sess.submit_user_text(
+                        value, interaction_id=interaction_id, run_id=run_id
+                    )
+                except Exception as e:  # noqa: BLE001 — a tap must not kill the call
+                    logger.warning("voice_livekit_interaction_answer_failed", error=str(e))
+                    return
+                if ok:
+                    await send_q.put(
+                        {"type": "interaction_answer_ack", "interaction_id": interaction_id}
+                    )
+
+            asyncio.create_task(_submit_tap(), name="voice-livekit-interaction-answer")
 
     def _on_sip_dtmf(dtmf: Any) -> None:
         digit = getattr(dtmf, "digit", "") or ""

--- a/python/timbal/voice/session.py
+++ b/python/timbal/voice/session.py
@@ -344,6 +344,10 @@ class VoiceSession:
         self._held_user_text: str | None = None
         self._hold_task: asyncio.Task | None = None
         self._hold_armed_timeout_secs: float | None = None
+        # Serializes interrupt + _begin_user_turn. Speech commits run on the
+        # STT loop (one at a time); taps arrive as fire-and-forget tasks and
+        # would otherwise both pass interrupt() and orphan the first turn.
+        self._user_turn_lock = asyncio.Lock()
 
         # Tracks the RunContext from the last completed turn so the agent's
         # __call__ auto-chains parent_id for multi-turn memory.
@@ -504,12 +508,20 @@ class VoiceSession:
         answer = getattr(self.agent, "answer_interaction", None)
         if callable(answer) and interaction_id:
             answer(interaction_id=interaction_id, value=text, run_id=run_id)
-        await self.interrupt()
-        if self._closed:
-            return False
-        self._cancel_turn.clear()
-        await self._begin_user_turn(text, replace_user_entry=False)
-        return True
+        async with self._user_turn_lock:
+            if self._closed:
+                return False
+            # Same disarm as a real STT accept — a pending HOLD expiry would
+            # otherwise interrupt() this tap and start a turn on leftover speech.
+            self._cancel_hold()
+            self._held_user_text = None
+            self._hold_armed_timeout_secs = None
+            await self.interrupt()
+            if self._closed:
+                return False
+            self._cancel_turn.clear()
+            await self._begin_user_turn(text, replace_user_entry=False)
+            return True
 
     async def run(self, audio_in: AsyncIterable[bytes]) -> AsyncIterator[VoiceSessionEvent]:
         """Main loop.  Yields events until the session is closed or errors out."""
@@ -1290,12 +1302,17 @@ class VoiceSession:
             # A refine/re-arm may have replaced us — do not wipe the new hold.
             if self._hold_task is not me:
                 return
-            held = self._held_user_text
-            self._held_user_text = None
-            self._hold_armed_timeout_secs = None
-            if self._hold_task is me:
+            async with self._user_turn_lock:
+                # Re-check under the lock: a tap/commit can cancel us after we
+                # woke and before we claim the turn.
+                if self._hold_task is not me or self._closed:
+                    return
+                held = self._held_user_text
+                self._held_user_text = None
+                self._hold_armed_timeout_secs = None
                 self._hold_task = None
-            if held and not self._closed:
+                if not held:
+                    return
                 # A HOLD exists because the fragment looked incomplete. If it is
                 # still just a dangling token ("I", "the", "and") when the timer
                 # fires, promoting it to a user turn invents ghost replies
@@ -1487,33 +1504,38 @@ class VoiceSession:
         # A real accept cancels any pending HOLD, then interrupts so truncation
         # can append a heard assistant fragment *before* we rewrite the user
         # entry (CONTINUE_TURN must see that fragment to pop it).
-        self._cancel_hold()
-        self._held_user_text = None
-        self._hold_armed_timeout_secs = None
-        await self.interrupt()
-        self._cancel_turn.clear()
+        async with self._user_turn_lock:
+            if self._closed:
+                return
+            self._cancel_hold()
+            self._held_user_text = None
+            self._hold_armed_timeout_secs = None
+            await self.interrupt()
+            if self._closed:
+                return
+            self._cancel_turn.clear()
 
-        replace = False
-        if decision.action is CommitAction.CONTINUE_TURN:
-            # interrupt() may have recorded the heard fragment of the aborted
-            # reply right after the fragment's user entry (interruption
-            # truncation). A continuation merges the fragment into a single
-            # utterance, so that reply is superseded — drop it so the merge
-            # below updates the fragment user entry instead of appending a
-            # duplicate user line around a stray assistant fragment.
-            if (
-                len(self._transcript) >= 2
-                and self._transcript[-1].role == "assistant"
-                and self._transcript[-2].role == "user"
-                and self._transcript[-2].text == state.active_user_text
-            ):
-                self._transcript.pop()
-            replace = bool(self._transcript and self._transcript[-1].role == "user")
-            # Transcript cleanup alone is not enough — parent-chain memory still
-            # has user:fragment + assistant:heard unless we mirror the rewrite.
-            await self._align_continue_memory(fragment_user_text=state.active_user_text)
+            replace = False
+            if decision.action is CommitAction.CONTINUE_TURN:
+                # interrupt() may have recorded the heard fragment of the aborted
+                # reply right after the fragment's user entry (interruption
+                # truncation). A continuation merges the fragment into a single
+                # utterance, so that reply is superseded — drop it so the merge
+                # below updates the fragment user entry instead of appending a
+                # duplicate user line around a stray assistant fragment.
+                if (
+                    len(self._transcript) >= 2
+                    and self._transcript[-1].role == "assistant"
+                    and self._transcript[-2].role == "user"
+                    and self._transcript[-2].text == state.active_user_text
+                ):
+                    self._transcript.pop()
+                replace = bool(self._transcript and self._transcript[-1].role == "user")
+                # Transcript cleanup alone is not enough — parent-chain memory still
+                # has user:fragment + assistant:heard unless we mirror the rewrite.
+                await self._align_continue_memory(fragment_user_text=state.active_user_text)
 
-        await self._begin_user_turn(final_text, replace_user_entry=replace, vad_endpointed=vad_endpointed)
+            await self._begin_user_turn(final_text, replace_user_entry=replace, vad_endpointed=vad_endpointed)
 
     # -- Internal: agent turn → TTS ----------------------------------------
 

--- a/python/timbal/voice/session.py
+++ b/python/timbal/voice/session.py
@@ -479,6 +479,38 @@ class VoiceSession:
 
     # -- Public API ---------------------------------------------------------
 
+    async def submit_user_text(
+        self,
+        text: str,
+        *,
+        interaction_id: str | None = None,
+        run_id: str | None = None,
+    ) -> bool:
+        """Start a user turn as if STT committed ``text``.
+
+        The LiveKit / WS ``interaction_answer`` path (tap an ``ask_user``
+        option) lands here so it shares interrupt + turn-begin with speech.
+        A runnable that implements ``answer_interaction`` can bind the
+        value to the exact parked id; otherwise the text is the utterance.
+
+        Returns whether a turn was started.
+        """
+        text = (text or "").strip()
+        if self._closed or not text:
+            return False
+        if self.started_at is None:
+            logger.info("interaction_answer_dropped", reason="session_not_started")
+            return False
+        answer = getattr(self.agent, "answer_interaction", None)
+        if callable(answer) and interaction_id:
+            answer(interaction_id=interaction_id, value=text, run_id=run_id)
+        await self.interrupt()
+        if self._closed:
+            return False
+        self._cancel_turn.clear()
+        await self._begin_user_turn(text, replace_user_entry=False)
+        return True
+
     async def run(self, audio_in: AsyncIterable[bytes]) -> AsyncIterator[VoiceSessionEvent]:
         """Main loop.  Yields events until the session is closed or errors out."""
         try:


### PR DESCRIPTION
## Summary

The "Talk it out" client can now answer an `ask_user` by tapping its option instead of saying it out loud. This adds the inbound half of the suspension protocol — the framework already emits `agent_interaction` / `agent_approval` (2.7.4); this accepts the client's answer back on the same channel:

```json
{
  "type": "interaction_answer",
  "interaction_id": "<the id from the ask_user suspension>",
  "run_id": "<the run the suspension belongs to, or null>",
  "value": "<the option text, verbatim>"
}
```

Direction: client → server, LiveKit data channel, `reliable: true`, topic `timbal.events`.

- **`VoiceSession.submit_user_text(text, *, interaction_id=None, run_id=None)`** — public API that starts a user turn as if STT committed the text. Shares `interrupt()` + `_begin_user_turn` with speech, so a tap resumes the suspension identically to a spoken answer (same barge-in/truncation semantics, same transcript entry). Generic beyond taps: typed-text-during-call, DTMF-menu-to-text.
- **Runnable seam:** a runnable implementing `answer_interaction(interaction_id=, value=, run_id=)` binds the value to the exact parked id (composer's `VoiceTurnRunnable` does; it maps to `resume={id: value}`). Without the method, the value is treated as the utterance — exactly how a spoken answer works for plain agents, so it degrades to correct behavior.
- **Ack:** on a successful submit the driver publishes `{"type": "interaction_answer_ack", "interaction_id": ...}` so clients can retire the card on fact instead of inferring resolution from the run chain advancing.
- **Guards:** frames missing `interaction_id`/`value` are ignored; frames from a participant other than the resolved caller are ignored; a tap racing session teardown is dropped, never fatal. `run_id` is accepted on the wire but the parked run on the session stays the source of truth.

Spoken vs tapped is deliberately indistinguishable downstream — no `source` field until someone actually needs one.

## Test plan

- [x] `python/tests/voice/test_suspension.py` — `submit_user_text` starts the same turn speech would (interrupt + `TranscriptCommitted` + reply), binds the id through `answer_interaction`, no-ops on empty text / unstarted session (83 pass with the existing suspension suite)
- [x] `python/tests/server/test_livekit_session.py` — `parse_interaction_answer` wire validation (id+value required, `run_id` optional)
- [x] Composer sidecar suite against this branch (73 pass) — `VoiceTurnRunnable.answer_interaction` resolves the named interaction, falls back to first-pending on an unknown id