### PR TITLE
feat(state): register background tasks on an explicit store

### DIFF
--- a/python/tests/core/test_background_tasks.py
+++ b/python/tests/core/test_background_tasks.py
@@ -1989,6 +1989,132 @@ class TestBackgroundLimits:
         assert current_background_store().max_concurrent is None
 
 
+class TestRegisterBackgroundTaskOn:
+    """Out-of-band registration on an explicit store — no ambient RunContext.
+
+    The seam for panel-initiated children (e.g. a follow-up POST that resolves
+    a session via ``store_for_run`` and spawns a continuation outside any turn).
+    """
+
+    @pytest.mark.asyncio
+    async def test_registers_without_run_context(self):
+        from timbal.state.background import BackgroundTaskStore, register_background_task_on
+
+        set_run_context(None)
+        store = BackgroundTaskStore()
+
+        async def child() -> str:
+            await asyncio.sleep(0.02)
+            return "done"
+
+        task = asyncio.create_task(child())
+        record = register_background_task_on(
+            store,
+            name="builder",
+            input={"prompt": "tighten the header"},
+            task=task,
+            title="Follow-up: landing page",
+        )
+        assert store.get(record.task_id) is record
+        assert record.title == "Follow-up: landing page"
+        assert [t["task_id"] for t in store.list()] == [record.task_id]
+
+        await task
+        assert record.status_code() == "completed"
+        assert store.list()[0]["title"] == "Follow-up: landing page"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_cap_enforced_on_explicit_store(self):
+        from timbal.state.background import (
+            BackgroundLimitError,
+            BackgroundTaskStore,
+            register_background_task_on,
+        )
+
+        store = BackgroundTaskStore(max_concurrent=1)
+        gate = asyncio.Event()
+
+        async def gated() -> str:
+            await gate.wait()
+            return "ok"
+
+        first = asyncio.create_task(gated())
+        register_background_task_on(store, name="builder", input={}, task=first)
+
+        second = asyncio.create_task(gated())
+        with pytest.raises(BackgroundLimitError, match="Concurrent"):
+            register_background_task_on(store, name="builder", input={}, task=second)
+        # On rejection the caller owns the orphan task.
+        second.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await second
+        assert len(store.list()) == 1
+
+        gate.set()
+        await first
+
+    @pytest.mark.asyncio
+    async def test_ambient_variant_still_requires_run_context(self):
+        from timbal.state.background import register_background_task
+
+        set_run_context(None)
+
+        async def child() -> str:
+            return "x"
+
+        task = asyncio.create_task(child())
+        with pytest.raises(RuntimeError, match="without a RunContext"):
+            register_background_task(name="builder", input={}, task=task)
+        await task
+
+    @pytest.mark.asyncio
+    async def test_follow_up_joins_session_bag_via_store_for_run(self):
+        """Spawn one child through a real turn, then attach a follow-up out-of-band."""
+        from timbal.state.background import register_background_task_on, store_for_run
+
+        async def quick(tag: str) -> str:
+            await asyncio.sleep(0.02)
+            return tag
+
+        agent = Agent(
+            name="composer",
+            model=TestModel(
+                responses=[
+                    _tool_call("quick", {"tag": "A"}, run_in_background=True),
+                    "Started.",
+                ]
+            ),
+            tools=[Tool(name="quick", handler=quick, background_mode="auto")],
+        )
+        result = await agent(prompt="go").collect()
+        assert_has_output_event(result)
+        store = store_for_run(result.run_id)
+        assert store is not None
+        original = store.list()
+        assert len(original) == 1
+        await _wait_until_terminal(original[0]["task_id"])
+
+        # Panel-shaped follow-up: same bag, fresh task row, no ambient context.
+        set_run_context(None)
+
+        async def follow_up() -> str:
+            await asyncio.sleep(0.02)
+            return "follow-up done"
+
+        task = asyncio.create_task(follow_up())
+        record = register_background_task_on(
+            store,
+            name="builder",
+            input={"prompt": "one more thing"},
+            task=task,
+            title=f"Follow-up: {original[0]['title']}",
+        )
+        await task
+        listed = {t["task_id"] for t in store.list()}
+        assert listed == {original[0]["task_id"], record.task_id}
+        assert store.get(record.task_id).status_code() == "completed"
+
+
 class TestBackgroundLogRetention:
     """Ring-buffer logs + finished-task retention on the session bag."""
 

--- a/python/tests/core/test_background_tasks.py
+++ b/python/tests/core/test_background_tasks.py
@@ -2054,6 +2054,45 @@ class TestRegisterBackgroundTaskOn:
         await first
 
     @pytest.mark.asyncio
+    async def test_does_not_ride_a_racing_turns_reservation(self):
+        """A foreign ``begin_spawn`` reservation is neither a free pass nor consumed.
+
+        Regression: the guard inherited from the ambient path skipped the cap
+        check whenever ``_pending_spawns > 0`` and ``add()`` decremented it —
+        an out-of-band registration racing a parent turn's spawn would both
+        bypass the cap and eat the turn's reserved slot.
+        """
+        from timbal.state.background import (
+            BackgroundLimitError,
+            BackgroundTaskStore,
+            register_background_task_on,
+        )
+
+        store = BackgroundTaskStore(max_concurrent=1)
+        store.begin_spawn()  # a parent turn mid-spawn holds the only slot
+        assert store._pending_spawns == 1
+
+        async def follow_up() -> str:
+            return "late"
+
+        task = asyncio.create_task(follow_up())
+        with pytest.raises(BackgroundLimitError, match="Concurrent"):
+            register_background_task_on(store, name="builder", input={}, task=task)
+        # The turn's reservation survives the rejected registration.
+        assert store._pending_spawns == 1
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # A caller that owns the reservation registers against it: no
+        # re-check, and registration consumes exactly that slot.
+        owned = asyncio.create_task(follow_up())
+        record = register_background_task_on(store, name="builder", input={}, task=owned, reserved=True)
+        assert store._pending_spawns == 0
+        assert store.get(record.task_id) is record
+        await owned
+
+    @pytest.mark.asyncio
     async def test_ambient_variant_still_requires_run_context(self):
         from timbal.state.background import register_background_task
 
@@ -2113,6 +2152,16 @@ class TestRegisterBackgroundTaskOn:
         listed = {t["task_id"] for t in store.list()}
         assert listed == {original[0]["task_id"], record.task_id}
         assert store.get(record.task_id).status_code() == "completed"
+
+        # The done-callback wired by store.add() enqueues a completion notice
+        # for the out-of-band child — the same inbox the parent agent drains at
+        # the start of its next turn. Callbacks run on the next loop tick.
+        await asyncio.sleep(0)
+        notices = store.drain_completions()
+        by_id = {n["task_id"]: n for n in notices}
+        assert record.task_id in by_id
+        assert by_id[record.task_id]["status"] == "completed"
+        assert by_id[record.task_id]["title"] == f"Follow-up: {original[0]['title']}"
 
 
 class TestBackgroundLogRetention:

--- a/python/timbal/state/background.py
+++ b/python/timbal/state/background.py
@@ -962,8 +962,8 @@ class BackgroundTaskStore:
         if self._pending_spawns > 0:
             self._pending_spawns -= 1
 
-    def add(self, record: BackgroundTask) -> None:
-        if self._pending_spawns > 0:
+    def add(self, record: BackgroundTask, *, consume_reservation: bool = True) -> None:
+        if consume_reservation and self._pending_spawns > 0:
             self._pending_spawns -= 1
         self._tasks[record.task_id] = record
         # Enqueue when the asyncio.Task reaches a terminal state. Done callbacks
@@ -1353,6 +1353,7 @@ def register_background_task_on(
     started_at: int | None = None,
     timeout: float | None = None,
     stall_timeout: float | None = None,
+    reserved: bool = False,
 ) -> BackgroundTask:
     """Register a running child on an explicit session bag.
 
@@ -1362,13 +1363,17 @@ def register_background_task_on(
     child for it. Slot caps apply exactly as in the ambient variant; on
     :class:`BackgroundLimitError` the caller owns cancelling ``task``.
 
+    ``reserved`` declares slot ownership: pass True only if *this caller*
+    already holds a :meth:`BackgroundTaskStore.begin_spawn` reservation, which
+    registration then consumes (the cap was checked at reserve time). When
+    False (the default for out-of-band callers) the cap is checked here and
+    no reservation is consumed — a racing turn's ``begin_spawn`` stays intact.
+
     ``timeout`` is seconds until the child is cancelled as ``timed_out``.
     ``stall_timeout`` is seconds without log events until ``stalled``.
     Raises :class:`BackgroundLimitError` if concurrent/depth caps would be exceeded.
     """
-    # Slot already reserved by Runnable._spawn_background_task via begin_spawn;
-    # direct callers must begin_spawn (or accept check_can_spawn here without reserve).
-    if store._pending_spawns == 0:
+    if not reserved:
         store.check_can_spawn()
     record = BackgroundTask(
         _new_task_id(),
@@ -1383,7 +1388,7 @@ def register_background_task_on(
         log_max_events=store.max_log_events,
         log_max_bytes=store.max_log_bytes,
     )
-    store.add(record)
+    store.add(record, consume_reservation=reserved)
     return record
 
 
@@ -1410,6 +1415,8 @@ def register_background_task(
     if run_context is None:
         raise RuntimeError("Cannot register a background task without a RunContext.")
     store = ensure_background_store(run_context)
+    # Slot already reserved by Runnable._spawn_background_task via begin_spawn;
+    # direct callers must begin_spawn (or accept check_can_spawn here without reserve).
     return register_background_task_on(
         store,
         name=name,
@@ -1420,6 +1427,7 @@ def register_background_task(
         started_at=started_at,
         timeout=timeout,
         stall_timeout=stall_timeout,
+        reserved=store._pending_spawns > 0,
     )
 
 

--- a/python/timbal/state/background.py
+++ b/python/timbal/state/background.py
@@ -1342,11 +1342,57 @@ async def wait_for_background(
         await rec.log.wait(after, timeout=wait_timeout)
 
 
+def register_background_task_on(
+    store: BackgroundTaskStore,
+    *,
+    name: str,
+    input: dict[str, Any],
+    task: asyncio.Task,
+    title: str | None = None,
+    on_cancel: Callable[..., Any] | None = None,
+    started_at: int | None = None,
+    timeout: float | None = None,
+    stall_timeout: float | None = None,
+) -> BackgroundTask:
+    """Register a running child on an explicit session bag.
+
+    Out-of-band variant of :func:`register_background_task` for callers that
+    hold a store reference but run outside any RunContext — e.g. an HTTP route
+    that resolves a session via :func:`store_for_run` and spawns a follow-up
+    child for it. Slot caps apply exactly as in the ambient variant; on
+    :class:`BackgroundLimitError` the caller owns cancelling ``task``.
+
+    ``timeout`` is seconds until the child is cancelled as ``timed_out``.
+    ``stall_timeout`` is seconds without log events until ``stalled``.
+    Raises :class:`BackgroundLimitError` if concurrent/depth caps would be exceeded.
+    """
+    # Slot already reserved by Runnable._spawn_background_task via begin_spawn;
+    # direct callers must begin_spawn (or accept check_can_spawn here without reserve).
+    if store._pending_spawns == 0:
+        store.check_can_spawn()
+    record = BackgroundTask(
+        _new_task_id(),
+        name=name,
+        input=input,
+        task=task,
+        started_at=started_at if started_at is not None else int(time.time() * 1000),
+        title=title,
+        on_cancel=on_cancel,
+        timeout=timeout,
+        stall_timeout=stall_timeout,
+        log_max_events=store.max_log_events,
+        log_max_bytes=store.max_log_bytes,
+    )
+    store.add(record)
+    return record
+
+
 def register_background_task(
     *,
     name: str,
     input: dict[str, Any],
     task: asyncio.Task,
+    title: str | None = None,
     on_cancel: Callable[..., Any] | None = None,
     started_at: int | None = None,
     timeout: float | None = None,
@@ -1364,24 +1410,17 @@ def register_background_task(
     if run_context is None:
         raise RuntimeError("Cannot register a background task without a RunContext.")
     store = ensure_background_store(run_context)
-    # Slot already reserved by Runnable._spawn_background_task via begin_spawn;
-    # direct callers must begin_spawn (or accept check_can_spawn here without reserve).
-    if store._pending_spawns == 0:
-        store.check_can_spawn()
-    record = BackgroundTask(
-        _new_task_id(),
+    return register_background_task_on(
+        store,
         name=name,
         input=input,
         task=task,
-        started_at=started_at if started_at is not None else int(time.time() * 1000),
+        title=title,
         on_cancel=on_cancel,
+        started_at=started_at,
         timeout=timeout,
         stall_timeout=stall_timeout,
-        log_max_events=store.max_log_events,
-        log_max_bytes=store.max_log_bytes,
     )
-    store.add(record)
-    return record
 
 
 def clear_background_stores() -> None:


### PR DESCRIPTION
## Summary
- Adds `register_background_task_on(store, ...)`: registers a detached child on an explicit `BackgroundTaskStore`, for callers with a store reference but no ambient RunContext (e.g. an HTTP route that resolves a session via `store_for_run` and spawns a follow-up child outside any turn).
- Same body and semantics as the ambient variant: `begin_spawn` reservation protocol respected, `check_can_spawn` caps enforced, store log limits inherited, and `store.add()` wires the completion-notice inbox so out-of-band children still notify the parent on its next turn. On `BackgroundLimitError` the caller owns cancelling the task.
- `register_background_task` now delegates to it (single body, no drift). Both gain an optional `title=` passthrough — `BackgroundTask` already accepted it, but the registration API didn't expose it; out-of-band callers need it to label rows (e.g. `Follow-up: <original title>`) without post-hoc mutation.

Groundwork for the composer follow-up endpoint (panel → subagent without a parent turn); same primitive-then-seam motion as #155.

## Test plan
- [x] `TestRegisterBackgroundTaskOn`: registration + completion with no ambient RunContext, title lands in `store.list()`
- [x] `max_concurrent` cap raises `BackgroundLimitError` on the explicit store; rejected task doesn't leak into the bag
- [x] Ambient variant still raises `RuntimeError` without a RunContext (contract unchanged)
- [x] Composer-shaped flow: real turn spawns a child, then `store_for_run(run_id)` → `register_background_task_on` attaches a follow-up to the same session bag
- [x] Full suite: `python/tests/core/test_background_tasks.py` — 99 passed