### PR TITLE
feat(models): add anthropic/claude-fable-5-1

### DIFF
--- a/docs/models/anthropic.mdx
+++ b/docs/models/anthropic.mdx
@@ -1,27 +1,28 @@
 ---
 title: "Anthropic"
-description: "Claude Fable 5, Opus 5, Sonnet 5, and Haiku models with specs, pricing, and capabilities"
+description: "Claude Fable 5.1, Opus 5, Sonnet 5, and Haiku models with specs, pricing, and capabilities"
 ---
 
-<Note>Source: [Anthropic model docs](https://docs.anthropic.com/en/docs/about-claude/models) · [What's new in Opus 5](https://platform.claude.com/docs/en/about-claude/models/whats-new-opus-5) · [Pricing](https://docs.anthropic.com/en/about-claude/pricing)</Note>
+<Note>Source: [Anthropic model docs](https://platform.claude.com/docs/en/about-claude/models/overview) · [Release notes](https://platform.claude.com/docs/en/release-notes/overview) · [Pricing](https://platform.claude.com/docs/en/about-claude/pricing)</Note>
 
 ## Latest
 
 <CardGroup cols={2}>
-  <Card title="claude-fable-5">
+  <Card title="claude-fable-5-1">
   <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> Reasoning · <Icon icon="bolt" size={14} /> Speed
 
-  `anthropic/claude-fable-5`
+  `anthropic/claude-fable-5-1`
 
-  Anthropic's most capable widely released model for long-horizon agentic work, complex reasoning, and ambitious multi-day coding tasks.
+  Anthropic's most capable generally available model. Successor to Fable 5 for long-running agentic coding, knowledge work, and research, with fewer false-positive safety refusals in multi-turn agent loops. Same price as Fable 5; cache reads are 75% cheaper.
 
-  - &#36;10 / &#36;50 per 1M tokens (input / output)
+  - &#36;10 / &#36;50 per 1M tokens (input / output); cache reads &#36;0.25 (0.025x input); batch &#36;5 / &#36;25
   - <Icon icon="window-maximize" size={14} /> 1M context
   - <Icon icon="right-from-bracket" size={14} /> 128K max output
   - <Icon icon="keyboard" size={14} /> Text, Image input
   - <Icon icon="brain" size={14} /> Adaptive thinking (always on)
   - <Icon icon="globe" size={14} /> Web search
-  - <Icon icon="calendar" size={14} /> Knowledge cutoff Jan 2026
+  - <Icon icon="calendar" size={14} /> Knowledge cutoff Jun 2026
+  - <Icon icon="triangle-exclamation" size={14} /> `tool_choice` `any` / `tool` not supported (400); requires 30-day data retention (no ZDR)
   </Card>
 
   <Card title="claude-opus-5">
@@ -126,6 +127,22 @@ description: "Claude Fable 5, Opus 5, Sonnet 5, and Haiku models with specs, pri
 ## Legacy
 
 <CardGroup cols={2}>
+  <Card title="claude-fable-5">
+  <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> Reasoning · <Icon icon="bolt" size={14} /> Speed
+
+  `anthropic/claude-fable-5`
+
+  Previous Fable generation for long-horizon agentic work, complex reasoning, and ambitious multi-day coding tasks. Superseded by Fable 5.1 at the same price.
+
+  - &#36;10 / &#36;50 per 1M tokens (input / output)
+  - <Icon icon="window-maximize" size={14} /> 1M context
+  - <Icon icon="right-from-bracket" size={14} /> 128K max output
+  - <Icon icon="keyboard" size={14} /> Text, Image input
+  - <Icon icon="brain" size={14} /> Adaptive thinking (always on)
+  - <Icon icon="globe" size={14} /> Web search
+  - <Icon icon="calendar" size={14} /> Knowledge cutoff Jan 2026
+  </Card>
+
   <Card title="claude-opus-4-5">
   <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> Reasoning · <Icon icon="bolt" size={14} /> <Icon icon="bolt" size={14} /> Speed
 

--- a/docs/models/overview.mdx
+++ b/docs/models/overview.mdx
@@ -7,7 +7,7 @@ Every model supported by Timbal with full specs, pricing, capability scores, and
 
 <CardGroup cols={3}>
   <Card title="Anthropic" icon="https://timbalusercontent.com/assets/claude_favicon.svg" href="/models/anthropic">
-    Claude Fable 5, Opus 5, Sonnet 5, and Haiku
+    Claude Fable 5.1, Opus 5, Sonnet 5, and Haiku
   </Card>
   <Card title="BytePlus" icon="https://timbalusercontent.com/assets/byteplus_favicon.svg" href="/models/byteplus">
     Seed 2.0 and Seed 1.8 models

--- a/python/timbal/core/models.py
+++ b/python/timbal/core/models.py
@@ -43,6 +43,7 @@ def get_context_window(model_id: str) -> int | None:
 # ---------------------------------------------------------------------------
 # Model type with provider prefixes
 Model = Literal[
+    "anthropic/claude-fable-5-1",
     "anthropic/claude-fable-5",
     "anthropic/claude-opus-5",
     "anthropic/claude-opus-4-8",

--- a/python/timbal/models.yaml
+++ b/python/timbal/models.yaml
@@ -9,11 +9,23 @@
 #   notes: "..."              — required when either flag is set (shown in UI/docs)
 
 models:
+- id: anthropic/claude-fable-5-1
+  provider: anthropic
+  display_name: Claude Fable 5.1
+  description: Anthropic's most capable generally available model — successor to Fable 5 for long-running agentic coding,
+    knowledge work, and research, with fewer false-positive safety refusals in multi-turn agent loops.
+  notes: Adaptive thinking is always on. Cache reads are $0.25 per 1M tokens (0.025x input, vs 0.1x on other models).
+    `tool_choice` any/tool return 400 — use strict tools or structured outputs instead. Requires 30-day data retention;
+    not available under ZDR.
+  input_price: 10.0
+  output_price: 50.0
+  context_window: 1000000
+  capabilities: [vision, tools, reasoning]
 - id: anthropic/claude-fable-5
   provider: anthropic
   display_name: Claude Fable 5
-  description: Anthropic's most capable widely released model for long-horizon agentic work, complex reasoning, and ambitious
-    coding tasks.
+  description: Previous Fable generation for long-horizon agentic work, complex reasoning, and ambitious coding tasks.
+    Superseded by Fable 5.1 at the same price.
   notes: Includes safety classifiers; blocked requests return stop_reason refusal. Configure Opus 5 fallback for production
     workloads.
   input_price: 10.0
@@ -79,7 +91,7 @@ models:
   provider: anthropic
   display_name: Claude Opus 4.1
   description: Previous-generation Opus model with high intelligence for complex reasoning tasks.
-  notes: Deprecated; retires August 5, 2026. Prefer claude-opus-5 or claude-fable-5.
+  notes: Deprecated; retires August 5, 2026. Prefer claude-opus-5 or claude-fable-5-1.
   input_price: 15.0
   output_price: 75.0
   context_window: 200000


### PR DESCRIPTION
## Summary
- Add `anthropic/claude-fable-5-1` to `models.yaml` and regenerate the `Model` Literal in `core/models.py` via `scripts/generate_models.py`
- Add a Fable 5.1 card to `docs/models/anthropic.mdx`; move Fable 5 to Legacy (Anthropic lists it as legacy now); update source links and the overview blurb
- Point the Opus 4.1 deprecation note at `claude-fable-5-1`

## Rates (verified against Anthropic's pricing page, 2026-09-01)
| | Fable 5.1 |
|---|---|
| Input | $10 / MTok |
| Output | $50 / MTok |
| Cache read | $0.25 / MTok (0.025x — was $1 on Fable 5) |
| 5m / 1h cache write | $12.50 / $20 |
| Batch | $5 / $25 |
| Context / max output | 1M / 128K |
| Knowledge cutoff | Jun 2026 |

Sources: [pricing](https://platform.claude.com/docs/en/about-claude/pricing) · [models overview](https://platform.claude.com/docs/en/about-claude/models/overview) · [release notes](https://platform.claude.com/docs/en/release-notes/overview)

## Notes
- `tool_choice: any|tool` returns 400 on Fable 5.1. Timbal doesn't set `tool_choice` anywhere, so no client change is needed; documented in notes so users passing it via `model_params` know why.
- Requires 30-day data retention (no ZDR), same as Fable 5.

## Test plan
- [x] `uv run python scripts/generate_models.py` produces a one-line diff in `models.py`
- [x] `get_context_window("anthropic/claude-fable-5-1") == 1_000_000`, prices load as 10.0 / 50.0
- [x] `uv run pytest python/tests/core -k model` — 118 passed
- [x] `uv run ruff check` clean
