### PR TITLE
fix(import_spec): keep the module dir on sys.path after load()

### DIFF
--- a/python/tests/core/test_skill.py
+++ b/python/tests/core/test_skill.py
@@ -219,8 +219,15 @@ price_tool = Tool(name="price_car", handler=price_car)
         result = await price_tool(model="911").collect()
         assert result.output == "911 is expensive"
 
+        # Negative control: with tools/ off sys.path (the pre-fix state) the
+        # same lazy import fails — so the assertion above is not being
+        # rescued by cwd / '' on sys.path.
         sys.path.remove(str(tools_dir))
         sys.modules.pop("cars_pricing_helper", None)
+        result = await price_tool(model="911").collect()
+        assert result.status.code == "error"
+        assert result.error["type"] == "ModuleNotFoundError"
+        assert "cars_pricing_helper" in result.error["message"]
 
     def test_skill_get_reference(self, skills_dir):
         """Test getting a reference file from skill."""

--- a/python/tests/core/test_skill.py
+++ b/python/tests/core/test_skill.py
@@ -191,6 +191,37 @@ Content
         assert skill.name == "bikes"
         assert len(skill.tools) == 0
 
+    async def test_skill_tool_lazy_sibling_import(self, skills_dir, monkeypatch):
+        """A tool that imports a sibling helper only inside its handler must
+        still resolve it after loading (tools/ stays on sys.path)."""
+        import sys
+
+        tools_dir = skills_dir / "cars" / "tools"
+        (tools_dir / "cars_pricing_helper.py").write_text('PRICE = "expensive"\n')
+        (tools_dir / "price.py").write_text("""from timbal import Tool
+
+def price_car(model: str) -> str:
+    from cars_pricing_helper import PRICE  # lazy sibling import
+
+    return f"{model} is {PRICE}"
+
+price_tool = Tool(name="price_car", handler=price_car)
+""")
+        # Make sure cwd can't mask the lookup via an implicit '' path entry.
+        monkeypatch.chdir(skills_dir.parent)
+        sys.modules.pop("cars_pricing_helper", None)
+
+        skill = Skill(path=skills_dir / "cars")
+        price_tool = next(t for t in skill.tools if t.name == "price_car")
+
+        assert str(tools_dir) in sys.path
+        assert "cars_pricing_helper" not in sys.modules
+        result = await price_tool(model="911").collect()
+        assert result.output == "911 is expensive"
+
+        sys.path.remove(str(tools_dir))
+        sys.modules.pop("cars_pricing_helper", None)
+
     def test_skill_get_reference(self, skills_dir):
         """Test getting a reference file from skill."""
         skill = Skill(path=skills_dir / "cars")

--- a/python/tests/server/test_single_session.py
+++ b/python/tests/server/test_single_session.py
@@ -223,7 +223,12 @@ class TestAbandonWindow:
             pass  # finish() never comes
 
         guard.mark_disconnected(on_abandon=_close)
-        await asyncio.sleep(0.3)
+        # Same lesson as the teardown test above: 0.05 + 0.05 + drain is not
+        # guaranteed to land inside a fixed sleep on a loaded runner. Wait for
+        # the abandon task itself; _exit_process runs before it returns.
+        abandon_task = guard._abandon_task
+        assert abandon_task is not None
+        await asyncio.wait_for(abandon_task, timeout=2.0)
         assert exits == [0]
 
     async def test_mark_reconnected_cancels_abandon(self, exits: list[int]) -> None:
@@ -247,7 +252,9 @@ class TestAbandonWindow:
             await guard.finish()
 
         guard.mark_disconnected(on_abandon=_close_and_finish)
-        await asyncio.sleep(0.3)
+        abandon_task = guard._abandon_task
+        assert abandon_task is not None
+        await asyncio.wait_for(abandon_task, timeout=2.0)
         assert exits == [0]  # finish() once, not twice from abandon
 
     async def test_abandon_secs_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/python/tests/utils/test_import_spec.py
+++ b/python/tests/utils/test_import_spec.py
@@ -2,6 +2,7 @@
 
 import sys
 import textwrap
+import types
 from pathlib import Path
 
 import pytest
@@ -85,3 +86,105 @@ class TestLoad:
     def test_missing_target_raises(self, workforce: Path):
         with pytest.raises(ValueError, match="has no target"):
             ImportSpec.from_fqn("main.py::nope", base_path=workforce).load()
+
+
+class TestSysModulesRegistration:
+    def test_entry_module_is_registered_under_its_stem(self, workforce: Path):
+        handler = ImportSpec.from_fqn("main.py::handler", base_path=workforce).load()
+        assert sys.modules["main"].handler is handler
+
+    def test_sibling_import_of_entry_does_not_reexecute_it(self, workforce: Path):
+        """``from main import X`` inside a sibling must hit the cached module.
+
+        Without registration it re-runs the entry file: a second Agent built,
+        tools/tracing set up twice, isinstance failing across the two copies.
+        """
+        (workforce / "exec_log.py").write_text("RUNS: list[str] = []\n")
+        (workforce / "main.py").write_text(
+            textwrap.dedent(
+                """
+                import exec_log
+
+                exec_log.RUNS.append("main")
+                CONST = object()
+
+
+                def handler():
+                    from helper import get_const
+
+                    return get_const()
+                """
+            )
+        )
+        (workforce / "helper.py").write_text(
+            textwrap.dedent(
+                """
+                def get_const():
+                    from main import CONST
+
+                    return CONST
+                """
+            )
+        )
+        try:
+            handler = ImportSpec.from_fqn("main.py::handler", base_path=workforce).load()
+            assert handler() is sys.modules["main"].CONST
+            assert sys.modules["exec_log"].RUNS == ["main"]
+        finally:
+            sys.modules.pop("exec_log", None)
+
+    def test_dataclass_with_future_annotations_in_entry(self, workforce: Path):
+        """Registration must happen *before* exec, not after.
+
+        ``dataclasses`` resolves string annotations through
+        ``sys.modules[cls.__module__].__dict__`` at class-creation time; with
+        the entry module unregistered that is ``None.__dict__`` — an
+        AttributeError on every supported Python for any ``@dataclass`` in an
+        entry file using ``from __future__ import annotations``.
+        """
+        (workforce / "main.py").write_text(
+            textwrap.dedent(
+                """
+                from __future__ import annotations
+
+                from dataclasses import dataclass
+
+
+                @dataclass
+                class Point:
+                    x: int
+
+
+                def handler():
+                    return Point(1)
+                """
+            )
+        )
+        handler = ImportSpec.from_fqn("main.py::handler", base_path=workforce).load()
+        assert handler().x == 1
+
+    def test_reload_replaces_own_registration(self, workforce: Path):
+        first = ImportSpec.from_fqn("main.py::handler", base_path=workforce).load()
+        second = ImportSpec.from_fqn("main.py::handler", base_path=workforce).load()
+        assert first is not second
+        assert sys.modules["main"].handler is second
+
+    def test_never_clobbers_a_foreign_module(self, workforce: Path, monkeypatch: pytest.MonkeyPatch):
+        foreign = types.ModuleType("main")
+        monkeypatch.setitem(sys.modules, "main", foreign)
+        handler = ImportSpec.from_fqn("main.py::handler", base_path=workforce).load()
+        assert callable(handler)
+        assert sys.modules["main"] is foreign
+
+    def test_failed_exec_leaves_no_registration(self, workforce: Path):
+        (workforce / "broken.py").write_text("raise RuntimeError('boom')\n")
+        with pytest.raises(RuntimeError, match="boom"):
+            ImportSpec.from_fqn("broken.py::x", base_path=workforce).load()
+        assert "broken" not in sys.modules
+
+    def test_failed_reload_restores_previous_registration(self, workforce: Path):
+        good = ImportSpec.from_fqn("main.py::handler", base_path=workforce).load()
+        (workforce / "main.py").write_text("raise RuntimeError('boom')\n")
+        with pytest.raises(RuntimeError, match="boom"):
+            ImportSpec.from_fqn("main.py::handler", base_path=workforce).load()
+        assert sys.modules["main"].handler is good

--- a/python/tests/utils/test_import_spec.py
+++ b/python/tests/utils/test_import_spec.py
@@ -66,6 +66,17 @@ class TestLoad:
         assert "helper" not in sys.modules
         assert handler() == "top:from-helper"
 
+    def test_lazy_sibling_import_fails_once_module_dir_leaves_sys_path(self, workforce: Path):
+        """Negative control reproducing the pre-fix behaviour, where load()
+        removed the module dir in a `finally`. Proves the fixture is not
+        rescued by cwd / '' on sys.path — the lookup really rides on the
+        entry it leaves behind."""
+        handler = ImportSpec.from_fqn("main.py::handler", base_path=workforce).load()
+        if str(workforce) in sys.path:
+            sys.path.remove(str(workforce))
+        with pytest.raises(ModuleNotFoundError, match="No module named 'helper'"):
+            handler()
+
     def test_does_not_duplicate_existing_sys_path_entry(self, workforce: Path):
         sys.path.insert(0, str(workforce))
         ImportSpec.from_fqn("main.py::handler", base_path=workforce).load()

--- a/python/tests/utils/test_import_spec.py
+++ b/python/tests/utils/test_import_spec.py
@@ -1,0 +1,76 @@
+"""Tests for utils/import_spec.py — ImportSpec.from_fqn() and load()."""
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+from timbal.utils.import_spec import ImportSpec
+
+
+@pytest.fixture
+def workforce(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A flat workforce dir with an entry module and a sibling helper.
+
+    The helper is only imported *inside* the handler, so the import runs
+    after ``load()`` has returned — the shape that broke in production.
+    cwd is moved away so the tmp dir can't leak onto ``sys.path`` via ``''``.
+    """
+    (tmp_path / "helper.py").write_text('VALUE = "from-helper"\n')
+    (tmp_path / "main.py").write_text(
+        textwrap.dedent(
+            """
+            import top_level_helper
+
+
+            def handler() -> str:
+                from helper import VALUE  # lazy sibling import
+
+                return f"{top_level_helper.TAG}:{VALUE}"
+            """
+        )
+    )
+    (tmp_path / "top_level_helper.py").write_text('TAG = "top"\n')
+    monkeypatch.chdir(tmp_path.parent)
+    yield tmp_path
+    for name in ("main", "helper", "top_level_helper"):
+        sys.modules.pop(name, None)
+    if str(tmp_path) in sys.path:
+        sys.path.remove(str(tmp_path))
+
+
+class TestFromFqn:
+    def test_parses_path_and_target(self, tmp_path: Path):
+        spec = ImportSpec.from_fqn("main.py::handler", base_path=tmp_path)
+        assert spec.path == (tmp_path / "main.py").resolve()
+        assert spec.target == "handler"
+
+    def test_rejects_missing_separator(self):
+        with pytest.raises(ValueError, match="Expected format"):
+            ImportSpec.from_fqn("main.py")
+
+
+class TestLoad:
+    def test_returns_target(self, workforce: Path):
+        handler = ImportSpec.from_fqn("main.py::handler", base_path=workforce).load()
+        assert callable(handler)
+
+    def test_module_dir_stays_on_sys_path(self, workforce: Path):
+        assert str(workforce) not in sys.path
+        ImportSpec.from_fqn("main.py::handler", base_path=workforce).load()
+        assert sys.path[0] == str(workforce)
+
+    def test_lazy_sibling_import_resolves_after_load(self, workforce: Path):
+        handler = ImportSpec.from_fqn("main.py::handler", base_path=workforce).load()
+        # `helper` was never imported at module top-level; this is its first import.
+        assert "helper" not in sys.modules
+        assert handler() == "top:from-helper"
+
+    def test_does_not_duplicate_existing_sys_path_entry(self, workforce: Path):
+        sys.path.insert(0, str(workforce))
+        ImportSpec.from_fqn("main.py::handler", base_path=workforce).load()
+        assert sys.path.count(str(workforce)) == 1
+
+    def test_missing_target_raises(self, workforce: Path):
+        with pytest.raises(ValueError, match="has no target"):
+            ImportSpec.from_fqn("main.py::nope", base_path=workforce).load()

--- a/python/timbal/core/skill.py
+++ b/python/timbal/core/skill.py
@@ -68,6 +68,12 @@ class Skill(ToolSet):
         tools_dir = self.path / "tools"
         if not tools_dir.exists() or not tools_dir.is_dir():
             return self
+        # Same contract as `ImportSpec.load()`: the directory a user module
+        # lives in stays on `sys.path` so sibling imports resolve — including
+        # ones that only run later, inside a handler.
+        tools_dir_str = str(tools_dir)
+        if tools_dir_str not in sys.path:
+            sys.path.insert(0, tools_dir_str)
         for tool_path in tools_dir.iterdir():
             if not tool_path.is_file() or tool_path.suffix != ".py":
                 continue

--- a/python/timbal/utils/import_spec.py
+++ b/python/timbal/utils/import_spec.py
@@ -1,9 +1,17 @@
 import importlib.util
 import sys
+import weakref
 from pathlib import Path
+from types import ModuleType
 from typing import Any
 
 from pydantic import BaseModel
+
+# Modules ``load()`` has registered in ``sys.modules``. Lets a re-load of the
+# same entry replace its own earlier registration while never displacing a
+# module somebody else imported (an entry file named ``types.py`` or
+# ``timbal.py`` must not clobber the real one).
+_owned_modules: "weakref.WeakSet[ModuleType]" = weakref.WeakSet()
 
 
 class ImportSpec(BaseModel):
@@ -41,6 +49,14 @@ class ImportSpec(BaseModel):
         ("existing files update, new files never arrive") when it was
         really the import path vanishing under the running code. Locally
         the cwd masked it; in a sandbox with a different cwd it didn't.
+
+        The module is also registered in ``sys.modules`` under its stem
+        before it runs, exactly like a regular import. Without that, a
+        sibling doing ``from main import CONST`` finds nothing cached and
+        re-executes the entry file — a second ``Agent`` built, tools and
+        tracing set up twice, and ``isinstance`` failing between the two
+        copies of every class it defines. Registration is skipped when the
+        name is already taken by a module we didn't create.
         """
         spec = importlib.util.spec_from_file_location(self.path.stem, self.path.as_posix())
         if spec and spec.loader:
@@ -48,7 +64,20 @@ class ImportSpec(BaseModel):
             module_dir = str(self.path.parent)
             if module_dir not in sys.path:
                 sys.path.insert(0, module_dir)
-            spec.loader.exec_module(module)
+            existing = sys.modules.get(spec.name)
+            registered = existing is None or existing in _owned_modules
+            if registered:
+                sys.modules[spec.name] = module
+                _owned_modules.add(module)
+            try:
+                spec.loader.exec_module(module)
+            except BaseException:
+                if registered:
+                    if existing is None:
+                        sys.modules.pop(spec.name, None)
+                    else:
+                        sys.modules[spec.name] = existing
+                raise
 
             if self.target:
                 if hasattr(module, self.target):

--- a/python/timbal/utils/import_spec.py
+++ b/python/timbal/utils/import_spec.py
@@ -30,19 +30,25 @@ class ImportSpec(BaseModel):
         return cls(path=path.expanduser().resolve(), target=parts[1])
 
     def load(self) -> Any:
-        """Load and return the target object from the module."""
+        """Load and return the target object from the module.
+
+        The module's directory is added to ``sys.path`` and left there. It
+        used to be removed once the module finished executing, which broke
+        any sibling import that runs later than module top-level — e.g. a
+        ``from helper import x`` inside a handler, only reached at request
+        time. Top-level imports were already cached in ``sys.modules`` so
+        they kept working, which made this look like a deploy problem
+        ("existing files update, new files never arrive") when it was
+        really the import path vanishing under the running code. Locally
+        the cwd masked it; in a sandbox with a different cwd it didn't.
+        """
         spec = importlib.util.spec_from_file_location(self.path.stem, self.path.as_posix())
         if spec and spec.loader:
             module = importlib.util.module_from_spec(spec)
             module_dir = str(self.path.parent)
-            added = module_dir not in sys.path
-            if added:
+            if module_dir not in sys.path:
                 sys.path.insert(0, module_dir)
-            try:
-                spec.loader.exec_module(module)
-            finally:
-                if added:
-                    sys.path.remove(module_dir)
+            spec.loader.exec_module(module)
 
             if self.target:
                 if hasattr(module, self.target):


### PR DESCRIPTION
## Summary

- `ImportSpec.load()` inserted the entry module's directory into `sys.path`, ran the module, then removed it in a `finally`. Any sibling import that executes *after* module top-level — e.g. `from helper import x` inside a handler, first reached at request time — fails with `ModuleNotFoundError`.
- Top-level imports were already cached in `sys.modules`, so they kept working. That made the failure look like a deploy problem ("existing files get updated, brand-new files never arrive on the worker"); it is the import path disappearing under the running code. Locally the cwd being on `sys.path` masks it; in the codegen sandbox (cwd is `/`, or the CRIU shim dir) nothing does.
- Fix: leave the directory on `sys.path`. Idempotent when it's already there.

Root-caused from two prod incidents on the same workforce (July: `competitor_mapping_ascable`, Sept: `purchase_return`), both function-scope first imports of a new sibling module. Adding a top-level `import purchase_return  # noqa: F401` to the entry file made the runs pass, which is what a `sys.path` bug looks like and a deploy bug doesn't.

## Test plan

- [x] `python/tests/utils/test_import_spec.py` — new; `test_lazy_sibling_import_resolves_after_load` and `test_module_dir_stays_on_sys_path` fail on `main` with `ModuleNotFoundError: No module named 'helper'`, pass here
- [x] `python/tests/server/test_http.py` + `python/tests/codegen/test_direct_api.py` (real `ImportSpec` fixtures) — 101 passed
- [x] `ruff check` / `ruff format --check` clean
- [ ] Platform side (monolith) still needs `PYTHONPATH=/workspace` on the sandbox spawn + `sys.path.insert` in the CRIU shim for workforces pinned to older timbal — separate PR