### PR TITLE
feat(cli): secret-aware env pull/push, TIMBAL_APP_ID per workforce member, safe .env placement

### DIFF
--- a/cli/commands/env.zig
+++ b/cli/commands/env.zig
@@ -28,24 +28,43 @@ fn printUsage() !void {
         "\x1b[1;32mUsage: \x1b[1;36mtimbal env \x1b[0;36m<pull|push> \x1b[0m[OPTIONS]\n" ++
         "\n" ++
         "\x1b[1;32mCommands:\n" ++
-        "    \x1b[1;36mpull \x1b[0mDownload vars for the env tracking --rev into a local .env file\n" ++
-        "    \x1b[1;36mpush \x1b[0mUpsert local .env vars into the env tracking --rev\n" ++
+        "    \x1b[1;36mpull \x1b[0mDownload vars for the env tracking --rev into <project>/.env\n" ++
+        "    \x1b[1;36mpush \x1b[0mUpsert <project>/.env vars into the env tracking --rev\n" ++
         "\n" ++
         "\x1b[1;32mOptions:\n" ++
-        "    \x1b[1;36m--rev <BRANCH>    \x1b[0mGit branch whose env to sync (default: current branch)\n" ++
-        "    \x1b[1;36m--default         \x1b[0mOmit rev; use the project's default-branch env\n" ++
-        "    \x1b[1;36m-f\x1b[0m, \x1b[1;36m--file <PATH> \x1b[0mLocal env file (default: .env)\n" ++
-        "    \x1b[1;36m--force           \x1b[0mOverwrite an existing local env file on pull\n" ++
-        "    \x1b[1;36m--dry-run         \x1b[0mPush only: show what would be sent (values redacted)\n" ++
-        "    \x1b[1;36m--base-url <URL>  \x1b[0mOverride API host (https://api[.env].timbal.ai)\n" ++
+        "    \x1b[1;36m--rev <BRANCH>           \x1b[0mGit branch whose env to sync (default: current branch)\n" ++
+        "    \x1b[1;36m--default                \x1b[0mOmit rev; use the project's default-branch env\n" ++
+        "    \x1b[1;36m-f\x1b[0m, \x1b[1;36m--file <PATH>        \x1b[0mLocal env file (default: .env at the project root)\n" ++
+        "    \x1b[1;36m--force                  \x1b[0mPull: overwrite an existing local env file\n" ++
+        "    \x1b[1;36m--dry-run                \x1b[0mShow what would be written/sent (values redacted); change nothing\n" ++
+        "    \x1b[1;36m--secret <NAME[,NAME]>   \x1b[0mPush: treat these vars as secrets (repeatable)\n" ++
+        "    \x1b[1;36m--plain <NAME[,NAME]>    \x1b[0mPush: treat these vars as plain (also acknowledges a secret-on-platform mismatch)\n" ++
+        "    \x1b[1;36m--include-platform-vars  \x1b[0mPull: write the platform-managed TIMBAL_* runtime vars active (default: commented)\n" ++
+        "    \x1b[1;36m--no-app-ids             \x1b[0mDo not write TIMBAL_APP_ID into workforce/<name>/.env\n" ++
+        "    \x1b[1;36m--base-url <URL>         \x1b[0mOverride API host (https://api[.env].timbal.ai)\n" ++
+        "\n" ++
+        "\x1b[1;32mSecrets vs plain:\n" ++
+        "\x1b[0m    A `# type: secret` (or `# secret`) comment directly above a var marks it secret; `# type: plain`\n" ++
+        "    (or `# plain`) marks it plain. Vars without a comment keep their current platform type. New vars\n" ++
+        "    are inferred from their name/value (KEY, SECRET, TOKEN, PASSWORD, sk-..., ... → secret).\n" ++
+        "    --secret / --plain always win. The platform fixes a var's type at creation — an update only changes\n" ++
+        "    the value — so change types in the Timbal UI. Push refuses a file that marks a platform secret plain.\n" ++
+        "\n" ++
+        "\x1b[1;32mFile placement:\n" ++
+        "\x1b[0m    <project>/.env is what `timbal start` loads into every service, so that is the sync target.\n" ++
+        "    TIMBAL_* / VITE_TIMBAL_* are the platform's namespace: resolved before every deploy/preview, so\n" ++
+        "    pull writes them commented out (loading them locally reroutes service calls to the deployed\n" ++
+        "    gateway) and push NEVER sends them, whatever the file or flags say.\n" ++
+        "    TIMBAL_APP_ID is per workforce member: pull/push merge it into workforce/<name>/.env by matching\n" ++
+        "    the timbal.yaml _id against the platform. It is never written to the project-root .env.\n" ++
         "\n" ++
         "\x1b[1;32mNotes:\n" ++
         "\x1b[0m    Org/project are resolved from the Timbal git remote in .git/config:\n" ++
         "    https://api[.env].timbal.ai/orgs/{org_id}/projects/{project_id}/git\n" ++
         "    Auth uses the configured profile API key (timbal configure).\n" ++
         "    Secrets are written in plaintext to the local file — keep it gitignored.\n" ++
-        "    Push is upsert-only: existing platform vars not in the file are left alone\n" ++
-        "    (no delete / replace-all). Reserved names (TIMBAL_PROJECT_SECRET, PORT) are skipped.\n" ++
+        "    Push is upsert-only: platform vars not in the file are left alone (no delete / replace-all).\n" ++
+        "    Reserved names (PORT, TIMBAL_PROJECT_SECRET, TIMBAL_APP_ID) are never pushed.\n" ++
         "\n" ++
         utils.global_options_help ++
         "\n");
@@ -355,6 +374,138 @@ fn currentGitBranch(allocator: std.mem.Allocator) !?[]u8 {
     return null;
 }
 
+/// The Timbal project root is the directory `timbal start` runs from and loads `.env` in.
+/// Walk up from cwd (never past the git checkout root) to the nearest directory that has a
+/// `workforce/` dir; fall back to the repo root, which is also what the platform builds from.
+fn resolveProjectRoot(allocator: std.mem.Allocator, cwd_path: []const u8, repo_root: []const u8) ![]u8 {
+    var current: []const u8 = cwd_path;
+    while (true) {
+        const probe = try std.fmt.allocPrint(allocator, "{s}{s}workforce", .{ current, sep });
+        defer allocator.free(probe);
+        if (fs.cwd().openDir(probe, .{})) |d| {
+            var dir = d;
+            dir.close();
+            return allocator.dupe(u8, current);
+        } else |_| {}
+
+        if (std.mem.eql(u8, current, repo_root)) break;
+        const parent = fs.path.dirname(current) orelse break;
+        if (parent.len >= current.len) break;
+        current = parent;
+    }
+    return allocator.dupe(u8, repo_root);
+}
+
+// ---------------------------------------------------------------------------
+// Var names: reserved / platform-managed / type helpers
+// ---------------------------------------------------------------------------
+
+/// Never pushed. PORT and TIMBAL_PROJECT_SECRET are platform-assigned. TIMBAL_APP_ID is
+/// per workforce member and lives in workforce/<name>/.env — a project-level value would
+/// point every member at the same app.
+pub fn isReservedVarName(name: []const u8) bool {
+    return std.mem.eql(u8, name, "TIMBAL_PROJECT_SECRET") or
+        std.mem.eql(u8, name, "PORT") or
+        std.mem.eql(u8, name, "TIMBAL_APP_ID");
+}
+
+/// The platform's own namespace (TIMBAL_PROJECT_ENV_ID, TIMBAL_ORG_ID, VITE_TIMBAL_*, ...):
+/// resolved by the platform before every deploy/preview, so they appear in the effective env
+/// returned by pull but are never user-defined project vars and are never pushed. Loading
+/// them under `timbal start` changes SDK routing (TIMBAL_PROJECT_ENV_ID points service calls
+/// at the deployed gateway).
+pub fn isPlatformManagedName(name: []const u8) bool {
+    return std.mem.startsWith(u8, name, "TIMBAL_") or
+        std.mem.startsWith(u8, name, "VITE_TIMBAL_") or
+        // Injected into UI deploys alongside the VITE_TIMBAL_* mirrors; the only one outside the prefixes.
+        std.mem.eql(u8, name, "VITE_AUTH_TIMBAL_IAM");
+}
+
+/// Canonical static type string, or null when the input is neither plain nor secret.
+pub fn canonType(t: []const u8) ?[]const u8 {
+    const trimmed = std.mem.trim(u8, t, " \t\r");
+    if (std.ascii.eqlIgnoreCase(trimmed, "secret")) return "secret";
+    if (std.ascii.eqlIgnoreCase(trimmed, "plain")) return "plain";
+    return null;
+}
+
+fn isSecretType(t: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(std.mem.trim(u8, t, " \t\r"), "secret");
+}
+
+const strong_secret_tokens = [_][]const u8{
+    "SECRET",     "SECRETS",     "PASSWORD", "PASSWORDS", "PASSWD", "PASSPHRASE", "PRIVATE",
+    "CREDENTIAL", "CREDENTIALS", "DSN",      "TOKEN",     "TOKENS", "APIKEY",     "JWT",
+    "SALT",       "SIGNING",     "BEARER",
+};
+const weak_secret_tokens = [_][]const u8{ "KEY", "KEYS", "PASS", "PWD" };
+/// Tokens that turn TOKEN/TOKENS into a count, not a credential (MAX_TOKENS, TOKEN_LIMIT).
+const count_tokens = [_][]const u8{ "MAX", "MIN", "NUM", "COUNT", "LIMIT", "BUDGET" };
+const strong_secret_substrings = [_][]const u8{ "SECRET", "PASSWORD", "PASSWD", "APIKEY", "PRIVATE" };
+const secret_value_prefixes = [_][]const u8{
+    "sk-",   "sk_live_", "sk_test_", "rk_live_", "rk_test_", "ghp_", "gho_",       "ghu_", "github_pat_",
+    "xoxb-", "xoxp-",    "xoxa-",    "xapp-",    "AKIA",     "AIza", "-----BEGIN", "eyJ",
+};
+
+fn tokenIn(tok: []const u8, set: []const []const u8) bool {
+    for (set) |s| if (std.mem.eql(u8, tok, s)) return true;
+    return false;
+}
+
+/// Heuristic used only for vars that are new to the platform and carry no metadata.
+/// Errs towards `secret` (a secret is still injected everywhere; only the UI hides it).
+pub fn inferSecret(name: []const u8, value: []const u8) bool {
+    var upper_buf: [512]u8 = undefined;
+    const upper = if (name.len <= upper_buf.len)
+        std.ascii.upperString(upper_buf[0..name.len], name)
+    else
+        name;
+
+    var has_public = false;
+    var has_count = false;
+    var strong = false;
+    var weak = false;
+    var token_word = false;
+    var it = std.mem.tokenizeScalar(u8, upper, '_');
+    while (it.next()) |tok| {
+        if (std.mem.eql(u8, tok, "PUBLIC") or std.mem.eql(u8, tok, "PUBLISHABLE")) {
+            has_public = true;
+        } else if (std.mem.eql(u8, tok, "TOKEN") or std.mem.eql(u8, tok, "TOKENS")) {
+            token_word = true;
+        } else if (tokenIn(tok, &count_tokens)) {
+            has_count = true;
+        } else if (tokenIn(tok, &strong_secret_tokens)) {
+            strong = true;
+        } else if (tokenIn(tok, &weak_secret_tokens)) {
+            weak = true;
+        }
+    }
+    if (token_word and !has_count) strong = true;
+    if (!strong) {
+        for (strong_secret_substrings) |s| {
+            if (std.mem.indexOf(u8, upper, s) != null) {
+                strong = true;
+                break;
+            }
+        }
+    }
+    if (strong) return true;
+    if (weak and !has_public) return true;
+
+    for (secret_value_prefixes) |p| {
+        if (std.mem.startsWith(u8, value, p)) return true;
+    }
+    // Credentials embedded in a URL: scheme://user:pass@host/...
+    if (std.mem.indexOf(u8, value, "://")) |i| {
+        const rest = value[i + 3 ..];
+        if (std.mem.indexOfScalar(u8, rest, '@')) |at| {
+            const slash = std.mem.indexOfScalar(u8, rest, '/') orelse rest.len;
+            if (at < slash and std.mem.indexOfScalar(u8, rest[0..at], ':') != null) return true;
+        }
+    }
+    return false;
+}
+
 // ---------------------------------------------------------------------------
 // SyncVar + local .env store
 // ---------------------------------------------------------------------------
@@ -364,6 +515,15 @@ pub const SyncVar = struct {
     type: []const u8, // "plain" | "secret"
     value: []const u8,
     description: ?[]const u8 = null,
+    /// True when the type came from explicit metadata (a `# type:` line, or the platform).
+    /// Without it, push keeps the platform's current type instead of assuming plain.
+    type_explicit: bool = false,
+    /// Platform-computed runtime var: present in the effective deploy env but not user-defined.
+    /// Written commented out on pull (active with --include-platform-vars); never pushed.
+    managed: bool = false,
+    /// Secret whose value the platform did not return. Written as a commented placeholder so a
+    /// later push cannot overwrite the remote value with an empty string.
+    value_missing: bool = false,
 
     pub fn deinit(self: *SyncVar, allocator: std.mem.Allocator) void {
         allocator.free(self.name);
@@ -376,6 +536,11 @@ pub const SyncVar = struct {
 fn freeSyncVars(allocator: std.mem.Allocator, vars: *std.ArrayList(SyncVar)) void {
     for (vars.items) |*v| v.deinit(allocator);
     vars.deinit();
+}
+
+fn findSyncVar(vars: []const SyncVar, name: []const u8) ?usize {
+    for (vars, 0..) |v, i| if (std.mem.eql(u8, v.name, name)) return i;
+    return null;
 }
 
 fn needsQuoting(value: []const u8) bool {
@@ -403,9 +568,96 @@ fn appendQuotedValue(buf: *std.ArrayList(u8), value: []const u8) !void {
     try buf.append(quote);
 }
 
+/// Append `value` quoted iff needed, flattening newlines so the line-oriented file stays valid.
+fn appendEnvValue(allocator: std.mem.Allocator, buf: *std.ArrayList(u8), value: []const u8) !void {
+    if (std.mem.indexOfAny(u8, value, "\n\r") != null) {
+        const flat = try allocator.alloc(u8, value.len);
+        defer allocator.free(flat);
+        for (value, 0..) |c, i| {
+            flat[i] = if (c == '\n' or c == '\r') ' ' else c;
+        }
+        if (needsQuoting(flat)) {
+            try appendQuotedValue(buf, flat);
+        } else {
+            try buf.appendSlice(flat);
+        }
+    } else if (needsQuoting(value)) {
+        try appendQuotedValue(buf, value);
+    } else {
+        try buf.appendSlice(value);
+    }
+}
+
+pub const FormatOptions = struct {
+    /// Write platform-managed vars as active lines instead of commented placeholders.
+    managed_active: bool = false,
+};
+
+fn isMultiline(value: []const u8) bool {
+    return std.mem.indexOfAny(u8, value, "\n\r") != null;
+}
+
+/// Key rules `timbal start`'s loader enforces: letters, digits, underscore, no leading digit.
+/// Anything else is silently dropped by start, so pushing it would never work locally.
+pub fn isValidEnvKey(key: []const u8) bool {
+    if (key.len == 0 or std.ascii.isDigit(key[0])) return false;
+    for (key) |c| {
+        if (!(std.ascii.isAlphanumeric(c) or c == '_')) return false;
+    }
+    return true;
+}
+
+fn appendEnvEntry(allocator: std.mem.Allocator, buf: *std.ArrayList(u8), v: SyncVar, active_in: bool) !void {
+    // Reserved names are never active in a project-level file, whatever the caller asked.
+    const active = active_in and !isReservedVarName(v.name);
+    if (v.managed) try buf.appendSlice("# managed: platform\n");
+    try buf.appendSlice("# type: ");
+    try buf.appendSlice(v.type);
+    try buf.append('\n');
+    if (v.description) |d| {
+        if (d.len > 0) {
+            try buf.appendSlice("# description: ");
+            // Keep description on one line.
+            for (d) |c| {
+                try buf.append(if (c == '\n' or c == '\r') ' ' else c);
+            }
+            try buf.append('\n');
+        }
+    }
+    if (v.value_missing) {
+        try buf.appendSlice("# value not returned by the platform: set it here to use it locally, or leave the\n");
+        try buf.appendSlice("# line commented so `timbal env push` keeps the remote value untouched.\n");
+        try buf.appendSlice("# ");
+        try buf.appendSlice(v.name);
+        try buf.appendSlice("=\n\n");
+        return;
+    }
+    if (isMultiline(v.value)) {
+        // This line-oriented format (and `timbal start`'s loader) cannot carry newlines. Writing
+        // a flattened copy would break the value locally and, if pushed back, on the platform.
+        try buf.appendSlice("# multi-line value: not representable in a .env file, so it is kept on the platform only.\n");
+        try buf.appendSlice("# Provide it locally via your shell or `timbal start --env`; leave this line commented.\n");
+        try buf.appendSlice("# ");
+        try buf.appendSlice(v.name);
+        try buf.appendSlice("=\n\n");
+        return;
+    }
+    if (std.mem.eql(u8, v.name, "TIMBAL_APP_ID")) {
+        try buf.appendSlice("# TIMBAL_APP_ID is per workforce member — it belongs in workforce/<name>/.env, not here.\n");
+    }
+    if (!active) try buf.appendSlice("# ");
+    try buf.appendSlice(v.name);
+    try buf.append('=');
+    try appendEnvValue(allocator, buf, v.value);
+    try buf.append('\n');
+    try buf.append('\n');
+}
+
 /// Serialize SyncVars to a .env file with type/description comment metadata.
 /// Format is compatible with `timbal start`'s .env loader (quote strip, no escapes).
-pub fn formatEnvFile(allocator: std.mem.Allocator, rev: []const u8, vars: []const SyncVar) ![]u8 {
+/// User-defined vars come first; platform-managed vars go in a trailing block that is
+/// commented out unless `managed_active` is set.
+pub fn formatEnvFile(allocator: std.mem.Allocator, rev: []const u8, vars: []const SyncVar, fmt_opts: FormatOptions) ![]u8 {
     var buf = std.ArrayList(u8).init(allocator);
     errdefer buf.deinit();
 
@@ -413,102 +665,126 @@ pub fn formatEnvFile(allocator: std.mem.Allocator, rev: []const u8, vars: []cons
     try buf.appendSlice("# rev: ");
     try buf.appendSlice(rev);
     try buf.append('\n');
+    try buf.appendSlice("#\n");
+    try buf.appendSlice("# `timbal env push` reads the metadata comments directly above each var:\n");
+    try buf.appendSlice("#   # type: secret | plain   (shorthand: `# secret` / `# plain`)\n");
+    try buf.appendSlice("#   # description: ...\n");
+    try buf.appendSlice("# A var without metadata keeps its current platform type; a brand-new var is inferred\n");
+    try buf.appendSlice("# from its name/value. Override at the CLI with --secret NAME / --plain NAME. The type is\n");
+    try buf.appendSlice("# fixed when a var is created on the platform; change it in the Timbal UI afterwards.\n");
     try buf.append('\n');
 
+    var managed_count: usize = 0;
     for (vars) |v| {
-        try buf.appendSlice("# type: ");
-        try buf.appendSlice(v.type);
-        try buf.append('\n');
-        if (v.description) |d| {
-            if (d.len > 0) {
-                try buf.appendSlice("# description: ");
-                // Keep description on one line.
-                for (d) |c| {
-                    try buf.append(if (c == '\n' or c == '\r') ' ' else c);
-                }
-                try buf.append('\n');
-            }
+        if (v.managed) {
+            managed_count += 1;
+            continue;
         }
-        try buf.appendSlice(v.name);
-        try buf.append('=');
-        // Flatten newlines so the line-oriented .env stays start-compatible.
-        if (std.mem.indexOfAny(u8, v.value, "\n\r") != null) {
-            var flat = try allocator.alloc(u8, v.value.len);
-            defer allocator.free(flat);
-            for (v.value, 0..) |c, i| {
-                flat[i] = if (c == '\n' or c == '\r') ' ' else c;
-            }
-            if (needsQuoting(flat)) {
-                try appendQuotedValue(&buf, flat);
-            } else {
-                try buf.appendSlice(flat);
-            }
-        } else if (needsQuoting(v.value)) {
-            try appendQuotedValue(&buf, v.value);
+        try appendEnvEntry(allocator, &buf, v, true);
+    }
+
+    if (managed_count > 0) {
+        try buf.appendSlice("# ---- Platform-managed runtime vars ----\n");
+        if (fmt_opts.managed_active) {
+            try buf.appendSlice("# Written ACTIVE because of --include-platform-vars. The platform resolves these before every\n");
+            try buf.appendSlice("# deploy/preview; under `timbal start` they can reroute service calls (TIMBAL_PROJECT_ENV_ID) to\n");
+            try buf.appendSlice("# the deployed gateway. `timbal env push` never sends TIMBAL_* vars.\n");
         } else {
-            try buf.appendSlice(v.value);
+            try buf.appendSlice("# Resolved by the platform before every deploy/preview; not user-defined project vars. Kept\n");
+            try buf.appendSlice("# commented out on purpose: loading them under `timbal start` breaks local routing\n");
+            try buf.appendSlice("# (TIMBAL_PROJECT_ENV_ID sends service calls to the deployed gateway instead of localhost).\n");
+            try buf.appendSlice("# Uncomment a line only if you need it locally; `timbal env push` never sends TIMBAL_* vars.\n");
         }
         try buf.append('\n');
-        try buf.append('\n');
+        for (vars) |v| {
+            if (!v.managed) continue;
+            try appendEnvEntry(allocator, &buf, v, fmt_opts.managed_active);
+        }
     }
 
     return buf.toOwnedSlice();
 }
 
+const Assignment = struct { key: []const u8, value: []const u8 };
+
+/// Parse one `KEY=VALUE` line the way `timbal start` does: optional `export `, matching
+/// outer quotes stripped, no escapes, no trailing comments. Null for blanks/comments.
+pub fn parseEnvAssignment(raw_line: []const u8) ?Assignment {
+    var line = std.mem.trim(u8, raw_line, " \t\r");
+    if (line.len == 0 or line[0] == '#') return null;
+    if (std.mem.startsWith(u8, line, "export ")) {
+        line = std.mem.trimLeft(u8, line["export ".len..], " \t");
+    }
+    const eq = std.mem.indexOfScalar(u8, line, '=') orelse return null;
+    const key = std.mem.trim(u8, line[0..eq], " \t");
+    if (key.len == 0) return null;
+
+    var value = std.mem.trim(u8, line[eq + 1 ..], " \t");
+    if (value.len >= 2) {
+        const first = value[0];
+        const last = value[value.len - 1];
+        if ((first == '"' and last == '"') or (first == '\'' and last == '\'')) {
+            value = value[1 .. value.len - 1];
+        }
+    }
+    return .{ .key = key, .value = value };
+}
+
 /// Parse a local .env written by pull (or a plain KEY=VALUE file).
-/// Type defaults to "plain" when metadata is missing.
+/// Metadata comments bind to the next assignment; a blank line ends a metadata block so a
+/// stray `# type: secret` left behind after deleting a var cannot retag its neighbour.
+/// Type defaults to "plain" with `type_explicit = false` when metadata is missing.
 pub fn parseEnvFile(allocator: std.mem.Allocator, content: []const u8) !std.ArrayList(SyncVar) {
     var out = std.ArrayList(SyncVar).init(allocator);
     errdefer freeSyncVars(allocator, &out);
 
     var pending_type: ?[]const u8 = null;
     var pending_desc: ?[]const u8 = null;
+    var pending_managed = false;
     defer if (pending_type) |t| allocator.free(t);
     defer if (pending_desc) |d| allocator.free(d);
 
     var lines = std.mem.splitScalar(u8, content, '\n');
     while (lines.next()) |raw_line| {
-        var line = std.mem.trim(u8, raw_line, " \t\r");
-        if (line.len == 0) continue;
+        const line = std.mem.trim(u8, raw_line, " \t\r");
+        if (line.len == 0) {
+            if (pending_type) |t| allocator.free(t);
+            if (pending_desc) |d| allocator.free(d);
+            pending_type = null;
+            pending_desc = null;
+            pending_managed = false;
+            continue;
+        }
 
         if (line[0] == '#') {
             const body = std.mem.trim(u8, line[1..], " \t");
             if (std.mem.startsWith(u8, body, "type:")) {
                 const t = std.mem.trim(u8, body["type:".len..], " \t");
                 if (pending_type) |old| allocator.free(old);
-                pending_type = try allocator.dupe(u8, t);
+                pending_type = try allocator.dupe(u8, canonType(t) orelse t);
             } else if (std.mem.startsWith(u8, body, "description:")) {
                 const d = std.mem.trim(u8, body["description:".len..], " \t");
                 if (pending_desc) |old| allocator.free(old);
                 pending_desc = try allocator.dupe(u8, d);
+            } else if (std.mem.startsWith(u8, body, "managed:")) {
+                const m = std.mem.trim(u8, body["managed:".len..], " \t");
+                pending_managed = std.ascii.eqlIgnoreCase(m, "platform");
+            } else if (canonType(body)) |shorthand| {
+                if (pending_type) |old| allocator.free(old);
+                pending_type = try allocator.dupe(u8, shorthand);
             }
             continue;
         }
 
-        if (std.mem.startsWith(u8, line, "export ")) {
-            line = std.mem.trimLeft(u8, line["export ".len..], " \t");
-        }
+        const assignment = parseEnvAssignment(line) orelse continue;
 
-        const eq = std.mem.indexOfScalar(u8, line, '=') orelse continue;
-        const key = std.mem.trim(u8, line[0..eq], " \t");
-        if (key.len == 0) continue;
-
-        // Match `timbal start`: strip matching outer quotes only; no unescape.
-        var value_raw = std.mem.trim(u8, line[eq + 1 ..], " \t");
-        if (value_raw.len >= 2) {
-            const first = value_raw[0];
-            const last = value_raw[value_raw.len - 1];
-            if ((first == '"' and last == '"') or (first == '\'' and last == '\'')) {
-                value_raw = value_raw[1 .. value_raw.len - 1];
-            }
-        }
-        const value = try allocator.dupe(u8, value_raw);
+        const value = try allocator.dupe(u8, assignment.value);
         errdefer allocator.free(value);
 
+        const explicit = pending_type != null;
         const typ = if (pending_type) |t| blk: {
-            const owned = t;
             pending_type = null;
-            break :blk owned;
+            break :blk t;
         } else try allocator.dupe(u8, "plain");
         errdefer allocator.free(typ);
 
@@ -519,39 +795,158 @@ pub fn parseEnvFile(allocator: std.mem.Allocator, content: []const u8) !std.Arra
             }
             break :blk null;
         };
+        errdefer if (desc) |d| allocator.free(d);
+
+        const name = try allocator.dupe(u8, assignment.key);
+        errdefer allocator.free(name);
 
         try out.append(.{
-            .name = try allocator.dupe(u8, key),
+            .name = name,
             .type = typ,
             .value = value,
             .description = desc,
+            .type_explicit = explicit,
+            .managed = pending_managed,
         });
+        pending_managed = false;
     }
 
     return out;
+}
+
+pub const UpsertOutcome = enum { added, updated, unchanged };
+
+pub const UpsertResult = struct {
+    content: []u8,
+    outcome: UpsertOutcome,
+    /// First replaced value when `outcome == .updated`.
+    previous: ?[]u8 = null,
+
+    pub fn deinit(self: *UpsertResult, allocator: std.mem.Allocator) void {
+        allocator.free(self.content);
+        if (self.previous) |p| allocator.free(p);
+    }
+};
+
+/// Set `key=value` in .env content while preserving every other byte (comments, order,
+/// blank lines, CRLF). Existing definitions are rewritten in place — all of them, so
+/// last-wins loaders agree — otherwise the assignment is appended (with `comment` above it).
+pub fn upsertEnvLine(
+    allocator: std.mem.Allocator,
+    existing: ?[]const u8,
+    key: []const u8,
+    value: []const u8,
+    comment: ?[]const u8,
+) !UpsertResult {
+    var out = std.ArrayList(u8).init(allocator);
+    errdefer out.deinit();
+    var previous: ?[]u8 = null;
+    errdefer if (previous) |p| allocator.free(p);
+
+    const content = existing orelse "";
+    const eol: []const u8 = if (std.mem.indexOf(u8, content, "\r\n") != null) "\r\n" else "\n";
+
+    var found = false;
+    var changed = false;
+    var first = true;
+    var it = std.mem.splitScalar(u8, content, '\n');
+    while (it.next()) |raw| {
+        if (!first) try out.append('\n');
+        first = false;
+
+        const has_cr = raw.len > 0 and raw[raw.len - 1] == '\r';
+        if (parseEnvAssignment(raw)) |a| {
+            if (std.mem.eql(u8, a.key, key)) {
+                found = true;
+                if (std.mem.eql(u8, a.value, value)) {
+                    try out.appendSlice(raw);
+                } else {
+                    changed = true;
+                    if (previous == null) previous = try allocator.dupe(u8, a.value);
+                    try out.appendSlice(key);
+                    try out.append('=');
+                    try appendEnvValue(allocator, &out, value);
+                    if (has_cr) try out.append('\r');
+                }
+                continue;
+            }
+        }
+        try out.appendSlice(raw);
+    }
+
+    if (found) {
+        return .{
+            .content = try out.toOwnedSlice(),
+            .outcome = if (changed) .updated else .unchanged,
+            .previous = previous,
+        };
+    }
+
+    if (content.len > 0 and !std.mem.endsWith(u8, content, "\n")) try out.appendSlice(eol);
+    if (comment) |c| {
+        try out.appendSlice("# ");
+        try out.appendSlice(c);
+        try out.appendSlice(eol);
+    }
+    try out.appendSlice(key);
+    try out.append('=');
+    try appendEnvValue(allocator, &out, value);
+    try out.appendSlice(eol);
+    return .{ .content = try out.toOwnedSlice(), .outcome = .added, .previous = null };
+}
+
+// ---------------------------------------------------------------------------
+// JSON helpers (tolerant, shape-agnostic)
+// ---------------------------------------------------------------------------
+
+fn jsonStr(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const v = obj.get(key) orelse return null;
+    return switch (v) {
+        .string => |s| s,
+        else => null,
+    };
+}
+
+fn jsonBool(obj: std.json.ObjectMap, key: []const u8) ?bool {
+    const v = obj.get(key) orelse return null;
+    return switch (v) {
+        .bool => |b| b,
+        else => null,
+    };
+}
+
+/// Ids come back as int64 in some schemas and strings in others; normalize to an owned string.
+fn jsonIdString(allocator: std.mem.Allocator, obj: std.json.ObjectMap, key: []const u8) !?[]u8 {
+    const v = obj.get(key) orelse return null;
+    return switch (v) {
+        .string => |s| try allocator.dupe(u8, s),
+        .integer => |i| try std.fmt.allocPrint(allocator, "{d}", .{i}),
+        .number_string => |s| try allocator.dupe(u8, s),
+        else => null,
+    };
+}
+
+fn jsonObject(v: std.json.Value) ?std.json.ObjectMap {
+    return switch (v) {
+        .object => |o| o,
+        else => null,
+    };
+}
+
+fn jsonArray(v: std.json.Value) ?std.json.Array {
+    return switch (v) {
+        .array => |a| a,
+        else => null,
+    };
 }
 
 // ---------------------------------------------------------------------------
 // API
 // ---------------------------------------------------------------------------
 
-const PullResponse = struct {
-    rev: []const u8,
-    vars: []SyncVarJson,
-};
-
-const SyncVarJson = struct {
-    name: []const u8,
-    type: []const u8,
-    value: []const u8,
-    description: ?[]const u8 = null,
-};
-
-const PushResponse = struct {
-    rev: []const u8,
-    created: [][]const u8 = &.{},
-    updated: [][]const u8 = &.{},
-    skipped: [][]const u8 = &.{},
+const ApiResponse = struct {
+    status: u16,
+    body: []u8,
 };
 
 fn printApiError(status: u16, body: []const u8, rev: ?[]const u8) void {
@@ -602,15 +997,15 @@ fn printApiError(status: u16, body: []const u8, rev: ?[]const u8) void {
     }
 }
 
-fn apiRequest(
+/// Perform a request and return status + body without judging the status code.
+fn apiRequestRaw(
     allocator: std.mem.Allocator,
     method: std.http.Method,
     url: []const u8,
     api_key: []const u8,
     payload: ?[]const u8,
     verbose: bool,
-    rev: ?[]const u8,
-) ![]u8 {
+) !ApiResponse {
     var client: std.http.Client = .{ .allocator = allocator };
     defer client.deinit();
 
@@ -649,30 +1044,503 @@ fn apiRequest(
         return error.HttpError;
     };
 
-    const status = @intFromEnum(result.status);
-    if (status < 200 or status >= 300) {
-        printApiError(status, body.items, rev);
-        return error.HttpStatus;
-    }
-
-    return body.toOwnedSlice();
+    return .{ .status = @intFromEnum(result.status), .body = try body.toOwnedSlice() };
 }
 
-fn buildPushPayload(allocator: std.mem.Allocator, rev: ?[]const u8, vars: []const SyncVar) ![]u8 {
+/// Request that must succeed: prints a friendly error and fails on non-2xx.
+fn apiRequest(
+    allocator: std.mem.Allocator,
+    method: std.http.Method,
+    url: []const u8,
+    api_key: []const u8,
+    payload: ?[]const u8,
+    verbose: bool,
+    rev: ?[]const u8,
+) ![]u8 {
+    const res = try apiRequestRaw(allocator, method, url, api_key, payload, verbose);
+    if (res.status < 200 or res.status >= 300) {
+        printApiError(res.status, res.body, rev);
+        allocator.free(res.body);
+        return error.HttpStatus;
+    }
+    return res.body;
+}
+
+fn projectUrl(allocator: std.mem.Allocator, remote: TimbalRemote, suffix: []const u8) ![]u8 {
+    return std.fmt.allocPrint(allocator, "{s}/orgs/{s}/projects/{s}{s}", .{ remote.base_url, remote.org_id, remote.project_id, suffix });
+}
+
+// --- effective env (pull) ---------------------------------------------------
+
+pub const PullResult = struct {
+    rev: []u8,
+    vars: std.ArrayList(SyncVar),
+
+    pub fn deinit(self: *PullResult, allocator: std.mem.Allocator) void {
+        allocator.free(self.rev);
+        freeSyncVars(allocator, &self.vars);
+    }
+};
+
+/// Parse `GET /vars/pull`. Accepts `value` as a string, as a `VarValue` object
+/// (`{type, value|decrypted|preview}`), or missing/null → `value_missing`.
+pub fn parsePullResponse(allocator: std.mem.Allocator, body: []const u8) !PullResult {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, body, .{});
+    defer parsed.deinit();
+
+    const root = jsonObject(parsed.value) orelse return error.UnexpectedResponse;
+    const rev = try allocator.dupe(u8, jsonStr(root, "rev") orelse "");
+    errdefer allocator.free(rev);
+
+    var vars = std.ArrayList(SyncVar).init(allocator);
+    errdefer freeSyncVars(allocator, &vars);
+
+    const arr = jsonArray(root.get("vars") orelse return error.UnexpectedResponse) orelse return error.UnexpectedResponse;
+    for (arr.items) |item| {
+        const obj = jsonObject(item) orelse continue;
+        const name = jsonStr(obj, "name") orelse continue;
+
+        var typ: []const u8 = jsonStr(obj, "type") orelse "plain";
+        var value: ?[]const u8 = null;
+        if (obj.get("value")) |vv| {
+            switch (vv) {
+                .string => |s| value = s,
+                .object => |vo| {
+                    if (jsonStr(vo, "type")) |t| typ = t;
+                    value = jsonStr(vo, "value") orelse jsonStr(vo, "decrypted");
+                },
+                else => {},
+            }
+        }
+        const canon = canonType(typ) orelse "plain";
+        const missing = value == null;
+        // A plain var can legitimately be empty; only secrets get placeholder treatment.
+        const treat_missing = missing and std.mem.eql(u8, canon, "secret");
+        // Forward-compatible: honour an explicit platform flag if the API starts sending one.
+        const flagged_managed = (jsonBool(obj, "managed") orelse false) or
+            (if (jsonStr(obj, "source")) |s| std.ascii.eqlIgnoreCase(s, "platform") else false);
+
+        var sv = SyncVar{
+            .name = try allocator.dupe(u8, name),
+            .type = undefined,
+            .value = undefined,
+            .type_explicit = true,
+            .managed = flagged_managed,
+            .value_missing = treat_missing,
+        };
+        errdefer allocator.free(sv.name);
+        sv.type = try allocator.dupe(u8, canon);
+        errdefer allocator.free(sv.type);
+        sv.value = try allocator.dupe(u8, value orelse "");
+        errdefer allocator.free(sv.value);
+        if (jsonStr(obj, "description")) |d| sv.description = try allocator.dupe(u8, d);
+        errdefer if (sv.description) |d| allocator.free(d);
+        try vars.append(sv);
+    }
+
+    return .{ .rev = rev, .vars = vars };
+}
+
+// --- user-defined vars (list) -----------------------------------------------
+
+pub const RemoteVar = struct {
+    id: []const u8,
+    name: []const u8,
+    type: []const u8, // canonical "plain" | "secret"
+    description: ?[]const u8 = null,
+    applies_to_all_envs: bool = false,
+    env_ids: []const []const u8 = &.{},
+
+    pub fn deinit(self: *RemoteVar, allocator: std.mem.Allocator) void {
+        allocator.free(self.id);
+        allocator.free(self.name);
+        allocator.free(self.type);
+        if (self.description) |d| allocator.free(d);
+        for (self.env_ids) |e| allocator.free(e);
+        allocator.free(self.env_ids);
+    }
+
+    pub fn hasEnv(self: RemoteVar, env_id: []const u8) bool {
+        for (self.env_ids) |e| if (std.mem.eql(u8, e, env_id)) return true;
+        return false;
+    }
+};
+
+fn freeRemoteVars(allocator: std.mem.Allocator, vars: *std.ArrayList(RemoteVar)) void {
+    for (vars.items) |*v| v.deinit(allocator);
+    vars.deinit();
+}
+
+/// Type of a user-defined var by name. Vars can exist once per env; if any copy is a
+/// secret the name is treated as secret (the conservative direction). Null when the
+/// name is not user-defined on the platform.
+pub fn remoteTypeFor(remote: []const RemoteVar, name: []const u8) ?[]const u8 {
+    var found: ?[]const u8 = null;
+    for (remote) |rv| {
+        if (!std.mem.eql(u8, rv.name, name)) continue;
+        if (isSecretType(rv.type)) return "secret";
+        found = "plain";
+    }
+    return found;
+}
+
+/// Parse `GET /vars` (`ListVarsResBody`): `{vars: [{id, name, value: {type, ...}, envs, applies_to_all_envs}]}`.
+pub fn parseRemoteVarList(allocator: std.mem.Allocator, body: []const u8) !std.ArrayList(RemoteVar) {
+    var out = std.ArrayList(RemoteVar).init(allocator);
+    errdefer freeRemoteVars(allocator, &out);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, body, .{});
+    defer parsed.deinit();
+
+    const root = jsonObject(parsed.value) orelse return error.UnexpectedResponse;
+    const arr = jsonArray(root.get("vars") orelse return error.UnexpectedResponse) orelse return error.UnexpectedResponse;
+
+    for (arr.items) |item| {
+        const obj = jsonObject(item) orelse continue;
+        const name = jsonStr(obj, "name") orelse continue;
+
+        var typ: []const u8 = jsonStr(obj, "type") orelse "plain";
+        if (obj.get("value")) |vv| {
+            if (jsonObject(vv)) |vo| {
+                if (jsonStr(vo, "type")) |t| typ = t;
+            }
+        }
+
+        var env_ids = std.ArrayList([]const u8).init(allocator);
+        errdefer {
+            for (env_ids.items) |e| allocator.free(e);
+            env_ids.deinit();
+        }
+        if (obj.get("envs")) |ev| {
+            if (jsonArray(ev)) |ea| {
+                for (ea.items) |e| {
+                    const eo = jsonObject(e) orelse continue;
+                    if (try jsonIdString(allocator, eo, "id")) |eid| {
+                        errdefer allocator.free(eid);
+                        try env_ids.append(eid);
+                    }
+                }
+            }
+        }
+
+        var rv = RemoteVar{
+            .id = (try jsonIdString(allocator, obj, "id")) orelse try allocator.dupe(u8, ""),
+            .name = undefined,
+            .type = undefined,
+            .applies_to_all_envs = jsonBool(obj, "applies_to_all_envs") orelse false,
+        };
+        errdefer allocator.free(rv.id);
+        rv.name = try allocator.dupe(u8, name);
+        errdefer allocator.free(rv.name);
+        rv.type = try allocator.dupe(u8, canonType(typ) orelse "plain");
+        errdefer allocator.free(rv.type);
+        if (jsonStr(obj, "description")) |d| rv.description = try allocator.dupe(u8, d);
+        errdefer if (rv.description) |d| allocator.free(d);
+        rv.env_ids = try env_ids.toOwnedSlice();
+        try out.append(rv);
+    }
+
+    return out;
+}
+
+const RemoteVarListing = struct {
+    vars: std.ArrayList(RemoteVar),
+    ok: bool,
+    status: u16,
+    error_body: ?[]u8,
+
+    fn deinit(self: *RemoteVarListing, allocator: std.mem.Allocator) void {
+        freeRemoteVars(allocator, &self.vars);
+        if (self.error_body) |b| allocator.free(b);
+    }
+};
+
+/// Fetch user-defined project vars. Never fails on HTTP status — callers decide how hard
+/// to fail (push needs it; pull degrades gracefully).
+fn fetchRemoteVarListing(allocator: std.mem.Allocator, remote: TimbalRemote, api_key: []const u8, verbose: bool) !RemoteVarListing {
+    const url = try projectUrl(allocator, remote, "/vars");
+    defer allocator.free(url);
+
+    const res = try apiRequestRaw(allocator, .GET, url, api_key, null, verbose);
+    if (res.status < 200 or res.status >= 300) {
+        return .{ .vars = std.ArrayList(RemoteVar).init(allocator), .ok = false, .status = res.status, .error_body = res.body };
+    }
+    defer allocator.free(res.body);
+
+    const vars = parseRemoteVarList(allocator, res.body) catch {
+        return .{ .vars = std.ArrayList(RemoteVar).init(allocator), .ok = false, .status = res.status, .error_body = null };
+    };
+    return .{ .vars = vars, .ok = true, .status = res.status, .error_body = null };
+}
+
+/// `GET /vars/{id}` → decrypted secret value when the platform returns one.
+pub fn parseVarDecrypted(allocator: std.mem.Allocator, body: []const u8) !?[]u8 {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, body, .{});
+    defer parsed.deinit();
+    const root = jsonObject(parsed.value) orelse return null;
+    const vv = root.get("value") orelse return null;
+    switch (vv) {
+        .string => |s| return try allocator.dupe(u8, s),
+        .object => |vo| {
+            if (jsonStr(vo, "decrypted")) |d| return try allocator.dupe(u8, d);
+            if (jsonStr(vo, "value")) |v| return try allocator.dupe(u8, v);
+            return null;
+        },
+        else => return null,
+    }
+}
+
+fn fetchVarDecrypted(allocator: std.mem.Allocator, remote: TimbalRemote, api_key: []const u8, var_id: []const u8, verbose: bool) !?[]u8 {
+    if (var_id.len == 0) return null;
+    const suffix = try std.fmt.allocPrint(allocator, "/vars/{s}", .{var_id});
+    defer allocator.free(suffix);
+    const url = try projectUrl(allocator, remote, suffix);
+    defer allocator.free(url);
+
+    const res = try apiRequestRaw(allocator, .GET, url, api_key, null, verbose);
+    defer allocator.free(res.body);
+    if (res.status < 200 or res.status >= 300) return null;
+    return parseVarDecrypted(allocator, res.body) catch null;
+}
+
+// --- environments ------------------------------------------------------------
+
+/// `GET /envs` → id of the environment whose `branch` equals `branch`.
+pub fn parseEnvIdForBranch(allocator: std.mem.Allocator, body: []const u8, branch: []const u8) !?[]u8 {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, body, .{});
+    defer parsed.deinit();
+    const root = jsonObject(parsed.value) orelse return null;
+    const arr = jsonArray(root.get("envs") orelse return null) orelse return null;
+    for (arr.items) |item| {
+        const obj = jsonObject(item) orelse continue;
+        const b = jsonStr(obj, "branch") orelse continue;
+        if (std.mem.eql(u8, b, branch)) return try jsonIdString(allocator, obj, "id");
+    }
+    return null;
+}
+
+fn fetchEnvIdForBranch(allocator: std.mem.Allocator, remote: TimbalRemote, api_key: []const u8, branch: []const u8, verbose: bool) !?[]u8 {
+    const url = try projectUrl(allocator, remote, "/envs");
+    defer allocator.free(url);
+    const res = try apiRequestRaw(allocator, .GET, url, api_key, null, verbose);
+    defer allocator.free(res.body);
+    if (res.status < 200 or res.status >= 300) return null;
+    return parseEnvIdForBranch(allocator, res.body, branch) catch null;
+}
+
+// --- workforce components ---------------------------------------------------
+
+pub const RemoteComponent = struct {
+    id: []const u8, // numeric app id (the value the SDK reads from TIMBAL_APP_ID)
+    name: []const u8,
+    uid: ?[]const u8, // manifest _id from timbal.yaml, when the platform knows it
+
+    pub fn deinit(self: *RemoteComponent, allocator: std.mem.Allocator) void {
+        allocator.free(self.id);
+        allocator.free(self.name);
+        if (self.uid) |u| allocator.free(u);
+    }
+
+    /// A member that exists in the worktree but has no `OrgsApps` row yet is listed with a
+    /// negative synthetic hash of its manifest id. That is not a real app id and must never
+    /// be written as TIMBAL_APP_ID — traces sent under it would be dropped or misattributed.
+    pub fn isRegistered(self: RemoteComponent) bool {
+        return self.id.len > 0 and self.id[0] != '-';
+    }
+};
+
+fn freeRemoteComponents(allocator: std.mem.Allocator, comps: *std.ArrayList(RemoteComponent)) void {
+    for (comps.items) |*c| c.deinit(allocator);
+    comps.deinit();
+}
+
+/// Parse `GET /workforce?rev=` (`ListWorkforceResBody`): `{workforce: [{id, name, type, uid}]}`.
+pub fn parseWorkforceList(allocator: std.mem.Allocator, body: []const u8) !std.ArrayList(RemoteComponent) {
+    var out = std.ArrayList(RemoteComponent).init(allocator);
+    errdefer freeRemoteComponents(allocator, &out);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, body, .{});
+    defer parsed.deinit();
+
+    const root = jsonObject(parsed.value) orelse return error.UnexpectedResponse;
+    const arr = jsonArray(root.get("workforce") orelse return error.UnexpectedResponse) orelse return error.UnexpectedResponse;
+    for (arr.items) |item| {
+        const obj = jsonObject(item) orelse continue;
+        const id = (try jsonIdString(allocator, obj, "id")) orelse continue;
+        errdefer allocator.free(id);
+        if (id.len == 0) {
+            allocator.free(id);
+            continue;
+        }
+        const name = try allocator.dupe(u8, jsonStr(obj, "name") orelse "");
+        errdefer allocator.free(name);
+        var uid: ?[]const u8 = null;
+        if (jsonStr(obj, "uid")) |u| {
+            if (u.len > 0) uid = try allocator.dupe(u8, u);
+        }
+        errdefer if (uid) |u| allocator.free(u);
+        try out.append(.{ .id = id, .name = name, .uid = uid });
+    }
+    return out;
+}
+
+fn fetchWorkforce(allocator: std.mem.Allocator, remote: TimbalRemote, api_key: []const u8, rev: []const u8, verbose: bool) !?std.ArrayList(RemoteComponent) {
+    const encoded = try urlEncodeQuery(allocator, rev);
+    defer allocator.free(encoded);
+    const suffix = try std.fmt.allocPrint(allocator, "/workforce?rev={s}", .{encoded});
+    defer allocator.free(suffix);
+    const url = try projectUrl(allocator, remote, suffix);
+    defer allocator.free(url);
+
+    const res = try apiRequestRaw(allocator, .GET, url, api_key, null, verbose);
+    defer allocator.free(res.body);
+    if (res.status < 200 or res.status >= 300) {
+        const stderr = std.io.getStdErr().writer();
+        try stderr.print(
+            "{s}Warning:{s} could not list workforce components for rev {s} (HTTP {d}); TIMBAL_APP_ID not synced.\n",
+            .{ Color.bold_yellow, Color.reset, rev, res.status },
+        );
+        if (verbose and res.body.len > 0) {
+            const snippet = if (res.body.len > 500) res.body[0..500] else res.body;
+            try stderr.print("{s}\n", .{snippet});
+        }
+        return null;
+    }
+    return parseWorkforceList(allocator, res.body) catch {
+        const stderr = std.io.getStdErr().writer();
+        try stderr.print("{s}Warning:{s} unexpected workforce response; TIMBAL_APP_ID not synced.\n", .{ Color.bold_yellow, Color.reset });
+        return null;
+    };
+}
+
+pub const MatchKind = enum { uid, name };
+pub const ComponentMatch = struct { index: usize, kind: MatchKind };
+
+/// Find the platform component for a local member. The manifest uid is canonical. A name
+/// match is accepted only when the platform component has no uid at all: a component
+/// with a *different* uid is a different manifest identity, and pointing local traces at
+/// it would be wrong even if the directory name agrees.
+pub fn matchComponent(comps: []const RemoteComponent, member_name: []const u8, member_uid: []const u8, claimed: []const bool) ?ComponentMatch {
+    for (comps, 0..) |c, i| {
+        if (claimed[i]) continue;
+        if (c.uid) |u| {
+            if (std.mem.eql(u8, u, member_uid)) return .{ .index = i, .kind = .uid };
+        }
+    }
+    var found: ?usize = null;
+    var count: usize = 0;
+    for (comps, 0..) |c, i| {
+        if (claimed[i] or c.uid != null) continue;
+        if (std.mem.eql(u8, c.name, member_name)) {
+            count += 1;
+            found = i;
+        }
+    }
+    if (count == 1) return .{ .index = found.?, .kind = .name };
+    return null;
+}
+
+/// Same-name component whose uid differs from the local manifest (for diagnostics only).
+fn findNameOnlyConflict(comps: []const RemoteComponent, member_name: []const u8, member_uid: []const u8) ?usize {
+    for (comps, 0..) |c, i| {
+        if (!std.mem.eql(u8, c.name, member_name)) continue;
+        if (c.uid) |u| {
+            if (!std.mem.eql(u8, u, member_uid)) return i;
+        }
+    }
+    return null;
+}
+
+// --- push -------------------------------------------------------------------
+
+pub const TypeSource = enum { flag, file, remote, inferred };
+pub const PlanAction = enum { push, skip_reserved, skip_managed, blocked_downgrade };
+
+pub const PlanEntry = struct {
+    action: PlanAction,
+    type: []const u8, // static "plain" | "secret"
+    source: TypeSource,
+    remote_type: ?[]const u8, // static, null when not user-defined on the platform
+};
+
+fn nameIn(names: []const []const u8, name: []const u8) bool {
+    for (names) |n| if (std.mem.eql(u8, n, name)) return true;
+    return false;
+}
+
+/// Decide, per local var, whether/how to push it. Type precedence: --secret/--plain flag >
+/// file metadata > current platform type > name/value inference (new vars only). A
+/// platform secret is never downgraded to plain unless the flag says so explicitly.
+/// Reserved names and TIMBAL_* / VITE_TIMBAL_* are never pushed.
+pub fn planPush(
+    allocator: std.mem.Allocator,
+    vars: []const SyncVar,
+    remote: []const RemoteVar,
+    secret_names: []const []const u8,
+    plain_names: []const []const u8,
+) ![]PlanEntry {
+    const plan = try allocator.alloc(PlanEntry, vars.len);
+    errdefer allocator.free(plan);
+
+    for (vars, 0..) |v, i| {
+        const remote_type = remoteTypeFor(remote, v.name);
+        const file_type = canonType(v.type) orelse "plain";
+
+        if (isReservedVarName(v.name)) {
+            plan[i] = .{ .action = .skip_reserved, .type = file_type, .source = .file, .remote_type = remote_type };
+            continue;
+        }
+        // TIMBAL_* is the platform's namespace: those values are resolved by the platform before a
+        // deploy/preview, so a pushed copy can only be stale or wrong. Never pushed, no override.
+        if (v.managed or isPlatformManagedName(v.name)) {
+            plan[i] = .{ .action = .skip_managed, .type = file_type, .source = .file, .remote_type = remote_type };
+            continue;
+        }
+
+        var typ: []const u8 = undefined;
+        var src: TypeSource = undefined;
+        if (nameIn(secret_names, v.name)) {
+            typ = "secret";
+            src = .flag;
+        } else if (nameIn(plain_names, v.name)) {
+            typ = "plain";
+            src = .flag;
+        } else if (v.type_explicit) {
+            typ = file_type;
+            src = .file;
+        } else if (remote_type) |rt| {
+            typ = rt;
+            src = .remote;
+        } else {
+            typ = if (inferSecret(v.name, v.value)) "secret" else "plain";
+            src = .inferred;
+        }
+
+        const downgrade = remote_type != null and isSecretType(remote_type.?) and !isSecretType(typ) and src != .flag;
+        plan[i] = .{
+            .action = if (downgrade) .blocked_downgrade else .push,
+            .type = typ,
+            .source = src,
+            .remote_type = remote_type,
+        };
+    }
+    return plan;
+}
+
+pub fn buildPushPayload(allocator: std.mem.Allocator, rev: ?[]const u8, vars: []const SyncVar, plan: []const PlanEntry) ![]u8 {
     var buf = std.ArrayList(u8).init(allocator);
     errdefer buf.deinit();
     var w = buf.writer();
 
-    // Omit reserved names so the POST body matches dry-run / platform skip behavior.
     try w.writeAll("{\"vars\":[");
     var written: usize = 0;
-    for (vars) |v| {
-        if (isReservedVarName(v.name)) continue;
+    for (vars, plan) |v, p| {
+        if (p.action != .push) continue;
         if (written > 0) try w.writeAll(",");
         try w.writeAll("{\"name\":");
         try std.json.stringify(v.name, .{}, w);
         try w.writeAll(",\"type\":");
-        try std.json.stringify(v.type, .{}, w);
+        try std.json.stringify(p.type, .{}, w);
         try w.writeAll(",\"value\":");
         try std.json.stringify(v.value, .{}, w);
         if (v.description) |d| {
@@ -690,6 +1558,13 @@ fn buildPushPayload(allocator: std.mem.Allocator, rev: ?[]const u8, vars: []cons
     try w.writeAll("}");
     return buf.toOwnedSlice();
 }
+
+const PushResponse = struct {
+    rev: []const u8,
+    created: [][]const u8 = &.{},
+    updated: [][]const u8 = &.{},
+    skipped: [][]const u8 = &.{},
+};
 
 fn printNameList(stdout: anytype, label: []const u8, names: []const []const u8) !void {
     if (names.len == 0) return;
@@ -713,16 +1588,22 @@ const Options = struct {
     use_default_rev: bool = false, // --default → omit rev
     file: []const u8 = ".env",
     force: bool = false, // overwrite existing local file on pull
-    dry_run: bool = false, // push only: print plan, no HTTP
-    base_url: ?[]const u8 = null, // override API host from remote
+    dry_run: bool = false, // print plan, write/send nothing
+    include_platform: bool = false, // pull only: write the TIMBAL_* runtime vars active
+    no_app_ids: bool = false, // skip workforce/<name>/.env TIMBAL_APP_ID sync
+    secret_names: std.ArrayList([]const u8),
+    plain_names: std.ArrayList([]const u8),
+    base_url: ?[]u8 = null, // normalized --base-url override (owned)
     profile: ?[]const u8 = null,
     verbose: bool = false,
     quiet: bool = false,
-};
 
-fn isReservedVarName(name: []const u8) bool {
-    return std.mem.eql(u8, name, "TIMBAL_PROJECT_SECRET") or std.mem.eql(u8, name, "PORT");
-}
+    fn deinit(self: *Options, allocator: std.mem.Allocator) void {
+        self.secret_names.deinit();
+        self.plain_names.deinit();
+        if (self.base_url) |b| allocator.free(b);
+    }
+};
 
 /// Normalize/validate `--base-url` (https + Timbal API host). Caller owns returned slice.
 fn normalizeBaseUrlOverride(allocator: std.mem.Allocator, raw: []const u8) ![]u8 {
@@ -740,8 +1621,16 @@ fn normalizeBaseUrlOverride(allocator: std.mem.Allocator, raw: []const u8) ![]u8
     return std.fmt.allocPrint(allocator, "https://{s}", .{url});
 }
 
+fn appendNameList(list: *std.ArrayList([]const u8), raw: []const u8) !void {
+    var it = std.mem.splitScalar(u8, raw, ',');
+    while (it.next()) |piece| {
+        const name = std.mem.trim(u8, piece, " \t");
+        if (name.len == 0) continue;
+        try list.append(name);
+    }
+}
+
 fn parseArgs(allocator: std.mem.Allocator, args: []const []const u8) !Options {
-    _ = allocator;
     if (args.len == 0) {
         try printUsageWithError("Error: missing command (pull or push)");
         std.process.exit(2);
@@ -761,8 +1650,12 @@ fn parseArgs(allocator: std.mem.Allocator, args: []const []const u8) !Options {
             try printUsageWithError("Error: unknown env command (expected pull or push)");
             std.process.exit(2);
         },
+        .secret_names = std.ArrayList([]const u8).init(allocator),
+        .plain_names = std.ArrayList([]const u8).init(allocator),
     };
+    errdefer opts.deinit(allocator);
 
+    var raw_base_url: ?[]const u8 = null;
     var i: usize = 1;
     while (i < args.len) : (i += 1) {
         const arg = args[i];
@@ -776,6 +1669,24 @@ fn parseArgs(allocator: std.mem.Allocator, args: []const []const u8) !Options {
             opts.dry_run = true;
         } else if (std.mem.eql(u8, arg, "--default")) {
             opts.use_default_rev = true;
+        } else if (std.mem.eql(u8, arg, "--include-platform-vars")) {
+            opts.include_platform = true;
+        } else if (std.mem.eql(u8, arg, "--no-app-ids")) {
+            opts.no_app_ids = true;
+        } else if (std.mem.eql(u8, arg, "--secret")) {
+            i += 1;
+            if (i >= args.len) {
+                try printUsageWithError("Error: --secret requires a var name");
+                std.process.exit(2);
+            }
+            try appendNameList(&opts.secret_names, args[i]);
+        } else if (std.mem.eql(u8, arg, "--plain")) {
+            i += 1;
+            if (i >= args.len) {
+                try printUsageWithError("Error: --plain requires a var name");
+                std.process.exit(2);
+            }
+            try appendNameList(&opts.plain_names, args[i]);
         } else if (std.mem.eql(u8, arg, "--rev")) {
             i += 1;
             if (i >= args.len) {
@@ -796,7 +1707,7 @@ fn parseArgs(allocator: std.mem.Allocator, args: []const []const u8) !Options {
                 try printUsageWithError("Error: --base-url requires a URL");
                 std.process.exit(2);
             }
-            opts.base_url = args[i];
+            raw_base_url = args[i];
         } else if (std.mem.eql(u8, arg, "--profile")) {
             i += 1;
             if (i >= args.len) {
@@ -814,20 +1725,43 @@ fn parseArgs(allocator: std.mem.Allocator, args: []const []const u8) !Options {
         try printUsageWithError("Error: --rev and --default are mutually exclusive");
         std.process.exit(2);
     }
-    if (opts.dry_run and opts.action != .push) {
-        try printUsageWithError("Error: --dry-run is only valid with `timbal env push`");
-        std.process.exit(2);
-    }
     if (opts.force and opts.action != .pull) {
         try printUsageWithError("Error: --force is only valid with `timbal env pull`");
         std.process.exit(2);
+    }
+    if ((opts.secret_names.items.len > 0 or opts.plain_names.items.len > 0) and opts.action != .push) {
+        try printUsageWithError("Error: --secret / --plain are only valid with `timbal env push`");
+        std.process.exit(2);
+    }
+    if (opts.include_platform and opts.action != .pull) {
+        try printUsageWithError("Error: --include-platform-vars is only valid with `timbal env pull` (TIMBAL_* vars are never pushed)");
+        std.process.exit(2);
+    }
+    for (opts.secret_names.items) |s| {
+        if (nameIn(opts.plain_names.items, s)) {
+            try printUsageWithError("Error: the same var cannot be both --secret and --plain");
+            std.process.exit(2);
+        }
+    }
+    if (raw_base_url) |raw| {
+        opts.base_url = normalizeBaseUrlOverride(allocator, raw) catch |err| {
+            switch (err) {
+                error.InsecureBaseUrl => try printUsageWithError("Error: --base-url must be https."),
+                error.InvalidBaseUrl => try printUsageWithError(
+                    "Error: --base-url must be https://api.timbal.ai or https://api.<env>.timbal.ai",
+                ),
+                else => return err,
+            }
+            std.process.exit(2);
+        };
     }
 
     return opts;
 }
 
 pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
-    const opts = try parseArgs(allocator, args);
+    var opts = try parseArgs(allocator, args);
+    defer opts.deinit(allocator);
     const stderr = std.io.getStdErr().writer();
     const stdout = std.io.getStdOut().writer();
 
@@ -888,19 +1822,9 @@ pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
     };
     defer remote.deinit(allocator);
 
-    if (opts.base_url) |raw| {
-        const overridden = normalizeBaseUrlOverride(allocator, raw) catch |err| {
-            switch (err) {
-                error.InsecureBaseUrl => try stderr.writeAll("Error: --base-url must be https.\n"),
-                error.InvalidBaseUrl => try stderr.writeAll(
-                    "Error: --base-url must be https://api.timbal.ai or https://api.<env>.timbal.ai\n",
-                ),
-                else => try stderr.print("Error: invalid --base-url: {}\n", .{err}),
-            }
-            std.process.exit(2);
-        };
+    if (opts.base_url) |overridden| {
         allocator.free(remote.base_url);
-        remote.base_url = overridden;
+        remote.base_url = try allocator.dupe(u8, overridden);
     }
 
     // Resolve rev
@@ -919,6 +1843,10 @@ pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
         std.process.exit(1);
     };
 
+    // The .env must live where `timbal start` loads it from: the project root.
+    const project_root = try resolveProjectRoot(allocator, cwd_path, repo_root);
+    defer allocator.free(project_root);
+
     if (opts.verbose or opts.dry_run) {
         try stderr.print("remote: {s} → org={s} project={s} base={s}\n", .{
             remote.remote_name,
@@ -931,19 +1859,79 @@ pub fn run(allocator: std.mem.Allocator, args: []const []const u8) !void {
         } else {
             try stderr.writeAll("rev: (project default)\n");
         }
+        try stderr.print("project root: {s}\n", .{project_root});
+    }
+
+    if (std.mem.eql(u8, project_root, repo_root) and !hasTimbalLayout(allocator, project_root)) {
+        try stderr.print(
+            "{s}Warning:{s} no Timbal project layout (workforce/, ui/, api/) found under {s}; using it as the project root anyway.\n" ++
+                "Run this from inside the project so the .env lands where `timbal start` loads it.\n",
+            .{ Color.bold_yellow, Color.reset, project_root },
+        );
     }
 
     const file_path = if (fs.path.isAbsolute(opts.file))
         try allocator.dupe(u8, opts.file)
     else
-        try std.fmt.allocPrint(allocator, "{s}{s}{s}", .{ repo_root, sep, opts.file });
+        try std.fmt.allocPrint(allocator, "{s}{s}{s}", .{ project_root, sep, opts.file });
     defer allocator.free(file_path);
 
+    try warnIfScopedFile(allocator, project_root, file_path, stderr);
     try warnIfNotGitignored(allocator, repo_root, file_path, stderr);
 
     switch (opts.action) {
-        .pull => try runPull(allocator, opts, remote, rev, api_key, file_path, stdout, stderr),
-        .push => try runPush(allocator, opts, remote, rev, api_key, file_path, stdout, stderr),
+        .pull => try runPull(allocator, opts, remote, rev, api_key, file_path, project_root, repo_root, stdout, stderr),
+        .push => try runPush(allocator, opts, remote, rev, api_key, file_path, project_root, repo_root, stdout, stderr),
+    }
+}
+
+fn hasTimbalLayout(allocator: std.mem.Allocator, root: []const u8) bool {
+    for ([_][]const u8{ "workforce", "ui", "api" }) |d| {
+        const p = std.fmt.allocPrint(allocator, "{s}{s}{s}", .{ root, sep, d }) catch return true;
+        defer allocator.free(p);
+        if (fs.cwd().openDir(p, .{})) |dir| {
+            var dd = dir;
+            dd.close();
+            return true;
+        } else |_| {}
+    }
+    return false;
+}
+
+/// Which `timbal start` service loads a file under the project root, or null for the shared root.
+pub fn scopedFileOwner(project_root: []const u8, file_path: []const u8) ?[]const u8 {
+    if (!std.mem.startsWith(u8, file_path, project_root)) return null;
+    var rel = file_path[project_root.len..];
+    if (rel.len == 0 or (rel[0] != '/' and rel[0] != '\\')) return null;
+    rel = rel[1..];
+    const first_sep = std.mem.indexOfAny(u8, rel, "/\\") orelse return null;
+    const top = rel[0..first_sep];
+    if (std.mem.eql(u8, top, "ui") or std.mem.eql(u8, top, "api")) return top;
+    if (std.mem.eql(u8, top, "workforce")) {
+        const rest = rel[first_sep + 1 ..];
+        const next = std.mem.indexOfAny(u8, rest, "/\\") orelse return null;
+        if (next == 0) return null;
+        return rest[0..next];
+    }
+    return null;
+}
+
+/// A -f path inside ui/, api/ or workforce/<name>/ is only ever seen by that one service.
+fn warnIfScopedFile(allocator: std.mem.Allocator, project_root: []const u8, file_path: []const u8, stderr: anytype) !void {
+    _ = allocator;
+    const owner = scopedFileOwner(project_root, file_path) orelse return;
+    if (std.mem.eql(u8, owner, "ui") or std.mem.eql(u8, owner, "api")) {
+        try stderr.print(
+            "{s}Note:{s} {s} lives under {s}/ — `timbal start` does not auto-load it; only the {s} toolchain reads it.\n" ++
+                "Project-wide vars belong in <project>/.env.\n",
+            .{ Color.bold_yellow, Color.reset, file_path, owner, owner },
+        );
+    } else {
+        try stderr.print(
+            "{s}Note:{s} {s} is scoped to workforce member '{s}' — `timbal start` loads it into that member only.\n" ++
+                "Project-wide vars belong in <project>/.env.\n",
+            .{ Color.bold_yellow, Color.reset, file_path, owner },
+        );
     }
 }
 
@@ -1050,6 +2038,108 @@ fn gitignoreCoversBasename(content: []const u8, basename: []const u8) bool {
     return false;
 }
 
+// ---------------------------------------------------------------------------
+// Placement audit: what is *already* sitting in the files `timbal start` loads
+// ---------------------------------------------------------------------------
+
+/// Active locally, these make the SDK treat the process as deployed: service calls go to the
+/// deployed env gateway instead of localhost (see python/timbal/platform/utils.py).
+const reroute_vars = [_][]const u8{ "TIMBAL_PROJECT_ENV_ID", "TIMBAL_PROJECT_ENV_ORIGIN", "TIMBAL_DEPLOYMENTS_DOMAIN" };
+/// `timbal start` sets these in its hard runtime layer; a .env copy is dead weight.
+const runtime_wired_vars = [_][]const u8{ "TIMBAL_START_WORKFORCE", "TIMBAL_WORKFORCE", "TIMBAL_START_API_PORT", "TIMBAL_START_UI_PORT", "PORT" };
+
+pub const PlacementKind = enum { reroute, app_id_scope, dead };
+pub const PlacementFinding = struct { kind: PlacementKind, key: []const u8 };
+
+/// Scan one auto-loaded .env's *active* assignments. `member_scope` is true for
+/// workforce/<name>/.env, where TIMBAL_APP_ID is exactly where it belongs.
+pub fn auditEnvContent(content: []const u8, member_scope: bool, out: *std.ArrayList(PlacementFinding)) !void {
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |raw| {
+        const a = parseEnvAssignment(raw) orelse continue;
+        if (tokenIn(a.key, &reroute_vars)) {
+            try out.append(.{ .kind = .reroute, .key = a.key });
+        } else if (!member_scope and std.mem.eql(u8, a.key, "TIMBAL_APP_ID")) {
+            try out.append(.{ .kind = .app_id_scope, .key = a.key });
+        } else if (tokenIn(a.key, &runtime_wired_vars)) {
+            try out.append(.{ .kind = .dead, .key = a.key });
+        }
+    }
+}
+
+fn auditOneEnvFile(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    label: []const u8,
+    member_scope: bool,
+    printed_header: *bool,
+    stderr: anytype,
+) !void {
+    const content = fs.cwd().readFileAlloc(allocator, path, 1024 * 1024) catch return;
+    defer allocator.free(content);
+
+    var findings = std.ArrayList(PlacementFinding).init(allocator);
+    defer findings.deinit();
+    try auditEnvContent(content, member_scope, &findings);
+
+    for (findings.items) |f| {
+        if (!printed_header.*) {
+            try stderr.print("{s}Placement check{s} (files `timbal start` auto-loads):\n", .{ Color.bold_yellow, Color.reset });
+            printed_header.* = true;
+        }
+        switch (f.kind) {
+            .reroute => try stderr.print(
+                "  ! {s}: {s} is active — `timbal start` will send service calls to the deployed gateway instead of\n" ++
+                    "    localhost. Comment it out (or re-run `timbal env pull --force`).\n",
+                .{ label, f.key },
+            ),
+            .app_id_scope => try stderr.print(
+                "  ! {s}: TIMBAL_APP_ID here is loaded into every service. It belongs in workforce/<name>/.env\n" ++
+                    "    (`timbal env pull` writes it there); remove it from this file.\n",
+                .{label},
+            ),
+            .dead => try stderr.print(
+                "  · {s}: {s} is overridden by `timbal start`'s runtime wiring; it has no effect locally.\n",
+                .{ label, f.key },
+            ),
+        }
+    }
+}
+
+/// Warn about hazardous active vars in `<project>/.env` and every `workforce/<name>/.env`.
+/// Read-only; never edits anything. Runs on both pull and push so users who pulled with an
+/// older CLI (which wrote TIMBAL_PROJECT_ENV_ID active) find out why local routing is off.
+fn auditEnvPlacement(allocator: std.mem.Allocator, project_root: []const u8, stderr: anytype) !void {
+    var printed_header = false;
+
+    const root_path = try std.fmt.allocPrint(allocator, "{s}{s}.env", .{ project_root, sep });
+    defer allocator.free(root_path);
+    try auditOneEnvFile(allocator, root_path, ".env", false, &printed_header, stderr);
+
+    const wf_path = try std.fmt.allocPrint(allocator, "{s}{s}workforce", .{ project_root, sep });
+    defer allocator.free(wf_path);
+    var wf_dir = fs.cwd().openDir(wf_path, .{ .iterate = true }) catch return;
+    defer wf_dir.close();
+    var iter = wf_dir.iterate();
+    while (try iter.next()) |entry| {
+        if (entry.kind != .directory) continue;
+        if (entry.name.len == 0 or entry.name[0] == '.') continue;
+        const path = try std.fmt.allocPrint(allocator, "{s}{s}{s}{s}.env", .{ wf_path, sep, entry.name, sep });
+        defer allocator.free(path);
+        const label = try std.fmt.allocPrint(allocator, "workforce/{s}/.env", .{entry.name});
+        defer allocator.free(label);
+        try auditOneEnvFile(allocator, path, label, true, &printed_header, stderr);
+    }
+}
+
+fn describeVarState(v: SyncVar, active_managed: bool) []const u8 {
+    if (v.value_missing) return "placeholder (value not returned by platform)";
+    if (isMultiline(v.value)) return "commented out (multi-line value; not representable in .env)";
+    if (isReservedVarName(v.name)) return "commented out (reserved)";
+    if (v.managed) return if (active_managed) "active (platform-managed, --include-platform-vars)" else "commented out (platform-managed)";
+    return "active";
+}
+
 fn runPull(
     allocator: std.mem.Allocator,
     opts: Options,
@@ -1057,11 +2147,18 @@ fn runPull(
     rev: ?[]const u8,
     api_key: []const u8,
     file_path: []const u8,
+    project_root: []const u8,
+    repo_root: []const u8,
     stdout: anytype,
     stderr: anytype,
 ) !void {
-    // Refuse to clobber an existing local file unless --force.
-    if (!opts.force) {
+    // With --force the root file is about to be rewritten, so audit afterwards; otherwise audit
+    // what is on disk now — a refused pull should still tell the user what is wrong locally.
+    const overwriting = opts.force and !opts.dry_run;
+    if (!overwriting) try auditEnvPlacement(allocator, project_root, stderr);
+
+    // Refuse to clobber an existing local file unless --force (dry-run touches nothing).
+    if (!opts.force and !opts.dry_run) {
         if (fs.cwd().access(file_path, .{})) |_| {
             try stderr.print(
                 "Error: {s} already exists. Re-run with --force to overwrite.\n",
@@ -1071,55 +2168,172 @@ fn runPull(
         } else |_| {}
     }
 
-    const url = if (rev) |r| blk: {
+    // 1. Effective env for the rev (what a deployment would see).
+    const pull_suffix = if (rev) |r| blk: {
         const encoded = try urlEncodeQuery(allocator, r);
         defer allocator.free(encoded);
-        break :blk try std.fmt.allocPrint(
-            allocator,
-            "{s}/orgs/{s}/projects/{s}/vars/pull?rev={s}",
-            .{ remote.base_url, remote.org_id, remote.project_id, encoded },
-        );
-    } else try std.fmt.allocPrint(
-        allocator,
-        "{s}/orgs/{s}/projects/{s}/vars/pull",
-        .{ remote.base_url, remote.org_id, remote.project_id },
-    );
+        break :blk try std.fmt.allocPrint(allocator, "/vars/pull?rev={s}", .{encoded});
+    } else try allocator.dupe(u8, "/vars/pull");
+    defer allocator.free(pull_suffix);
+    const url = try projectUrl(allocator, remote, pull_suffix);
     defer allocator.free(url);
 
     const body = try apiRequest(allocator, .GET, url, api_key, null, opts.verbose, rev);
     defer allocator.free(body);
 
-    const parsed = std.json.parseFromSlice(PullResponse, allocator, body, .{
-        .ignore_unknown_fields = true,
-        .allocate = .alloc_always,
-    }) catch |err| {
+    var pulled = parsePullResponse(allocator, body) catch |err| {
         try stderr.print("Error: failed to parse pull response: {}\n", .{err});
         if (opts.verbose) try stderr.print("{s}\n", .{body});
         std.process.exit(1);
     };
-    defer parsed.deinit();
+    defer pulled.deinit(allocator);
 
-    var sync_vars = std.ArrayList(SyncVar).init(allocator);
-    defer freeSyncVars(allocator, &sync_vars);
-    for (parsed.value.vars) |v| {
-        try sync_vars.append(.{
-            .name = try allocator.dupe(u8, v.name),
-            .type = try allocator.dupe(u8, v.type),
-            .value = try allocator.dupe(u8, v.value),
-            .description = if (v.description) |d| try allocator.dupe(u8, d) else null,
-        });
+    const effective_rev: []const u8 = if (pulled.rev.len > 0) pulled.rev else (rev orelse "");
+
+    // 2. User-defined project vars: the source of truth for types and for which names are
+    //    platform-computed. Soft failure — the pulled file is still valid without it.
+    var listing = try fetchRemoteVarListing(allocator, remote, api_key, opts.verbose);
+    defer listing.deinit(allocator);
+    if (!listing.ok) {
+        try stderr.print(
+            "{s}Warning:{s} could not list project vars (HTTP {d}). Platform-managed detection falls back to the\n" ++
+                "TIMBAL_* prefix and secrets absent from the effective env cannot be recovered.\n",
+            .{ Color.bold_yellow, Color.reset, listing.status },
+        );
     }
 
-    const content = try formatEnvFile(allocator, parsed.value.rev, sync_vars.items);
+    // 3. Reconcile: mark managed (anything the platform computes rather than the user defines),
+    //    never let a platform secret be written as plain.
+    var upgraded: usize = 0;
+    for (pulled.vars.items) |*v| {
+        if (listing.ok) {
+            const rt = remoteTypeFor(listing.vars.items, v.name);
+            if (rt == null) {
+                v.managed = true;
+            } else if (isSecretType(rt.?) and !isSecretType(v.type)) {
+                allocator.free(v.type);
+                v.type = try allocator.dupe(u8, "secret");
+                upgraded += 1;
+            }
+        } else if (!v.managed) {
+            v.managed = isPlatformManagedName(v.name);
+        }
+    }
+
+    // 4. Secrets the effective env left out: fetch individually (scoped to this rev's env).
+    var recovered: usize = 0;
+    var placeholders: usize = 0;
+    var other_env: usize = 0;
+    if (listing.ok) {
+        var env_id: ?[]u8 = null;
+        defer if (env_id) |e| allocator.free(e);
+        var env_resolved = false;
+        for (listing.vars.items) |rv| {
+            if (!isSecretType(rv.type)) continue;
+            if (isReservedVarName(rv.name)) continue;
+            if (findSyncVar(pulled.vars.items, rv.name) != null) continue;
+
+            if (!rv.applies_to_all_envs) {
+                if (!env_resolved) {
+                    env_resolved = true;
+                    if (effective_rev.len > 0) env_id = try fetchEnvIdForBranch(allocator, remote, api_key, effective_rev, opts.verbose);
+                }
+                const eid = env_id orelse {
+                    other_env += 1;
+                    continue;
+                };
+                if (!rv.hasEnv(eid)) {
+                    other_env += 1;
+                    continue;
+                }
+            }
+
+            const decrypted = try fetchVarDecrypted(allocator, remote, api_key, rv.id, opts.verbose);
+            errdefer if (decrypted) |d| allocator.free(d);
+            var sv = SyncVar{
+                .name = try allocator.dupe(u8, rv.name),
+                .type = undefined,
+                .value = undefined,
+                .type_explicit = true,
+                .value_missing = decrypted == null,
+            };
+            errdefer allocator.free(sv.name);
+            sv.type = try allocator.dupe(u8, "secret");
+            errdefer allocator.free(sv.type);
+            sv.value = decrypted orelse try allocator.dupe(u8, "");
+            errdefer if (decrypted == null) allocator.free(sv.value);
+            if (rv.description) |d| sv.description = try allocator.dupe(u8, d);
+            errdefer if (sv.description) |d| allocator.free(d);
+            try pulled.vars.append(sv);
+            if (sv.value_missing) placeholders += 1 else recovered += 1;
+        }
+    }
+
+    // A project-level TIMBAL_APP_ID applies to every workforce member under `timbal start`.
+    if (findSyncVar(pulled.vars.items, "TIMBAL_APP_ID")) |idx| {
+        if (!pulled.vars.items[idx].managed) {
+            try stderr.print(
+                "{s}Warning:{s} the platform has a project-level TIMBAL_APP_ID. It is written commented out — TIMBAL_APP_ID\n" ++
+                    "is per workforce member and is synced into workforce/<name>/.env instead.\n",
+                .{ Color.bold_yellow, Color.reset },
+            );
+        }
+    }
+
+    const content = try formatEnvFile(allocator, effective_rev, pulled.vars.items, .{ .managed_active = opts.include_platform });
     defer allocator.free(content);
 
-    try persistPulledEnvFile(allocator, file_path, content, opts.force, stderr);
+    var active: usize = 0;
+    var managed: usize = 0;
+    var multiline: usize = 0;
+    for (pulled.vars.items) |v| {
+        if (v.managed) {
+            managed += 1;
+        } else if (isMultiline(v.value)) {
+            multiline += 1;
+        } else if (!v.value_missing and !isReservedVarName(v.name)) {
+            active += 1;
+        }
+    }
 
-    if (!opts.quiet) {
-        try stdout.print(
-            "{s}✓{s} Pulled {d} var(s) for rev {s}{s}{s} → {s}\n",
-            .{ Color.bold_green, Color.reset, sync_vars.items.len, Color.bold_cyan, parsed.value.rev, Color.reset, file_path },
-        );
+    if (opts.dry_run) {
+        try stdout.print("Dry run — would write {s}\n", .{file_path});
+        try stdout.print("rev: {s}\nvars ({d}):\n", .{ effective_rev, pulled.vars.items.len });
+        for (pulled.vars.items) |v| {
+            try stdout.print("  {s} ({s})  {s}\n", .{ v.name, v.type, describeVarState(v, opts.include_platform) });
+        }
+        if (other_env > 0) try stdout.print("  ({d} secret(s) scoped to other environments not included)\n", .{other_env});
+    } else {
+        try persistPulledEnvFile(allocator, file_path, content, opts.force, stderr);
+        if (!opts.quiet) {
+            try stdout.print(
+                "{s}✓{s} Pulled {d} var(s) for rev {s}{s}{s} → {s}\n",
+                .{ Color.bold_green, Color.reset, active, Color.bold_cyan, effective_rev, Color.reset, file_path },
+            );
+            if (managed > 0) {
+                if (opts.include_platform) {
+                    try stdout.print("  {d} platform-managed var(s) written active (--include-platform-vars)\n", .{managed});
+                } else {
+                    try stdout.print("  {d} platform-managed var(s) kept commented out (TIMBAL_*/VITE_TIMBAL_* runtime wiring)\n", .{managed});
+                }
+            }
+            if (upgraded > 0) try stdout.print("  {d} var(s) re-tagged secret to match the platform\n", .{upgraded});
+            if (recovered > 0) try stdout.print("  {d} secret(s) fetched individually\n", .{recovered});
+            if (placeholders > 0) try stdout.print("  {d} secret(s) written as commented placeholders (value not returned by the platform)\n", .{placeholders});
+            if (multiline > 0) try stdout.print("  {d} multi-line value(s) kept commented out (not representable in .env; set them via shell or `timbal start --env`)\n", .{multiline});
+            if (other_env > 0) try stdout.print("  {d} secret(s) scoped to other environments not included\n", .{other_env});
+        }
+        if (overwriting) try auditEnvPlacement(allocator, project_root, stderr);
+    }
+
+    if (!opts.no_app_ids) {
+        if (effective_rev.len > 0) {
+            try syncAppIds(allocator, opts, remote, api_key, effective_rev, project_root, repo_root, stdout, stderr);
+        } else if (opts.verbose) {
+            try stderr.writeAll("note: pull response carried no rev; TIMBAL_APP_ID not synced.\n");
+        }
+    } else if (opts.dry_run) {
+        try stdout.writeAll("No changes made.\n");
     }
 }
 
@@ -1134,6 +2348,14 @@ fn persistPulledEnvFile(
     force: bool,
     stderr: anytype,
 ) !void {
+    if (!force) {
+        try writeFileExclusive(file_path, content, stderr);
+        return;
+    }
+    try writeFileAtomic(allocator, file_path, content, stderr);
+}
+
+fn ensureParentDir(file_path: []const u8, stderr: anytype) !void {
     if (fs.path.dirname(file_path)) |dir| {
         fs.cwd().makePath(dir) catch |err| {
             if (err != error.PathAlreadyExists) {
@@ -1142,33 +2364,35 @@ fn persistPulledEnvFile(
             }
         };
     }
+}
 
-    if (!force) {
-        // exclusive create closes the TOCTOU window: a file created during the HTTP pull
-        // cannot be truncated by a non-force pull.
-        const file = fs.cwd().createFile(file_path, .{ .exclusive = true }) catch |err| {
-            if (err == error.PathAlreadyExists) {
-                try stderr.print(
-                    "Error: {s} already exists. Re-run with --force to overwrite.\n",
-                    .{file_path},
-                );
-                std.process.exit(1);
-            }
-            try stderr.print("Error: could not write {s}: {}\n", .{ file_path, err });
+/// Exclusive create: a file created concurrently cannot be truncated.
+fn writeFileExclusive(file_path: []const u8, content: []const u8, stderr: anytype) !void {
+    try ensureParentDir(file_path, stderr);
+    const file = fs.cwd().createFile(file_path, .{ .exclusive = true }) catch |err| {
+        if (err == error.PathAlreadyExists) {
+            try stderr.print(
+                "Error: {s} already exists. Re-run with --force to overwrite.\n",
+                .{file_path},
+            );
             std.process.exit(1);
-        };
-        defer file.close();
-        file.writeAll(content) catch |err| {
-            // Best-effort cleanup of a partial new file; there was no prior content to preserve.
-            fs.cwd().deleteFile(file_path) catch {};
-            try stderr.print("Error: could not write {s}: {}\n", .{ file_path, err });
-            std.process.exit(1);
-        };
-        file.setEndPos(content.len) catch {};
-        return;
-    }
+        }
+        try stderr.print("Error: could not write {s}: {}\n", .{ file_path, err });
+        std.process.exit(1);
+    };
+    defer file.close();
+    file.writeAll(content) catch |err| {
+        // Best-effort cleanup of a partial new file; there was no prior content to preserve.
+        fs.cwd().deleteFile(file_path) catch {};
+        try stderr.print("Error: could not write {s}: {}\n", .{ file_path, err });
+        std.process.exit(1);
+    };
+    file.setEndPos(content.len) catch {};
+}
 
-    // --force: never delete the destination until the new contents are safely on disk.
+/// Temp file + rename: the destination is never deleted until the new contents are on disk.
+fn writeFileAtomic(allocator: std.mem.Allocator, file_path: []const u8, content: []const u8, stderr: anytype) !void {
+    try ensureParentDir(file_path, stderr);
     const tmp_path = try std.fmt.allocPrint(allocator, "{s}.timbal-pull.tmp", .{file_path});
     defer allocator.free(tmp_path);
 
@@ -1215,6 +2439,15 @@ fn persistPulledEnvFile(
     };
 }
 
+fn sourceLabel(src: TypeSource) []const u8 {
+    return switch (src) {
+        .flag => "--secret/--plain",
+        .file => "file metadata",
+        .remote => "platform type",
+        .inferred => "inferred from name/value",
+    };
+}
+
 fn runPush(
     allocator: std.mem.Allocator,
     opts: Options,
@@ -1222,6 +2455,8 @@ fn runPush(
     rev: ?[]const u8,
     api_key: []const u8,
     file_path: []const u8,
+    project_root: []const u8,
+    repo_root: []const u8,
     stdout: anytype,
     stderr: anytype,
 ) !void {
@@ -1242,62 +2477,137 @@ fn runPush(
         std.process.exit(1);
     }
 
-    // Validate types
     for (sync_vars.items) |v| {
-        if (!std.mem.eql(u8, v.type, "plain") and !std.mem.eql(u8, v.type, "secret")) {
+        if (canonType(v.type) == null) {
             try stderr.print("Error: var '{s}' has invalid type '{s}' (expected plain|secret)\n", .{ v.name, v.type });
             std.process.exit(1);
         }
+        if (!isValidEnvKey(v.name)) {
+            try stderr.print(
+                "{s}Warning:{s} '{s}' is not a valid env name for `timbal start` (letters, digits, underscore; no leading digit).\n" ++
+                    "It will be pushed but never loaded locally.\n",
+                .{ Color.bold_yellow, Color.reset, v.name },
+            );
+        }
     }
+
+    try auditEnvPlacement(allocator, project_root, stderr);
+    for (opts.secret_names.items) |n| {
+        if (findSyncVar(sync_vars.items, n) == null) try stderr.print("{s}Warning:{s} --secret {s}: not present in {s}\n", .{ Color.bold_yellow, Color.reset, n, file_path });
+    }
+    for (opts.plain_names.items) |n| {
+        if (findSyncVar(sync_vars.items, n) == null) try stderr.print("{s}Warning:{s} --plain {s}: not present in {s}\n", .{ Color.bold_yellow, Color.reset, n, file_path });
+    }
+
+    // Current platform types are required: without them we cannot tell a new var from an
+    // existing secret, and pushing blind is exactly how secrets get downgraded to plain.
+    var listing = try fetchRemoteVarListing(allocator, remote, api_key, opts.verbose);
+    defer listing.deinit(allocator);
+    if (!listing.ok) {
+        if (listing.error_body) |b| {
+            printApiError(listing.status, b, rev);
+        } else {
+            try stderr.print("Error: unexpected response listing project vars (HTTP {d}).\n", .{listing.status});
+        }
+        try stderr.writeAll("Push needs the current platform var types to classify secrets safely; aborting.\n");
+        std.process.exit(1);
+    }
+
+    const plan = try planPush(allocator, sync_vars.items, listing.vars.items, opts.secret_names.items, opts.plain_names.items);
+    defer allocator.free(plan);
 
     var pushable: usize = 0;
-    for (sync_vars.items) |v| {
-        if (!isReservedVarName(v.name)) pushable += 1;
+    var blocked: usize = 0;
+    var type_changes: usize = 0;
+    var name_width: usize = 0;
+    for (sync_vars.items, plan) |v, p| {
+        if (p.action == .push) pushable += 1;
+        if (p.action == .blocked_downgrade) blocked += 1;
+        if (p.action == .push and p.remote_type != null and !std.mem.eql(u8, p.remote_type.?, p.type)) type_changes += 1;
+        if (v.name.len > name_width) name_width = v.name.len;
     }
 
-    const url = try std.fmt.allocPrint(
-        allocator,
-        "{s}/orgs/{s}/projects/{s}/vars/push",
-        .{ remote.base_url, remote.org_id, remote.project_id },
-    );
+    const url = try projectUrl(allocator, remote, "/vars/push");
     defer allocator.free(url);
 
-    if (opts.dry_run) {
-        try stdout.print("Dry run — would POST {s}\n", .{url});
+    if (!opts.quiet or blocked > 0) {
+        if (opts.dry_run) {
+            try stdout.print("Dry run — would POST {s}\n", .{url});
+        }
         if (rev) |r| {
             try stdout.print("rev: {s}\n", .{r});
         } else {
             try stdout.writeAll("rev: (project default)\n");
         }
-        try stdout.print("file: {s}\n", .{file_path});
-        try stdout.print("vars ({d}):\n", .{sync_vars.items.len});
-        for (sync_vars.items) |v| {
-            if (isReservedVarName(v.name)) {
-                try stdout.print("  {s} ({s})  → skipped (reserved)\n", .{ v.name, v.type });
-            } else {
-                try stdout.print("  {s} ({s})  value: <redacted>\n", .{ v.name, v.type });
+        try stdout.print("file: {s}\nvars ({d}, values redacted):\n", .{ file_path, sync_vars.items.len });
+        for (sync_vars.items, plan) |v, p| {
+            try stdout.print("  {s}", .{v.name});
+            var pad = name_width - v.name.len + 2;
+            while (pad > 0) : (pad -= 1) try stdout.writeAll(" ");
+            switch (p.action) {
+                .push => {
+                    if (p.remote_type) |rt| {
+                        if (std.mem.eql(u8, rt, p.type)) {
+                            try stdout.print("{s:<7} {s} — value update\n", .{ p.type, sourceLabel(p.source) });
+                        } else {
+                            // The platform keeps a var's stored type on update; only the value changes.
+                            try stdout.print(
+                                "{s:<7} {s} requested {s}; the platform keeps the stored type on update — change it in the Timbal UI\n",
+                                .{ rt, sourceLabel(p.source), p.type },
+                            );
+                        }
+                    } else {
+                        try stdout.print("{s:<7} {s} — new on the platform\n", .{ p.type, sourceLabel(p.source) });
+                    }
+                },
+                .skip_reserved => {
+                    if (std.mem.eql(u8, v.name, "TIMBAL_APP_ID")) {
+                        try stdout.writeAll("skipped  reserved — per workforce member; belongs in workforce/<name>/.env, not the project root\n");
+                    } else {
+                        try stdout.writeAll("skipped  reserved (platform-assigned)\n");
+                    }
+                },
+                .skip_managed => try stdout.writeAll("skipped  TIMBAL_* is platform-managed (resolved by the platform before deploy/preview); never pushed\n"),
+                .blocked_downgrade => try stdout.print("{s}BLOCKED{s}  secret on the platform, marked plain here\n", .{ Color.bold_yellow, Color.reset }),
             }
         }
-        if (pushable == 0) {
-            try stderr.print(
-                "Error: nothing to push — {s} only contains reserved names (PORT, TIMBAL_PROJECT_SECRET).\n",
-                .{file_path},
+        if (type_changes > 0) {
+            try stdout.print(
+                "\n{s}Note:{s} {d} var(s) request a different type than the platform has stored. Types are fixed at creation;\n" ++
+                    "an update only changes the value. Change the type in the Timbal UI (project → variables).\n",
+                .{ Color.bold_yellow, Color.reset, type_changes },
             );
-            std.process.exit(1);
         }
-        try stdout.writeAll("No changes made.\n");
-        return;
+    }
+
+    if (blocked > 0) {
+        try stderr.print(
+            "\nError: {d} var(s) are secrets on the platform but marked plain in the local file. Refusing to push\n" ++
+                "with mismatched metadata (the platform keeps the stored type, so a downgrade would not happen, but the\n" ++
+                "file is lying about what these are). Fix the file — write `# type: secret` or drop the `# type: plain`\n" ++
+                "line — or pass --plain <NAME> to acknowledge and push the value anyway.\n",
+            .{blocked},
+        );
+        std.process.exit(1);
     }
 
     if (pushable == 0) {
         try stderr.print(
-            "Error: nothing to push — {s} only contains reserved names (PORT, TIMBAL_PROJECT_SECRET).\n",
+            "Error: nothing to push — every var in {s} is reserved or platform-managed.\n",
             .{file_path},
         );
         std.process.exit(1);
     }
 
-    const payload = try buildPushPayload(allocator, rev, sync_vars.items);
+    if (opts.dry_run) {
+        try stdout.writeAll("No changes made.\n");
+        if (!opts.no_app_ids) {
+            if (rev) |r| try syncAppIds(allocator, opts, remote, api_key, r, project_root, repo_root, stdout, stderr);
+        }
+        return;
+    }
+
+    const payload = try buildPushPayload(allocator, rev, sync_vars.items, plan);
     defer allocator.free(payload);
 
     const body = try apiRequest(allocator, .POST, url, api_key, payload, opts.verbose, rev);
@@ -1315,12 +2625,189 @@ fn runPush(
 
     if (!opts.quiet) {
         try stdout.print(
-            "{s}✓{s} Pushed to rev {s}{s}{s} from {s}\n",
-            .{ Color.bold_green, Color.reset, Color.bold_cyan, parsed.value.rev, Color.reset, file_path },
+            "{s}✓{s} Pushed {d} var(s) to rev {s}{s}{s} from {s}\n",
+            .{ Color.bold_green, Color.reset, pushable, Color.bold_cyan, parsed.value.rev, Color.reset, file_path },
         );
         try printNameList(stdout, "created", parsed.value.created);
         try printNameList(stdout, "updated", parsed.value.updated);
         try printNameList(stdout, "skipped", parsed.value.skipped);
+    }
+
+    if (!opts.no_app_ids) {
+        const effective_rev: []const u8 = if (parsed.value.rev.len > 0) parsed.value.rev else (rev orelse "");
+        if (effective_rev.len > 0) try syncAppIds(allocator, opts, remote, api_key, effective_rev, project_root, repo_root, stdout, stderr);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TIMBAL_APP_ID → workforce/<name>/.env
+// ---------------------------------------------------------------------------
+
+const LocalMember = struct {
+    name: []u8,
+    uid: []u8,
+
+    fn deinit(self: *LocalMember, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        allocator.free(self.uid);
+    }
+};
+
+/// Every `workforce/<name>/timbal.yaml` under the project root (same rules as `timbal start`:
+/// dot-prefixed directories are skipped, invalid manifests are reported and skipped).
+fn discoverLocalMembers(allocator: std.mem.Allocator, project_root: []const u8, stderr: anytype) !std.ArrayList(LocalMember) {
+    var out = std.ArrayList(LocalMember).init(allocator);
+    errdefer {
+        for (out.items) |*m| m.deinit(allocator);
+        out.deinit();
+    }
+
+    const wf_path = try std.fmt.allocPrint(allocator, "{s}{s}workforce", .{ project_root, sep });
+    defer allocator.free(wf_path);
+    var wf_dir = fs.cwd().openDir(wf_path, .{ .iterate = true }) catch return out;
+    defer wf_dir.close();
+
+    var iter = wf_dir.iterate();
+    while (try iter.next()) |entry| {
+        if (entry.kind != .directory) continue;
+        if (entry.name.len == 0 or entry.name[0] == '.') continue;
+
+        const yaml_rel = try std.fmt.allocPrint(allocator, "{s}{s}timbal.yaml", .{ entry.name, sep });
+        defer allocator.free(yaml_rel);
+        const yaml = wf_dir.readFileAlloc(allocator, yaml_rel, 64 * 1024) catch continue;
+        defer allocator.free(yaml);
+
+        var config = utils.parseTimbalYaml(allocator, yaml) orelse {
+            try stderr.print("{s}Warning:{s} invalid timbal.yaml in workforce/{s}; skipping TIMBAL_APP_ID sync for it.\n", .{ Color.bold_yellow, Color.reset, entry.name });
+            continue;
+        };
+        defer config.deinit(allocator);
+
+        const name = try allocator.dupe(u8, entry.name);
+        errdefer allocator.free(name);
+        const uid = try allocator.dupe(u8, config.id);
+        errdefer allocator.free(uid);
+        try out.append(.{ .name = name, .uid = uid });
+    }
+    return out;
+}
+
+fn shortId(s: []const u8) []const u8 {
+    return if (s.len > 8) s[0..8] else s;
+}
+
+/// Merge `TIMBAL_APP_ID=<platform app id>` into each matched `workforce/<name>/.env`.
+/// Only that one line is ever added or rewritten; everything else in the file is preserved
+/// byte for byte. The project-root .env is never touched here (it applies to every member).
+fn syncAppIds(
+    allocator: std.mem.Allocator,
+    opts: Options,
+    remote: TimbalRemote,
+    api_key: []const u8,
+    rev: []const u8,
+    project_root: []const u8,
+    repo_root: []const u8,
+    stdout: anytype,
+    stderr: anytype,
+) !void {
+    var members = try discoverLocalMembers(allocator, project_root, stderr);
+    defer {
+        for (members.items) |*m| m.deinit(allocator);
+        members.deinit();
+    }
+    if (members.items.len == 0) {
+        if (opts.verbose) try stderr.writeAll("note: no workforce/<name>/timbal.yaml under the project root; TIMBAL_APP_ID sync skipped.\n");
+        return;
+    }
+
+    var comps = (try fetchWorkforce(allocator, remote, api_key, rev, opts.verbose)) orelse return;
+    defer freeRemoteComponents(allocator, &comps);
+
+    const claimed = try allocator.alloc(bool, comps.items.len);
+    defer allocator.free(claimed);
+    @memset(claimed, false);
+
+    if (!opts.quiet) {
+        if (opts.dry_run) {
+            try stdout.print("Workforce app ids (rev {s}) — dry run, nothing written:\n", .{rev});
+        } else {
+            try stdout.print("Workforce app ids (rev {s}):\n", .{rev});
+        }
+    }
+
+    const comment = "Platform app id for this workforce member; kept in sync by `timbal env pull/push`.";
+
+    for (members.items) |m| {
+        const match = matchComponent(comps.items, m.name, m.uid, claimed) orelse {
+            if (opts.quiet) continue;
+            if (findNameOnlyConflict(comps.items, m.name, m.uid)) |ci| {
+                try stdout.print(
+                    "  {s}!{s} workforce/{s}  uid mismatch — local timbal.yaml _id {s}…, platform component \"{s}\" has uid {s}… (app id {s}). Not written.\n",
+                    .{ Color.bold_yellow, Color.reset, m.name, shortId(m.uid), comps.items[ci].name, shortId(comps.items[ci].uid.?), comps.items[ci].id },
+                );
+            } else {
+                try stdout.print(
+                    "  {s}!{s} workforce/{s}  no platform component on rev {s} (not deployed yet, or timbal.yaml _id differs). Not written.\n",
+                    .{ Color.bold_yellow, Color.reset, m.name, rev },
+                );
+            }
+            continue;
+        };
+        claimed[match.index] = true;
+        const comp = comps.items[match.index];
+
+        if (!comp.isRegistered()) {
+            if (!opts.quiet) {
+                try stdout.print(
+                    "  {s}!{s} workforce/{s}  known to the platform but not registered on rev {s} yet (synthetic id {s}); deploy it first. Not written.\n",
+                    .{ Color.bold_yellow, Color.reset, m.name, rev, comp.id },
+                );
+            }
+            continue;
+        }
+
+        const env_path = try std.fmt.allocPrint(allocator, "{s}{s}workforce{s}{s}{s}.env", .{ project_root, sep, sep, m.name, sep });
+        defer allocator.free(env_path);
+        const rel_path = try std.fmt.allocPrint(allocator, "workforce{s}{s}{s}.env", .{ sep, m.name, sep });
+        defer allocator.free(rel_path);
+
+        const existing: ?[]u8 = fs.cwd().readFileAlloc(allocator, env_path, 1024 * 1024) catch |err| switch (err) {
+            error.FileNotFound => null,
+            else => {
+                try stderr.print("{s}Warning:{s} could not read {s}: {}; skipped.\n", .{ Color.bold_yellow, Color.reset, rel_path, err });
+                continue;
+            },
+        };
+        defer if (existing) |e| allocator.free(e);
+
+        var result = try upsertEnvLine(allocator, existing, "TIMBAL_APP_ID", comp.id, comment);
+        defer result.deinit(allocator);
+
+        const via: []const u8 = if (match.kind == .uid) "" else " (matched by name — platform component has no manifest uid)";
+        if (!opts.dry_run and result.outcome != .unchanged) {
+            if (existing == null) {
+                try writeFileExclusive(env_path, result.content, stderr);
+                if (try gitCheckIgnore(allocator, repo_root, env_path)) |ignored| {
+                    if (!ignored) try stderr.print("{s}Warning:{s} {s} is not gitignored.\n", .{ Color.bold_yellow, Color.reset, rel_path });
+                }
+            } else {
+                try writeFileAtomic(allocator, env_path, result.content, stderr);
+            }
+        }
+
+        if (opts.quiet) continue;
+        switch (result.outcome) {
+            .unchanged => try stdout.print("  · {s}  TIMBAL_APP_ID={s}  unchanged{s}\n", .{ rel_path, comp.id, via }),
+            .added => try stdout.print("  {s}✓{s} {s}  TIMBAL_APP_ID={s}  {s}{s}\n", .{ Color.bold_green, Color.reset, rel_path, comp.id, if (opts.dry_run) "would add" else "added", via }),
+            .updated => try stdout.print("  {s}✓{s} {s}  TIMBAL_APP_ID={s}  {s} (was {s}){s}\n", .{ Color.bold_green, Color.reset, rel_path, comp.id, if (opts.dry_run) "would update" else "updated", result.previous orelse "?", via }),
+        }
+    }
+
+    if (!opts.quiet) {
+        for (comps.items, 0..) |c, i| {
+            if (claimed[i] or !c.isRegistered()) continue;
+            try stdout.print("  note: platform component \"{s}\" (app id {s}) has no matching workforce/ directory here\n", .{ c.name, c.id });
+        }
     }
 }
 
@@ -1413,7 +2900,7 @@ test "env file round-trip preserves type and description" {
         .{ .name = "VITE_FOO", .type = "plain", .value = "bar", .description = null },
         .{ .name = "MSG", .type = "plain", .value = "hello world", .description = "has spaces" },
     };
-    const content = try formatEnvFile(allocator, "main", &vars);
+    const content = try formatEnvFile(allocator, "main", &vars, .{});
     defer allocator.free(content);
 
     var parsed = try parseEnvFile(allocator, content);
@@ -1422,21 +2909,186 @@ test "env file round-trip preserves type and description" {
     try std.testing.expectEqual(@as(usize, 3), parsed.items.len);
     try std.testing.expectEqualStrings("DATABASE_URL", parsed.items[0].name);
     try std.testing.expectEqualStrings("secret", parsed.items[0].type);
+    try std.testing.expect(parsed.items[0].type_explicit);
     try std.testing.expectEqualStrings("postgres://u:p@h/db", parsed.items[0].value);
     try std.testing.expectEqualStrings("Primary DB", parsed.items[0].description.?);
     try std.testing.expectEqualStrings("VITE_FOO", parsed.items[1].name);
     try std.testing.expectEqualStrings("plain", parsed.items[1].type);
     try std.testing.expectEqualStrings("bar", parsed.items[1].value);
     try std.testing.expectEqualStrings("hello world", parsed.items[2].value);
+    try std.testing.expect(!parsed.items[0].managed);
 }
 
-test "parseEnvFile defaults type to plain" {
+test "parseEnvFile defaults type to plain without explicit metadata" {
     const allocator = std.testing.allocator;
     var parsed = try parseEnvFile(allocator, "FOO=1\nBAR=\"x y\"\n");
     defer freeSyncVars(allocator, &parsed);
     try std.testing.expectEqual(@as(usize, 2), parsed.items.len);
     try std.testing.expectEqualStrings("plain", parsed.items[0].type);
+    try std.testing.expect(!parsed.items[0].type_explicit);
     try std.testing.expectEqualStrings("x y", parsed.items[1].value);
+}
+
+test "parseEnvFile accepts shorthand metadata and case-insensitive types" {
+    const allocator = std.testing.allocator;
+    var parsed = try parseEnvFile(allocator,
+        \\# secret
+        \\A=1
+        \\# Plain
+        \\B=2
+        \\# type: SECRET
+        \\C=3
+        \\# managed: platform
+        \\# type: plain
+        \\TIMBAL_ORG_ID=1
+        \\
+    );
+    defer freeSyncVars(allocator, &parsed);
+    try std.testing.expectEqual(@as(usize, 4), parsed.items.len);
+    try std.testing.expectEqualStrings("secret", parsed.items[0].type);
+    try std.testing.expect(parsed.items[0].type_explicit);
+    try std.testing.expectEqualStrings("plain", parsed.items[1].type);
+    try std.testing.expect(parsed.items[1].type_explicit);
+    try std.testing.expectEqualStrings("secret", parsed.items[2].type);
+    try std.testing.expect(parsed.items[3].managed);
+    try std.testing.expect(!parsed.items[2].managed);
+}
+
+test "parseEnvFile: blank line ends a metadata block; commented placeholders are ignored" {
+    const allocator = std.testing.allocator;
+    var parsed = try parseEnvFile(allocator,
+        \\# type: secret
+        \\# description: orphaned after deleting its var
+        \\
+        \\NEXT=1
+        \\
+        \\# type: secret
+        \\# value not returned by the platform
+        \\# HIDDEN=
+        \\
+        \\# note: an ordinary comment
+        \\LAST=2
+        \\
+    );
+    defer freeSyncVars(allocator, &parsed);
+    try std.testing.expectEqual(@as(usize, 2), parsed.items.len);
+    try std.testing.expectEqualStrings("NEXT", parsed.items[0].name);
+    try std.testing.expect(!parsed.items[0].type_explicit);
+    try std.testing.expect(parsed.items[0].description == null);
+    try std.testing.expectEqualStrings("LAST", parsed.items[1].name);
+    try std.testing.expect(!parsed.items[1].type_explicit);
+}
+
+test "formatEnvFile writes platform-managed vars commented out unless requested" {
+    const allocator = std.testing.allocator;
+    const vars = [_]SyncVar{
+        .{ .name = "OPENAI_API_KEY", .type = "secret", .value = "sk-x" },
+        .{ .name = "TIMBAL_PROJECT_ENV_ID", .type = "plain", .value = "1234", .managed = true },
+        .{ .name = "VITE_TIMBAL_ORG_ID", .type = "plain", .value = "1", .managed = true },
+    };
+    const content = try formatEnvFile(allocator, "main", &vars, .{});
+    defer allocator.free(content);
+    try std.testing.expect(std.mem.indexOf(u8, content, "\nOPENAI_API_KEY=sk-x\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "\n# TIMBAL_PROJECT_ENV_ID=1234\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "\nTIMBAL_PROJECT_ENV_ID=") == null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "# managed: platform\n") != null);
+
+    // A start-compatible parse must only see the user var.
+    var parsed = try parseEnvFile(allocator, content);
+    defer freeSyncVars(allocator, &parsed);
+    try std.testing.expectEqual(@as(usize, 1), parsed.items.len);
+    try std.testing.expectEqualStrings("OPENAI_API_KEY", parsed.items[0].name);
+
+    const active = try formatEnvFile(allocator, "main", &vars, .{ .managed_active = true });
+    defer allocator.free(active);
+    try std.testing.expect(std.mem.indexOf(u8, active, "\nTIMBAL_PROJECT_ENV_ID=1234\n") != null);
+    var parsed_active = try parseEnvFile(allocator, active);
+    defer freeSyncVars(allocator, &parsed_active);
+    try std.testing.expectEqual(@as(usize, 3), parsed_active.items.len);
+    try std.testing.expect(parsed_active.items[1].managed);
+}
+
+test "formatEnvFile never writes TIMBAL_APP_ID active and writes missing secrets as placeholders" {
+    const allocator = std.testing.allocator;
+    const vars = [_]SyncVar{
+        .{ .name = "TIMBAL_APP_ID", .type = "plain", .value = "77" },
+        .{ .name = "STRIPE_KEY", .type = "secret", .value = "", .value_missing = true },
+    };
+    const content = try formatEnvFile(allocator, "main", &vars, .{ .managed_active = true });
+    defer allocator.free(content);
+    try std.testing.expect(std.mem.indexOf(u8, content, "\n# TIMBAL_APP_ID=77\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "\nTIMBAL_APP_ID=") == null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "\n# STRIPE_KEY=\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "\nSTRIPE_KEY=") == null);
+
+    var parsed = try parseEnvFile(allocator, content);
+    defer freeSyncVars(allocator, &parsed);
+    try std.testing.expectEqual(@as(usize, 0), parsed.items.len);
+}
+
+test "formatEnvFile keeps multi-line values commented out so a round trip cannot corrupt them" {
+    const allocator = std.testing.allocator;
+    const vars = [_]SyncVar{
+        .{ .name = "PEM", .type = "secret", .value = "-----BEGIN KEY-----\nabc\n-----END KEY-----" },
+        .{ .name = "OK", .type = "plain", .value = "1" },
+    };
+    const content = try formatEnvFile(allocator, "main", &vars, .{});
+    defer allocator.free(content);
+    try std.testing.expect(std.mem.indexOf(u8, content, "\n# PEM=\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "\nPEM=") == null);
+    try std.testing.expect(std.mem.indexOf(u8, content, "BEGIN KEY") == null);
+
+    var parsed = try parseEnvFile(allocator, content);
+    defer freeSyncVars(allocator, &parsed);
+    try std.testing.expectEqual(@as(usize, 1), parsed.items.len);
+    try std.testing.expectEqualStrings("OK", parsed.items[0].name);
+}
+
+test "auditEnvContent flags rerouting, misplaced TIMBAL_APP_ID, and dead runtime vars" {
+    const allocator = std.testing.allocator;
+    const root =
+        \\OPENAI_API_KEY=sk-x
+        \\# TIMBAL_PROJECT_ENV_ID=1
+        \\TIMBAL_PROJECT_ENV_ID=1234
+        \\export TIMBAL_APP_ID="5"
+        \\PORT=3000
+        \\TIMBAL_ORG_ID=1
+        \\
+    ;
+    var findings = std.ArrayList(PlacementFinding).init(allocator);
+    defer findings.deinit();
+    try auditEnvContent(root, false, &findings);
+    try std.testing.expectEqual(@as(usize, 3), findings.items.len);
+    try std.testing.expectEqual(PlacementKind.reroute, findings.items[0].kind);
+    try std.testing.expectEqualStrings("TIMBAL_PROJECT_ENV_ID", findings.items[0].key);
+    try std.testing.expectEqual(PlacementKind.app_id_scope, findings.items[1].kind);
+    try std.testing.expectEqual(PlacementKind.dead, findings.items[2].kind);
+    try std.testing.expectEqualStrings("PORT", findings.items[2].key);
+
+    // In a member file TIMBAL_APP_ID is exactly where it belongs.
+    findings.clearRetainingCapacity();
+    try auditEnvContent("TIMBAL_APP_ID=2335\nTIMBAL_DEPLOYMENTS_DOMAIN=x\n", true, &findings);
+    try std.testing.expectEqual(@as(usize, 1), findings.items.len);
+    try std.testing.expectEqual(PlacementKind.reroute, findings.items[0].kind);
+}
+
+test "isValidEnvKey mirrors timbal start's loader" {
+    try std.testing.expect(isValidEnvKey("OPENAI_API_KEY"));
+    try std.testing.expect(isValidEnvKey("_x1"));
+    try std.testing.expect(!isValidEnvKey("1ABC"));
+    try std.testing.expect(!isValidEnvKey("my-var"));
+    try std.testing.expect(!isValidEnvKey("a.b"));
+    try std.testing.expect(!isValidEnvKey(""));
+}
+
+test "scopedFileOwner identifies single-service env files" {
+    try std.testing.expectEqualStrings("ui", scopedFileOwner("/p", "/p/ui/.env").?);
+    try std.testing.expectEqualStrings("api", scopedFileOwner("/p", "/p/api/.env.local").?);
+    try std.testing.expectEqualStrings("copilot", scopedFileOwner("/p", "/p/workforce/copilot/.env").?);
+    try std.testing.expect(scopedFileOwner("/p", "/p/.env") == null);
+    try std.testing.expect(scopedFileOwner("/p", "/p/workforce/.env") == null);
+    try std.testing.expect(scopedFileOwner("/p", "/elsewhere/.env") == null);
+    try std.testing.expect(scopedFileOwner("/p", "/pp/ui/.env") == null);
 }
 
 test "formatEnvFile quoting is start-compatible (no backslash escapes)" {
@@ -1446,7 +3098,7 @@ test "formatEnvFile quoting is start-compatible (no backslash escapes)" {
         .{ .name = "QUOTED", .type = "secret", .value = "say \"hi\"", .description = null },
         .{ .name = "BOTH", .type = "plain", .value = "a\"b'c", .description = null },
     };
-    const content = try formatEnvFile(allocator, "main", &vars);
+    const content = try formatEnvFile(allocator, "main", &vars, .{});
     defer allocator.free(content);
 
     // Must not emit shell-style escapes that start's loader would leave literal.
@@ -1461,29 +3113,298 @@ test "formatEnvFile quoting is start-compatible (no backslash escapes)" {
     try std.testing.expectEqualStrings("a\"b'c", parsed.items[2].value);
 }
 
-test "buildPushPayload includes rev and vars" {
+test "inferSecret: credentials by name and value, counts and public keys are plain" {
+    try std.testing.expect(inferSecret("OPENAI_API_KEY", "x"));
+    try std.testing.expect(inferSecret("DATABASE_PASSWORD", "x"));
+    try std.testing.expect(inferSecret("GITHUB_TOKEN", "x"));
+    try std.testing.expect(inferSecret("ACCESS_TOKEN", "x"));
+    try std.testing.expect(inferSecret("clientSecret", "x"));
+    try std.testing.expect(inferSecret("SENTRY_DSN", "x"));
+    try std.testing.expect(inferSecret("AWS_SECRET_ACCESS_KEY", "x"));
+    try std.testing.expect(inferSecret("OPENAI", "sk-abc"));
+    try std.testing.expect(inferSecret("SLACK", "xoxb-1-2"));
+    try std.testing.expect(inferSecret("PEM", "-----BEGIN PRIVATE KEY-----"));
+    try std.testing.expect(inferSecret("DATABASE_URL", "postgres://user:pass@host:5432/db"));
+
+    try std.testing.expect(!inferSecret("MAX_TOKENS", "1024"));
+    try std.testing.expect(!inferSecret("TOKEN_LIMIT", "10"));
+    try std.testing.expect(!inferSecret("STRIPE_PUBLISHABLE_KEY", "pk_live_x"));
+    try std.testing.expect(!inferSecret("NEXT_PUBLIC_KEY_PREFIX", "x"));
+    try std.testing.expect(!inferSecret("DATABASE_URL", "postgres://host:5432/db"));
+    try std.testing.expect(!inferSecret("LOG_LEVEL", "debug"));
+    try std.testing.expect(!inferSecret("VITE_API_BASE", "https://api.example.com/v1"));
+    try std.testing.expect(!inferSecret("TOKENIZER", "cl100k"));
+}
+
+fn testRemote(name: []const u8, typ: []const u8) RemoteVar {
+    return .{ .id = "1", .name = name, .type = typ };
+}
+
+test "planPush: flag > file > remote > inferred; downgrades blocked without --plain" {
+    const allocator = std.testing.allocator;
+    const vars = [_]SyncVar{
+        .{ .name = "A_KEY", .type = "plain", .value = "1" }, // no metadata, remote secret → secret (remote)
+        .{ .name = "B", .type = "plain", .value = "1", .type_explicit = true }, // file plain, remote secret → BLOCKED
+        .{ .name = "C", .type = "plain", .value = "1", .type_explicit = true }, // file plain + --plain → downgrade allowed
+        .{ .name = "D_TOKEN", .type = "plain", .value = "1" }, // new, inferred secret
+        .{ .name = "E", .type = "plain", .value = "1" }, // new, inferred plain
+        .{ .name = "F", .type = "plain", .value = "1" }, // new + --secret
+        .{ .name = "G", .type = "secret", .value = "1", .type_explicit = true }, // file secret, remote plain → upgrade ok
+        .{ .name = "H", .type = "plain", .value = "1" }, // no metadata, remote plain → plain (remote)
+    };
+    const remote = [_]RemoteVar{
+        testRemote("A_KEY", "secret"),
+        testRemote("B", "secret"),
+        testRemote("C", "secret"),
+        testRemote("G", "plain"),
+        testRemote("H", "plain"),
+        testRemote("H", "secret"), // same name secret in another env → conservative secret
+    };
+    const secret_names = [_][]const u8{"F"};
+    const plain_names = [_][]const u8{"C"};
+    const plan = try planPush(allocator, &vars, &remote, &secret_names, &plain_names);
+    defer allocator.free(plan);
+
+    try std.testing.expectEqual(PlanAction.push, plan[0].action);
+    try std.testing.expectEqualStrings("secret", plan[0].type);
+    try std.testing.expectEqual(TypeSource.remote, plan[0].source);
+
+    try std.testing.expectEqual(PlanAction.blocked_downgrade, plan[1].action);
+
+    try std.testing.expectEqual(PlanAction.push, plan[2].action);
+    try std.testing.expectEqualStrings("plain", plan[2].type);
+    try std.testing.expectEqual(TypeSource.flag, plan[2].source);
+
+    try std.testing.expectEqual(PlanAction.push, plan[3].action);
+    try std.testing.expectEqualStrings("secret", plan[3].type);
+    try std.testing.expectEqual(TypeSource.inferred, plan[3].source);
+
+    try std.testing.expectEqualStrings("plain", plan[4].type);
+    try std.testing.expectEqual(TypeSource.inferred, plan[4].source);
+
+    try std.testing.expectEqualStrings("secret", plan[5].type);
+    try std.testing.expectEqual(TypeSource.flag, plan[5].source);
+
+    try std.testing.expectEqual(PlanAction.push, plan[6].action);
+    try std.testing.expectEqualStrings("secret", plan[6].type);
+    try std.testing.expectEqual(TypeSource.file, plan[6].source);
+
+    try std.testing.expectEqualStrings("secret", plan[7].type);
+    try std.testing.expectEqual(TypeSource.remote, plan[7].source);
+}
+
+test "planPush: reserved and TIMBAL_* vars are never pushed, whatever the platform or flags say" {
+    const allocator = std.testing.allocator;
+    const vars = [_]SyncVar{
+        .{ .name = "PORT", .type = "plain", .value = "3000" },
+        .{ .name = "TIMBAL_PROJECT_SECRET", .type = "secret", .value = "x" },
+        .{ .name = "TIMBAL_APP_ID", .type = "plain", .value = "77" },
+        .{ .name = "TIMBAL_PROJECT_ENV_ID", .type = "plain", .value = "12" }, // prefix, not user-defined
+        .{ .name = "VITE_TIMBAL_ORG_ID", .type = "plain", .value = "1" },
+        .{ .name = "TIMBAL_KB_ID", .type = "plain", .value = "9", .type_explicit = true }, // even user-defined on the platform
+        .{ .name = "TIMBAL_LOG_EVENTS", .type = "plain", .value = "START" }, // even when named by --secret
+        .{ .name = "FOO", .type = "plain", .value = "1", .managed = true }, // annotated managed
+        .{ .name = "OK", .type = "plain", .value = "1" },
+    };
+    const remote = [_]RemoteVar{testRemote("TIMBAL_KB_ID", "plain")};
+    const secret_names = [_][]const u8{"TIMBAL_LOG_EVENTS"};
+    const plan = try planPush(allocator, &vars, &remote, &secret_names, &.{});
+    defer allocator.free(plan);
+    try std.testing.expectEqual(PlanAction.skip_reserved, plan[0].action);
+    try std.testing.expectEqual(PlanAction.skip_reserved, plan[1].action);
+    try std.testing.expectEqual(PlanAction.skip_reserved, plan[2].action);
+    try std.testing.expectEqual(PlanAction.skip_managed, plan[3].action);
+    try std.testing.expectEqual(PlanAction.skip_managed, plan[4].action);
+    try std.testing.expectEqual(PlanAction.skip_managed, plan[5].action);
+    try std.testing.expectEqual(PlanAction.skip_managed, plan[6].action);
+    try std.testing.expectEqual(PlanAction.skip_managed, plan[7].action);
+    try std.testing.expectEqual(PlanAction.push, plan[8].action);
+
+    const payload = try buildPushPayload(allocator, "main", &vars, plan);
+    defer allocator.free(payload);
+    try std.testing.expect(std.mem.indexOf(u8, payload, "TIMBAL_") == null);
+    try std.testing.expect(std.mem.indexOf(u8, payload, "\"name\":\"OK\"") != null);
+}
+
+test "buildPushPayload includes rev and only planned vars with resolved types" {
     const allocator = std.testing.allocator;
     const vars = [_]SyncVar{
         .{ .name = "A", .type = "plain", .value = "1", .description = null },
+        .{ .name = "PORT", .type = "plain", .value = "3000", .description = null },
+        .{ .name = "TIMBAL_APP_ID", .type = "plain", .value = "77", .description = null },
+        .{ .name = "MY_KEY", .type = "plain", .value = "1", .description = "d" },
     };
-    const payload = try buildPushPayload(allocator, "main", &vars);
+    const plan = try planPush(allocator, &vars, &.{}, &.{}, &.{});
+    defer allocator.free(plan);
+    const payload = try buildPushPayload(allocator, "main", &vars, plan);
     defer allocator.free(payload);
     try std.testing.expect(std.mem.indexOf(u8, payload, "\"rev\":\"main\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, payload, "\"name\":\"A\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, payload, "\"name\":\"A\",\"type\":\"plain\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, payload, "\"name\":\"MY_KEY\",\"type\":\"secret\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, payload, "\"description\":\"d\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, payload, "\"name\":\"PORT\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, payload, "\"name\":\"TIMBAL_APP_ID\"") == null);
 }
 
-test "buildPushPayload omits reserved var names" {
+test "upsertEnvLine appends, updates in place, preserves everything else" {
     const allocator = std.testing.allocator;
-    const vars = [_]SyncVar{
-        .{ .name = "PORT", .type = "plain", .value = "3000", .description = null },
-        .{ .name = "TIMBAL_PROJECT_SECRET", .type = "secret", .value = "x", .description = null },
-        .{ .name = "OK", .type = "plain", .value = "1", .description = null },
-    };
-    const payload = try buildPushPayload(allocator, "main", &vars);
-    defer allocator.free(payload);
-    try std.testing.expect(std.mem.indexOf(u8, payload, "\"name\":\"PORT\"") == null);
-    try std.testing.expect(std.mem.indexOf(u8, payload, "\"name\":\"TIMBAL_PROJECT_SECRET\"") == null);
-    try std.testing.expect(std.mem.indexOf(u8, payload, "\"name\":\"OK\"") != null);
+
+    var r1 = try upsertEnvLine(allocator, null, "TIMBAL_APP_ID", "2335", "note");
+    defer r1.deinit(allocator);
+    try std.testing.expectEqual(UpsertOutcome.added, r1.outcome);
+    try std.testing.expectEqualStrings("# note\nTIMBAL_APP_ID=2335\n", r1.content);
+
+    // No trailing newline on the existing file; comments and order untouched.
+    var r2 = try upsertEnvLine(allocator, "# my stuff\nFOO=bar", "TIMBAL_APP_ID", "2335", null);
+    defer r2.deinit(allocator);
+    try std.testing.expectEqual(UpsertOutcome.added, r2.outcome);
+    try std.testing.expectEqualStrings("# my stuff\nFOO=bar\nTIMBAL_APP_ID=2335\n", r2.content);
+
+    var r3 = try upsertEnvLine(allocator, "FOO=bar\nexport TIMBAL_APP_ID=\"999\"\n# tail\n", "TIMBAL_APP_ID", "2335", "note");
+    defer r3.deinit(allocator);
+    try std.testing.expectEqual(UpsertOutcome.updated, r3.outcome);
+    try std.testing.expectEqualStrings("999", r3.previous.?);
+    try std.testing.expectEqualStrings("FOO=bar\nTIMBAL_APP_ID=2335\n# tail\n", r3.content);
+
+    var r4 = try upsertEnvLine(allocator, "TIMBAL_APP_ID=2335\nX=1\n", "TIMBAL_APP_ID", "2335", "note");
+    defer r4.deinit(allocator);
+    try std.testing.expectEqual(UpsertOutcome.unchanged, r4.outcome);
+    try std.testing.expectEqualStrings("TIMBAL_APP_ID=2335\nX=1\n", r4.content);
+
+    // CRLF files stay CRLF; the commented-out placeholder is not a definition.
+    var r5 = try upsertEnvLine(allocator, "A=1\r\n# TIMBAL_APP_ID=1\r\n", "TIMBAL_APP_ID", "5", null);
+    defer r5.deinit(allocator);
+    try std.testing.expectEqual(UpsertOutcome.added, r5.outcome);
+    try std.testing.expectEqualStrings("A=1\r\n# TIMBAL_APP_ID=1\r\nTIMBAL_APP_ID=5\r\n", r5.content);
+
+    var r6 = try upsertEnvLine(allocator, "TIMBAL_APP_ID=1\r\nB=2\r\n", "TIMBAL_APP_ID", "5", null);
+    defer r6.deinit(allocator);
+    try std.testing.expectEqual(UpsertOutcome.updated, r6.outcome);
+    try std.testing.expectEqualStrings("TIMBAL_APP_ID=5\r\nB=2\r\n", r6.content);
+}
+
+test "parsePullResponse tolerates string, VarValue object, and missing values" {
+    const allocator = std.testing.allocator;
+    const body =
+        \\{"rev":"main","vars":[
+        \\  {"name":"A","type":"plain","value":"1","description":null},
+        \\  {"name":"B","type":"secret","value":{"type":"secret","decrypted":"s3"}},
+        \\  {"name":"C","value":{"type":"plain","value":"v"}},
+        \\  {"name":"D","type":"secret","value":{"type":"secret","preview":"ab…"}},
+        \\  {"name":"E","type":"plain"},
+        \\  {"name":"TIMBAL_ORG_ID","type":"plain","value":"1","source":"platform"},
+        \\  {"name":"F","type":"plain","value":"1","managed":true}
+        \\]}
+    ;
+    var res = try parsePullResponse(allocator, body);
+    defer res.deinit(allocator);
+    try std.testing.expectEqualStrings("main", res.rev);
+    try std.testing.expectEqual(@as(usize, 7), res.vars.items.len);
+    try std.testing.expect(!res.vars.items[0].managed);
+    try std.testing.expect(res.vars.items[5].managed);
+    try std.testing.expect(res.vars.items[6].managed);
+    try std.testing.expectEqualStrings("1", res.vars.items[0].value);
+    try std.testing.expect(res.vars.items[0].type_explicit);
+    try std.testing.expectEqualStrings("secret", res.vars.items[1].type);
+    try std.testing.expectEqualStrings("s3", res.vars.items[1].value);
+    try std.testing.expectEqualStrings("plain", res.vars.items[2].type);
+    try std.testing.expectEqualStrings("v", res.vars.items[2].value);
+    try std.testing.expect(res.vars.items[3].value_missing);
+    try std.testing.expect(!res.vars.items[4].value_missing); // empty plain var is legitimate
+    try std.testing.expectEqualStrings("", res.vars.items[4].value);
+}
+
+test "parseRemoteVarList reads types, env scoping, and ids as strings" {
+    const allocator = std.testing.allocator;
+    const body =
+        \\{"vars":[
+        \\  {"id":41,"name":"TIMBAL_PROJECT_SECRET","value":{"type":"secret","preview":"x","decrypted":null},"envs":[{"id":7,"name":"main","color":"#fff"}],"applies_to_all_envs":false},
+        \\  {"id":"42","name":"FOO","value":{"type":"plain","value":"1"},"envs":[],"applies_to_all_envs":true}
+        \\]}
+    ;
+    var list = try parseRemoteVarList(allocator, body);
+    defer freeRemoteVars(allocator, &list);
+    try std.testing.expectEqual(@as(usize, 2), list.items.len);
+    try std.testing.expectEqualStrings("41", list.items[0].id);
+    try std.testing.expectEqualStrings("secret", list.items[0].type);
+    try std.testing.expect(list.items[0].hasEnv("7"));
+    try std.testing.expect(!list.items[0].hasEnv("8"));
+    try std.testing.expect(!list.items[0].applies_to_all_envs);
+    try std.testing.expectEqualStrings("42", list.items[1].id);
+    try std.testing.expectEqualStrings("plain", list.items[1].type);
+    try std.testing.expect(list.items[1].applies_to_all_envs);
+
+    try std.testing.expectEqualStrings("secret", remoteTypeFor(list.items, "TIMBAL_PROJECT_SECRET").?);
+    try std.testing.expectEqualStrings("plain", remoteTypeFor(list.items, "FOO").?);
+    try std.testing.expect(remoteTypeFor(list.items, "NOPE") == null);
+}
+
+test "parseVarDecrypted and parseEnvIdForBranch" {
+    const allocator = std.testing.allocator;
+    const d = try parseVarDecrypted(allocator, "{\"id\":1,\"name\":\"X\",\"value\":{\"type\":\"secret\",\"preview\":\"a\",\"decrypted\":\"plaintext\"}}");
+    defer if (d) |s| allocator.free(s);
+    try std.testing.expectEqualStrings("plaintext", d.?);
+    try std.testing.expect((try parseVarDecrypted(allocator, "{\"value\":{\"type\":\"secret\",\"decrypted\":null}}")) == null);
+
+    const envs = "{\"envs\":[{\"id\":3,\"name\":\"prod\",\"branch\":\"main\"},{\"id\":4,\"name\":\"stg\",\"branch\":null}]}";
+    const id = try parseEnvIdForBranch(allocator, envs, "main");
+    defer if (id) |s| allocator.free(s);
+    try std.testing.expectEqualStrings("3", id.?);
+    try std.testing.expect((try parseEnvIdForBranch(allocator, envs, "feature")) == null);
+}
+
+test "parseWorkforceList and matchComponent" {
+    const allocator = std.testing.allocator;
+    const body =
+        \\{"workforce":[
+        \\  {"id":"2335","name":"copilot","type":"agent","uid":"ac673db8356ab7d319a667290179b735"},
+        \\  {"id":88,"name":"legacy","type":"workflow","uid":null},
+        \\  {"id":"90","name":"renamed","type":"agent","uid":"ffff"},
+        \\  {"id":-731055215,"name":"fresh","type":"agent","uid":"0123"}
+        \\]}
+    ;
+    var comps = try parseWorkforceList(allocator, body);
+    defer freeRemoteComponents(allocator, &comps);
+    try std.testing.expectEqual(@as(usize, 4), comps.items.len);
+    try std.testing.expectEqualStrings("2335", comps.items[0].id);
+    try std.testing.expectEqualStrings("88", comps.items[1].id);
+    try std.testing.expect(comps.items[1].uid == null);
+    try std.testing.expect(comps.items[0].isRegistered());
+    // Unregistered worktree members carry a negative synthetic hash — never a TIMBAL_APP_ID.
+    try std.testing.expectEqualStrings("-731055215", comps.items[3].id);
+    try std.testing.expect(!comps.items[3].isRegistered());
+
+    var claimed = [_]bool{ false, false, false, false };
+    // uid wins even when the directory name differs.
+    const m1 = matchComponent(comps.items, "copilot-renamed-locally", "ac673db8356ab7d319a667290179b735", &claimed).?;
+    try std.testing.expectEqual(@as(usize, 0), m1.index);
+    try std.testing.expectEqual(MatchKind.uid, m1.kind);
+    // Name fallback only for components without a uid.
+    const m2 = matchComponent(comps.items, "legacy", "0000", &claimed).?;
+    try std.testing.expectEqual(@as(usize, 1), m2.index);
+    try std.testing.expectEqual(MatchKind.name, m2.kind);
+    // Same name but a different uid is a different manifest identity → no match.
+    try std.testing.expect(matchComponent(comps.items, "renamed", "0000", &claimed) == null);
+    try std.testing.expectEqual(@as(usize, 2), findNameOnlyConflict(comps.items, "renamed", "0000").?);
+    // Claimed components are not matched twice.
+    claimed[0] = true;
+    try std.testing.expect(matchComponent(comps.items, "copilot", "ac673db8356ab7d319a667290179b735", &claimed) == null);
+}
+
+test "reserved and platform-managed name rules" {
+    try std.testing.expect(isReservedVarName("TIMBAL_APP_ID"));
+    try std.testing.expect(isReservedVarName("PORT"));
+    try std.testing.expect(isReservedVarName("TIMBAL_PROJECT_SECRET"));
+    try std.testing.expect(!isReservedVarName("TIMBAL_ORG_ID"));
+    try std.testing.expect(isPlatformManagedName("TIMBAL_PROJECT_ENV_ID"));
+    try std.testing.expect(isPlatformManagedName("VITE_TIMBAL_PROJECT_REV"));
+    try std.testing.expect(isPlatformManagedName("TIMBAL_STUDIO"));
+    try std.testing.expect(isPlatformManagedName("VITE_TIMBAL_PREVIEW_HOST"));
+    try std.testing.expect(isPlatformManagedName("VITE_AUTH_TIMBAL_IAM"));
+    try std.testing.expect(!isPlatformManagedName("VITE_API_URL"));
+    try std.testing.expect(!isPlatformManagedName("OPENAI_API_KEY"));
+    try std.testing.expectEqualStrings("secret", canonType(" Secret ").?);
+    try std.testing.expect(canonType("hidden") == null);
 }
 
 test "gitignoreCoversBasename matches the actual file" {

--- a/cli/integration_tests_env.sh
+++ b/cli/integration_tests_env.sh
@@ -1,0 +1,512 @@
+#!/usr/bin/env bash
+#
+# Integration tests for `timbal env pull` / `timbal env push`.
+#
+# These exercise the built binary end to end — exit-code contract, where files land,
+# what is written commented out vs active, and what push refuses — against a temp git
+# checkout. Three tiers:
+#
+#   default                     hermetic: usage / precondition errors. Fake $HOME, no network.
+#   TIMBAL_CLI_E2E_NETWORK=1    read-only against the platform: pulls a real project from
+#                               api.dev.timbal.ai (default) and checks file placement against
+#                               what the API itself returns. Never POSTs (push runs --dry-run).
+#   TIMBAL_CLI_E2E_WRITE=1      also exercises real push: creates uniquely named probe vars on
+#                               the project via the API, pushes, verifies types/values, deletes
+#                               them again (implies NETWORK). Only run against a dev project.
+#
+# Network tiers read the API key the same way the CLI does (~/.timbal/credentials, profile
+# from TIMBAL_E2E_PROFILE / TIMBAL_PROFILE / default) unless TIMBAL_E2E_API_KEY is set.
+# They need `curl` and `jq`.
+#
+#   TIMBAL_E2E_HOST      api.dev.timbal.ai
+#   TIMBAL_E2E_ORG       1
+#   TIMBAL_E2E_PROJECT   1460
+#   TIMBAL_E2E_REV       main
+#
+# Usage:
+#   cli/integration_tests_env.sh
+#   TIMBAL_CLI_E2E_NETWORK=1 cli/integration_tests_env.sh
+#   TIMBAL_CLI_E2E_WRITE=1 TIMBAL_E2E_PROJECT=1460 cli/integration_tests_env.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERSION="${TIMBAL_CLI_VERSION:-dev}"
+
+PASS=0
+FAIL=0
+
+red() { printf '\033[31m%s\033[0m\n' "$1"; }
+green() { printf '\033[32m%s\033[0m\n' "$1"; }
+dim() { printf '\033[2m%s\033[0m\n' "$1"; }
+
+pass() { PASS=$((PASS + 1)); green "ok   $1"; }
+fail() { FAIL=$((FAIL + 1)); red "FAIL $1"; }
+
+detect_bin() {
+    local os arch zos zarch bin
+    os="$(uname -s)"
+    arch="$(uname -m)"
+    case "$os" in
+        Darwin) zos="macos" ;;
+        Linux) zos="linux" ;;
+        *) red "Unsupported OS for integration tests: $os"; exit 1 ;;
+    esac
+    case "$arch" in
+        arm64 | aarch64) zarch="aarch64" ;;
+        x86_64 | amd64) zarch="x86_64" ;;
+        *) red "Unsupported arch for integration tests: $arch"; exit 1 ;;
+    esac
+    bin="$SCRIPT_DIR/zig-out/$VERSION/timbal-$VERSION-$zos-$zarch"
+    [ "$zos" = "linux" ] && bin="$bin-gnu"
+    printf '%s' "$bin"
+}
+
+# Run the CLI with cwd=$1 and capture stdout/stderr/exit into globals.
+# Env for the child is whatever the caller exported (HOME, TIMBAL_PROFILE).
+OUT=""
+ERR=""
+CODE=0
+run_cli() {
+    local dir="$1"
+    shift
+    local outfile errfile
+    outfile="$(mktemp)"
+    errfile="$(mktemp)"
+    ( cd "$dir" && "$BIN" "$@" ) >"$outfile" 2>"$errfile" </dev/null
+    CODE=$?
+    OUT="$(cat "$outfile")"
+    ERR="$(cat "$errfile")"
+    rm -f "$outfile" "$errfile"
+}
+
+# expect <desc> <exit> [stderr_substr] [stdout_substr]
+expect() {
+    local desc="$1" want="$2" err_sub="${3:-}" out_sub="${4:-}" ok=1
+    [ "$CODE" -eq "$want" ] || { ok=0; red "  exit: got $CODE, want $want"; }
+    if [ -n "$err_sub" ] && ! printf '%s' "$ERR" | grep -qF -- "$err_sub"; then
+        ok=0; red "  stderr missing: '$err_sub' (got: '$(printf '%s' "$ERR" | head -3)')"
+    fi
+    if [ -n "$out_sub" ] && ! printf '%s' "$OUT" | grep -qF -- "$out_sub"; then
+        ok=0; red "  stdout missing: '$out_sub' (got: '$(printf '%s' "$OUT" | head -5)')"
+    fi
+    if [ "$ok" -eq 1 ]; then pass "$desc (exit $CODE)"; else fail "$desc"; fi
+}
+
+# check <desc> <shell-condition...>
+check() {
+    local desc="$1"
+    shift
+    if "$@"; then pass "$desc"; else fail "$desc"; fi
+}
+
+out_has() { printf '%s' "$OUT" | grep -qF -- "$1"; }
+err_has() { printf '%s' "$ERR" | grep -qF -- "$1"; }
+err_lacks() { ! printf '%s' "$ERR" | grep -qF -- "$1"; }
+# The stdout line containing <needle> also contains <substr>.
+out_line_has() { printf '%s\n' "$OUT" | grep -F -- "$1" | grep -qF -- "$2"; }
+not_grep() { ! grep -Eq -- "$1" "$2"; }
+count_is() { [ "$(grep -cE -- "$1" "$2")" = "$3" ]; }
+line_count_is() { [ "$(wc -l <"$1" | tr -d ' ')" = "$2" ]; }
+
+# Active (non-comment) keys in a .env, one per line.
+active_keys() { grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "$1" 2>/dev/null | cut -d= -f1 | sort -u; }
+no_active_platform_keys() { ! active_keys "$1" | grep -Eq '^(TIMBAL_|VITE_TIMBAL_)'; }
+# Every active key in $1 is one of the newline-separated names in $2.
+active_subset_of() {
+    local extra
+    extra="$(comm -23 <(active_keys "$1") <(printf '%s\n' "$2" | sort -u))"
+    [ -z "$extra" ] || { red "  unexpected active keys: $(printf '%s' "$extra" | tr '\n' ' ')"; return 1; }
+}
+member_env_is_only_app_id() { [ "$(active_keys "$1")" = TIMBAL_APP_ID ] && grep -qx "TIMBAL_APP_ID=$2" "$1"; }
+# `KEY=VALUE` line in $2 has `# type: $3` within the 3 lines above it.
+tagged_as() { grep -B3 -x -- "$1" "$2" | grep -qx "# type: $3"; }
+
+git_init_repo() {
+    local dir="$1" remote="$2" branch="$3"
+    mkdir -p "$dir"
+    git -C "$dir" -c init.defaultBranch="$branch" init -q
+    git -C "$dir" -c user.name=e2e -c user.email=e2e@example.com commit -q --allow-empty -m init
+    git -C "$dir" checkout -q -B "$branch"
+    git -C "$dir" remote add origin "$remote"
+    printf '.env\n' >"$dir/.gitignore"
+}
+
+write_member() {
+    local dir="$1" name="$2" uid="$3"
+    mkdir -p "$dir/workforce/$name"
+    printf '_id: "%s"\n_type: "agent"\nfqn: "agent.py::agent"\n' "$uid" >"$dir/workforce/$name/timbal.yaml"
+}
+
+# ---------------------------------------------------------------------------
+# Hermetic tier
+# ---------------------------------------------------------------------------
+hermetic_tier() {
+    echo
+    echo "== env: hermetic usage / precondition contract =="
+
+    local FAKE_HOME="$T/home"
+    mkdir -p "$FAKE_HOME/.timbal"
+    printf '[default]\napi_key = fake-key-for-tests\n' >"$FAKE_HOME/.timbal/credentials"
+
+    # Not configured at all.
+    local EMPTY_HOME="$T/emptyhome"
+    mkdir -p "$EMPTY_HOME"
+    HOME="$EMPTY_HOME" run_cli "$T" env pull --dry-run
+    expect "not configured → exit 1" 1 "Timbal is not configured"
+
+    export HOME="$FAKE_HOME"
+    unset TIMBAL_PROFILE
+
+    run_cli "$T" env
+    expect "missing command" 2 "missing command (pull or push)"
+    run_cli "$T" env frobnicate
+    expect "unknown command" 2 "unknown env command"
+    run_cli "$T" env pull --bogus
+    expect "unknown option" 2 "unknown option"
+    run_cli "$T" env pull --rev
+    expect "--rev without value" 2 "--rev requires a branch name"
+    run_cli "$T" env pull --rev main --default
+    expect "--rev + --default" 2 "mutually exclusive"
+    run_cli "$T" env push --force
+    expect "--force with push" 2 "--force is only valid with"
+    run_cli "$T" env pull --secret X
+    expect "--secret with pull" 2 "--secret / --plain are only valid with"
+    run_cli "$T" env push --include-platform-vars
+    expect "--include-platform-vars with push" 2 "only valid with \`timbal env pull\`"
+    run_cli "$T" env push --secret X --plain X
+    expect "same var --secret and --plain" 2 "cannot be both"
+    run_cli "$T" env pull --base-url http://api.dev.timbal.ai
+    expect "--base-url http" 2 "must be https"
+    run_cli "$T" env pull --base-url https://evil.example.com
+    expect "--base-url lookalike host" 2 "must be https://api.timbal.ai"
+    run_cli "$T" env -h
+    expect "env -h" 0
+
+    # Precondition: not a git repo.
+    mkdir -p "$T/nogit"
+    run_cli "$T/nogit" env pull --dry-run
+    expect "outside a git repo" 1 "not inside a git repository"
+
+    # Precondition: git repo without a Timbal remote.
+    git_init_repo "$T/github" "git@github.com:acme/app.git" main
+    run_cli "$T/github" env pull --dry-run
+    expect "no Timbal remote" 1 "no Timbal git remote found"
+
+    # Precondition: detached HEAD → needs --rev / --default (parsed before any network).
+    git_init_repo "$T/detached" "https://api.dev.timbal.ai/orgs/1/projects/1/git" main
+    git -C "$T/detached" checkout -q --detach
+    run_cli "$T/detached" env pull --dry-run
+    expect "detached HEAD" 1 "could not determine current git branch"
+
+    # Push preconditions on the local file happen before any network call.
+    git_init_repo "$T/proj" "https://api.dev.timbal.ai/orgs/1/projects/1/git" main
+    mkdir -p "$T/proj/workforce"
+    run_cli "$T/proj" env push --dry-run
+    expect "push without local file" 1 "local env file not found"
+    : >"$T/proj/.env"
+    run_cli "$T/proj" env push --dry-run
+    expect "push empty file" 1 "no variables found"
+    printf '# type: hidden\nFOO=1\n' >"$T/proj/.env"
+    run_cli "$T/proj" env push --dry-run
+    expect "push invalid type metadata" 1 "invalid type 'hidden'"
+    rm -f "$T/proj/.env"
+}
+
+# ---------------------------------------------------------------------------
+# Network tier (read-only)
+# ---------------------------------------------------------------------------
+API_HOST="${TIMBAL_E2E_HOST:-api.dev.timbal.ai}"
+API_ORG="${TIMBAL_E2E_ORG:-1}"
+API_PROJECT="${TIMBAL_E2E_PROJECT:-1460}"
+API_REV="${TIMBAL_E2E_REV:-main}"
+API_KEY=""
+API=""
+
+resolve_api_key() {
+    if [ -n "${TIMBAL_E2E_API_KEY:-}" ]; then
+        API_KEY="$TIMBAL_E2E_API_KEY"
+        return 0
+    fi
+    local profile="${TIMBAL_E2E_PROFILE:-${TIMBAL_PROFILE:-default}}" header
+    if [ "$profile" = "default" ]; then header='[default]'; else header="[profile $profile]"; fi
+    API_KEY="$(awk -v h="$header" '
+        $0 == h { f = 1; next }
+        /^\[/ { f = 0 }
+        f && /^[ \t]*api_key[ \t]*=/ { sub(/^[^=]*=[ \t]*/, ""); print; exit }
+    ' "$HOME/.timbal/credentials" 2>/dev/null)"
+    [ -n "$API_KEY" ]
+}
+
+api_get() { curl -sS -H "Authorization: Bearer $API_KEY" -H "Accept: application/json" "$API$1"; }
+api_post() { curl -sS -o /dev/null -w '%{http_code}' -X POST -H "Authorization: Bearer $API_KEY" -H "Content-Type: application/json" -d "$2" "$API$1"; }
+api_delete() { curl -sS -o /dev/null -w '%{http_code}' -X DELETE -H "Authorization: Bearer $API_KEY" "$API$1"; }
+
+network_tier() {
+    echo
+    echo "== env: network (read-only) against https://$API_HOST org=$API_ORG project=$API_PROJECT rev=$API_REV =="
+
+    command -v jq >/dev/null 2>&1 || { red "jq is required for the network tier"; FAIL=$((FAIL + 1)); return; }
+    resolve_api_key || { red "no API key (set TIMBAL_E2E_API_KEY or run timbal configure)"; FAIL=$((FAIL + 1)); return; }
+    API="https://$API_HOST/orgs/$API_ORG/projects/$API_PROJECT"
+    export TIMBAL_PROFILE="${TIMBAL_E2E_PROFILE:-${TIMBAL_PROFILE:-default}}"
+
+    # Expectations come from the API itself, so the test follows the project.
+    local wf pull list
+    wf="$(api_get "/workforce?rev=$API_REV")" || { fail "GET /workforce"; return; }
+    pull="$(api_get "/vars/pull?rev=$API_REV")" || { fail "GET /vars/pull"; return; }
+    list="$(api_get "/vars")" || { fail "GET /vars"; return; }
+    printf '%s' "$pull" | jq -e '.vars' >/dev/null 2>&1 || { fail "GET /vars/pull returned no vars array: $(printf '%s' "$pull" | head -c 300)"; return; }
+
+    MEMBER_NAME="$(printf '%s' "$wf" | jq -r '[.workforce[] | select(.uid != null and .uid != "" and (.id|tostring|startswith("-")|not))][0].name // empty')"
+    MEMBER_UID="$(printf '%s' "$wf" | jq -r '[.workforce[] | select(.uid != null and .uid != "" and (.id|tostring|startswith("-")|not))][0].uid // empty')"
+    MEMBER_ID="$(printf '%s' "$wf" | jq -r '[.workforce[] | select(.uid != null and .uid != "" and (.id|tostring|startswith("-")|not))][0].id // empty' | tr -d '"')"
+    [ -n "$MEMBER_NAME" ] || dim "  (project has no registered workforce component with a uid; TIMBAL_APP_ID checks will be skipped)"
+
+    # Names in the effective env that are not user-defined project vars → must land commented out.
+    local managed_names user_names
+    managed_names="$(jq -rn --argjson p "$pull" --argjson l "$list" '[$p.vars[].name] - [$l.vars[].name] | .[]')"
+    user_names="$(jq -rn --argjson p "$pull" --argjson l "$list" '[$p.vars[].name] - ([$p.vars[].name] - [$l.vars[].name]) | .[]')"
+
+    P="$T/net"
+    git_init_repo "$P" "https://$API_HOST/orgs/$API_ORG/projects/$API_PROJECT/git" "$API_REV"
+    mkdir -p "$P/workforce"
+    [ -n "$MEMBER_NAME" ] && write_member "$P" "$MEMBER_NAME" "$MEMBER_UID"
+    write_member "$P" e2e-orphan "deadbeefdeadbeefdeadbeefdeadbeef"
+
+    # --- pull --dry-run writes nothing ---------------------------------------
+    run_cli "$P" env pull --dry-run
+    expect "pull --dry-run" 0 "" "Dry run — would write"
+    check "pull --dry-run creates no .env" test ! -e "$P/.env"
+    check "pull --dry-run reports the orphan member" out_has "workforce/e2e-orphan  no platform component"
+    check "pull --dry-run writes no member .env" test ! -e "$P/workforce/e2e-orphan/.env"
+    if [ -n "$MEMBER_NAME" ]; then
+        check "pull --dry-run plans TIMBAL_APP_ID=$MEMBER_ID for $MEMBER_NAME" out_has "workforce/$MEMBER_NAME/.env  TIMBAL_APP_ID=$MEMBER_ID  would add"
+        check "pull --dry-run did not write member .env" test ! -e "$P/workforce/$MEMBER_NAME/.env"
+    fi
+
+    # --- pull: placement ------------------------------------------------------
+    run_cli "$P" env pull
+    expect "pull" 0 "" "Pulled"
+    check "pull wrote <project>/.env" test -f "$P/.env"
+    check "pull: no active TIMBAL_* / VITE_TIMBAL_* in root .env" no_active_platform_keys "$P/.env"
+    local n ok=1
+    while IFS= read -r n; do
+        [ -n "$n" ] || continue
+        grep -qF "# $n=" "$P/.env" || { ok=0; red "  managed $n not present as a commented line"; }
+        grep -Eq "^$n=" "$P/.env" && { ok=0; red "  managed $n is active"; }
+    done <<<"$managed_names"
+    [ "$ok" -eq 1 ] && pass "pull: every platform-managed var is commented out" || fail "pull: platform-managed vars"
+    ok=1
+    while IFS= read -r n; do
+        [ -n "$n" ] || continue
+        # Reserved or multi-line values are legitimately commented; anything else must be active.
+        case "$n" in PORT | TIMBAL_PROJECT_SECRET | TIMBAL_APP_ID) continue ;; esac
+        if ! grep -Eq "^$n=" "$P/.env" && ! grep -qF "# $n=" "$P/.env"; then ok=0; red "  user var $n missing"; fi
+    done <<<"$user_names"
+    [ "$ok" -eq 1 ] && pass "pull: every user-defined var is present" || fail "pull: user-defined vars"
+    check "pull: active keys ⊆ user-defined names" active_subset_of "$P/.env" "$user_names"
+    check "pull: file carries the rev header" grep -qF "# rev: $API_REV" "$P/.env"
+    check "pull: orphan member got no .env" test ! -e "$P/workforce/e2e-orphan/.env"
+    if [ -n "$MEMBER_NAME" ]; then
+        check "pull: member .env has exactly TIMBAL_APP_ID=$MEMBER_ID" member_env_is_only_app_id "$P/workforce/$MEMBER_NAME/.env" "$MEMBER_ID"
+        check "pull: TIMBAL_APP_ID not active in root .env" not_grep '^TIMBAL_APP_ID=' "$P/.env"
+        cp "$P/workforce/$MEMBER_NAME/.env" "$T/member-before.env"
+    fi
+
+    # --- pull refuses to clobber; --force keeps member files untouched --------
+    run_cli "$P" env pull
+    expect "pull again without --force" 1 "already exists. Re-run with --force"
+    run_cli "$P" env pull --force
+    expect "pull --force" 0 "" "Pulled"
+    if [ -n "$MEMBER_NAME" ]; then
+        check "pull --force: member .env byte-identical" cmp -s "$T/member-before.env" "$P/workforce/$MEMBER_NAME/.env"
+        check "pull --force reports member unchanged" out_has "TIMBAL_APP_ID=$MEMBER_ID  unchanged"
+
+        # Merge: other lines survive, stale value is replaced in place, exactly once.
+        printf '# my local overrides\nDEBUG=1\nTIMBAL_APP_ID=1\n\nOTHER="a b"\n' >"$P/workforce/$MEMBER_NAME/.env"
+        run_cli "$P" env pull --force
+        expect "pull --force merges member .env" 0 "" "updated (was 1)"
+        check "merge keeps comment" grep -qxF '# my local overrides' "$P/workforce/$MEMBER_NAME/.env"
+        check "merge keeps DEBUG=1" grep -qxF 'DEBUG=1' "$P/workforce/$MEMBER_NAME/.env"
+        check "merge keeps quoted OTHER" grep -qxF 'OTHER="a b"' "$P/workforce/$MEMBER_NAME/.env"
+        check "merge replaced TIMBAL_APP_ID exactly once" count_is '^TIMBAL_APP_ID=' "$P/workforce/$MEMBER_NAME/.env" 1
+        check "merge wrote the platform id" grep -qx "TIMBAL_APP_ID=$MEMBER_ID" "$P/workforce/$MEMBER_NAME/.env"
+        check "merge keeps line count" line_count_is "$P/workforce/$MEMBER_NAME/.env" 5
+    fi
+
+    # --- --include-platform-vars writes them active and the audit says so -----
+    if printf '%s\n' "$managed_names" | grep -qx TIMBAL_PROJECT_ENV_ID; then
+        run_cli "$P" env pull --force --include-platform-vars
+        expect "pull --include-platform-vars" 0 "Placement check" "written active"
+        check "include-platform-vars: TIMBAL_PROJECT_ENV_ID active" grep -Eq '^TIMBAL_PROJECT_ENV_ID=' "$P/.env"
+        check "audit flags the reroute" err_has "TIMBAL_PROJECT_ENV_ID is active"
+        run_cli "$P" env pull --force
+        expect "pull --force restores commented layout" 0 "" "Pulled"
+        check "no audit finding after normal pull" err_lacks "Placement check"
+    else
+        dim "  (TIMBAL_PROJECT_ENV_ID not in this project's pull set; skipping --include-platform-vars audit case)"
+    fi
+
+    # --- push --dry-run: plan, never POSTs -------------------------------------
+    local probe="E2E_PROBE_$(date +%s)_$$"
+    printf '%s_KEY=sk-not-a-real-key\nLOG_LEVEL=debug\nMAX_TOKENS=1024\n# secret\nCUSTOM_THING=abc\nTIMBAL_PROJECT_ENV_ID=999\nVITE_TIMBAL_ORG_ID=1\nTIMBAL_APP_ID=5\nPORT=3000\n' "$probe" >"$P/.env"
+    run_cli "$P" env push --dry-run --plain LOG_LEVEL
+    expect "push --dry-run" 0 "" "No changes made."
+    check "plan: inferred secret for *_KEY" out_line_has "${probe}_KEY" "secret  inferred from name/value"
+    check "plan: --plain wins" out_line_has "LOG_LEVEL" "plain   --secret/--plain"
+    check "plan: MAX_TOKENS is plain" out_line_has "MAX_TOKENS" "plain   inferred"
+    check "plan: # secret shorthand honoured" out_line_has "CUSTOM_THING" "secret  file metadata"
+    check "plan: TIMBAL_PROJECT_ENV_ID never pushed" out_line_has "TIMBAL_PROJECT_ENV_ID" "never pushed"
+    check "plan: VITE_TIMBAL_* never pushed" out_line_has "VITE_TIMBAL_ORG_ID" "never pushed"
+    check "plan: TIMBAL_APP_ID reserved with placement hint" out_line_has "TIMBAL_APP_ID" "belongs in workforce/<name>/.env"
+    check "plan: PORT reserved" out_line_has "  PORT " "reserved"
+    check "audit: active TIMBAL_PROJECT_ENV_ID in root .env flagged on push" err_has "TIMBAL_PROJECT_ENV_ID is active"
+    check "audit: root TIMBAL_APP_ID flagged on push" err_has "TIMBAL_APP_ID here is loaded into every service"
+    check "push --dry-run did not create the probe var" var_absent "${probe}_KEY"
+    if [ -n "$MEMBER_NAME" ]; then
+        check "push --dry-run plans member app id" out_has "TIMBAL_APP_ID=$MEMBER_ID"
+    fi
+
+    printf 'TIMBAL_PROJECT_ENV_ID=1\nPORT=1\n' >"$P/.env"
+    run_cli "$P" env push --dry-run
+    expect "push with only reserved/managed vars" 1 "nothing to push"
+
+    run_cli "$P" env pull --dry-run --rev "e2e-no-such-branch-$$"
+    expect "pull unknown branch" 1 "Error"
+
+    run_cli "$P" env pull --dry-run -f "workforce/e2e-orphan/.env.e2e"
+    check "-f inside a member dir warns about scope" err_has "scoped to workforce member 'e2e-orphan'"
+
+    rm -f "$P/.env"
+}
+
+# ---------------------------------------------------------------------------
+# Write tier (real push against a dev project, probe vars only, cleaned up)
+# ---------------------------------------------------------------------------
+PROBE_IDS=()
+cleanup_probes() {
+    local id
+    for id in "${PROBE_IDS[@]:-}"; do
+        [ -n "$id" ] && api_delete "/vars/$id" >/dev/null 2>&1
+    done
+}
+
+var_id_by_name() { api_get /vars | jq -r --arg n "$1" '.vars[] | select(.name == $n) | .id' | head -1; }
+var_type_by_name() { api_get /vars | jq -r --arg n "$1" '.vars[] | select(.name == $n) | .value.type' | head -1; }
+var_decrypted_by_id() { api_get "/vars/$1" | jq -r '.value.decrypted // .value.value // empty'; }
+var_absent() { [ -z "$(var_id_by_name "$1")" ]; }
+value_is() { [ "$(var_decrypted_by_id "$1")" = "$2" ]; }
+type_is() { [ "$(var_type_by_name "$1")" = "$2" ]; }
+
+write_tier() {
+    echo
+    echo "== env: WRITE tier — real push against https://$API_HOST project=$API_PROJECT (probe vars only) =="
+    [ -n "$API" ] || { red "network tier did not initialise; skipping write tier"; FAIL=$((FAIL + 1)); return; }
+
+    local stamp="$(date +%s)_$$" env_id env_ids='null'
+    local S="E2E_PROBE_${stamp}_SECRET" PL="E2E_PROBE_${stamp}_PLAIN"
+    env_id="$(api_get /envs | jq -r --arg b "$API_REV" '.envs[] | select(.branch == $b) | .id' | head -1)"
+    [ -n "$env_id" ] && env_ids="[$env_id]"
+
+    local code
+    code="$(api_post /vars "{\"name\":\"$S\",\"type\":\"secret\",\"value\":\"s1\",\"env_ids\":$env_ids}")"
+    case "$code" in 200 | 201) ;; *) fail "create probe secret (HTTP $code)"; return ;; esac
+    local sid pid
+    sid="$(var_id_by_name "$S")"
+    PROBE_IDS=("$sid")
+    code="$(api_post /vars "{\"name\":\"$PL\",\"type\":\"plain\",\"value\":\"p1\",\"env_ids\":$env_ids}")"
+    case "$code" in 200 | 201) ;; *) fail "create probe plain (HTTP $code)"; cleanup_probes; return ;; esac
+    pid="$(var_id_by_name "$PL")"
+    PROBE_IDS=("$sid" "$pid")
+    [ -n "$sid" ] && [ -n "$pid" ] || { fail "probe vars not visible in GET /vars after create"; cleanup_probes; return; }
+    trap 'cleanup_probes; rm -rf "$T"' EXIT
+    pass "created probe vars $S (secret) and $PL (plain)"
+
+    P="$T/write"
+    git_init_repo "$P" "https://$API_HOST/orgs/$API_ORG/projects/$API_PROJECT/git" "$API_REV"
+    mkdir -p "$P/workforce"
+
+    # Secrets come back decrypted with their type.
+    run_cli "$P" env pull
+    expect "write: pull with probe vars" 0 "" "Pulled"
+    check "pull: secret is active and decrypted" grep -qx "$S=s1" "$P/.env"
+    check "pull: secret tagged # type: secret" tagged_as "$S=s1" "$P/.env" secret
+    check "pull: plain is active" grep -qx "$PL=p1" "$P/.env"
+    check "pull: plain tagged # type: plain" tagged_as "$PL=p1" "$P/.env" plain
+
+    # A file that marks the platform secret plain is refused; nothing changes.
+    printf '# type: plain\n%s=s-wrong\n\n%s=p1\n' "$S" "$PL" >"$P/.env"
+    run_cli "$P" env push
+    expect "push: secret marked plain is BLOCKED" 1 "secrets on the platform but marked plain" "BLOCKED"
+    check "blocked push left the secret value untouched" value_is "$sid" s1
+
+    # Value updates go through; the platform keeps the stored type (backend-confirmed).
+    printf '%s=s2\n# type: secret\n%s=p2\nTIMBAL_PROJECT_ENV_ID=999\nPORT=1\n' "$S" "$PL" >"$P/.env"
+    run_cli "$P" env push
+    expect "push: value updates" 0 "" "Pushed"
+    check "push: secret value updated" value_is "$sid" s2
+    check "push: secret type still secret (no metadata → platform type)" type_is "$S" secret
+    check "push: plain value updated" value_is "$pid" p2
+    check "push: requested type change reported as not applied" out_has "keeps the stored type on update"
+    check "push: plain stays plain on the platform" type_is "$PL" plain
+    check "push: TIMBAL_PROJECT_ENV_ID not created on the platform" var_absent TIMBAL_PROJECT_ENV_ID
+    check "push: audit flagged active TIMBAL_PROJECT_ENV_ID" err_has "TIMBAL_PROJECT_ENV_ID is active"
+
+    # --plain acknowledges the mismatch and pushes the value; type still cannot flip.
+    printf '# type: plain\n%s=s3\n' "$S" >"$P/.env"
+    run_cli "$P" env push --plain "$S"
+    expect "push --plain acknowledges mismatch" 0 "" "Pushed"
+    check "push --plain: value updated" value_is "$sid" s3
+    check "push --plain: type still secret on the platform" type_is "$S" secret
+
+    cleanup_probes
+    PROBE_IDS=()
+    trap 'rm -rf "$T"' EXIT
+    check "cleanup: probe secret deleted" var_absent "$S"
+    check "cleanup: probe plain deleted" var_absent "$PL"
+}
+
+main() {
+    BIN="$(detect_bin)"
+    if [ ! -x "$BIN" ]; then
+        echo "Building CLI (zig build)..."
+        (cd "$SCRIPT_DIR" && zig build) || { red "zig build failed"; exit 1; }
+    fi
+    [ -x "$BIN" ] || { red "binary not found: $BIN"; exit 1; }
+    echo "Using binary: $BIN"
+
+    T="$(mktemp -d)"
+    trap 'rm -rf "$T"' EXIT
+
+    local REAL_HOME="$HOME"
+    hermetic_tier
+    export HOME="$REAL_HOME"
+
+    if [ "${TIMBAL_CLI_E2E_WRITE:-0}" = "1" ]; then
+        export TIMBAL_CLI_E2E_NETWORK=1
+    fi
+    if [ "${TIMBAL_CLI_E2E_NETWORK:-0}" = "1" ]; then
+        network_tier
+        if [ "${TIMBAL_CLI_E2E_WRITE:-0}" = "1" ]; then
+            write_tier
+        else
+            echo
+            dim "(skipping write tier; set TIMBAL_CLI_E2E_WRITE=1 to exercise real push against a dev project)"
+        fi
+    else
+        echo
+        dim "(skipping network tier; set TIMBAL_CLI_E2E_NETWORK=1 to pull from https://$API_HOST)"
+    fi
+
+    echo
+    echo "----------------------------------------"
+    if [ "$FAIL" -eq 0 ]; then
+        green "All $PASS checks passed."
+        exit 0
+    fi
+    red "$FAIL failed, $PASS passed."
+    exit 1
+}
+
+main "$@"

--- a/docs/deployment/index.mdx
+++ b/docs/deployment/index.mdx
@@ -74,6 +74,31 @@ Restart services (`r` in the `timbal start` terminal, or quit and re-run) after 
 Vite and Bun may also read `ui/.env` and `api/.env` from those directories at dev time. Project-root `.env` is still the usual place for secrets shared across the stack (model API keys, integration tokens).
 </Tip>
 
+### Syncing with the platform: `timbal env pull` / `push`
+
+For projects connected to the [Timbal Platform](/deployment/platform), `timbal env` keeps the local files above in sync with the project's variables for one environment (the env tracking your current branch, `--rev <branch>`, or `--default`).
+
+```bash
+timbal env pull                 # platform → <project>/.env (+ TIMBAL_APP_ID per member)
+timbal env push                 # <project>/.env → platform (upsert only)
+timbal env push --dry-run       # show the plan, send nothing
+timbal env push --secret DB_URL --plain LOG_LEVEL
+```
+
+What lands where:
+
+| Var | Written to | Why |
+|-----|-----------|-----|
+| Your project vars (`OPENAI_API_KEY`, ...) | `<project>/.env` | Loaded into every service by `timbal start` |
+| `TIMBAL_APP_ID` | `workforce/<name>/.env` | Per workforce member; matched via the `_id` in that member's `timbal.yaml`. Merged into the file — other lines are untouched |
+| Platform runtime vars (`TIMBAL_*`, `VITE_TIMBAL_*`) | `<project>/.env`, **commented out** (`--include-platform-vars` writes them active) | The platform resolves these before every deploy/preview. Active locally, `TIMBAL_PROJECT_ENV_ID` reroutes service calls to the deployed gateway instead of localhost. **Push never sends `TIMBAL_*` vars**, whatever the file or flags say |
+
+Secrets vs plain: a `# type: secret` (or `# secret`) comment directly above a var marks it as a secret, `# type: plain` (or `# plain`) as plain. A var without a comment keeps its current type on the platform; a brand-new var is inferred from its name and value (`*_KEY`, `*_TOKEN`, `*_PASSWORD`, `sk-...`, `user:pass@` URLs → secret). `--secret NAME` / `--plain NAME` override everything. The platform fixes a var's type when it is created — pushing an existing var only updates its value — so change types in the platform UI. Push refuses a file that marks a platform secret as plain unless you pass `--plain NAME` explicitly. The push plan always lists every var with its resolved type and where that decision came from.
+
+<Warning>
+Pulled files contain secrets in plaintext — keep `.env` files gitignored (`timbal create` does this). `PORT`, `TIMBAL_PROJECT_SECRET`, and `TIMBAL_APP_ID` are never pushed as project vars.
+</Warning>
+
 ## Production
 
 For production you have two paths:


### PR DESCRIPTION
## Summary

Users reported that `timbal env pull/push` only really worked for plain vars, that secrets vs plain could not be managed properly, and that `TIMBAL_APP_ID` could not be placed per workforce member. Digging in surfaced a worse issue: pull wrote the platform's runtime wiring (`TIMBAL_PROJECT_ENV_ID`, `VITE_TIMBAL_*`, …) *active* into the root `.env`, which makes the SDK route local `timbal start` service calls to the deployed gateway instead of localhost — and push then sent those back as project vars.

- **Secrets vs plain on push.** Type resolves as `--secret/--plain` flag > file metadata (`# type: secret`, shorthand `# secret`/`# plain`) > **current platform type** (from `GET /vars`) > name/value inference for brand-new vars only. A file that marks a platform secret `plain` is refused unless `--plain NAME` acknowledges it. The plan is always printed (values redacted) with the source of every decision, and says explicitly that the platform keeps a var's stored type on update (backend-confirmed: `type` applies on create only).
- **`TIMBAL_*` is the platform's namespace.** Pull writes `TIMBAL_*` / `VITE_TIMBAL_*` (+ `VITE_AUTH_TIMBAL_IAM`) **commented out** with an explanation (`--include-platform-vars` writes them active); push **never** sends them, whatever the file or flags say. Reserved `PORT`, `TIMBAL_PROJECT_SECRET`, `TIMBAL_APP_ID` are never pushed either.
- **`TIMBAL_APP_ID` per workforce member.** Pull and push finish by merging `TIMBAL_APP_ID=<app id>` into `workforce/<name>/.env`, matching `timbal.yaml _id` ↔ platform `uid` (name fallback only when the platform component has no uid; unregistered components with synthetic negative ids are reported, never written). Only that one line is added/rewritten; the rest of the file is preserved byte for byte, atomically. Never written to the root `.env`. `--no-app-ids` opts out.
- **Placement safety.** `.env` lands at the project root `timbal start` actually loads from (nearest ancestor with `workforce/`, capped at the repo root). Both commands audit the auto-loaded files and warn about active rerouting vars, a misplaced root `TIMBAL_APP_ID`, and dead runtime vars. Multi-line values and secrets the platform did not return are written as commented placeholders so a round trip cannot corrupt or blank them. `-f` paths inside `ui/`, `api/`, `workforce/<x>/` get a scope note. A blank line now terminates a metadata block so a stray `# type:` cannot retag its neighbour. `--dry-run` works for pull too.
- Pull is tolerant of `value` as string / `VarValue` object / missing, honours a future `source: "platform"` flag, and recovers secrets missing from the bulk endpoint via `GET /vars/{id}` scoped to the rev's env.

Where things land:

| Var | File |
|---|---|
| Project vars (API keys, …) | `<project>/.env` (active) |
| `TIMBAL_APP_ID` | `workforce/<name>/.env` (merged) |
| Platform runtime vars (`TIMBAL_*`, `VITE_TIMBAL_*`) | `<project>/.env`, commented out; never pushed |

Backend facts this relies on were confirmed in Slack (secrets come decrypted on pull, `GET /vars/{id}` decrypts, type not changed on update, `id` = `OrgsApps.id` = `TIMBAL_APP_ID`, `uid` = manifest `_id`, synthetic negative ids for unregistered members).

Docs: `docs/deployment/index.mdx` gains a `timbal env` subsection with the placement table.

## Test plan

- [x] `cd cli && zig build test` — 88/88 (16 new: parsers, planner precedence + downgrade block, `TIMBAL_*` never in payload, heuristics, `upsertEnvLine`, tolerant API parsers, component matching incl. synthetic ids, placement audit, key validation, `-f` scoping)
- [x] `cli/integration_tests_env.sh` (hermetic) — 19/19: exit-code contract with a fake `$HOME`, no network
- [x] `TIMBAL_CLI_E2E_NETWORK=1 cli/integration_tests_env.sh` — 67/67 against `api.dev.timbal.ai` org 1 / project 1460 / `main`; expectations are derived from the API itself (managed = `/vars/pull` − `/vars`, member from `/workforce`)
- [x] `TIMBAL_CLI_E2E_WRITE=1 cli/integration_tests_env.sh` — 88/88; creates `E2E_PROBE_<ts>_{SECRET,PLAIN}`, verifies decrypted pull, blocked downgrade, real value updates with stored type kept, `TIMBAL_PROJECT_ENV_ID` not created, then deletes the probes (verified gone)
- [x] `zig fmt --check`; cross-compiled binaries build
- [ ] Reviewer: run the read-only network tier locally (`TIMBAL_CLI_E2E_NETWORK=1 cli/integration_tests_env.sh`, needs `curl` + `jq` and a `timbal configure` profile with access to the dev project)

Not in this PR (open questions): making relative `-f` cwd-relative instead of project-root-relative; a `--merge` pull mode that keeps local-only vars; wiring `zig build test` + the hermetic tier into CI (CI runs no CLI tests today).
