### PR TITLE
feat(models): add openai/gpt-6-astra + fix cache-write and long-context billing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,6 +280,7 @@ anthropic/claude-opus-4-7
 anthropic/claude-opus-4-6
 anthropic/claude-sonnet-4-6
 anthropic/claude-haiku-4-5
+openai/gpt-6-astra
 openai/gpt-5.5
 openai/gpt-5.5-2026-04-23
 openai/gpt-4o

--- a/docs/models/anthropic.mdx
+++ b/docs/models/anthropic.mdx
@@ -5,6 +5,22 @@ description: "Claude Fable 5.1, Opus 5, Sonnet 5, and Haiku models with specs, p
 
 <Note>Source: [Anthropic model docs](https://platform.claude.com/docs/en/about-claude/models/overview) · [Release notes](https://platform.claude.com/docs/en/release-notes/overview) · [Pricing](https://platform.claude.com/docs/en/about-claude/pricing)</Note>
 
+### How cache and fast-mode pricing is tracked
+
+Every 1M-context Claude model bills the full window at standard rates — there is no long-context tier. The pricing modifiers Anthropic does apply are all reported in the response `usage`, and Timbal's collector emits one unit per disjoint bucket:
+
+| Anthropic `usage` field | Usage key on `OutputEvent.usage` | Rate |
+| --- | --- | --- |
+| `input_tokens` | `input_tokens` | 1x |
+| `cache_read_input_tokens` | `cache_read_input_tokens` | 0.1x (0.025x on Fable 5.1) |
+| `cache_creation.ephemeral_5m_input_tokens` | `ephemeral_5m_input_tokens` | 1.25x |
+| `cache_creation.ephemeral_1h_input_tokens` | `ephemeral_1h_input_tokens` | 2x |
+| `cache_creation_input_tokens` (only when no per-TTL breakdown is reported) | `cache_creation_input_tokens` | 1.25x |
+| `output_tokens` | `output_tokens` | output rate |
+| `server_tool_use.*_requests` | e.g. `web_search_requests` | per call |
+
+`output_tokens_details.thinking_tokens` is a subset of `output_tokens` and is **not** emitted as a separate unit (it would be billed twice). On Opus 5 / Opus 4.8, `usage.speed == "fast"` ([fast mode](https://platform.claude.com/docs/en/build-with-claude/fast-mode), 2x) suffixes every token unit with `_fast`, e.g. `anthropic/claude-opus-5:output_tokens_fast`; pass `model_params={"extra_body": {"speed": "fast"}, "extra_headers": {"anthropic-beta": "fast-mode-2026-02-01"}}` to opt in. If a stream is interrupted before the final `message_delta`, the prompt-side units are still recorded from `message_start` (Anthropic charges them regardless); output is left unbilled.
+
 ## Latest
 
 <CardGroup cols={2}>

--- a/docs/models/openai.mdx
+++ b/docs/models/openai.mdx
@@ -31,14 +31,14 @@ description: "GPT-6, GPT-5, GPT-4, and o-series models with specs, pricing, and 
 
 ### How long-context and cache pricing is tracked
 
-Every 1.05M-context OpenAI model (GPT-6 Astra, GPT-5.6 Sol/Terra/Luna, GPT-5.5, GPT-5.4, GPT-5.4 Pro) bills the **entire request** at long-context rates once the prompt exceeds **272K input tokens** — including cache reads, cache writes, and output. Timbal's collectors decide the tier from the raw prompt size reported by OpenAI (cache hits included; exactly 272K is still short context) and emit distinct usage units so each tier can be priced separately:
+GPT-6 Astra, GPT-5.6 Sol/Terra/Luna, GPT-5.5, GPT-5.4 and GPT-5.4 Pro bill the **entire request** at long-context rates once the prompt exceeds **272K input tokens** — including cache reads, cache writes, and output. (GPT-5.5 Pro's model card publishes no long-context tier and no cached-input discount, so it is billed flat.) Timbal's collectors decide the tier from the raw prompt size reported by OpenAI (cache hits included; exactly 272K is still short context) and emit distinct usage units so each tier can be priced separately:
 
 | Request | Usage keys on `OutputEvent.usage` |
 | --- | --- |
 | ≤ 272K input | `input_text_tokens`, `input_cached_tokens`, `input_cache_write_tokens`, `output_text_tokens` |
 | > 272K input | the same units suffixed `_long_context`, e.g. `openai/gpt-6-astra:output_text_tokens_long_context` |
 
-`input_cache_write_tokens` is split out because OpenAI bills prompt-cache writes at 1.25x the input rate. Reasoning tokens are folded into `output_text_tokens` (they are billed as output). The per-model thresholds and tier rates live in `python/timbal/models.yaml` (`cached_input_price`, `cache_write_price`, `long_context`); `get_long_context_threshold()` in `timbal.core.models` exposes the threshold at runtime.
+`input_cache_write_tokens` is split out only for models whose catalog entry has a `cache_write_price` (OpenAI bills prompt-cache writes at 1.25x the input rate); on any other model those tokens stay in `input_text_tokens` so they are still billed. Reasoning tokens are folded into `output_text_tokens` (they are billed as output). Eval usage assertions (`output_text_tokens` etc.) and the TUI token summary treat both tiers as the same tokens. The per-model thresholds and tier rates live in `python/timbal/models.yaml` (`cached_input_price`, `cache_write_price`, `long_context`); `get_long_context_threshold()` in `timbal.core.models` exposes the threshold at runtime.
 
 ---
 

--- a/docs/models/openai.mdx
+++ b/docs/models/openai.mdx
@@ -29,6 +29,17 @@ description: "GPT-6, GPT-5, GPT-4, and o-series models with specs, pricing, and 
 
 <Note>GPT-6 Astra was released September 3, 2026 in a staged rollout. Verified reachable on a standard API key via both `/v1/responses` and `/v1/chat/completions` on September 5, 2026; if your org still gets `model_not_found`, the rollout hasn't reached it yet.</Note>
 
+### How long-context and cache pricing is tracked
+
+Every 1.05M-context OpenAI model (GPT-6 Astra, GPT-5.6 Sol/Terra/Luna, GPT-5.5, GPT-5.4, GPT-5.4 Pro) bills the **entire request** at long-context rates once the prompt exceeds **272K input tokens** — including cache reads, cache writes, and output. Timbal's collectors decide the tier from the raw prompt size reported by OpenAI (cache hits included; exactly 272K is still short context) and emit distinct usage units so each tier can be priced separately:
+
+| Request | Usage keys on `OutputEvent.usage` |
+| --- | --- |
+| ≤ 272K input | `input_text_tokens`, `input_cached_tokens`, `input_cache_write_tokens`, `output_text_tokens` |
+| > 272K input | the same units suffixed `_long_context`, e.g. `openai/gpt-6-astra:output_text_tokens_long_context` |
+
+`input_cache_write_tokens` is split out because OpenAI bills prompt-cache writes at 1.25x the input rate. Reasoning tokens are folded into `output_text_tokens` (they are billed as output). The per-model thresholds and tier rates live in `python/timbal/models.yaml` (`cached_input_price`, `cache_write_price`, `long_context`); `get_long_context_threshold()` in `timbal.core.models` exposes the threshold at runtime.
+
 ---
 
 ## GPT-5 Series

--- a/docs/models/openai.mdx
+++ b/docs/models/openai.mdx
@@ -1,9 +1,35 @@
 ---
 title: "OpenAI"
-description: "GPT-5, GPT-4, and o-series models with specs, pricing, and capabilities"
+description: "GPT-6, GPT-5, GPT-4, and o-series models with specs, pricing, and capabilities"
 ---
 
-<Note>Source: [OpenAI model docs](https://platform.openai.com/docs/models) · [API pricing](https://developers.openai.com/api/docs/pricing) (GPT-5.6 Sol promo at least through Nov 21, 2026)</Note>
+<Note>Source: [OpenAI model docs](https://platform.openai.com/docs/models) · [API pricing](https://developers.openai.com/api/docs/pricing) (GPT-5.6 Sol promo at least through Nov 21, 2026). Prices are Standard tier; Batch/Flex are 50%, Fast mode (`service_tier: "fast"`) is 2x.</Note>
+
+## GPT-6 Series
+
+<CardGroup cols={2}>
+  <Card title="gpt-6-astra">
+  <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> <Icon icon="lightbulb" size={14} /> Reasoning · <Icon icon="bolt" size={14} /> <Icon icon="bolt" size={14} /> <Icon icon="bolt" size={14} /> Speed
+
+  `openai/gpt-6-astra`
+
+  OpenAI's most capable model, built for the hardest end-to-end work: complex reasoning, agentic coding, computer use, research, and document creation. Successor to GPT-5.6 Sol. `reasoning.effort` accepts `low`, `medium`, `high`, `xhigh`, and `max` (API default `low`).
+
+  - &#36;10 / &#36;50 per 1M tokens (input / output); cached input &#36;1 / 1M; cache writes &#36;12.50 / 1M
+  - <Icon icon="triangle-exclamation" size={14} /> Prompts over 272K input tokens bill the **full request** at long-context rates: &#36;20 / &#36;75, cached &#36;2, cache writes &#36;25
+  - <Icon icon="triangle-exclamation" size={14} /> Function tools require the Responses API (Timbal's default). With `TIMBAL_OPENAI_API=chat_completions`, tool calls return 400 and `reasoning_effort: "none"` is rejected
+  - <Icon icon="window-maximize" size={14} /> 1.05M context
+  - <Icon icon="right-from-bracket" size={14} /> 128K max output
+  - <Icon icon="keyboard" size={14} /> Text, Image input
+  - <Icon icon="brain" size={14} /> Extended thinking
+  - <Icon icon="globe" size={14} /> Web search
+  - <Icon icon="calendar" size={14} /> Knowledge cutoff Apr 30, 2026
+  </Card>
+</CardGroup>
+
+<Note>GPT-6 Astra was released September 3, 2026 in a staged rollout. Verified reachable on a standard API key via both `/v1/responses` and `/v1/chat/completions` on September 5, 2026; if your org still gets `model_not_found`, the rollout hasn't reached it yet.</Note>
+
+---
 
 ## GPT-5 Series
 

--- a/docs/models/openai.mdx
+++ b/docs/models/openai.mdx
@@ -38,7 +38,7 @@ GPT-6 Astra, GPT-5.6 Sol/Terra/Luna, GPT-5.5, GPT-5.4 and GPT-5.4 Pro bill the *
 | ≤ 272K input | `input_text_tokens`, `input_cached_tokens`, `input_cache_write_tokens`, `output_text_tokens` |
 | > 272K input | the same units suffixed `_long_context`, e.g. `openai/gpt-6-astra:output_text_tokens_long_context` |
 
-`input_cache_write_tokens` is split out only for models whose catalog entry has a `cache_write_price` (OpenAI bills prompt-cache writes at 1.25x the input rate); on any other model those tokens stay in `input_text_tokens` so they are still billed. Reasoning tokens are folded into `output_text_tokens` (they are billed as output). Eval usage assertions (`output_text_tokens` etc.) and the TUI token summary treat both tiers as the same tokens. The per-model thresholds and tier rates live in `python/timbal/models.yaml` (`cached_input_price`, `cache_write_price`, `long_context`); `get_long_context_threshold()` in `timbal.core.models` exposes the threshold at runtime.
+`input_cache_write_tokens` is split out only for models whose catalog entry has a `cache_write_price` (OpenAI bills prompt-cache writes at 1.25x the input rate); on any other model those tokens stay in `input_text_tokens` so they are still billed. Reasoning tokens are folded into `output_text_tokens` (they are billed as output). Astra responses served by Flex or Fast processing additionally use `_flex` or `_fast` (for example, `output_text_tokens_long_context_fast`) so the processing multiplier is preserved. Eval usage assertions treat all pricing tiers as the same underlying tokens. The per-model thresholds and tier rates live in `python/timbal/models.yaml` (`cached_input_price`, `cache_write_price`, `long_context`, `service_tiers`).
 
 ---
 

--- a/docs/models/overview.mdx
+++ b/docs/models/overview.mdx
@@ -3,7 +3,7 @@ title: "Overview"
 description: "Specs, pricing, and capabilities for every supported model"
 ---
 
-Every model supported by Timbal with full specs, pricing, capability scores, and short descriptions. **Price** = per 1M tokens (input / output). All models support tool/function calling unless noted.
+Every model supported by Timbal with full specs, pricing, capability scores, and short descriptions. **Price** = per 1M tokens (input / output) at the provider's standard short-context tier. Models with a long-context surcharge (OpenAI &gt;272K, xAI &gt;200K, BytePlus &gt;128K input tokens) reprice the whole request; Timbal reports those requests under `<unit>_long_context` usage keys so they can be billed at the higher rate — see the [OpenAI page](/models/openai#how-long-context-and-cache-pricing-is-tracked). All models support tool/function calling unless noted.
 
 <CardGroup cols={3}>
   <Card title="Anthropic" icon="https://timbalusercontent.com/assets/claude_favicon.svg" href="/models/anthropic">

--- a/docs/models/overview.mdx
+++ b/docs/models/overview.mdx
@@ -28,7 +28,7 @@ Every model supported by Timbal with full specs, pricing, capability scores, and
     Kimi K3 / K2.x via Moonshot's OpenAI-compatible API
   </Card>
   <Card title="OpenAI" icon="https://timbalusercontent.com/assets/openai_favicon.svg" href="/models/openai">
-    GPT-5, GPT-4, and o-series reasoning models
+    GPT-6 Astra, GPT-5, GPT-4, and o-series reasoning models
   </Card>
   <Card title="SambaNova" icon="https://timbalusercontent.com/assets/sambanova_favicon.svg" href="/models/sambanova">
     High-throughput inference on custom RDU hardware
@@ -51,4 +51,4 @@ Each model is rated on two axes using a **1-5 scale**:
 - **Reasoning** — depth of analytical and chain-of-thought capability
 - **Speed** — relative latency and throughput for its class
 
-Scores are **relative within the full set of models on this page**, not within a single provider. A reasoning score of 5 means frontier-class reasoning (e.g. o3-pro, Claude Opus 4.7, GPT-5.5, Gemini 2.5 Pro). A speed score of 5 means the fastest tier (nano/mini/flash-lite models, or Groq-hosted inference).
+Scores are **relative within the full set of models on this page**, not within a single provider. A reasoning score of 5 means frontier-class reasoning (e.g. GPT-6 Astra, Claude Fable 5.1, o3-pro, GPT-5.5, Gemini 2.5 Pro). A speed score of 5 means the fastest tier (nano/mini/flash-lite models, or Groq-hosted inference).

--- a/python/tests/collectors/test_anthropic_collector.py
+++ b/python/tests/collectors/test_anthropic_collector.py
@@ -34,7 +34,7 @@ from anthropic.types.beta import (
 )
 
 from timbal.collectors.impl.anthropic import AnthropicCollector
-from timbal.state import set_call_id, set_run_context
+from timbal.state import set_billing_id, set_call_id, set_run_context
 from timbal.state.context import RunContext
 from timbal.state.tracing.span import Span
 from timbal.types.content.custom import CustomContent
@@ -60,12 +60,14 @@ async def _empty_gen():
 @pytest.fixture(autouse=True)
 def clean_context():
     """Reset context vars after each test to avoid state pollution."""
-    from timbal.state import _run_context_var, _call_id, set_call_id
+    from timbal.state import _billing_id, _run_context_var, _call_id, set_call_id
     token_ctx = _run_context_var.set(None)
     token_cid = _call_id.set(None)
+    token_bid = _billing_id.set(None)
     yield
     _run_context_var.reset(token_ctx)
     _call_id.reset(token_cid)
+    _billing_id.reset(token_bid)
 
 
 def _make_context():
@@ -465,3 +467,217 @@ class TestAnthropicCollectorContentBlockStop:
         collector.process(_make_message_start())
         item = collector.process(RawContentBlockStopEvent(**{"type": "content_block_stop", "index": 99}))
         assert item is None
+
+
+def _usage_message_start(usage: dict, *, model: str = "claude-sonnet-5", msg_id: str = "msg_usage") -> RawMessageStartEvent:
+    """message_start with a caller-supplied usage payload (shape copied from live API captures)."""
+    return RawMessageStartEvent(**{
+        "type": "message_start",
+        "message": {
+            "id": msg_id,
+            "type": "message",
+            "role": "assistant",
+            "content": [],
+            "model": model,
+            "stop_reason": None,
+            "stop_sequence": None,
+            "usage": usage,
+        },
+    })
+
+
+def _usage_message_delta(usage: dict) -> RawMessageDeltaEvent:
+    return RawMessageDeltaEvent(**{
+        "type": "message_delta",
+        "delta": {"type": "message_delta", "stop_reason": "end_turn", "stop_sequence": None},
+        "usage": usage,
+    })
+
+
+class TestAnthropicCollectorUsageAccounting:
+    """Billing units derived from message_start + message_delta.
+
+    Payload shapes below are copied from live captures against api.anthropic.com
+    (2026-09-06): the per-TTL cache breakdown and ``speed`` ship only on
+    ``message_start``; ``message_delta`` repeats the aggregate input-side totals and
+    carries the final ``output_tokens`` (+ ``output_tokens_details.thinking_tokens``,
+    a subset of ``output_tokens``).
+    """
+
+    def _run(self, start_usage: dict, delta_usage: dict | None, *, billing_id: str = "anthropic/claude-sonnet-5"):
+        ctx = _make_context()
+        set_billing_id(billing_id)
+        collector = _make_collector()
+        collector.process(_usage_message_start(start_usage, model=billing_id.split("/", 1)[1]))
+        if delta_usage is not None:
+            collector.process(_usage_message_delta(delta_usage))
+        collector.result()
+        return dict(ctx._trace["test_call"].usage)
+
+    def test_five_minute_cache_write_bills_per_ttl_unit(self):
+        usage = self._run(
+            {"input_tokens": 18, "output_tokens": 1, "cache_creation_input_tokens": 13315, "cache_read_input_tokens": 0,
+             "cache_creation": {"ephemeral_5m_input_tokens": 13315, "ephemeral_1h_input_tokens": 0},
+             "service_tier": "standard", "inference_geo": "not_available"},
+            {"input_tokens": 18, "output_tokens": 4, "cache_creation_input_tokens": 13315, "cache_read_input_tokens": 0},
+        )
+        assert usage == {
+            "anthropic/claude-sonnet-5:input_tokens": 18,
+            "anthropic/claude-sonnet-5:ephemeral_5m_input_tokens": 13315,
+            "anthropic/claude-sonnet-5:output_tokens": 4,
+        }
+
+    def test_one_hour_cache_write_bills_at_its_own_unit(self):
+        """1h writes are 2x input (vs 1.25x for 5m); the aggregate unit would under-bill them."""
+        usage = self._run(
+            {"input_tokens": 9, "output_tokens": 1, "cache_creation_input_tokens": 13320, "cache_read_input_tokens": 0,
+             "cache_creation": {"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 13320}},
+            {"input_tokens": 9, "output_tokens": 5, "cache_creation_input_tokens": 13320, "cache_read_input_tokens": 0},
+        )
+        assert usage["anthropic/claude-sonnet-5:ephemeral_1h_input_tokens"] == 13320
+        assert "anthropic/claude-sonnet-5:ephemeral_5m_input_tokens" not in usage
+        assert "anthropic/claude-sonnet-5:cache_creation_input_tokens" not in usage
+
+    def test_mixed_ttl_writes_split_without_double_billing(self):
+        usage = self._run(
+            {"input_tokens": 5, "output_tokens": 1, "cache_creation_input_tokens": 248, "cache_read_input_tokens": 1000,
+             "cache_creation": {"ephemeral_5m_input_tokens": 148, "ephemeral_1h_input_tokens": 100}},
+            {"input_tokens": 5, "output_tokens": 7, "cache_creation_input_tokens": 248, "cache_read_input_tokens": 1000},
+        )
+        assert usage["anthropic/claude-sonnet-5:ephemeral_5m_input_tokens"] == 148
+        assert usage["anthropic/claude-sonnet-5:ephemeral_1h_input_tokens"] == 100
+        assert usage["anthropic/claude-sonnet-5:cache_read_input_tokens"] == 1000
+        assert "anthropic/claude-sonnet-5:cache_creation_input_tokens" not in usage
+
+    def test_missing_breakdown_falls_back_to_aggregate_unit(self):
+        usage = self._run(
+            {"input_tokens": 5, "output_tokens": 1, "cache_creation_input_tokens": 500, "cache_read_input_tokens": 0},
+            {"input_tokens": 5, "output_tokens": 7, "cache_creation_input_tokens": 500, "cache_read_input_tokens": 0},
+        )
+        assert usage["anthropic/claude-sonnet-5:cache_creation_input_tokens"] == 500
+        assert not any("ephemeral" in k for k in usage)
+
+    def test_breakdown_that_does_not_reconcile_falls_back_to_aggregate_unit(self):
+        usage = self._run(
+            {"input_tokens": 5, "output_tokens": 1, "cache_creation_input_tokens": 500, "cache_read_input_tokens": 0,
+             "cache_creation": {"ephemeral_5m_input_tokens": 100, "ephemeral_1h_input_tokens": 100}},
+            {"input_tokens": 5, "output_tokens": 7, "cache_creation_input_tokens": 500, "cache_read_input_tokens": 0},
+        )
+        assert usage["anthropic/claude-sonnet-5:cache_creation_input_tokens"] == 500
+        assert not any("ephemeral" in k for k in usage)
+
+    def test_thinking_tokens_are_not_billed_on_top_of_output(self):
+        """output_tokens_details.thinking_tokens ⊂ output_tokens (live: 524 output / 519 thinking / 4 visible)."""
+        usage = self._run(
+            {"input_tokens": 66, "output_tokens": 2, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
+             "cache_creation": {"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 0}},
+            {"input_tokens": 66, "output_tokens": 524, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
+             "output_tokens_details": {"thinking_tokens": 519}},
+        )
+        assert usage == {
+            "anthropic/claude-sonnet-5:input_tokens": 66,
+            "anthropic/claude-sonnet-5:output_tokens": 524,
+        }
+
+    def test_delta_without_input_fields_falls_back_to_message_start(self):
+        usage = self._run(
+            {"input_tokens": 40, "output_tokens": 1, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 300},
+            {"output_tokens": 12},
+        )
+        assert usage == {
+            "anthropic/claude-sonnet-5:input_tokens": 40,
+            "anthropic/claude-sonnet-5:cache_read_input_tokens": 300,
+            "anthropic/claude-sonnet-5:output_tokens": 12,
+        }
+
+    def test_server_tool_requests_are_billed_unsuffixed(self):
+        usage = self._run(
+            {"input_tokens": 40, "output_tokens": 1, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0},
+            {"input_tokens": 40, "output_tokens": 12, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
+             "server_tool_use": {"web_search_requests": 2, "web_fetch_requests": 0}},
+        )
+        assert usage["anthropic/claude-sonnet-5:web_search_requests"] == 2
+        assert "anthropic/claude-sonnet-5:web_fetch_requests" not in usage
+
+    def test_fast_mode_suffixes_token_units_when_catalog_prices_it(self):
+        """Opus 5 fast mode (2x): ``usage.speed == "fast"`` ships on message_start only."""
+        usage = self._run(
+            {"input_tokens": 11, "output_tokens": 1, "cache_creation_input_tokens": 200, "cache_read_input_tokens": 50,
+             "cache_creation": {"ephemeral_5m_input_tokens": 200, "ephemeral_1h_input_tokens": 0},
+             "service_tier": "standard", "inference_geo": "global", "speed": "fast"},
+            {"input_tokens": 11, "output_tokens": 5, "cache_creation_input_tokens": 200, "cache_read_input_tokens": 50,
+             "server_tool_use": {"web_search_requests": 1, "web_fetch_requests": 0}},
+            billing_id="anthropic/claude-opus-5",
+        )
+        assert usage == {
+            "anthropic/claude-opus-5:input_tokens_fast": 11,
+            "anthropic/claude-opus-5:cache_read_input_tokens_fast": 50,
+            "anthropic/claude-opus-5:ephemeral_5m_input_tokens_fast": 200,
+            "anthropic/claude-opus-5:output_tokens_fast": 5,
+            "anthropic/claude-opus-5:web_search_requests": 1,
+        }
+
+    def test_fast_mode_is_ignored_for_models_without_a_fast_tier(self):
+        usage = self._run(
+            {"input_tokens": 11, "output_tokens": 1, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
+             "speed": "fast"},
+            {"input_tokens": 11, "output_tokens": 5, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0},
+            billing_id="anthropic/claude-haiku-4-5",
+        )
+        assert usage == {
+            "anthropic/claude-haiku-4-5:input_tokens": 11,
+            "anthropic/claude-haiku-4-5:output_tokens": 5,
+        }
+
+    def test_standard_speed_never_suffixes(self):
+        usage = self._run(
+            {"input_tokens": 11, "output_tokens": 1, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
+             "speed": "standard"},
+            {"input_tokens": 11, "output_tokens": 5, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0},
+            billing_id="anthropic/claude-opus-5",
+        )
+        assert set(usage) == {"anthropic/claude-opus-5:input_tokens", "anthropic/claude-opus-5:output_tokens"}
+
+    def test_interrupted_stream_bills_prompt_from_message_start(self):
+        """No message_delta (cancelled mid-stream): Anthropic still charges the prompt; output is unknown."""
+        usage = self._run(
+            {"input_tokens": 40, "output_tokens": 1, "cache_creation_input_tokens": 1000, "cache_read_input_tokens": 300,
+             "cache_creation": {"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 1000}},
+            None,
+        )
+        assert usage == {
+            "anthropic/claude-sonnet-5:input_tokens": 40,
+            "anthropic/claude-sonnet-5:cache_read_input_tokens": 300,
+            "anthropic/claude-sonnet-5:ephemeral_1h_input_tokens": 1000,
+        }
+
+    def test_usage_is_recorded_exactly_once(self):
+        ctx = _make_context()
+        set_billing_id("anthropic/claude-sonnet-5")
+        collector = _make_collector()
+        collector.process(_usage_message_start(
+            {"input_tokens": 40, "output_tokens": 1, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0},
+        ))
+        collector.process(_usage_message_delta(
+            {"input_tokens": 40, "output_tokens": 12, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0},
+        ))
+        collector.result()
+        collector.result()
+        assert ctx._trace["test_call"].usage == {
+            "anthropic/claude-sonnet-5:input_tokens": 40,
+            "anthropic/claude-sonnet-5:output_tokens": 12,
+        }
+
+    def test_malformed_undeclared_extras_are_ignored(self):
+        """``speed`` / ``output_tokens_details`` are pydantic extras (undeclared by the SDK), so
+        nothing validates them upstream; garbage there must not crash or skew billing."""
+        usage = self._run(
+            {"input_tokens": 40, "output_tokens": 1, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
+             "cache_creation": None, "speed": 42},
+            {"input_tokens": 40, "output_tokens": 12, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
+             "output_tokens_details": {"thinking_tokens": "bad"}, "server_tool_use": None},
+        )
+        assert usage == {
+            "anthropic/claude-sonnet-5:input_tokens": 40,
+            "anthropic/claude-sonnet-5:output_tokens": 12,
+        }

--- a/python/tests/collectors/test_openai_collector.py
+++ b/python/tests/collectors/test_openai_collector.py
@@ -897,6 +897,14 @@ class TestChatCompletionCollectorPricingTiers:
         assert usage["openai/gpt-6-astra:input_text_tokens"] == 50  # 100 - 20 - 30
         assert usage["openai/gpt-6-astra:output_text_tokens"] == 5
 
+    def test_cache_writes_stay_in_input_when_catalog_cannot_price_them(self):
+        """gpt-5.5 has no cache_write_price: splitting would leave the tokens in a unit with no cost
+        row (unbilled). They must stay in input_text_tokens and bill at the input rate instead."""
+        usage = self._run("openai/gpt-5.5", prompt_tokens=100, completion_tokens=5, cached=20, cache_write=30)
+        assert "openai/gpt-5.5:input_cache_write_tokens" not in usage
+        assert usage["openai/gpt-5.5:input_cached_tokens"] == 20
+        assert usage["openai/gpt-5.5:input_text_tokens"] == 80  # 100 - 20; cache writes NOT removed
+
     def test_missing_cache_write_field_is_tolerated(self):
         """Older SDK payloads / other providers do not send cache_write_tokens at all."""
         from openai.types.completion_usage import CompletionTokensDetails, CompletionUsage, PromptTokensDetails
@@ -1564,6 +1572,11 @@ class TestResponseCollectorPricingTiers:
         assert usage["openai/gpt-6-astra:input_cached_tokens"] == 20
         assert usage["openai/gpt-6-astra:input_text_tokens"] == 50
         assert usage["openai/gpt-6-astra:output_text_tokens"] == 5
+
+    def test_cache_writes_stay_in_input_when_catalog_cannot_price_them(self):
+        usage = self._run("openai/gpt-5.4", input_tokens=100, output_tokens=5, cache_write=30)
+        assert "openai/gpt-5.4:input_cache_write_tokens" not in usage
+        assert usage["openai/gpt-5.4:input_text_tokens"] == 100
 
     def test_exactly_at_threshold_is_still_short_context(self):
         usage = self._run("openai/gpt-6-astra", input_tokens=272_000, output_tokens=10)

--- a/python/tests/collectors/test_openai_collector.py
+++ b/python/tests/collectors/test_openai_collector.py
@@ -856,6 +856,115 @@ class TestChatCompletionCollectorHandleUsage:
         assert span.usage.get("openai/gpt-4o:output_text_tokens") == 6  # 10 - 4
 
 
+def _cc_usage_chunk(*, model: str, prompt_tokens: int, completion_tokens: int, cached: int = 0, cache_write: int = 0):
+    """Build a usage-only chunk; ``cache_write_tokens`` is a pydantic extra (SDK does not declare it yet)."""
+    from openai.types.completion_usage import CompletionTokensDetails, CompletionUsage, PromptTokensDetails
+
+    usage = CompletionUsage(
+        completion_tokens=completion_tokens,
+        prompt_tokens=prompt_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+        prompt_tokens_details=PromptTokensDetails(cached_tokens=cached, audio_tokens=None, cache_write_tokens=cache_write),
+        completion_tokens_details=CompletionTokensDetails(audio_tokens=None, reasoning_tokens=0),
+    )
+    return ChatCompletionChunk(
+        id="chatcmpl_usage_tier",
+        choices=[],
+        created=int(time.time()),
+        model=model,
+        object="chat.completion.chunk",
+        usage=usage,
+    )
+
+
+class TestChatCompletionCollectorPricingTiers:
+    """Cache-write accounting and long-context repricing on the chat-completions path."""
+
+    def _run(self, billing_id: str, **usage_kwargs):
+        ctx = _make_context()
+        set_billing_id(billing_id)
+        collector = ChatCompletionCollector(async_gen=_empty_gen(), start=time.perf_counter())
+        collector.process(_make_cc_chunk(content="hi"))
+        collector.process(_cc_usage_chunk(model=billing_id.split("/", 1)[1], **usage_kwargs))
+        collector.result()
+        return ctx._trace["test_call"].usage
+
+    def test_cache_write_tokens_are_split_out_of_input(self):
+        """Cache writes bill at 1.25x input on OpenAI — they must not be folded into plain input."""
+        usage = self._run("openai/gpt-6-astra", prompt_tokens=100, completion_tokens=5, cached=20, cache_write=30)
+        assert usage["openai/gpt-6-astra:input_cache_write_tokens"] == 30
+        assert usage["openai/gpt-6-astra:input_cached_tokens"] == 20
+        assert usage["openai/gpt-6-astra:input_text_tokens"] == 50  # 100 - 20 - 30
+        assert usage["openai/gpt-6-astra:output_text_tokens"] == 5
+
+    def test_missing_cache_write_field_is_tolerated(self):
+        """Older SDK payloads / other providers do not send cache_write_tokens at all."""
+        from openai.types.completion_usage import CompletionTokensDetails, CompletionUsage, PromptTokensDetails
+
+        ctx = _make_context()
+        set_billing_id("openai/gpt-4o")
+        collector = ChatCompletionCollector(async_gen=_empty_gen(), start=time.perf_counter())
+        collector.process(_make_cc_chunk(content="hi"))
+        usage = CompletionUsage(
+            completion_tokens=5,
+            prompt_tokens=20,
+            total_tokens=25,
+            prompt_tokens_details=PromptTokensDetails(cached_tokens=None, audio_tokens=None),
+            completion_tokens_details=CompletionTokensDetails(audio_tokens=None, reasoning_tokens=0),
+        )
+        collector.process(
+            ChatCompletionChunk(
+                id="chatcmpl_plain", choices=[], created=int(time.time()), model="gpt-4o",
+                object="chat.completion.chunk", usage=usage,
+            )
+        )
+        collector.result()
+        span_usage = ctx._trace["test_call"].usage
+        assert "openai/gpt-4o:input_cache_write_tokens" not in span_usage
+        assert span_usage["openai/gpt-4o:input_text_tokens"] == 20
+
+    def test_short_context_uses_base_units(self):
+        usage = self._run("openai/gpt-6-astra", prompt_tokens=200_000, completion_tokens=10)
+        assert usage["openai/gpt-6-astra:input_text_tokens"] == 200_000
+        assert usage["openai/gpt-6-astra:output_text_tokens"] == 10
+        assert not any(k.endswith("_long_context") for k in usage)
+
+    def test_exactly_at_threshold_is_still_short_context(self):
+        """OpenAI reprices prompts *over* 272K — 272K itself is short context."""
+        usage = self._run("openai/gpt-6-astra", prompt_tokens=272_000, completion_tokens=10)
+        assert usage["openai/gpt-6-astra:input_text_tokens"] == 272_000
+        assert not any(k.endswith("_long_context") for k in usage)
+
+    def test_over_threshold_reprices_every_bucket(self):
+        """One token over the threshold moves input, cache reads, cache writes AND output to the long tier."""
+        usage = self._run(
+            "openai/gpt-6-astra", prompt_tokens=272_001, completion_tokens=500, cached=1_000, cache_write=2_000
+        )
+        assert usage["openai/gpt-6-astra:input_text_tokens_long_context"] == 272_001 - 1_000 - 2_000
+        assert usage["openai/gpt-6-astra:input_cached_tokens_long_context"] == 1_000
+        assert usage["openai/gpt-6-astra:input_cache_write_tokens_long_context"] == 2_000
+        assert usage["openai/gpt-6-astra:output_text_tokens_long_context"] == 500
+        assert "openai/gpt-6-astra:input_text_tokens" not in usage
+        assert "openai/gpt-6-astra:output_text_tokens" not in usage
+
+    def test_threshold_is_measured_on_raw_prompt_including_cache_hits(self):
+        """A 300K prompt that is 290K cached is still a 300K prompt to the provider."""
+        usage = self._run("openai/gpt-6-astra", prompt_tokens=300_000, completion_tokens=1, cached=290_000)
+        assert usage["openai/gpt-6-astra:input_cached_tokens_long_context"] == 290_000
+        assert usage["openai/gpt-6-astra:input_text_tokens_long_context"] == 10_000
+
+    def test_models_without_a_tier_never_reprice(self):
+        usage = self._run("openai/gpt-4o", prompt_tokens=120_000, completion_tokens=10)
+        assert usage["openai/gpt-4o:input_text_tokens"] == 120_000
+        assert not any(k.endswith("_long_context") for k in usage)
+
+    def test_byteplus_tier_via_chat_completions(self):
+        """BytePlus (OpenAI-compatible) surcharges above 128K and flows through this collector."""
+        usage = self._run("byteplus/seed-2-0-pro-260328", prompt_tokens=130_000, completion_tokens=10)
+        assert usage["byteplus/seed-2-0-pro-260328:input_text_tokens_long_context"] == 130_000
+        assert usage["byteplus/seed-2-0-pro-260328:output_text_tokens_long_context"] == 10
+
+
 class TestChatCompletionCollectorGoogleThoughtSignature:
     """Lines 196-198: Google Gemini thought_signature stored in tool call extra_content."""
 
@@ -1414,6 +1523,99 @@ class TestResponseCollectorHandleCompleted:
         span = ctx._trace["test_call"]
         assert span.usage.get("openai/gpt-4o:output_audio_tokens") == 3
         assert span.usage.get("openai/gpt-4o:output_text_tokens") == 7  # 10 - 3
+
+
+class TestResponseCollectorPricingTiers:
+    """Cache-write accounting and long-context repricing on the Responses path."""
+
+    def _run(self, billing_id: str, *, input_tokens: int, output_tokens: int, cached: int = 0, cache_write: int = 0):
+        api_model = billing_id.split("/", 1)[1]
+        ctx = _make_context()
+        set_billing_id(billing_id)
+        collector = ResponseCollector(async_gen=_empty_gen(), start=time.perf_counter())
+        collector.process(ResponseCreatedEvent(
+            type="response.created", response=_make_response(model=api_model), sequence_number=0,
+        ))
+        item_id = "tier_item_001"
+        collector.process(ResponseContentPartAddedEvent(
+            type="response.content_part.added",
+            item_id=item_id, output_index=0, content_index=0,
+            part=ResponseOutputText(type="output_text", text="", annotations=[]), sequence_number=1,
+        ))
+        collector.process(ResponseTextDeltaEvent(
+            type="response.output_text.delta",
+            item_id=item_id, output_index=0, content_index=0, delta="hi", logprobs=[], sequence_number=2,
+        ))
+        usage = ResponseUsage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            total_tokens=input_tokens + output_tokens,
+            # cache_write_tokens is a pydantic extra — the SDK does not declare it yet.
+            input_tokens_details=InputTokensDetails(cached_tokens=cached, cache_write_tokens=cache_write),
+            output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+        )
+        completed = _make_response(model=api_model, status="completed").model_copy(update={"usage": usage})
+        collector.process(ResponseCompletedEvent(type="response.completed", response=completed, sequence_number=3))
+        return ctx._trace["test_call"].usage
+
+    def test_cache_write_tokens_are_split_out_of_input(self):
+        usage = self._run("openai/gpt-6-astra", input_tokens=100, output_tokens=5, cached=20, cache_write=30)
+        assert usage["openai/gpt-6-astra:input_cache_write_tokens"] == 30
+        assert usage["openai/gpt-6-astra:input_cached_tokens"] == 20
+        assert usage["openai/gpt-6-astra:input_text_tokens"] == 50
+        assert usage["openai/gpt-6-astra:output_text_tokens"] == 5
+
+    def test_exactly_at_threshold_is_still_short_context(self):
+        usage = self._run("openai/gpt-6-astra", input_tokens=272_000, output_tokens=10)
+        assert usage["openai/gpt-6-astra:input_text_tokens"] == 272_000
+        assert not any(k.endswith("_long_context") for k in usage)
+
+    def test_over_threshold_reprices_every_bucket(self):
+        usage = self._run("openai/gpt-6-astra", input_tokens=272_001, output_tokens=500, cached=1_000, cache_write=2_000)
+        assert usage["openai/gpt-6-astra:input_text_tokens_long_context"] == 272_001 - 1_000 - 2_000
+        assert usage["openai/gpt-6-astra:input_cached_tokens_long_context"] == 1_000
+        assert usage["openai/gpt-6-astra:input_cache_write_tokens_long_context"] == 2_000
+        assert usage["openai/gpt-6-astra:output_text_tokens_long_context"] == 500
+        assert "openai/gpt-6-astra:input_text_tokens" not in usage
+
+    def test_xai_tier_via_responses(self):
+        """xAI runs through the Responses collector and surcharges above 200K."""
+        usage = self._run("xai/grok-4.6", input_tokens=200_001, output_tokens=10)
+        assert usage["xai/grok-4.6:input_text_tokens_long_context"] == 200_001
+        assert usage["xai/grok-4.6:output_text_tokens_long_context"] == 10
+        usage = self._run("xai/grok-4.6", input_tokens=200_000, output_tokens=10)
+        assert usage["xai/grok-4.6:input_text_tokens"] == 200_000
+
+    def test_reasoning_tokens_follow_output_into_long_tier(self):
+        """Hidden reasoning is billed as output; it must move tiers with the rest of the request."""
+        ctx = _make_context()
+        set_billing_id("openai/gpt-6-astra")
+        collector = ResponseCollector(async_gen=_empty_gen(), start=time.perf_counter())
+        collector.process(ResponseCreatedEvent(
+            type="response.created", response=_make_response(model="gpt-6-astra"), sequence_number=0,
+        ))
+        item_id = "tier_reasoning_001"
+        collector.process(ResponseContentPartAddedEvent(
+            type="response.content_part.added",
+            item_id=item_id, output_index=0, content_index=0,
+            part=ResponseOutputText(type="output_text", text="", annotations=[]), sequence_number=1,
+        ))
+        collector.process(ResponseTextDeltaEvent(
+            type="response.output_text.delta",
+            item_id=item_id, output_index=0, content_index=0, delta="hi", logprobs=[], sequence_number=2,
+        ))
+        usage = ResponseUsage(
+            input_tokens=300_000,
+            output_tokens=1_200,  # 200 visible + 1_000 reasoning, all billed as output
+            total_tokens=301_200,
+            input_tokens_details=InputTokensDetails(cached_tokens=0),
+            output_tokens_details=OutputTokensDetails(reasoning_tokens=1_000),
+        )
+        completed = _make_response(model="gpt-6-astra", status="completed").model_copy(update={"usage": usage})
+        collector.process(ResponseCompletedEvent(type="response.completed", response=completed, sequence_number=3))
+        span_usage = ctx._trace["test_call"].usage
+        assert span_usage["openai/gpt-6-astra:output_text_tokens_long_context"] == 1_200
+        assert span_usage["openai/gpt-6-astra:input_text_tokens_long_context"] == 300_000
 
 
 class TestResponseCollectorResult:

--- a/python/tests/collectors/test_openai_collector.py
+++ b/python/tests/collectors/test_openai_collector.py
@@ -856,7 +856,15 @@ class TestChatCompletionCollectorHandleUsage:
         assert span.usage.get("openai/gpt-4o:output_text_tokens") == 6  # 10 - 4
 
 
-def _cc_usage_chunk(*, model: str, prompt_tokens: int, completion_tokens: int, cached: int = 0, cache_write: int = 0):
+def _cc_usage_chunk(
+    *,
+    model: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+    cached: int = 0,
+    cache_write: object = 0,
+    service_tier: str | None = None,
+):
     """Build a usage-only chunk; ``cache_write_tokens`` is a pydantic extra (SDK does not declare it yet)."""
     from openai.types.completion_usage import CompletionTokensDetails, CompletionUsage, PromptTokensDetails
 
@@ -873,6 +881,7 @@ def _cc_usage_chunk(*, model: str, prompt_tokens: int, completion_tokens: int, c
         created=int(time.time()),
         model=model,
         object="chat.completion.chunk",
+        service_tier=service_tier,
         usage=usage,
     )
 
@@ -931,6 +940,29 @@ class TestChatCompletionCollectorPricingTiers:
         assert "openai/gpt-4o:input_cache_write_tokens" not in span_usage
         assert span_usage["openai/gpt-4o:input_text_tokens"] == 20
 
+    @pytest.mark.parametrize("cache_write", ["bad", -5, None])
+    def test_malformed_cache_write_tokens_stay_in_plain_input(self, cache_write):
+        usage = self._run(
+            "openai/gpt-6-astra",
+            prompt_tokens=100,
+            completion_tokens=5,
+            cache_write=cache_write,
+        )
+        assert "openai/gpt-6-astra:input_cache_write_tokens" not in usage
+        assert usage["openai/gpt-6-astra:input_text_tokens"] == 100
+
+    def test_usage_details_cannot_make_plain_input_negative(self):
+        usage = self._run(
+            "openai/gpt-6-astra",
+            prompt_tokens=100,
+            completion_tokens=5,
+            cached=80,
+            cache_write=80,
+        )
+        assert usage["openai/gpt-6-astra:input_cached_tokens"] == 80
+        assert usage["openai/gpt-6-astra:input_cache_write_tokens"] == 20
+        assert usage["openai/gpt-6-astra:input_text_tokens"] == 0
+
     def test_short_context_uses_base_units(self):
         usage = self._run("openai/gpt-6-astra", prompt_tokens=200_000, completion_tokens=10)
         assert usage["openai/gpt-6-astra:input_text_tokens"] == 200_000
@@ -965,6 +997,35 @@ class TestChatCompletionCollectorPricingTiers:
         usage = self._run("openai/gpt-4o", prompt_tokens=120_000, completion_tokens=10)
         assert usage["openai/gpt-4o:input_text_tokens"] == 120_000
         assert not any(k.endswith("_long_context") for k in usage)
+
+    def test_xai_threshold_is_inclusive(self):
+        usage = self._run("xai/grok-4.6", prompt_tokens=200_000, completion_tokens=10, cached=50_000)
+        assert usage["xai/grok-4.6:input_cached_tokens_long_context"] == 50_000
+        assert usage["xai/grok-4.6:input_text_tokens_long_context"] == 150_000
+
+    @pytest.mark.parametrize(
+        "service_tier,suffix",
+        [("priority", "_fast"), ("flex", "_flex")],
+    )
+    def test_astra_service_tier_uses_priced_units(self, service_tier, suffix):
+        usage = self._run(
+            "openai/gpt-6-astra",
+            prompt_tokens=100,
+            completion_tokens=5,
+            service_tier=service_tier,
+        )
+        assert usage[f"openai/gpt-6-astra:input_text_tokens{suffix}"] == 100
+        assert usage[f"openai/gpt-6-astra:output_text_tokens{suffix}"] == 5
+
+    def test_service_tier_combines_with_long_context(self):
+        usage = self._run(
+            "openai/gpt-6-astra",
+            prompt_tokens=300_000,
+            completion_tokens=5,
+            service_tier="priority",
+        )
+        assert usage["openai/gpt-6-astra:input_text_tokens_long_context_fast"] == 300_000
+        assert usage["openai/gpt-6-astra:output_text_tokens_long_context_fast"] == 5
 
     def test_byteplus_tier_via_chat_completions(self):
         """BytePlus (OpenAI-compatible) surcharges above 128K and flows through this collector."""
@@ -1536,7 +1597,16 @@ class TestResponseCollectorHandleCompleted:
 class TestResponseCollectorPricingTiers:
     """Cache-write accounting and long-context repricing on the Responses path."""
 
-    def _run(self, billing_id: str, *, input_tokens: int, output_tokens: int, cached: int = 0, cache_write: int = 0):
+    def _run(
+        self,
+        billing_id: str,
+        *,
+        input_tokens: int,
+        output_tokens: int,
+        cached: int = 0,
+        cache_write: object = 0,
+        service_tier: str | None = None,
+    ):
         api_model = billing_id.split("/", 1)[1]
         ctx = _make_context()
         set_billing_id(billing_id)
@@ -1562,7 +1632,9 @@ class TestResponseCollectorPricingTiers:
             input_tokens_details=InputTokensDetails(cached_tokens=cached, cache_write_tokens=cache_write),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         )
-        completed = _make_response(model=api_model, status="completed").model_copy(update={"usage": usage})
+        completed = _make_response(model=api_model, status="completed").model_copy(
+            update={"usage": usage, "service_tier": service_tier}
+        )
         collector.process(ResponseCompletedEvent(type="response.completed", response=completed, sequence_number=3))
         return ctx._trace["test_call"].usage
 
@@ -1592,12 +1664,22 @@ class TestResponseCollectorPricingTiers:
         assert "openai/gpt-6-astra:input_text_tokens" not in usage
 
     def test_xai_tier_via_responses(self):
-        """xAI runs through the Responses collector and surcharges above 200K."""
+        """xAI runs through the Responses collector and surcharges at 200K."""
         usage = self._run("xai/grok-4.6", input_tokens=200_001, output_tokens=10)
         assert usage["xai/grok-4.6:input_text_tokens_long_context"] == 200_001
         assert usage["xai/grok-4.6:output_text_tokens_long_context"] == 10
         usage = self._run("xai/grok-4.6", input_tokens=200_000, output_tokens=10)
-        assert usage["xai/grok-4.6:input_text_tokens"] == 200_000
+        assert usage["xai/grok-4.6:input_text_tokens_long_context"] == 200_000
+
+    def test_service_tier_via_responses(self):
+        usage = self._run(
+            "openai/gpt-6-astra",
+            input_tokens=300_000,
+            output_tokens=10,
+            service_tier="priority",
+        )
+        assert usage["openai/gpt-6-astra:input_text_tokens_long_context_fast"] == 300_000
+        assert usage["openai/gpt-6-astra:output_text_tokens_long_context_fast"] == 10
 
     def test_reasoning_tokens_follow_output_into_long_tier(self):
         """Hidden reasoning is billed as output; it must move tiers with the rest of the request."""

--- a/python/tests/core/test_frontier_models.py
+++ b/python/tests/core/test_frontier_models.py
@@ -16,6 +16,7 @@ NEW_MODEL_IDS = [
     "fireworks/accounts/fireworks/models/qwen3p7-plus",
     "fireworks/accounts/fireworks/models/deepseek-v4-flash-0731",
     "fireworks/accounts/fireworks/models/kimi-k2p7-code",
+    "openai/gpt-6-astra",
     "openai/gpt-5.6-sol",
     "openai/gpt-5.6-terra",
     "openai/gpt-5.6-luna",

--- a/python/tests/core/test_frontier_models_integration.py
+++ b/python/tests/core/test_frontier_models_integration.py
@@ -20,6 +20,12 @@ PROMPT = "Reply with exactly one word: ok"
 
 LIVE_MODELS = [
     pytest.param(
+        "openai/gpt-6-astra",
+        "OPENAI_API_KEY",
+        None,
+        id="openai-gpt-6-astra",
+    ),
+    pytest.param(
         "anthropic/claude-opus-5",
         "ANTHROPIC_API_KEY",
         None,

--- a/python/tests/core/test_memory_compaction.py
+++ b/python/tests/core/test_memory_compaction.py
@@ -1661,6 +1661,57 @@ class TestContextWindowTriggering:
         InMemoryTracingProvider._storage.clear()
 
     @pytest.mark.asyncio
+    async def test_per_ttl_cache_write_units_count_toward_utilization(self, monkeypatch) -> None:
+        """The Anthropic collector emits cache writes as `ephemeral_5m/1h_input_tokens` (per-TTL
+        pricing) instead of the aggregate; they occupy the context window all the same."""
+        from timbal.core.agent import Agent
+        from timbal.core.memory_compaction import keep_last_n_turns
+        from timbal.state import set_run_context
+        from timbal.state.context import RunContext
+        from timbal.state.tracing.providers import InMemoryTracingProvider
+
+        monkeypatch.setattr("timbal.core.agent.get_context_window", lambda _model: 100_000)
+
+        compaction_called = False
+
+        def tracking_compactor(n):
+            inner = keep_last_n_turns(n)
+
+            def wrapper(memory):
+                nonlocal compaction_called
+                compaction_called = True
+                return inner(memory)
+
+            return wrapper
+
+        agent = Agent(
+            name="test_agent",
+            model=TestModel(),
+            memory_compaction=tracking_compactor(1),
+            memory_compaction_ratio=0.75,
+        )
+
+        ctx1 = RunContext(tracing_provider=InMemoryTracingProvider)
+        set_run_context(ctx1)
+        await agent(prompt="Turn 1").collect()
+
+        # 90% utilization: 1k input + 40k 5m-write + 45k 1h-write + 4k output.
+        root1 = ctx1.root_span()
+        root1.usage["anthropic/claude-opus-5:input_tokens_fast"] = 1_000
+        root1.usage["anthropic/claude-opus-5:ephemeral_5m_input_tokens_fast"] = 40_000
+        root1.usage["anthropic/claude-opus-5:ephemeral_1h_input_tokens_fast"] = 45_000
+        root1.usage["anthropic/claude-opus-5:output_tokens_fast"] = 4_000
+        await ctx1._save_trace()
+
+        ctx2 = RunContext(parent_id=ctx1.id, tracing_provider=InMemoryTracingProvider)
+        set_run_context(ctx2)
+        await agent(prompt="Turn 2").collect()
+
+        assert compaction_called, "Per-TTL cache write units must count toward context utilization"
+
+        InMemoryTracingProvider._storage.clear()
+
+    @pytest.mark.asyncio
     async def test_compaction_skipped_at_low_utilization(self, monkeypatch) -> None:
         """When previous run used only 10% of context window, compactors should NOT fire."""
         from timbal.core.agent import Agent

--- a/python/tests/core/test_models.py
+++ b/python/tests/core/test_models.py
@@ -1,6 +1,7 @@
 """Tests for core/models.py — get_context_window and model metadata."""
 
-from timbal.core.models import get_context_window
+import pytest
+from timbal.core.models import get_context_window, get_long_context_threshold
 
 
 class TestGetContextWindow:
@@ -38,3 +39,34 @@ class TestGetContextWindow:
             result = get_context_window(model_id)
             assert result is not None, f"{model_id} should have a context window"
             assert result > 0
+
+
+class TestGetLongContextThreshold:
+    @pytest.mark.parametrize(
+        "model_id,expected",
+        [
+            ("openai/gpt-6-astra", 272_000),
+            ("openai/gpt-5.6-sol", 272_000),
+            ("openai/gpt-5.5", 272_000),
+            ("openai/gpt-5.4", 272_000),
+            ("xai/grok-4.6", 200_000),
+            ("byteplus/seed-2-0-pro-260328", 128_000),
+        ],
+    )
+    def test_models_with_long_context_tier(self, model_id: str, expected: int):
+        assert get_long_context_threshold(model_id) == expected
+
+    @pytest.mark.parametrize("model_id", ["openai/gpt-4o", "anthropic/claude-sonnet-4-6", "openai/gpt-5.4-nano"])
+    def test_models_without_long_context_tier(self, model_id: str):
+        assert get_long_context_threshold(model_id) is None
+
+    def test_unknown_model_returns_none(self):
+        assert get_long_context_threshold("fake/nonexistent-model-xyz") is None
+
+    def test_threshold_is_below_context_window(self):
+        """The tier must be reachable: threshold strictly inside the advertised window."""
+        for model_id in ("openai/gpt-6-astra", "xai/grok-4.6", "byteplus/seed-2-0-lite-260228"):
+            threshold = get_long_context_threshold(model_id)
+            window = get_context_window(model_id)
+            assert threshold is not None and window is not None
+            assert threshold < window

--- a/python/tests/core/test_models.py
+++ b/python/tests/core/test_models.py
@@ -1,7 +1,13 @@
 """Tests for core/models.py — get_context_window and model metadata."""
 
 import pytest
-from timbal.core.models import get_context_window, get_long_context_threshold
+from timbal.core.models import (
+    LONG_CONTEXT_USAGE_SUFFIX,
+    base_usage_metric,
+    get_context_window,
+    get_long_context_threshold,
+    has_cache_write_pricing,
+)
 
 
 class TestGetContextWindow:
@@ -70,3 +76,22 @@ class TestGetLongContextThreshold:
             window = get_context_window(model_id)
             assert threshold is not None and window is not None
             assert threshold < window
+
+
+class TestCacheWritePricing:
+    @pytest.mark.parametrize("model_id", ["openai/gpt-6-astra", "openai/gpt-5.6-sol", "openai/gpt-5.6-luna"])
+    def test_models_with_published_cache_write_rate(self, model_id: str):
+        assert has_cache_write_pricing(model_id) is True
+
+    @pytest.mark.parametrize("model_id", ["openai/gpt-5.5", "openai/gpt-4o", "xai/grok-4.6", "fake/nope"])
+    def test_models_without_cache_write_rate(self, model_id: str):
+        assert has_cache_write_pricing(model_id) is False
+
+
+class TestBaseUsageMetric:
+    def test_strips_long_context_suffix(self):
+        assert base_usage_metric(f"output_text_tokens{LONG_CONTEXT_USAGE_SUFFIX}") == "output_text_tokens"
+
+    def test_leaves_other_metrics_alone(self):
+        assert base_usage_metric("output_text_tokens") == "output_text_tokens"
+        assert base_usage_metric("web_search_requests") == "web_search_requests"

--- a/python/tests/core/test_models.py
+++ b/python/tests/core/test_models.py
@@ -2,11 +2,15 @@
 
 import pytest
 from timbal.core.models import (
+    FAST_USAGE_SUFFIX,
+    FLEX_USAGE_SUFFIX,
     LONG_CONTEXT_USAGE_SUFFIX,
     base_usage_metric,
     get_context_window,
     get_long_context_threshold,
     has_cache_write_pricing,
+    service_tier_usage_suffix,
+    uses_long_context_pricing,
 )
 
 
@@ -69,6 +73,12 @@ class TestGetLongContextThreshold:
     def test_unknown_model_returns_none(self):
         assert get_long_context_threshold("fake/nonexistent-model-xyz") is None
 
+    def test_provider_specific_boundary_semantics(self):
+        assert uses_long_context_pricing("openai/gpt-6-astra", 272_000) is False
+        assert uses_long_context_pricing("openai/gpt-6-astra", 272_001) is True
+        assert uses_long_context_pricing("xai/grok-4.6", 199_999) is False
+        assert uses_long_context_pricing("xai/grok-4.6", 200_000) is True
+
     def test_threshold_is_below_context_window(self):
         """The tier must be reachable: threshold strictly inside the advertised window."""
         for model_id in ("openai/gpt-6-astra", "xai/grok-4.6", "byteplus/seed-2-0-lite-260228"):
@@ -92,6 +102,21 @@ class TestBaseUsageMetric:
     def test_strips_long_context_suffix(self):
         assert base_usage_metric(f"output_text_tokens{LONG_CONTEXT_USAGE_SUFFIX}") == "output_text_tokens"
 
+    def test_strips_combined_pricing_suffixes(self):
+        metric = f"output_text_tokens{LONG_CONTEXT_USAGE_SUFFIX}{FAST_USAGE_SUFFIX}"
+        assert base_usage_metric(metric) == "output_text_tokens"
+
     def test_leaves_other_metrics_alone(self):
         assert base_usage_metric("output_text_tokens") == "output_text_tokens"
         assert base_usage_metric("web_search_requests") == "web_search_requests"
+
+
+class TestServiceTierUsageSuffix:
+    def test_astra_tiers(self):
+        assert service_tier_usage_suffix("openai/gpt-6-astra", "fast") == FAST_USAGE_SUFFIX
+        assert service_tier_usage_suffix("openai/gpt-6-astra", "priority") == FAST_USAGE_SUFFIX
+        assert service_tier_usage_suffix("openai/gpt-6-astra", "flex") == FLEX_USAGE_SUFFIX
+
+    def test_unpriced_tier_is_ignored(self):
+        assert service_tier_usage_suffix("openai/gpt-4o", "fast") == ""
+        assert service_tier_usage_suffix("openai/gpt-6-astra", "default") == ""

--- a/python/tests/evals/test_utils.py
+++ b/python/tests/evals/test_utils.py
@@ -226,5 +226,43 @@ class TestResolveUsageKey:
         assert _resolve_usage_key(usage, "output_text_tokens_long_context") == 40
         assert _resolve_usage_key(usage, "openai/gpt-6-astra:output_text_tokens_long_context") == 40
 
+    def test_exact_model_key_sums_long_context_sibling(self):
+        """Exact `model:metric` hit must still add the `_long_context` bucket from the same run."""
+        usage = {
+            "openai/gpt-6-astra:output_text_tokens": 10,
+            "openai/gpt-6-astra:output_text_tokens_long_context": 40,
+            "openai/gpt-6-astra-other:output_text_tokens": 999,  # exact match must NOT widen to prefix
+        }
+        assert _resolve_usage_key(usage, "openai/gpt-6-astra:output_text_tokens") == 50
+
+    def test_exact_key_without_sibling_is_unchanged(self):
+        usage = {"openai/gpt-6-astra:output_text_tokens": 10}
+        assert _resolve_usage_key(usage, "openai/gpt-6-astra:output_text_tokens") == 10
+
+    def test_resolve_target_uses_resolver_even_when_exact_key_exists(self):
+        """The `usage.<key>` path in resolve_target must not bypass the resolver on an exact hit."""
+        from timbal.evals.utils import resolve_target
+        from timbal.state.tracing.span import Span
+        from timbal.state.tracing.trace import Trace
+
+        span = Span(
+            path="agent.llm",
+            call_id="c1",
+            t0=0,
+            t1=1,
+            usage={
+                "openai/gpt-6-astra:output_text_tokens": 10,
+                "openai/gpt-6-astra:output_text_tokens_long_context": 40,
+            },
+        )
+        trace = Trace()
+        trace["c1"] = span
+        _, value = resolve_target(trace, "agent.llm.usage.openai/gpt-6-astra:output_text_tokens")
+        assert value == 50
+        _, value = resolve_target(trace, "agent.llm.usage.output_text_tokens")
+        assert value == 50
+        _, value = resolve_target(trace, "agent.llm.usage.openai/gpt-6-astra:output_text_tokens_long_context")
+        assert value == 40
+
     def test_missing_returns_none(self):
         assert _resolve_usage_key({"openai/gpt-4o:input_text_tokens": 1}, "output_text_tokens") is None

--- a/python/tests/evals/test_utils.py
+++ b/python/tests/evals/test_utils.py
@@ -6,7 +6,13 @@ from pathlib import Path
 import pytest
 from timbal.evals.models import EvalSummary
 from timbal.evals.runner import run_eval
-from timbal.evals.utils import discover_config, discover_eval_files, dump_summary, parse_eval_file
+from timbal.evals.utils import (
+    _resolve_usage_key,
+    discover_config,
+    discover_eval_files,
+    dump_summary,
+    parse_eval_file,
+)
 
 AGENT_MODULE = """\
 from timbal import Agent
@@ -179,3 +185,46 @@ class TestDiscoverConfig:
 
     def test_returns_empty_when_missing(self, tmp_path):
         assert discover_config(tmp_path) == {}
+
+
+class TestResolveUsageKey:
+    def test_exact_key(self):
+        usage = {"openai/gpt-4o:input_text_tokens": 100}
+        assert _resolve_usage_key(usage, "openai/gpt-4o:input_text_tokens") == 100
+
+    def test_metric_only_sums_across_models(self):
+        usage = {"openai/gpt-4o:output_text_tokens": 10, "openai/gpt-5.5:output_text_tokens": 5}
+        assert _resolve_usage_key(usage, "output_text_tokens") == 15
+
+    def test_model_prefix_sums_snapshots(self):
+        usage = {"anthropic/claude-haiku-4-5-20251001:input_tokens": 100, "anthropic/claude-haiku-4-5-20241120:input_tokens": 50}
+        assert _resolve_usage_key(usage, "anthropic/claude-haiku-4-5:input_tokens") == 150
+
+    def test_unsuffixed_metric_matches_long_context_tier(self):
+        """A request billed at the long-context tier is still the same tokens for an eval assertion."""
+        usage = {
+            "openai/gpt-6-astra:input_text_tokens_long_context": 300_000,
+            "openai/gpt-6-astra:output_text_tokens_long_context": 40,
+        }
+        assert _resolve_usage_key(usage, "output_text_tokens") == 40
+        assert _resolve_usage_key(usage, "input_text_tokens") == 300_000
+        assert _resolve_usage_key(usage, "openai/gpt-6-astra:output_text_tokens") == 40
+
+    def test_unsuffixed_metric_sums_both_tiers(self):
+        """Multi-step runs can cross the threshold mid-run: short and long buckets add up."""
+        usage = {
+            "openai/gpt-6-astra:output_text_tokens": 10,
+            "openai/gpt-6-astra:output_text_tokens_long_context": 40,
+        }
+        assert _resolve_usage_key(usage, "output_text_tokens") == 50
+
+    def test_explicit_long_context_metric_matches_only_that_tier(self):
+        usage = {
+            "openai/gpt-6-astra:output_text_tokens": 10,
+            "openai/gpt-6-astra:output_text_tokens_long_context": 40,
+        }
+        assert _resolve_usage_key(usage, "output_text_tokens_long_context") == 40
+        assert _resolve_usage_key(usage, "openai/gpt-6-astra:output_text_tokens_long_context") == 40
+
+    def test_missing_returns_none(self):
+        assert _resolve_usage_key({"openai/gpt-4o:input_text_tokens": 1}, "output_text_tokens") is None

--- a/python/tests/evals/test_utils.py
+++ b/python/tests/evals/test_utils.py
@@ -235,6 +235,18 @@ class TestResolveUsageKey:
         }
         assert _resolve_usage_key(usage, "openai/gpt-6-astra:output_text_tokens") == 50
 
+    def test_exact_model_key_sums_all_pricing_tiers(self):
+        usage = {
+            "openai/gpt-6-astra:output_text_tokens": 10,
+            "openai/gpt-6-astra:output_text_tokens_fast": 20,
+            "openai/gpt-6-astra:output_text_tokens_flex": 30,
+            "openai/gpt-6-astra:output_text_tokens_long_context_fast": 40,
+            "openai/gpt-6-astra-other:output_text_tokens_fast": 999,
+        }
+        assert _resolve_usage_key(usage, "openai/gpt-6-astra:output_text_tokens") == 100
+        assert _resolve_usage_key(usage, "output_text_tokens") == 1099
+        assert _resolve_usage_key(usage, "openai/gpt-6-astra:output_text_tokens_fast") == 20
+
     def test_exact_key_without_sibling_is_unchanged(self):
         usage = {"openai/gpt-6-astra:output_text_tokens": 10}
         assert _resolve_usage_key(usage, "openai/gpt-6-astra:output_text_tokens") == 10

--- a/python/timbal/collectors/impl/anthropic.py
+++ b/python/timbal/collectors/impl/anthropic.py
@@ -48,6 +48,7 @@ from anthropic.types.beta import (
     BetaWebSearchToolResultBlock,
 )
 
+from ...core.models import service_tier_usage_suffix
 from ...state import get_billing_id, get_run_context
 from ...types.content.custom import CustomContent
 from ...types.content.text import TextContent
@@ -86,6 +87,31 @@ AnthropicEvent = (
 logger = structlog.get_logger("timbal.collectors.impl.anthropic")
 
 
+def _usage_int(usage: Any, attr: str) -> int | None:
+    """Read a non-negative integer usage field; ``None`` when absent, null, or malformed.
+
+    Usage objects allow pydantic extras, so fields the SDK does not declare yet
+    (``speed``, ``output_tokens_details``) are still reachable via ``getattr``.
+    """
+    value = getattr(usage, attr, None) if usage is not None else None
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _first_usage_int(attr: str, *sources: Any) -> int:
+    """First source that reports ``attr``; 0 when none does."""
+    for source in sources:
+        value = _usage_int(source, attr)
+        if value is not None:
+            return value
+    return 0
+
+
 @register_collector
 class AnthropicCollector(BaseCollector):
     """Collector for Anthropic streaming events."""
@@ -98,6 +124,11 @@ class AnthropicCollector(BaseCollector):
         self._stop_reason: str | None = None
         self.content_blocks: set[str] = set()
         self.content: list[dict[str, Any]] = []
+        # ``message_start`` carries the request-side usage (prompt, cache breakdown,
+        # ``speed``); ``message_delta`` carries the final cumulative totals. Billing
+        # happens once, from whichever of the two we have by the end of the stream.
+        self._start_usage: Any = None
+        self._usage_recorded: bool = False
 
     @classmethod
     @override
@@ -129,6 +160,7 @@ class AnthropicCollector(BaseCollector):
         self.id = event.message.id
         self.anthropic_model = event.message.model
         self.content = []
+        self._start_usage = event.message.usage
 
     def _handle_content_block_start(self, event: RawContentBlockStartEvent) -> TimbalDeltaItem | None:
         """Handle content block start events."""
@@ -255,23 +287,89 @@ class AnthropicCollector(BaseCollector):
         if event.delta.stop_reason:
             self._stop_reason = event.delta.stop_reason
 
+        self._output_tokens = _first_usage_int("output_tokens", event.usage)
+        self._record_usage(delta_usage=event.usage)
+
+    def _record_usage(self, *, delta_usage: Any = None) -> None:
+        """Record this message's billable usage exactly once.
+
+        Anthropic's ``usage`` is a set of *disjoint* buckets, each priced at its own rate,
+        plus breakdowns that must not be billed on top of the bucket they detail:
+
+        - ``input_tokens`` / ``cache_read_input_tokens`` / ``output_tokens`` — disjoint.
+        - ``cache_creation_input_tokens`` = ``cache_creation.ephemeral_5m_input_tokens``
+          + ``cache_creation.ephemeral_1h_input_tokens``. 5m writes bill at 1.25x input,
+          1h writes at 2x, so the per-TTL units are emitted whenever the breakdown is
+          present and reconciles; otherwise the aggregate is emitted. Never both.
+          The breakdown only ships on ``message_start``; ``message_delta`` repeats the
+          aggregate.
+        - ``output_tokens_details.thinking_tokens`` is a *subset* of ``output_tokens``
+          (already billed at the output rate) and is therefore not emitted.
+        - ``server_tool_use.*_requests`` are per-call fees, emitted as-is.
+        - ``usage.speed == "fast"`` (Opus fast mode, 2x) suffixes every token unit with
+          ``_fast`` when the catalog prices that tier for the model.
+
+        Called from ``message_delta`` with the final cumulative totals, or from
+        ``result()`` when the stream ended without one (interrupted / cancelled): the
+        prompt side is charged by Anthropic regardless, so it is billed from
+        ``message_start``; output is unknown in that case and left unbilled.
+        """
+        if self._usage_recorded:
+            return
+        start_usage = self._start_usage
+        if delta_usage is None and start_usage is None:
+            return
         run_context = get_run_context()
         if not run_context:
-            return None
-        billing_id = get_billing_id() or self.anthropic_model  # anthropic_model from RawMessageStartEvent
+            return
+        self._usage_recorded = True
+        billing_id = get_billing_id() or getattr(self, "anthropic_model", None)
+        if not billing_id:
+            return
 
-        def _update_usage(usage):
-            for k, v in usage.items():
-                if isinstance(v, dict):
-                    _update_usage(v)
-                elif isinstance(v, int) and v > 0:
-                    run_context.update_usage(f"{billing_id}:{k}", v)
+        speed = getattr(start_usage, "speed", None) if start_usage is not None else None
+        tier = service_tier_usage_suffix(billing_id, "fast") if speed == "fast" else ""
 
-        _update_usage(event.usage.model_dump())
+        def _emit(unit: str, value: int, *, suffix: str = tier) -> None:
+            if value > 0:
+                run_context.update_usage(f"{billing_id}:{unit}{suffix}", value)
+
+        # Request side: the delta repeats these; fall back to message_start when it does not.
+        _emit("input_tokens", _first_usage_int("input_tokens", delta_usage, start_usage))
+        _emit("cache_read_input_tokens", _first_usage_int("cache_read_input_tokens", delta_usage, start_usage))
+
+        cache_creation_total = _first_usage_int("cache_creation_input_tokens", delta_usage, start_usage)
+        breakdown = getattr(start_usage, "cache_creation", None) if start_usage is not None else None
+        ephemeral_5m = _first_usage_int("ephemeral_5m_input_tokens", breakdown)
+        ephemeral_1h = _first_usage_int("ephemeral_1h_input_tokens", breakdown)
+        if cache_creation_total > 0 and ephemeral_5m + ephemeral_1h == cache_creation_total:
+            _emit("ephemeral_5m_input_tokens", ephemeral_5m)
+            _emit("ephemeral_1h_input_tokens", ephemeral_1h)
+        else:
+            _emit("cache_creation_input_tokens", cache_creation_total)
+
+        # Response side: only the delta knows the final count (message_start reports a
+        # placeholder of a few tokens while generation is still in flight).
+        if delta_usage is not None:
+            _emit("output_tokens", _first_usage_int("output_tokens", delta_usage))
+
+        server_tool_use = getattr(delta_usage, "server_tool_use", None) if delta_usage is not None else None
+        if server_tool_use is None and start_usage is not None:
+            server_tool_use = getattr(start_usage, "server_tool_use", None)
+        if hasattr(server_tool_use, "model_dump"):
+            server_tool_use = server_tool_use.model_dump()
+        if isinstance(server_tool_use, dict):
+            for name, value in server_tool_use.items():
+                if name.endswith("_requests") and isinstance(value, int) and not isinstance(value, bool):
+                    _emit(name, value, suffix="")
 
     @override
     def result(self) -> Message:
         """Returns structured Anthropic response."""
+        # Stream ended without a ``message_delta`` (interrupted / cancelled): Anthropic
+        # still charges the prompt, so bill what ``message_start`` reported.
+        self._record_usage()
+
         run_context = get_run_context()
         if run_context:
             if self._first_token:

--- a/python/timbal/collectors/impl/openai.py
+++ b/python/timbal/collectors/impl/openai.py
@@ -44,7 +44,11 @@ from openai.types.responses import (
 )
 from uuid_extensions import uuid7
 
-from ...core.models import get_long_context_threshold
+from ...core.models import (
+    LONG_CONTEXT_USAGE_SUFFIX,
+    get_long_context_threshold,
+    has_cache_write_pricing,
+)
 from ...state import get_billing_id, get_run_context
 from ...types.content.text import TextContent
 from ...types.content.thinking import ThinkingContent
@@ -74,8 +78,6 @@ from ...types.message import Message
 from .. import register_collector
 from ..base import BaseCollector
 
-LONG_CONTEXT_SUFFIX = "_long_context"
-
 
 def _usage_tier_suffix(billing_id: str, input_tokens: int) -> str:
     """Return the usage-key suffix for this request's pricing tier.
@@ -91,7 +93,7 @@ def _usage_tier_suffix(billing_id: str, input_tokens: int) -> str:
     """
     threshold = get_long_context_threshold(billing_id)
     if threshold is not None and input_tokens > threshold:
-        return LONG_CONTEXT_SUFFIX
+        return LONG_CONTEXT_USAGE_SUFFIX
     return ""
 
 
@@ -99,6 +101,20 @@ def _optional_int(obj: Any, attr: str) -> int:
     """Read an optional integer usage detail, tolerating missing attributes and ``None``."""
     value = getattr(obj, attr, None) if obj is not None else None
     return int(value) if value else 0
+
+
+def _cache_write_tokens(billing_id: str, input_tokens_details: Any) -> int:
+    """Cache-write tokens to split out of plain input, or 0 when the catalog cannot price them.
+
+    OpenAI bills prompt-cache writes at a premium (1.25x input). The SDK does not declare
+    ``cache_write_tokens`` yet, so it arrives as a pydantic extra. Only models with a
+    ``cache_write_price`` get a dedicated unit — for anything else the tokens must stay in
+    ``input_text_tokens`` so they are still billed (at the input rate) instead of vanishing
+    into a unit with no cost row.
+    """
+    if not has_cache_write_pricing(billing_id):
+        return 0
+    return _optional_int(input_tokens_details, "cache_write_tokens")
 
 
 # Create type aliases for OpenAI events
@@ -268,9 +284,7 @@ class ChatCompletionCollector(BaseCollector):
         if input_cached_tokens:
             input_tokens -= input_cached_tokens
             run_context.update_usage(f"{billing_id}:input_cached_tokens{tier}", input_cached_tokens)
-        # Prompt-cache writes are billed at a premium (1.25x input on OpenAI). The SDK
-        # does not declare this field yet; it arrives as a pydantic extra.
-        input_cache_write_tokens = _optional_int(input_tokens_details, "cache_write_tokens")
+        input_cache_write_tokens = _cache_write_tokens(billing_id, input_tokens_details)
         if input_cache_write_tokens:
             input_tokens -= input_cache_write_tokens
             run_context.update_usage(f"{billing_id}:input_cache_write_tokens{tier}", input_cache_write_tokens)
@@ -735,9 +749,7 @@ class ResponseCollector(BaseCollector):
         if input_cached_tokens:
             input_tokens -= input_cached_tokens
             run_context.update_usage(f"{billing_id}:input_cached_tokens{tier}", input_cached_tokens)
-        # Prompt-cache writes are billed at a premium (1.25x input on OpenAI). The SDK
-        # does not declare this field yet; it arrives as a pydantic extra.
-        input_cache_write_tokens = _optional_int(input_tokens_details, "cache_write_tokens")
+        input_cache_write_tokens = _cache_write_tokens(billing_id, input_tokens_details)
         if input_cache_write_tokens:
             input_tokens -= input_cache_write_tokens
             run_context.update_usage(f"{billing_id}:input_cache_write_tokens{tier}", input_cache_write_tokens)

--- a/python/timbal/collectors/impl/openai.py
+++ b/python/timbal/collectors/impl/openai.py
@@ -44,6 +44,7 @@ from openai.types.responses import (
 )
 from uuid_extensions import uuid7
 
+from ...core.models import get_long_context_threshold
 from ...state import get_billing_id, get_run_context
 from ...types.content.text import TextContent
 from ...types.content.thinking import ThinkingContent
@@ -72,6 +73,33 @@ from ...types.events.delta import (
 from ...types.message import Message
 from .. import register_collector
 from ..base import BaseCollector
+
+LONG_CONTEXT_SUFFIX = "_long_context"
+
+
+def _usage_tier_suffix(billing_id: str, input_tokens: int) -> str:
+    """Return the usage-key suffix for this request's pricing tier.
+
+    OpenAI (>272K on 1.05M-context models), xAI (>200K) and BytePlus (>128K) reprice
+    the *entire* request — input, cache reads/writes and output — once the prompt
+    exceeds the model's threshold. Emitting distinct units (``input_text_tokens_long_context``
+    etc.) lets cost tables bill each tier at its own rate instead of silently applying
+    the short-context rate.
+
+    ``input_tokens`` must be the raw prompt size as reported by the provider (cached and
+    cache-write tokens included) — that is the number the threshold is defined against.
+    """
+    threshold = get_long_context_threshold(billing_id)
+    if threshold is not None and input_tokens > threshold:
+        return LONG_CONTEXT_SUFFIX
+    return ""
+
+
+def _optional_int(obj: Any, attr: str) -> int:
+    """Read an optional integer usage detail, tolerating missing attributes and ``None``."""
+    value = getattr(obj, attr, None) if obj is not None else None
+    return int(value) if value else 0
+
 
 # Create type aliases for OpenAI events
 ChatCompletionEvent = ChatCompletionChunk
@@ -230,20 +258,27 @@ class ChatCompletionCollector(BaseCollector):
         raw_input = int(openai_usage.prompt_tokens)
         raw_output = int(openai_usage.completion_tokens)
         total_tokens = int(getattr(openai_usage, "total_tokens", 0) or 0)
+        # Long-context tier is decided on the raw prompt size (cache hits included)
+        # and applies to every token bucket of this request.
+        tier = _usage_tier_suffix(billing_id, raw_input)
 
         input_tokens = raw_input
         input_tokens_details = openai_usage.prompt_tokens_details
-        if hasattr(input_tokens_details, "cached_tokens") and input_tokens_details.cached_tokens is not None:
-            input_cached_tokens = int(input_tokens_details.cached_tokens)
-            if input_cached_tokens:
-                input_tokens -= input_cached_tokens
-                run_context.update_usage(f"{billing_id}:input_cached_tokens", input_cached_tokens)
-        if hasattr(input_tokens_details, "audio_tokens") and input_tokens_details.audio_tokens is not None:
-            input_audio_tokens = int(input_tokens_details.audio_tokens)
-            if input_audio_tokens:
-                input_tokens -= input_audio_tokens
-                run_context.update_usage(f"{billing_id}:input_audio_tokens", input_audio_tokens)
-        run_context.update_usage(f"{billing_id}:input_text_tokens", input_tokens)
+        input_cached_tokens = _optional_int(input_tokens_details, "cached_tokens")
+        if input_cached_tokens:
+            input_tokens -= input_cached_tokens
+            run_context.update_usage(f"{billing_id}:input_cached_tokens{tier}", input_cached_tokens)
+        # Prompt-cache writes are billed at a premium (1.25x input on OpenAI). The SDK
+        # does not declare this field yet; it arrives as a pydantic extra.
+        input_cache_write_tokens = _optional_int(input_tokens_details, "cache_write_tokens")
+        if input_cache_write_tokens:
+            input_tokens -= input_cache_write_tokens
+            run_context.update_usage(f"{billing_id}:input_cache_write_tokens{tier}", input_cache_write_tokens)
+        input_audio_tokens = _optional_int(input_tokens_details, "audio_tokens")
+        if input_audio_tokens:
+            input_tokens -= input_audio_tokens
+            run_context.update_usage(f"{billing_id}:input_audio_tokens", input_audio_tokens)
+        run_context.update_usage(f"{billing_id}:input_text_tokens{tier}", input_tokens)
 
         # Total-derived output: visible completion + OpenAI o-series
         # reasoning (already inside completion_tokens) + Gemini hidden
@@ -252,13 +287,11 @@ class ChatCompletionCollector(BaseCollector):
         # inconsistently.
         output_tokens = max(total_tokens - raw_input, raw_output) if total_tokens > 0 else raw_output
         self._output_tokens += output_tokens
-        output_tokens_details = openai_usage.completion_tokens_details
-        if hasattr(output_tokens_details, "audio_tokens") and output_tokens_details.audio_tokens is not None:
-            output_audio_tokens = int(output_tokens_details.audio_tokens)
-            if output_audio_tokens:
-                output_tokens -= output_audio_tokens
-                run_context.update_usage(f"{billing_id}:output_audio_tokens", output_audio_tokens)
-        run_context.update_usage(f"{billing_id}:output_text_tokens", output_tokens)
+        output_audio_tokens = _optional_int(openai_usage.completion_tokens_details, "audio_tokens")
+        if output_audio_tokens:
+            output_tokens -= output_audio_tokens
+            run_context.update_usage(f"{billing_id}:output_audio_tokens", output_audio_tokens)
+        run_context.update_usage(f"{billing_id}:output_text_tokens{tier}", output_tokens)
 
     def _handle_tool_calls(self, event: ChatCompletionEvent) -> TimbalToolUse | TimbalToolUseDelta | None:
         """Handle tool call events from OpenAI."""
@@ -692,33 +725,38 @@ class ResponseCollector(BaseCollector):
         raw_input = int(usage.input_tokens)
         raw_output = int(usage.output_tokens)
         total_tokens = int(getattr(usage, "total_tokens", 0) or 0)
+        # Long-context tier is decided on the raw prompt size (cache hits included)
+        # and applies to every token bucket of this request.
+        tier = _usage_tier_suffix(billing_id, raw_input)
 
         input_tokens = raw_input
         input_tokens_details = usage.input_tokens_details
-        if hasattr(input_tokens_details, "cached_tokens"):
-            input_cached_tokens = int(input_tokens_details.cached_tokens)
-            if input_cached_tokens:
-                input_tokens -= input_cached_tokens
-                run_context.update_usage(f"{billing_id}:input_cached_tokens", input_cached_tokens)
-        if hasattr(input_tokens_details, "audio_tokens"):
-            input_audio_tokens = int(input_tokens_details.audio_tokens)
-            if input_audio_tokens:
-                input_tokens -= input_audio_tokens
-                run_context.update_usage(f"{billing_id}:input_audio_tokens", input_audio_tokens)
-        run_context.update_usage(f"{billing_id}:input_text_tokens", input_tokens)
+        input_cached_tokens = _optional_int(input_tokens_details, "cached_tokens")
+        if input_cached_tokens:
+            input_tokens -= input_cached_tokens
+            run_context.update_usage(f"{billing_id}:input_cached_tokens{tier}", input_cached_tokens)
+        # Prompt-cache writes are billed at a premium (1.25x input on OpenAI). The SDK
+        # does not declare this field yet; it arrives as a pydantic extra.
+        input_cache_write_tokens = _optional_int(input_tokens_details, "cache_write_tokens")
+        if input_cache_write_tokens:
+            input_tokens -= input_cache_write_tokens
+            run_context.update_usage(f"{billing_id}:input_cache_write_tokens{tier}", input_cache_write_tokens)
+        input_audio_tokens = _optional_int(input_tokens_details, "audio_tokens")
+        if input_audio_tokens:
+            input_tokens -= input_audio_tokens
+            run_context.update_usage(f"{billing_id}:input_audio_tokens", input_audio_tokens)
+        run_context.update_usage(f"{billing_id}:input_text_tokens{tier}", input_tokens)
 
         # See `_handle_usage` in ChatCompletionCollector: collapse all
         # billed-as-output tokens (visible + reasoning + hidden thinking)
         # into a single bucket via `total - raw_input`.
         output_tokens = max(total_tokens - raw_input, raw_output) if total_tokens > 0 else raw_output
         self._output_tokens += output_tokens
-        output_tokens_details = usage.output_tokens_details
-        if hasattr(output_tokens_details, "audio_tokens"):
-            output_audio_tokens = int(output_tokens_details.audio_tokens)
-            if output_audio_tokens:
-                output_tokens -= output_audio_tokens
-                run_context.update_usage(f"{billing_id}:output_audio_tokens", output_audio_tokens)
-        run_context.update_usage(f"{billing_id}:output_text_tokens", output_tokens)
+        output_audio_tokens = _optional_int(usage.output_tokens_details, "audio_tokens")
+        if output_audio_tokens:
+            output_tokens -= output_audio_tokens
+            run_context.update_usage(f"{billing_id}:output_audio_tokens", output_audio_tokens)
+        run_context.update_usage(f"{billing_id}:output_text_tokens{tier}", output_tokens)
 
     @override
     def result(self) -> Message:

--- a/python/timbal/collectors/impl/openai.py
+++ b/python/timbal/collectors/impl/openai.py
@@ -46,8 +46,9 @@ from uuid_extensions import uuid7
 
 from ...core.models import (
     LONG_CONTEXT_USAGE_SUFFIX,
-    get_long_context_threshold,
     has_cache_write_pricing,
+    service_tier_usage_suffix,
+    uses_long_context_pricing,
 )
 from ...state import get_billing_id, get_run_context
 from ...types.content.text import TextContent
@@ -79,10 +80,10 @@ from .. import register_collector
 from ..base import BaseCollector
 
 
-def _usage_tier_suffix(billing_id: str, input_tokens: int) -> str:
+def _usage_tier_suffix(billing_id: str, input_tokens: int, service_tier: str | None = None) -> str:
     """Return the usage-key suffix for this request's pricing tier.
 
-    OpenAI (>272K on 1.05M-context models), xAI (>200K) and BytePlus (>128K) reprice
+    OpenAI (>272K on 1.05M-context models), xAI (>=200K) and BytePlus (>128K) reprice
     the *entire* request — input, cache reads/writes and output — once the prompt
     exceeds the model's threshold. Emitting distinct units (``input_text_tokens_long_context``
     etc.) lets cost tables bill each tier at its own rate instead of silently applying
@@ -91,16 +92,25 @@ def _usage_tier_suffix(billing_id: str, input_tokens: int) -> str:
     ``input_tokens`` must be the raw prompt size as reported by the provider (cached and
     cache-write tokens included) — that is the number the threshold is defined against.
     """
-    threshold = get_long_context_threshold(billing_id)
-    if threshold is not None and input_tokens > threshold:
-        return LONG_CONTEXT_USAGE_SUFFIX
-    return ""
+    suffix = LONG_CONTEXT_USAGE_SUFFIX if uses_long_context_pricing(billing_id, input_tokens) else ""
+    return f"{suffix}{service_tier_usage_suffix(billing_id, service_tier)}"
 
 
 def _optional_int(obj: Any, attr: str) -> int:
-    """Read an optional integer usage detail, tolerating missing attributes and ``None``."""
+    """Read a non-negative optional integer, tolerating malformed provider extras."""
     value = getattr(obj, attr, None) if obj is not None else None
-    return int(value) if value else 0
+    if value is None or isinstance(value, bool):
+        return 0
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return 0
+    return parsed if parsed > 0 else 0
+
+
+def _bounded_usage_detail(obj: Any, attr: str, remaining: int) -> int:
+    """Read a usage detail without allowing malformed telemetry to make a bucket negative."""
+    return min(_optional_int(obj, attr), max(remaining, 0))
 
 
 def _cache_write_tokens(billing_id: str, input_tokens_details: Any) -> int:
@@ -276,19 +286,19 @@ class ChatCompletionCollector(BaseCollector):
         total_tokens = int(getattr(openai_usage, "total_tokens", 0) or 0)
         # Long-context tier is decided on the raw prompt size (cache hits included)
         # and applies to every token bucket of this request.
-        tier = _usage_tier_suffix(billing_id, raw_input)
+        tier = _usage_tier_suffix(billing_id, raw_input, getattr(event, "service_tier", None))
 
         input_tokens = raw_input
         input_tokens_details = openai_usage.prompt_tokens_details
-        input_cached_tokens = _optional_int(input_tokens_details, "cached_tokens")
+        input_cached_tokens = _bounded_usage_detail(input_tokens_details, "cached_tokens", input_tokens)
         if input_cached_tokens:
             input_tokens -= input_cached_tokens
             run_context.update_usage(f"{billing_id}:input_cached_tokens{tier}", input_cached_tokens)
-        input_cache_write_tokens = _cache_write_tokens(billing_id, input_tokens_details)
+        input_cache_write_tokens = min(_cache_write_tokens(billing_id, input_tokens_details), max(input_tokens, 0))
         if input_cache_write_tokens:
             input_tokens -= input_cache_write_tokens
             run_context.update_usage(f"{billing_id}:input_cache_write_tokens{tier}", input_cache_write_tokens)
-        input_audio_tokens = _optional_int(input_tokens_details, "audio_tokens")
+        input_audio_tokens = _bounded_usage_detail(input_tokens_details, "audio_tokens", input_tokens)
         if input_audio_tokens:
             input_tokens -= input_audio_tokens
             run_context.update_usage(f"{billing_id}:input_audio_tokens", input_audio_tokens)
@@ -301,7 +311,7 @@ class ChatCompletionCollector(BaseCollector):
         # inconsistently.
         output_tokens = max(total_tokens - raw_input, raw_output) if total_tokens > 0 else raw_output
         self._output_tokens += output_tokens
-        output_audio_tokens = _optional_int(openai_usage.completion_tokens_details, "audio_tokens")
+        output_audio_tokens = _bounded_usage_detail(openai_usage.completion_tokens_details, "audio_tokens", output_tokens)
         if output_audio_tokens:
             output_tokens -= output_audio_tokens
             run_context.update_usage(f"{billing_id}:output_audio_tokens", output_audio_tokens)
@@ -741,19 +751,19 @@ class ResponseCollector(BaseCollector):
         total_tokens = int(getattr(usage, "total_tokens", 0) or 0)
         # Long-context tier is decided on the raw prompt size (cache hits included)
         # and applies to every token bucket of this request.
-        tier = _usage_tier_suffix(billing_id, raw_input)
+        tier = _usage_tier_suffix(billing_id, raw_input, getattr(event.response, "service_tier", None))
 
         input_tokens = raw_input
         input_tokens_details = usage.input_tokens_details
-        input_cached_tokens = _optional_int(input_tokens_details, "cached_tokens")
+        input_cached_tokens = _bounded_usage_detail(input_tokens_details, "cached_tokens", input_tokens)
         if input_cached_tokens:
             input_tokens -= input_cached_tokens
             run_context.update_usage(f"{billing_id}:input_cached_tokens{tier}", input_cached_tokens)
-        input_cache_write_tokens = _cache_write_tokens(billing_id, input_tokens_details)
+        input_cache_write_tokens = min(_cache_write_tokens(billing_id, input_tokens_details), max(input_tokens, 0))
         if input_cache_write_tokens:
             input_tokens -= input_cache_write_tokens
             run_context.update_usage(f"{billing_id}:input_cache_write_tokens{tier}", input_cache_write_tokens)
-        input_audio_tokens = _optional_int(input_tokens_details, "audio_tokens")
+        input_audio_tokens = _bounded_usage_detail(input_tokens_details, "audio_tokens", input_tokens)
         if input_audio_tokens:
             input_tokens -= input_audio_tokens
             run_context.update_usage(f"{billing_id}:input_audio_tokens", input_audio_tokens)
@@ -764,7 +774,7 @@ class ResponseCollector(BaseCollector):
         # into a single bucket via `total - raw_input`.
         output_tokens = max(total_tokens - raw_input, raw_output) if total_tokens > 0 else raw_output
         self._output_tokens += output_tokens
-        output_audio_tokens = _optional_int(usage.output_tokens_details, "audio_tokens")
+        output_audio_tokens = _bounded_usage_detail(usage.output_tokens_details, "audio_tokens", output_tokens)
         if output_audio_tokens:
             output_tokens -= output_audio_tokens
             run_context.update_usage(f"{billing_id}:output_audio_tokens", output_audio_tokens)

--- a/python/timbal/core/agent.py
+++ b/python/timbal/core/agent.py
@@ -66,7 +66,7 @@ from ..types.run_status import RunStatus
 from ..utils import coerce_to_dict, dump
 from .llm import _llm_router
 from .memory_compaction import MemoryCompactor
-from .models import Model, get_context_window
+from .models import Model, base_usage_metric, get_context_window
 from .runnable import Runnable, RunnableLike
 from .skill import ReadSkill, Skill
 from .tool import Tool
@@ -99,6 +99,34 @@ def _content_chars(c: TextContent | ToolUseContent | ToolResultContent) -> int:
 def _estimate_tokens_from_memory(memory: list[Message]) -> int:
     """Rough token estimate from message content. 1 token ≈ 4 chars (standard approximation)."""
     return max(1, sum(_content_chars(c) for msg in memory for c in msg.content) // 4)
+
+
+# Anthropic cache buckets that sit in the context window but do not start with "input".
+_CONTEXT_CACHE_UNITS = frozenset(
+    {
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+        "ephemeral_5m_input_tokens",
+        "ephemeral_1h_input_tokens",
+    }
+)
+
+
+def _usage_unit(key: str) -> str:
+    """``provider/model:unit_long_context`` -> ``unit``."""
+    unit = key.rsplit(":", 1)[1] if ":" in key else key
+    return base_usage_metric(unit)
+
+
+def _is_context_input_unit(key: str) -> bool:
+    """Prompt-side token buckets that occupy the context window (any provider)."""
+    unit = _usage_unit(key)
+    return (unit.startswith("input") and "token" in unit) or unit in _CONTEXT_CACHE_UNITS
+
+
+def _is_context_output_unit(key: str) -> bool:
+    unit = _usage_unit(key)
+    return unit.startswith("output") and "token" in unit
 
 
 def _coerce_model_to_str(model: Any) -> str:
@@ -958,17 +986,13 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
                 should_compact = True
             elif prev_usage:
                 # Anthropic's input_tokens excludes cached tokens: full context =
-                # input_tokens + cache_creation_input_tokens + cache_read_input_tokens
-                # (disjoint totals). Count the two cache totals explicitly — not via a
-                # loose "input" match, which would double-count the flattened per-TTL
-                # breakdown keys (e.g. ephemeral_5m_input_tokens).
-                prev_input_tokens = sum(
-                    v
-                    for k, v in prev_usage.items()
-                    if (":input" in k and "token" in k)
-                    or k.endswith((":cache_creation_input_tokens", ":cache_read_input_tokens"))
-                )
-                prev_output_tokens = sum(v for k, v in prev_usage.items() if ":output" in k and "token" in k)
+                # input_tokens + cache reads + cache writes (disjoint buckets). The
+                # collector emits cache writes either as the aggregate
+                # `cache_creation_input_tokens` or as the per-TTL `ephemeral_*` units —
+                # never both — so every cache unit is counted exactly once. Pricing-tier
+                # suffixes (`_long_context`, `_fast`, `_flex`) are stripped first.
+                prev_input_tokens = sum(v for k, v in prev_usage.items() if _is_context_input_unit(k))
+                prev_output_tokens = sum(v for k, v in prev_usage.items() if _is_context_output_unit(k))
                 utilization = (prev_input_tokens + prev_output_tokens) / context_window
                 should_compact = utilization >= self.memory_compaction_ratio
             else:

--- a/python/timbal/core/llm/messages.py
+++ b/python/timbal/core/llm/messages.py
@@ -56,6 +56,9 @@ def prepare_messages_request(
     # instead of letting dict.update clobber the generated list.
     provider_params = dict(provider_params)
     extra_tools = provider_params.pop("tools", None)
+    # Caller headers (e.g. `anthropic-beta: fast-mode-2026-02-01` for `speed: "fast"`)
+    # are merged under Timbal's own tracing headers instead of colliding with them.
+    extra_headers = {**(provider_params.pop("extra_headers", None) or {}), **request_headers}
     anthropic_kwargs.update(provider_params)
     if extra_tools:
         anthropic_kwargs["tools"] = [*anthropic_kwargs.get("tools", []), *extra_tools]
@@ -70,7 +73,7 @@ def prepare_messages_request(
                     "schema": transform_schema(output_model),
                 }
             }
-        res = await client.messages.create(extra_headers=request_headers, **anthropic_kwargs)
+        res = await client.messages.create(extra_headers=extra_headers, **anthropic_kwargs)
         async for chunk in res:
             yield chunk
 

--- a/python/timbal/core/models.py
+++ b/python/timbal/core/models.py
@@ -40,6 +40,31 @@ def get_context_window(model_id: str) -> int | None:
     return model.get("context_window")
 
 
+def get_long_context_threshold(model_id: str) -> int | None:
+    """Get the input-token threshold above which a model bills the full request at long-context rates.
+
+    Providers such as OpenAI (>272K on 1.05M-context models) and xAI (>200K) reprice the
+    *entire* request — not just the overflow — once the prompt exceeds this many input tokens.
+    Collectors use it to emit ``<unit>_long_context`` usage keys so cost tables can bill each
+    tier at its own rate.
+
+    Args:
+        model_id: Model identifier (e.g., 'openai/gpt-6-astra').
+
+    Returns:
+        Threshold in input tokens, or None if the model has no long-context tier (or is unknown).
+    """
+    models = _load_models()
+    model = models.get(model_id)
+    if model is None:
+        return None
+    long_context = model.get("long_context")
+    if not isinstance(long_context, dict):
+        return None
+    threshold = long_context.get("threshold")
+    return int(threshold) if threshold is not None else None
+
+
 # ---------------------------------------------------------------------------
 # Model type with provider prefixes
 Model = Literal[

--- a/python/timbal/core/models.py
+++ b/python/timbal/core/models.py
@@ -55,6 +55,7 @@ Model = Literal[
     "anthropic/claude-sonnet-4-6",
     "anthropic/claude-sonnet-4-5",
     "anthropic/claude-haiku-4-5",
+    "openai/gpt-6-astra",
     "openai/gpt-5.5",
     "openai/gpt-5.5-pro",
     "openai/gpt-5.6-sol",

--- a/python/timbal/core/models.py
+++ b/python/timbal/core/models.py
@@ -12,6 +12,22 @@ from typing import Any, Literal
 
 import yaml
 
+# Suffix collectors append to every token usage unit of a request billed at a provider's
+# long-context tier (e.g. ``openai/gpt-6-astra:output_text_tokens_long_context``).
+LONG_CONTEXT_USAGE_SUFFIX = "_long_context"
+
+
+def base_usage_metric(metric: str) -> str:
+    """Strip the long-context tier suffix from a usage metric name.
+
+    ``output_text_tokens_long_context`` -> ``output_text_tokens``. Use this wherever usage
+    is aggregated for display or assertions rather than for billing, so a request that
+    crossed the tier threshold still counts as the same tokens.
+    """
+    if metric.endswith(LONG_CONTEXT_USAGE_SUFFIX):
+        return metric[: -len(LONG_CONTEXT_USAGE_SUFFIX)]
+    return metric
+
 
 @lru_cache(maxsize=1)
 def _load_models() -> dict[str, dict[str, Any]]:
@@ -63,6 +79,20 @@ def get_long_context_threshold(model_id: str) -> int | None:
         return None
     threshold = long_context.get("threshold")
     return int(threshold) if threshold is not None else None
+
+
+def has_cache_write_pricing(model_id: str) -> bool:
+    """Whether the catalog prices prompt-cache writes separately for a model.
+
+    Collectors only split ``cache_write_tokens`` into their own usage unit when this is
+    True; otherwise those tokens stay in ``input_text_tokens`` (billed at the input rate)
+    rather than landing in a unit no cost table can price.
+    """
+    models = _load_models()
+    model = models.get(model_id)
+    if model is None:
+        return False
+    return model.get("cache_write_price") is not None
 
 
 # ---------------------------------------------------------------------------

--- a/python/timbal/core/models.py
+++ b/python/timbal/core/models.py
@@ -12,20 +12,27 @@ from typing import Any, Literal
 
 import yaml
 
-# Suffix collectors append to every token usage unit of a request billed at a provider's
-# long-context tier (e.g. ``openai/gpt-6-astra:output_text_tokens_long_context``).
+# Suffixes collectors append to token usage units for non-standard pricing.
 LONG_CONTEXT_USAGE_SUFFIX = "_long_context"
+FAST_USAGE_SUFFIX = "_fast"
+FLEX_USAGE_SUFFIX = "_flex"
+_PRICING_USAGE_SUFFIXES = (FAST_USAGE_SUFFIX, FLEX_USAGE_SUFFIX, LONG_CONTEXT_USAGE_SUFFIX)
 
 
 def base_usage_metric(metric: str) -> str:
-    """Strip the long-context tier suffix from a usage metric name.
+    """Strip all pricing-tier suffixes from a usage metric name.
 
-    ``output_text_tokens_long_context`` -> ``output_text_tokens``. Use this wherever usage
-    is aggregated for display or assertions rather than for billing, so a request that
-    crossed the tier threshold still counts as the same tokens.
+    ``output_text_tokens_long_context_fast`` -> ``output_text_tokens``. Use this wherever
+    usage is aggregated for display or assertions rather than billing.
     """
-    if metric.endswith(LONG_CONTEXT_USAGE_SUFFIX):
-        return metric[: -len(LONG_CONTEXT_USAGE_SUFFIX)]
+    changed = True
+    while changed:
+        changed = False
+        for suffix in _PRICING_USAGE_SUFFIXES:
+            if metric.endswith(suffix):
+                metric = metric[: -len(suffix)]
+                changed = True
+                break
     return metric
 
 
@@ -59,10 +66,8 @@ def get_context_window(model_id: str) -> int | None:
 def get_long_context_threshold(model_id: str) -> int | None:
     """Get the input-token threshold above which a model bills the full request at long-context rates.
 
-    Providers such as OpenAI (>272K on 1.05M-context models) and xAI (>200K) reprice the
-    *entire* request — not just the overflow — once the prompt exceeds this many input tokens.
-    Collectors use it to emit ``<unit>_long_context`` usage keys so cost tables can bill each
-    tier at its own rate.
+    Providers such as OpenAI (>272K on 1.05M-context models) and xAI (>=200K) reprice
+    the *entire* request — not just the overflow — at a model-specific boundary.
 
     Args:
         model_id: Model identifier (e.g., 'openai/gpt-6-astra').
@@ -79,6 +84,38 @@ def get_long_context_threshold(model_id: str) -> int | None:
         return None
     threshold = long_context.get("threshold")
     return int(threshold) if threshold is not None else None
+
+
+def uses_long_context_pricing(model_id: str, input_tokens: int) -> bool:
+    """Whether this prompt falls in the model's long-context pricing tier."""
+    model = _load_models().get(model_id)
+    if model is None:
+        return False
+    long_context = model.get("long_context")
+    if not isinstance(long_context, dict):
+        return False
+    threshold = long_context.get("threshold")
+    if threshold is None:
+        return False
+    if long_context.get("inclusive", False):
+        return input_tokens >= int(threshold)
+    return input_tokens > int(threshold)
+
+
+def service_tier_usage_suffix(model_id: str, service_tier: str | None) -> str:
+    """Return the priced usage suffix for the actual provider service tier."""
+    if not service_tier:
+        return ""
+    tier = "fast" if service_tier == "priority" else service_tier
+    model = _load_models().get(model_id)
+    tiers = model.get("service_tiers") if model is not None else None
+    if not isinstance(tiers, dict) or tier not in tiers:
+        return ""
+    if tier == "fast":
+        return FAST_USAGE_SUFFIX
+    if tier == "flex":
+        return FLEX_USAGE_SUFFIX
+    return ""
 
 
 def has_cache_write_pricing(model_id: str) -> bool:

--- a/python/timbal/evals/utils.py
+++ b/python/timbal/evals/utils.py
@@ -5,7 +5,7 @@ from typing import Any
 import structlog
 import yaml
 
-from ..core.models import base_usage_metric
+from ..core.models import LONG_CONTEXT_USAGE_SUFFIX, base_usage_metric
 from ..core.runnable import Runnable
 from ..state.tracing.span import Span
 from ..state.tracing.trace import Trace
@@ -83,6 +83,9 @@ def resolve_target(trace: Trace, target: str, path_key: str = "") -> tuple[Span 
         2. If not found and there's only one model in usage, return that model's metric
         3. If multiple models exist, sum the metric across all models
         4. You can still use full keys like "anthropic/claude-haiku-4-5:input_tokens" for specific models
+        5. A metric without the "_long_context" suffix also absorbs the long-context tier bucket of the
+           same metric (requests over a provider's threshold are the same tokens); a suffixed metric
+           selects only that tier
 
     Args:
         trace: The trace to search in.
@@ -140,13 +143,12 @@ def resolve_target(trace: Trace, target: str, path_key: str = "") -> tuple[Span 
             # Check if this dict is a usage dict (previous part was "usage")
             is_usage_dict = idx > 0 and prop_parts[idx - 1] == "usage"
 
-            # Smart usage resolution: handle model-prefixed keys
-            if part not in value and is_usage_dict:
-                resolved = _resolve_usage_key(value, part)
-                if resolved is not None:
-                    value = resolved
-                else:
-                    value = None
+            # Smart usage resolution: model-prefixed keys, snapshot prefixes, and the
+            # long-context tier sibling — always go through the resolver, even when the
+            # exact key exists, so `model:output_text_tokens` also picks up
+            # `model:output_text_tokens_long_context` from a run that crossed the threshold.
+            if is_usage_dict:
+                value = _resolve_usage_key(value, part)
             else:
                 value = value.get(part)
         elif isinstance(value, list):
@@ -193,9 +195,13 @@ def _resolve_usage_key(usage: dict[str, int], key: str) -> int | None:
     Returns:
         The resolved value, or None if not found
     """
-    # If exact key exists, return it
+    # Exact key: return it, plus its long-context sibling when the caller did not ask
+    # for a specific tier (a multi-step run can cross the threshold mid-run and leave
+    # tokens in both buckets). An explicitly suffixed key stays tier-specific.
     if key in usage:
-        return usage[key]
+        if key.endswith(LONG_CONTEXT_USAGE_SUFFIX):
+            return usage[key]
+        return usage[key] + usage.get(f"{key}{LONG_CONTEXT_USAGE_SUFFIX}", 0)
 
     def _metric_matches(usage_metric: str, wanted: str) -> bool:
         return usage_metric == wanted or base_usage_metric(usage_metric) == wanted

--- a/python/timbal/evals/utils.py
+++ b/python/timbal/evals/utils.py
@@ -5,6 +5,7 @@ from typing import Any
 import structlog
 import yaml
 
+from ..core.models import base_usage_metric
 from ..core.runnable import Runnable
 from ..state.tracing.span import Span
 from ..state.tracing.trace import Trace
@@ -176,12 +177,18 @@ def _resolve_usage_key(usage: dict[str, int], key: str) -> int | None:
         usage = {"anthropic/claude-haiku-4-5-20251001:input_tokens": 100, "anthropic/claude-haiku-4-5-20241120:input_tokens": 50}
         _resolve_usage_key(usage, "anthropic/claude-haiku-4-5:input_tokens") -> 150 (partial model match, returns sum)
 
+        usage = {"openai/gpt-6-astra:output_text_tokens_long_context": 40}
+        _resolve_usage_key(usage, "output_text_tokens") -> 40 (long-context tier is the same tokens)
+        _resolve_usage_key(usage, "output_text_tokens_long_context") -> 40 (explicit tier still works)
+
     Args:
         usage: The usage dictionary with `provider/model:metric` keys (split on the last ":").
         key: The metric key to resolve. Can be:
              - Just metric: "input_tokens" (matches all models)
              - Partial model: "anthropic/claude-haiku-4-5:input_tokens" (matches usage models starting with prefix)
              - Full model: "anthropic/claude-haiku-4-5-20251001:input_tokens" (exact match)
+             A metric without the ``_long_context`` suffix also matches the suffixed unit — requests
+             billed at a provider's long-context tier are still the same tokens for assertions.
 
     Returns:
         The resolved value, or None if not found
@@ -189,6 +196,9 @@ def _resolve_usage_key(usage: dict[str, int], key: str) -> int | None:
     # If exact key exists, return it
     if key in usage:
         return usage[key]
+
+    def _metric_matches(usage_metric: str, wanted: str) -> bool:
+        return usage_metric == wanted or base_usage_metric(usage_metric) == wanted
 
     # Check if the key contains a model prefix (model:metric or just metric)
     if ":" in key:
@@ -199,15 +209,15 @@ def _resolve_usage_key(usage: dict[str, int], key: str) -> int | None:
         for usage_key, usage_value in usage.items():
             if ":" in usage_key:
                 usage_model, usage_metric = usage_key.rsplit(":", 1)
-                if usage_model.startswith(model_prefix) and usage_metric == metric:
+                if usage_model.startswith(model_prefix) and _metric_matches(usage_metric, metric):
                     matching_values.append(usage_value)
     else:
         # No model specified, just a metric (e.g., "input_tokens")
         matching_values = []
         for usage_key, usage_value in usage.items():
             if ":" in usage_key:
-                _, metric = usage_key.rsplit(":", 1)
-                if metric == key:
+                _, usage_metric = usage_key.rsplit(":", 1)
+                if _metric_matches(usage_metric, key):
                     matching_values.append(usage_value)
 
     # If we found matches, sum them

--- a/python/timbal/evals/utils.py
+++ b/python/timbal/evals/utils.py
@@ -5,7 +5,7 @@ from typing import Any
 import structlog
 import yaml
 
-from ..core.models import LONG_CONTEXT_USAGE_SUFFIX, base_usage_metric
+from ..core.models import base_usage_metric
 from ..core.runnable import Runnable
 from ..state.tracing.span import Span
 from ..state.tracing.trace import Trace
@@ -195,13 +195,21 @@ def _resolve_usage_key(usage: dict[str, int], key: str) -> int | None:
     Returns:
         The resolved value, or None if not found
     """
-    # Exact key: return it, plus its long-context sibling when the caller did not ask
-    # for a specific tier (a multi-step run can cross the threshold mid-run and leave
-    # tokens in both buckets). An explicitly suffixed key stays tier-specific.
+    # Exact key: a caller asking for a base metric gets every pricing-tier variant
+    # for that exact model. An explicitly suffixed key stays tier-specific.
     if key in usage:
-        if key.endswith(LONG_CONTEXT_USAGE_SUFFIX):
+        if ":" not in key:
             return usage[key]
-        return usage[key] + usage.get(f"{key}{LONG_CONTEXT_USAGE_SUFFIX}", 0)
+        model, metric = key.rsplit(":", 1)
+        if base_usage_metric(metric) != metric:
+            return usage[key]
+        return sum(
+            value
+            for usage_key, value in usage.items()
+            if ":" in usage_key
+            and usage_key.rsplit(":", 1)[0] == model
+            and base_usage_metric(usage_key.rsplit(":", 1)[1]) == metric
+        )
 
     def _metric_matches(usage_metric: str, wanted: str) -> bool:
         return usage_metric == wanted or base_usage_metric(usage_metric) == wanted

--- a/python/timbal/models.yaml
+++ b/python/timbal/models.yaml
@@ -121,6 +121,21 @@ models:
   output_price: 5.0
   context_window: 200000
   capabilities: [vision, tools]
+- id: openai/gpt-6-astra
+  provider: openai
+  display_name: GPT-6 Astra
+  description: OpenAI's most capable model, built for the hardest end-to-end work — complex reasoning, agentic coding, computer
+    use, research, and document creation. Successor to GPT-5.6 Sol.
+  notes: 'Standard short-context pricing is $10/$50 per 1M tokens; cached input $1 (0.1x), cache writes $12.50 (1.25x). Prompts
+    over 272K input tokens bill the full request at long-context rates ($20/$75, cached $2, cache writes $25). Batch/Flex are
+    50% of Standard; Fast mode (`service_tier: "fast"`) is 2x. `reasoning.effort` accepts low|medium|high|xhigh|max (API
+    default low). Function tools require the Responses API (Timbal default) — /v1/chat/completions returns 400 for tools
+    with any reasoning_effort and does not accept `none`. 128K max output, Apr 30, 2026 knowledge cutoff. Supports ZDR
+    for eligible API customers.'
+  input_price: 10.0
+  output_price: 50.0
+  context_window: 1050000
+  capabilities: [vision, tools, reasoning]
 - id: openai/gpt-5.5
   provider: openai
   display_name: GPT-5.5

--- a/python/timbal/models.yaml
+++ b/python/timbal/models.yaml
@@ -7,6 +7,16 @@
 #   requires_activation: true  — model exists but must be enabled in the provider console first
 #   dedicated_only: true       — not serverless; requires a dedicated deployment/endpoint
 #   notes: "..."              — required when either flag is set (shown in UI/docs)
+#
+# Optional pricing detail (USD per 1M tokens; omit when the provider does not publish it):
+#   cached_input_price  — prompt-cache read rate (usage unit `input_cached_tokens`)
+#   cache_write_price   — prompt-cache write rate (usage unit `input_cache_write_tokens`)
+#   long_context:       — tier applied to the FULL request once input tokens exceed `threshold`.
+#     threshold: 272000   Collectors emit `<unit>_long_context` usage keys (e.g. `input_text_tokens_long_context`)
+#     input_price: 20.0   for these requests so cost tables can bill each tier at its own rate.
+#     output_price: 75.0
+#     cached_input_price: 2.0
+#     cache_write_price: 25.0
 
 models:
 - id: anthropic/claude-fable-5-1
@@ -134,14 +144,29 @@ models:
     for eligible API customers.'
   input_price: 10.0
   output_price: 50.0
+  cached_input_price: 1.0
+  cache_write_price: 12.5
+  long_context:
+    threshold: 272000
+    input_price: 20.0
+    output_price: 75.0
+    cached_input_price: 2.0
+    cache_write_price: 25.0
   context_window: 1050000
   capabilities: [vision, tools, reasoning]
 - id: openai/gpt-5.5
   provider: openai
   display_name: GPT-5.5
   description: OpenAI frontier model for coding, knowledge work, and research.
+  notes: Prompts over 272K input tokens bill the full request at 2x input / 1.5x output ($10/$60).
   input_price: 5.0
   output_price: 30.0
+  cached_input_price: 0.5
+  long_context:
+    threshold: 272000
+    input_price: 10.0
+    output_price: 60.0
+    cached_input_price: 1.0
   context_window: 1050000
   capabilities: [vision, tools, reasoning]
 - id: openai/gpt-5.5-pro
@@ -156,42 +181,82 @@ models:
   provider: openai
   display_name: GPT-5.6 Sol
   description: OpenAI GPT-5.6 flagship tier for the hardest coding, agentic, and long-horizon tasks.
-  notes: Promotional short-context API pricing ($4/$20 per 1M tokens, cached input $0.40) available at least through November
-    21, 2026. Long-context rates are $8/$30.
+  notes: Promotional short-context API pricing ($4/$20 per 1M tokens, cached input $0.40, cache writes $5) available at
+    least through November 21, 2026. Prompts over 272K input tokens bill the full request at long-context rates ($8/$30,
+    cached $0.80, cache writes $10).
   input_price: 4.0
   output_price: 20.0
+  cached_input_price: 0.4
+  cache_write_price: 5.0
+  long_context:
+    threshold: 272000
+    input_price: 8.0
+    output_price: 30.0
+    cached_input_price: 0.8
+    cache_write_price: 10.0
   context_window: 1050000
   capabilities: [vision, tools, reasoning]
 - id: openai/gpt-5.6-terra
   provider: openai
   display_name: GPT-5.6 Terra
   description: OpenAI GPT-5.6 balanced tier for everyday production work at roughly half the cost of Sol.
+  notes: Prompts over 272K input tokens bill the full request at long-context rates ($4/$18, cached $0.40, cache writes $5).
   input_price: 2.0
   output_price: 12.0
+  cached_input_price: 0.2
+  cache_write_price: 2.5
+  long_context:
+    threshold: 272000
+    input_price: 4.0
+    output_price: 18.0
+    cached_input_price: 0.4
+    cache_write_price: 5.0
   context_window: 1050000
   capabilities: [vision, tools, reasoning]
 - id: openai/gpt-5.6-luna
   provider: openai
   display_name: GPT-5.6 Luna
   description: OpenAI GPT-5.6 fast, cost-efficient tier for high-volume and latency-sensitive workloads.
+  notes: Prompts over 272K input tokens bill the full request at long-context rates ($0.40/$1.80, cached $0.04, cache writes
+    $0.50).
   input_price: 0.2
   output_price: 1.2
+  cached_input_price: 0.02
+  cache_write_price: 0.25
+  long_context:
+    threshold: 272000
+    input_price: 0.4
+    output_price: 1.8
+    cached_input_price: 0.04
+    cache_write_price: 0.5
   context_window: 1050000
   capabilities: [vision, tools, reasoning]
 - id: openai/gpt-5.4
   provider: openai
   display_name: GPT-5.4
   description: OpenAI's most capable and efficient frontier model for professional work, with native computer-use abilities.
+  notes: Prompts over 272K input tokens bill the full request at 2x input / 1.5x output ($5/$22.50).
   input_price: 2.5
   output_price: 15.0
+  cached_input_price: 0.25
+  long_context:
+    threshold: 272000
+    input_price: 5.0
+    output_price: 22.5
+    cached_input_price: 0.5
   context_window: 1050000
   capabilities: [vision, tools, reasoning]
 - id: openai/gpt-5.4-pro
   provider: openai
   display_name: GPT-5.4 Pro
   description: OpenAI GPT-5.4 Pro tier for maximum capability coding and agent workloads via the Responses API.
+  notes: Prompts over 272K input tokens bill the full request at 2x input / 1.5x output ($60/$270).
   input_price: 30.0
   output_price: 180.0
+  long_context:
+    threshold: 272000
+    input_price: 60.0
+    output_price: 270.0
   context_window: 1050000
   capabilities: [vision, tools, reasoning]
 - id: openai/gpt-5.4-mini
@@ -375,8 +440,15 @@ models:
   provider: openai
   display_name: GPT-5.5 (2026-04-23)
   description: Dated snapshot of GPT-5.5 for reproducible runs; same capabilities as gpt-5.5 per OpenAI API docs.
+  notes: Prompts over 272K input tokens bill the full request at 2x input / 1.5x output ($10/$60).
   input_price: 5.0
   output_price: 30.0
+  cached_input_price: 0.5
+  long_context:
+    threshold: 272000
+    input_price: 10.0
+    output_price: 60.0
+    cached_input_price: 1.0
   context_window: 1050000
   capabilities: [vision, tools, reasoning]
 - id: togetherai/meta-llama/Llama-3.3-70B-Instruct-Turbo
@@ -713,6 +785,10 @@ models:
   notes: Long-context surcharge applies above 200k tokens ($4/$12 per 1M).
   input_price: 2.0
   output_price: 6.0
+  long_context:
+    threshold: 200000
+    input_price: 4.0
+    output_price: 12.0
   context_window: 500000
   capabilities: [vision, tools, reasoning]
 - id: xai/grok-4.5
@@ -722,6 +798,10 @@ models:
   notes: Long-context surcharge applies above 200k tokens ($4/$12 per 1M).
   input_price: 2.0
   output_price: 6.0
+  long_context:
+    threshold: 200000
+    input_price: 4.0
+    output_price: 12.0
   context_window: 500000
   capabilities: [vision, tools, reasoning]
 - id: xai/grok-4.3
@@ -732,6 +812,10 @@ models:
   notes: Long-context surcharge applies above 200k tokens ($2.50/$5.00 per 1M).
   input_price: 1.25
   output_price: 2.5
+  long_context:
+    threshold: 200000
+    input_price: 2.5
+    output_price: 5.0
   context_window: 1000000
   capabilities: [vision, tools, reasoning]
 - id: groq/qwen/qwen3.6-27b
@@ -840,6 +924,10 @@ models:
   notes: Long-context surcharge applies above 128k tokens ($0.50/$4.00 per 1M).
   input_price: 0.25
   output_price: 2.0
+  long_context:
+    threshold: 128000
+    input_price: 0.5
+    output_price: 4.0
   context_window: 256000
   capabilities: [vision, tools, video]
 - id: byteplus/seed-2-0-mini-260215
@@ -878,6 +966,10 @@ models:
   requires_activation: true
   input_price: 0.5
   output_price: 3.0
+  long_context:
+    threshold: 128000
+    input_price: 1.0
+    output_price: 6.0
   context_window: 256000
   capabilities: [vision, tools, reasoning, video]
 - id: byteplus/kimi-k2-250905

--- a/python/timbal/models.yaml
+++ b/python/timbal/models.yaml
@@ -173,6 +173,7 @@ models:
   provider: openai
   display_name: GPT-5.5 Pro
   description: OpenAI GPT-5.5 Pro tier for the hardest coding, agentic, and research workloads via the Responses API.
+  notes: Flat $30/$180 — the model card publishes no cached-input discount and no long-context tier.
   input_price: 30.0
   output_price: 180.0
   context_window: 1050000

--- a/python/timbal/models.yaml
+++ b/python/timbal/models.yaml
@@ -17,6 +17,10 @@
 #     output_price: 75.0
 #     cached_input_price: 2.0
 #     cache_write_price: 25.0
+#     inclusive: true      Optional; use `>= threshold` instead of the default `> threshold`.
+#   service_tiers:         Multipliers for provider-reported processing tiers.
+#     flex: 0.5             Collectors append `_flex` / `_fast` to every priced token unit.
+#     fast: 2.0
 
 models:
 - id: anthropic/claude-fable-5-1
@@ -152,6 +156,9 @@ models:
     output_price: 75.0
     cached_input_price: 2.0
     cache_write_price: 25.0
+  service_tiers:
+    flex: 0.5
+    fast: 2.0
   context_window: 1050000
   capabilities: [vision, tools, reasoning]
 - id: openai/gpt-5.5
@@ -783,26 +790,32 @@ models:
   provider: xai
   display_name: Grok 4.6
   description: xAI's August 2026 flagship for coding, long-running agents, and ambitious interactive work.
-  notes: Long-context surcharge applies above 200k tokens ($4/$12 per 1M).
+  notes: Long-context surcharge applies at 200k tokens ($4/$12 per 1M; cached $1).
   input_price: 2.0
   output_price: 6.0
+  cached_input_price: 0.5
   long_context:
     threshold: 200000
+    inclusive: true
     input_price: 4.0
     output_price: 12.0
+    cached_input_price: 1.0
   context_window: 500000
   capabilities: [vision, tools, reasoning]
 - id: xai/grok-4.5
   provider: xai
   display_name: Grok 4.5
   description: xAI's July 2026 flagship for coding, agentic tool use, and knowledge work with configurable reasoning effort.
-  notes: Long-context surcharge applies above 200k tokens ($4/$12 per 1M).
+  notes: Long-context surcharge applies at 200k tokens ($4/$12 per 1M; cached $0.60).
   input_price: 2.0
   output_price: 6.0
+  cached_input_price: 0.3
   long_context:
     threshold: 200000
+    inclusive: true
     input_price: 4.0
     output_price: 12.0
+    cached_input_price: 0.6
   context_window: 500000
   capabilities: [vision, tools, reasoning]
 - id: xai/grok-4.3
@@ -810,13 +823,16 @@ models:
   display_name: Grok 4.3
   description: xAI production mid-tier for coding, agents, and general workloads; replacement for retired Grok 4 Fast / 4.1
     Fast slugs.
-  notes: Long-context surcharge applies above 200k tokens ($2.50/$5.00 per 1M).
+  notes: Long-context surcharge applies at 200k tokens ($2.50/$5.00 per 1M; cached $0.40).
   input_price: 1.25
   output_price: 2.5
+  cached_input_price: 0.2
   long_context:
     threshold: 200000
+    inclusive: true
     input_price: 2.5
     output_price: 5.0
+    cached_input_price: 0.4
   context_window: 1000000
   capabilities: [vision, tools, reasoning]
 - id: groq/qwen/qwen3.6-27b
@@ -925,18 +941,27 @@ models:
   notes: Long-context surcharge applies above 128k tokens ($0.50/$4.00 per 1M).
   input_price: 0.25
   output_price: 2.0
+  cached_input_price: 0.05
   long_context:
     threshold: 128000
     input_price: 0.5
     output_price: 4.0
+    cached_input_price: 0.1
   context_window: 256000
   capabilities: [vision, tools, video]
 - id: byteplus/seed-2-0-mini-260215
   provider: byteplus
   display_name: Seed 2.0 Mini
   description: Lightweight Seed 2.0 model designed for edge deployments and cost-sensitive scenarios requiring fast responses.
+  notes: Long-context surcharge applies above 128k tokens ($0.20/$0.80 per 1M; cached $0.04).
   input_price: 0.1
   output_price: 0.4
+  cached_input_price: 0.02
+  long_context:
+    threshold: 128000
+    input_price: 0.2
+    output_price: 0.8
+    cached_input_price: 0.04
   context_window: 256000
   capabilities: [tools, reasoning]
 - id: byteplus/seed-1-8-251228
@@ -944,8 +969,13 @@ models:
   display_name: Seed 1.8
   description: Advanced multimodal model with deep thinking and strong agent capabilities supporting text, image, video, and
     document understanding.
+  notes: Long-context surcharge applies above 128k tokens ($0.50/$4.00 per 1M).
   input_price: 0.25
   output_price: 2.0
+  long_context:
+    threshold: 128000
+    input_price: 0.5
+    output_price: 4.0
   context_window: 256000
   capabilities: [vision, tools, reasoning, video]
 - id: byteplus/seed-1-6-250915
@@ -967,10 +997,12 @@ models:
   requires_activation: true
   input_price: 0.5
   output_price: 3.0
+  cached_input_price: 0.1
   long_context:
     threshold: 128000
     input_price: 1.0
     output_price: 6.0
+    cached_input_price: 0.2
   context_window: 256000
   capabilities: [vision, tools, reasoning, video]
 - id: byteplus/kimi-k2-250905

--- a/python/timbal/models.yaml
+++ b/python/timbal/models.yaml
@@ -51,18 +51,25 @@ models:
   display_name: Claude Opus 5
   description: Anthropic's latest Opus — near-frontier intelligence at half the price of Fable 5, with step-change gains in
     deep reasoning, agentic coding, and long-horizon tasks.
-  notes: Thinking is on by default; effort defaults to high and `thinking.type=disabled` is rejected at xhigh/max effort.
-    Fast mode (~2.5x speed) is $10/$50 per 1M tokens on the Claude API only.
+  notes: 'Thinking is on by default; effort defaults to high and `thinking.type=disabled` is rejected at xhigh/max effort.
+    Fast mode (~2.5x speed, `speed: "fast"` + `fast-mode-2026-02-01` beta) is $10/$50 per 1M tokens on the Claude API only;
+    cache multipliers stack on top. Reported as `usage.speed` and metered with `_fast` units.'
   input_price: 5.0
   output_price: 25.0
+  service_tiers:
+    fast: 2.0
   context_window: 1000000
   capabilities: [vision, tools, reasoning]
 - id: anthropic/claude-opus-4-8
   provider: anthropic
   display_name: Claude Opus 4.8
   description: Previous-generation Opus for coding, agents, and long-context reasoning. Superseded by Opus 5 at the same price.
+  notes: 'Fast mode (`speed: "fast"` + `fast-mode-2026-02-01` beta) is $10/$50 per 1M tokens on the Claude API only; cache
+    multipliers stack on top. Reported as `usage.speed` and metered with `_fast` units.'
   input_price: 5.0
   output_price: 25.0
+  service_tiers:
+    fast: 2.0
   context_window: 1000000
   capabilities: [vision, tools, reasoning]
 - id: anthropic/claude-sonnet-5

--- a/scripts/audit_models.py
+++ b/scripts/audit_models.py
@@ -166,6 +166,53 @@ def _offline_audit(models: list[dict]) -> list[str]:
         if m.get("requires_activation") and m.get("dedicated_only"):
             errors.append(f"model has both requires_activation and dedicated_only: {mid}")
 
+        errors.extend(_check_pricing_fields(m))
+
+    return errors
+
+
+_PRICE_FIELDS = ("input_price", "output_price", "cached_input_price", "cache_write_price")
+
+
+def _check_pricing_fields(m: dict) -> list[str]:
+    """Validate optional cache / long-context pricing so collectors and cost tables can trust it."""
+    errors: list[str] = []
+    mid = m["id"]
+
+    for field in _PRICE_FIELDS:
+        value = m.get(field)
+        if value is not None and (not isinstance(value, (int, float)) or value < 0):
+            errors.append(f"{field} must be a non-negative number on {mid}: {value!r}")
+
+    long_context = m.get("long_context")
+    if long_context is None:
+        return errors
+    if not isinstance(long_context, dict):
+        return [*errors, f"long_context must be a mapping on {mid}"]
+
+    threshold = long_context.get("threshold")
+    if not isinstance(threshold, int) or isinstance(threshold, bool) or threshold <= 0:
+        errors.append(f"long_context.threshold must be a positive int on {mid}: {threshold!r}")
+    context_window = m.get("context_window")
+    if isinstance(threshold, int) and isinstance(context_window, int) and threshold >= context_window:
+        errors.append(f"long_context.threshold ({threshold}) must be below context_window ({context_window}) on {mid}")
+
+    for field in ("input_price", "output_price"):
+        if long_context.get(field) is None:
+            errors.append(f"long_context.{field} is required on {mid}")
+    for field in _PRICE_FIELDS:
+        value = long_context.get(field)
+        if value is not None and (not isinstance(value, (int, float)) or value < 0):
+            errors.append(f"long_context.{field} must be a non-negative number on {mid}: {value!r}")
+        # A long-context tier that is cheaper than the base tier is almost certainly a typo.
+        base = m.get(field)
+        if isinstance(value, (int, float)) and isinstance(base, (int, float)) and value < base:
+            errors.append(f"long_context.{field} ({value}) is below base {field} ({base}) on {mid}")
+
+    unknown = set(long_context) - {"threshold", *_PRICE_FIELDS}
+    if unknown:
+        errors.append(f"unknown long_context keys on {mid}: {sorted(unknown)}")
+
     return errors
 
 

--- a/scripts/audit_models.py
+++ b/scripts/audit_models.py
@@ -200,6 +200,10 @@ def _check_pricing_fields(m: dict) -> list[str]:
     for field in ("input_price", "output_price"):
         if long_context.get(field) is None:
             errors.append(f"long_context.{field} is required on {mid}")
+    # Collectors split cache writes into their own unit whenever the base tier prices them,
+    # and that unit carries the tier suffix over the threshold — so the long tier must price it too.
+    if m.get("cache_write_price") is not None and long_context.get("cache_write_price") is None:
+        errors.append(f"long_context.cache_write_price is required on {mid} because cache_write_price is set")
     for field in _PRICE_FIELDS:
         value = long_context.get(field)
         if value is not None and (not isinstance(value, (int, float)) or value < 0):

--- a/scripts/audit_models.py
+++ b/scripts/audit_models.py
@@ -184,6 +184,22 @@ def _check_pricing_fields(m: dict) -> list[str]:
         if value is not None and (not isinstance(value, (int, float)) or value < 0):
             errors.append(f"{field} must be a non-negative number on {mid}: {value!r}")
 
+    service_tiers = m.get("service_tiers")
+    if service_tiers is not None:
+        if not isinstance(service_tiers, dict):
+            errors.append(f"service_tiers must be a mapping on {mid}")
+        else:
+            unknown_tiers = set(service_tiers) - {"fast", "flex"}
+            if unknown_tiers:
+                errors.append(f"unknown service_tiers on {mid}: {sorted(unknown_tiers)}")
+            for tier, multiplier in service_tiers.items():
+                if (
+                    not isinstance(multiplier, (int, float))
+                    or isinstance(multiplier, bool)
+                    or multiplier <= 0
+                ):
+                    errors.append(f"service_tiers.{tier} must be a positive number on {mid}: {multiplier!r}")
+
     long_context = m.get("long_context")
     if long_context is None:
         return errors
@@ -204,6 +220,8 @@ def _check_pricing_fields(m: dict) -> list[str]:
     # and that unit carries the tier suffix over the threshold — so the long tier must price it too.
     if m.get("cache_write_price") is not None and long_context.get("cache_write_price") is None:
         errors.append(f"long_context.cache_write_price is required on {mid} because cache_write_price is set")
+    if m.get("cached_input_price") is not None and long_context.get("cached_input_price") is None:
+        errors.append(f"long_context.cached_input_price is required on {mid} because cached_input_price is set")
     for field in _PRICE_FIELDS:
         value = long_context.get(field)
         if value is not None and (not isinstance(value, (int, float)) or value < 0):
@@ -213,7 +231,11 @@ def _check_pricing_fields(m: dict) -> list[str]:
         if isinstance(value, (int, float)) and isinstance(base, (int, float)) and value < base:
             errors.append(f"long_context.{field} ({value}) is below base {field} ({base}) on {mid}")
 
-    unknown = set(long_context) - {"threshold", *_PRICE_FIELDS}
+    inclusive = long_context.get("inclusive")
+    if inclusive is not None and not isinstance(inclusive, bool):
+        errors.append(f"long_context.inclusive must be a bool on {mid}: {inclusive!r}")
+
+    unknown = set(long_context) - {"threshold", "inclusive", *_PRICE_FIELDS}
     if unknown:
         errors.append(f"unknown long_context keys on {mid}: {sorted(unknown)}")
 

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -1288,9 +1288,17 @@ asyncio.run(main())
                                             let mut output_tokens: u64 = 0;
                                             for (key, val) in usage_obj {
                                                 let count = val.as_u64().unwrap_or(0);
-                                                if key.ends_with(":input_tokens") || key.ends_with(":input_text_tokens") {
+                                                // Requests over a provider's long-context threshold are emitted
+                                                // under `<unit>_long_context` so they can be billed at their own
+                                                // rate; they are still the same tokens for display purposes.
+                                                let unit = key
+                                                    .rsplit_once(':')
+                                                    .map(|(_, unit)| unit)
+                                                    .unwrap_or(key.as_str())
+                                                    .trim_end_matches("_long_context");
+                                                if unit == "input_tokens" || unit == "input_text_tokens" {
                                                     input_tokens += count;
-                                                } else if key.ends_with(":output_tokens") || key.ends_with(":output_text_tokens") {
+                                                } else if unit == "output_tokens" || unit == "output_text_tokens" {
                                                     output_tokens += count;
                                                 }
                                             }


### PR DESCRIPTION
## Summary

Two commits:

1. **`feat(models): add openai/gpt-6-astra`** — catalog, docs, tests.
2. **`fix(billing): track cache writes and long-context repricing`** — two under-billing gaps that affect Astra *and* every other 1.05M-context OpenAI model, plus xAI and BytePlus.

## Availability check (2026-09-05)

Verified live against the OpenAI API with a **standard `sk-proj` key** (not Trusted Access):

| Probe | Result |
| --- | --- |
| `GET /v1/models` | `gpt-6-astra` listed (`owned_by: system`, `shutdown_date: null`) |
| `POST /v1/responses` | 200, `status: completed`, output `OK`, `reasoning.effort: low` |
| `POST /v1/chat/completions` | 200, output `OK` |
| Timbal `Agent` — Responses path | streaming ✅, tool call → `42` ✅, usage keyed `openai/gpt-6-astra:*` ✅ |
| Timbal `Agent` — chat-completions path | plain text ✅, **tools ❌ 400** (see caveat) |

GA for API use — the "staged rollout" coverage from Sep 3–4 is stale for at least this org.

## Pricing review

Cross-checked against [OpenAI's pricing page](https://developers.openai.com/api/docs/pricing) and the model cards for [gpt-6-astra](https://developers.openai.com/api/docs/models/gpt-6-astra), [gpt-5.6-sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol), [gpt-5.5](https://developers.openai.com/api/docs/models/gpt-5.5), [gpt-5.4](https://developers.openai.com/api/docs/models/gpt-5.4). Standard tier, USD per 1M:

| gpt-6-astra | Input | Cached input | Cache writes | Output |
| --- | --- | --- | --- | --- |
| Short context (≤272K input) | **$10.00** | $1.00 | $12.50 | **$50.00** |
| Long context (>272K input) | $20.00 | $2.00 | $25.00 | $75.00 |

- Long-context rates apply to the **full request**, not the overflow. Same rule (2× input/cache, 1.5× output) on GPT-5.6 Sol/Terra/Luna, GPT-5.5, GPT-5.4, GPT-5.4 Pro.
- Batch / Flex = 50%. Fast mode (`service_tier: "fast"`) = 2×. Cache writes = 1.25× input; cached reads = 0.1×. No promo (unlike Sol).
- 1,050,000 context, 128K max output, Apr 30 2026 cutoff, `reasoning.effort` ∈ `low|medium|high|xhigh|max`.

## Billing fixes (commit 2)

### Before
- `cache_write_tokens` (new in OpenAI usage payloads) were folded into `input_text_tokens` → cache writes billed at $10 instead of $12.50.
- No notion of long-context tiers anywhere → a 300K-token Astra prompt was recorded at $10/$50 instead of $20/$75. Same for 5.6/5.5/5.4, Grok 4.x (>200K), Seed 2.0 (>128K).

### After
- **Catalog schema** (`models.yaml`): optional `cached_input_price`, `cache_write_price`, and `long_context: {threshold, input_price, output_price, cached_input_price, cache_write_price}`. Populated for Astra, 5.6 Sol/Terra/Luna, 5.5 (+ dated snapshot), 5.4, 5.4 Pro, Grok 4.6/4.5/4.3, Seed 2.0 Lite/Pro.
- **`get_long_context_threshold(model_id)`** in `timbal.core.models`.
- **Both OpenAI collectors** (`ChatCompletionCollector`, `ResponseCollector`):
  - emit `input_cache_write_tokens` (read via `getattr` — SDK 2.24 doesn't declare the field; it arrives as a pydantic extra)
  - decide the tier on the **raw prompt size** (cache hits included, strictly `> threshold`) and suffix **every** token unit with `_long_context` for that request: `input_text_tokens_long_context`, `input_cached_tokens_long_context`, `input_cache_write_tokens_long_context`, `output_text_tokens_long_context`
- **Why a suffix**: `agent.py` compaction utilization sums keys by `:input` / `:output` substring — still correct with no change. The backend `Costs` lookup is `(name, unit)`, so a distinct unit is what lets it price the tier. Prefixing the *model* name would collide with the `LIKE name || '%'` match.
- **TUI** (`tui/src/app.rs`): token summary strips `_long_context` before matching the unit — please run `cargo build` / `cargo clippy` in `tui/` to confirm (I don't run cargo).
- **CI audit** (`scripts/audit_models.py --offline`): validates the new fields — numeric/non-negative, `threshold` inside `context_window`, tier `input_price`/`output_price` required, and rejects a long-context rate cheaper than the base rate as a typo.

### Platform follow-up (required to actually bill)
The platform `Costs` table needs rows for the new units per model: `input_cache_write_tokens`, and the four `*_long_context` units. `models.yaml` now carries the exact rates, so the (gitignored) `generate_costs_sql.py` should read `cached_input_price` / `cache_write_price` / `long_context.*` instead of its 0.5× heuristic — that heuristic is 5× too high for every GPT-5.x/6 model (actual cached = 0.1×). Until those rows land, long-context usage will find no matching cost row rather than being silently billed at the short rate.

## Caveat discovered during testing

**Function tools require the Responses API** on `gpt-6-astra`. `/v1/chat/completions` returns `Function tools with reasoning_effort are not supported ... set reasoning_effort to 'none'`, and then rejects `none` (`Supported values are: 'low', 'medium', 'high', and 'xhigh'`). Timbal defaults to `TIMBAL_OPENAI_API=responses`, so only the legacy path is affected. Documented in `notes` and the docs card.

## Verification

- `scripts/audit_models.py --offline` → passes (117 models; models.py + docs in sync)
- `pytest python/tests/collectors python/tests/core/test_models.py python/tests/core/test_frontier_models.py python/tests/core/test_agent.py python/tests/core/test_memory_compaction.py` → all green
- New tests: cache-write split, missing-field tolerance, exact-threshold boundary (272K stays short), one-over reprices every bucket, threshold measured on raw prompt incl. cache hits, reasoning tokens follow output into the long tier, models without a tier never reprice, xAI via Responses, BytePlus via chat completions, `get_long_context_threshold` known/unknown/below-window.
- Live `Agent` round-trips as in the table above. Long-context tier was **not** exercised live (a >272K prompt costs real money); covered by unit tests against the real catalog.

## Not covered / assumptions

- **GPT-5.5 Pro**: OpenAI's 5.4 card explicitly extends long-context pricing to 5.4 Pro; the 5.5 card only names GPT-5.5. I did not add a tier for 5.5 Pro rather than guess.
- Long-context **cached** rate for GPT-5.5 / 5.4 is set to 2× (matches every published 5.6 table); the 5.5/5.4 cards only state "2× input, 1.5× output" without naming cache explicitly.
- xAI / BytePlus tiers are wired from the rates already in `notes`; threshold semantics assumed to be input tokens (matches both providers' published tiering). Cached rates for their long tiers aren't published — omitted.
- Anthropic 1M-context models: no long-context handling added (the Anthropic collector is a different code path and Anthropic's current premium schedule wasn't verified here).
