### PR TITLE
fix(openai): keep GPT-5.x tool loops intact — replay reasoning + phase, recover leaked Harmony tool calls

### DIFF
--- a/python/tests/collectors/test_harmony_leak.py
+++ b/python/tests/collectors/test_harmony_leak.py
@@ -132,3 +132,41 @@ class TestBareRecipient:
     def test_functions_prefix_still_wins(self):
         text = ' to=functions.search json\n{"q":"x"}\n to=list_background_tasks json\n{}'
         assert [n for n, _ in parse_leaked_tool_calls(text)[1]] == ["search", "list_background_tasks"]
+
+
+class TestFalsePositiveGuards:
+    """Recover only what a leak produces — never a model *describing* the syntax."""
+
+    def test_header_quoted_in_a_code_fence_is_not_a_call(self):
+        text = 'Harmony renders a tool call like this:\n\n```\n to=functions.search json\n{"q":"x"}\n```\n\nThat is all.'
+        assert not contains_leak(text)
+        assert parse_leaked_tool_calls(text) == (text, [])
+
+    def test_header_mid_sentence_is_not_a_call(self):
+        text = 'The wire form is to=functions.search {"q":"x"} and the parser handles it.'
+        assert not contains_leak(text)
+        assert parse_leaked_tool_calls(text) == (text, [])
+
+    def test_header_at_line_start_after_prose_is_a_call(self):
+        text = 'Probing now.\n to=functions.search json\n{"q":"x"}'
+        assert contains_leak(text)
+        assert parse_leaked_tool_calls(text) == ("Probing now.", [("search", {"q": "x"})])
+
+    def test_debris_inside_the_object_is_not_recovered(self):
+        """Decoder debris inside the arguments: the JSON parses, the content is untrusted
+        (a `builder` prompt with a garbage line would still spawn a worker)."""
+        for raw in (
+            '{"prompt":"## Objective\\nBuild the In\U0004e7ff"}',
+            '{"prompt":"ok\ufffc"}',
+            '{"q":"x\ufffd"}',
+            '{"q":"\U000f0000"}',
+        ):
+            assert parse_leaked_tool_calls(" to=functions.builder code:\n" + raw) == ("", []), raw
+
+    def test_legit_non_latin_arguments_are_fine(self):
+        text = ' to=functions.search json\n{"q":"日本語 テスト — Català, Ελληνικά, Русский, 中文"}'
+        assert parse_leaked_tool_calls(text)[1] == [("search", {"q": "日本語 テスト — Català, Ελληνικά, Русский, 中文"})]
+
+    def test_debris_before_the_object_is_still_fine(self):
+        text = ' to=functions.timbal__get_preview_logs  code\U0004e7fejson\n{"component":"ui"}'
+        assert parse_leaked_tool_calls(text)[1] == [("timbal__get_preview_logs", {"component": "ui"})]

--- a/python/tests/collectors/test_harmony_leak.py
+++ b/python/tests/collectors/test_harmony_leak.py
@@ -111,3 +111,24 @@ class TestParallelWrapper:
 
     def test_wrapper_without_tool_uses_yields_nothing(self):
         assert parse_leaked_tool_calls(' to=multi_tool_use.parallel json\n{"foo":1}') == ("", [])
+
+
+class TestBareRecipient:
+    def test_bare_header_with_object_is_recovered(self):
+        text = ' to=timbal__codegen  code:\n{"action":"get-flow","name":"support"}'
+        assert leak_state(text) == "leak"
+        assert parse_leaked_tool_calls(text) == ("", [("timbal__codegen", {"action": "get-flow", "name": "support"})])
+
+    def test_bare_header_typing_is_undecided_then_leak(self):
+        assert leak_state(" to=timbal") == "undecided"
+        assert leak_state(" to=timbal__codegen ") == "leak"
+        assert leak_state(" to=timbal__codegen\n{") == "leak"
+
+    def test_prose_is_still_clean(self):
+        for t in ("today", "to be honest", "total: 5", "Tomorrow we ship."):
+            assert leak_state(t) == "clean", t
+        assert parse_leaked_tool_calls("Set the timeout to=30 seconds.") == ("Set the timeout to=30 seconds.", [])
+
+    def test_functions_prefix_still_wins(self):
+        text = ' to=functions.search json\n{"q":"x"}\n to=list_background_tasks json\n{}'
+        assert [n for n, _ in parse_leaked_tool_calls(text)[1]] == ["search", "list_background_tasks"]

--- a/python/tests/collectors/test_harmony_leak.py
+++ b/python/tests/collectors/test_harmony_leak.py
@@ -1,0 +1,83 @@
+"""Recovering tool calls GPT-5.x leaks into assistant text (Harmony wire form)."""
+from timbal.collectors.harmony_leak import contains_leak, leak_state, parse_leaked_tool_calls
+
+# Verbatim samples from a gpt-5.6-luna orchestration run (composer evals, 2026-09-06).
+SAMPLE_ONE = ' to=functions.timbal__get_preview_logs  (json 恒一\n{"service":"ui"}ંалда'
+SAMPLE_REPEATED = (
+    ' to=functions.wait_for_background_tasks  code:\n{"task_ids":["o20s53ln5l51"],"timeout_seconds":120}\n\n'
+    ' to=functions.wait_for_background_tasks  code:\n{"task_ids":["o20s53ln5l51"],"timeout_seconds":120}\n\n'
+    ' to=functions.list_background_tasks code:\n{}\n\n'
+    ' to=functions.wait_for_background_tasks code:\n{"task_ids":["o20s53ln5l51"],"timeout_seconds":30}\n\n'
+    "Invoice Triage backend is built and verified:\n\n- Knowledge base: `vendors` has 5 rows"
+)
+SAMPLE_AFTER_PROSE = (
+    "Wave 3 dependency check:\n- `UI`: depends on [API routes probed] → ready.\n\n\n\n"
+    ' to=functions.builder  code:\n{"title":"UI","resume_previous":false,"prompt":"## Objective\\nBuild {the} UI"}'
+)
+
+
+class TestLeakState:
+    def test_empty_and_whitespace_are_undecided(self):
+        assert leak_state("") == "undecided"
+        assert leak_state("  \n") == "undecided"
+
+    def test_prefix_of_marker_is_undecided(self):
+        for head in ("t", "to", "to=", "to=fun", " to=functions"):
+            assert leak_state(head) == "undecided", head
+
+    def test_marker_is_a_leak(self):
+        assert leak_state(" to=functions.") == "leak"
+        assert leak_state(SAMPLE_ONE) == "leak"
+
+    def test_divergence_is_clean(self):
+        assert leak_state("The") == "clean"
+        assert leak_state("tomorrow") == "clean"
+        assert leak_state("to be clear") == "clean"
+        # a marker after prose is not decidable while streaming
+        assert leak_state("Wave 3 dependency check: to=functions.x") == "clean"
+
+
+class TestParse:
+    def test_single_call_with_control_token_debris(self):
+        prefix, calls = parse_leaked_tool_calls(SAMPLE_ONE)
+        assert prefix == ""
+        assert calls == [("timbal__get_preview_logs", {"service": "ui"})]
+
+    def test_repeated_calls_dedupe_and_trailing_summary_is_dropped(self):
+        prefix, calls = parse_leaked_tool_calls(SAMPLE_REPEATED)
+        assert prefix == ""
+        assert calls == [
+            ("wait_for_background_tasks", {"task_ids": ["o20s53ln5l51"], "timeout_seconds": 120}),
+            ("list_background_tasks", {}),
+            ("wait_for_background_tasks", {"task_ids": ["o20s53ln5l51"], "timeout_seconds": 30}),
+        ]
+
+    def test_prose_before_the_leak_is_kept(self):
+        prefix, calls = parse_leaked_tool_calls(SAMPLE_AFTER_PROSE)
+        assert prefix == "Wave 3 dependency check:\n- `UI`: depends on [API routes probed] → ready."
+        assert calls == [("builder", {"title": "UI", "resume_previous": False, "prompt": "## Objective\nBuild {the} UI"})]
+
+    def test_braces_inside_strings_do_not_end_the_object(self):
+        text = ' to=functions.run json\n{"code":"if (x) { return {a:1}; }","n":2}'
+        assert parse_leaked_tool_calls(text)[1] == [("run", {"code": "if (x) { return {a:1}; }", "n": 2})]
+
+    def test_header_without_object_is_skipped(self):
+        text = " to=functions.wait_for_background_tasks  code:\n to=functions.list_background_tasks code:\n{}"
+        assert parse_leaked_tool_calls(text)[1] == [("list_background_tasks", {})]
+
+    def test_unparseable_object_is_skipped(self):
+        text = ' to=functions.x json\n{"a": tru}'
+        assert parse_leaked_tool_calls(text) == ("", [])
+
+    def test_non_object_json_is_skipped(self):
+        assert parse_leaked_tool_calls(" to=functions.x json\n[1,2]")[1] == []
+
+    def test_plain_text_passes_through(self):
+        assert parse_leaked_tool_calls("All done.") == ("All done.", [])
+        assert not contains_leak("All done.")
+        assert contains_leak(SAMPLE_ONE)
+
+    def test_mentioning_functions_in_prose_is_not_a_leak(self):
+        text = "The `functions.search` helper is documented in README."
+        assert not contains_leak(text)
+        assert parse_leaked_tool_calls(text) == (text, [])

--- a/python/tests/collectors/test_harmony_leak.py
+++ b/python/tests/collectors/test_harmony_leak.py
@@ -81,3 +81,33 @@ class TestParse:
         text = "The `functions.search` helper is documented in README."
         assert not contains_leak(text)
         assert parse_leaked_tool_calls(text) == (text, [])
+
+
+class TestParallelWrapper:
+    SAMPLE = (
+        ' to=multi_tool_use.parallel  (json in assistant code)\n'
+        '{"tool_uses":[{"recipient_name":"functions.timbal__codegen","parameters":{"command":"get-flow","workforce":"triage"}},'
+        '{"recipient_name":"functions.timbal__get_preview_logs","parameters":{"component":"ui"}},'
+        '{"recipient_name":"functions.timbal__codegen","parameters":{"command":"get-flow","workforce":"triage"}}]}'
+    )
+
+    def test_state_and_detection(self):
+        assert leak_state(" to=multi") == "undecided"
+        assert leak_state(" to=multi_tool_use.parallel") == "leak"
+        assert contains_leak(self.SAMPLE)
+
+    def test_expands_into_individual_calls_deduped(self):
+        prefix, calls = parse_leaked_tool_calls(self.SAMPLE)
+        assert prefix == ""
+        assert calls == [
+            ("timbal__codegen", {"command": "get-flow", "workforce": "triage"}),
+            ("timbal__get_preview_logs", {"component": "ui"}),
+        ]
+
+    def test_mixed_with_plain_headers(self):
+        text = self.SAMPLE + '\n\n to=functions.list_background_tasks code:\n{}'
+        _, calls = parse_leaked_tool_calls(text)
+        assert [n for n, _ in calls] == ["timbal__codegen", "timbal__get_preview_logs", "list_background_tasks"]
+
+    def test_wrapper_without_tool_uses_yields_nothing(self):
+        assert parse_leaked_tool_calls(' to=multi_tool_use.parallel json\n{"foo":1}') == ("", [])

--- a/python/tests/collectors/test_openai_collector.py
+++ b/python/tests/collectors/test_openai_collector.py
@@ -2244,3 +2244,72 @@ class TestResponseCollectorLeakedToolCalls:
         msg = c.result()
         assert [b.name for b in msg.content] == ["a", "b"]
         assert ctx.current_span().usage.get("recovered_tool_calls") == 2
+
+
+class TestResponseCollectorTextAfterLeak:
+    """Prose the model writes after a leaked call is its account of work that never ran."""
+
+    def _collector(self):
+        _make_context()
+        c = ResponseCollector(async_gen=_empty_gen(), start=time.perf_counter())
+        c.process(ResponseCreatedEvent(type="response.created", response=_make_response(model="gpt-5.6-luna"), sequence_number=0))
+        return c
+
+    def test_summary_after_a_leak_is_neither_streamed_nor_kept(self):
+        leak = ' to=functions.timbal__get_preview_logs  code:\n{"component":"ui"}'
+        summary = "Invoice Triage is built.\n\n- Knowledge base: 5 vendors, 12 invoices"
+        c = self._collector()
+        c.process(_added(_msg_item("msg_1"), 0, 1))
+        c.process(_part_added("msg_1", 2))
+        assert c.process(_delta("msg_1", leak, 3)) is None
+        c.process(_done(_msg_item("msg_1", status="completed", text=leak), 0, 4))
+        c.process(_added(_msg_item("msg_2", phase="final_answer"), 1, 5))
+        c.process(_part_added("msg_2", 6))
+        streamed = [c.process(_delta("msg_2", part, 7 + i)) for i, part in enumerate(summary.split(" "))]
+        assert all(s is None for s in streamed), "the fake summary must not reach the stream"
+        assert c.process(_done(_msg_item("msg_2", phase="final_answer", status="completed", text=summary), 1, 40)) is None
+        c.process(_completed(41))
+        msg = c.result()
+        assert [type(b).__name__ for b in msg.content] == ["ToolUseContent"]
+        assert msg.content[0].name == "timbal__get_preview_logs"
+        # replays as just the call — no "final answer" wedged before the tool output
+        assert [i["type"] for i in msg.to_openai_responses_input()] == ["function_call"]
+
+    def test_later_leaked_blocks_are_still_recovered_and_deduped(self):
+        c = self._collector()
+        blocks = [
+            ' to=functions.timbal__get_preview_logs  code:\n{"component":"ui"}',
+            ' to=functions.timbal__get_preview_logs  code:\n{"component":"ui"}',
+            ' to=functions.list_background_tasks code:\n{}',
+            "All done here.",
+        ]
+        for n, text in enumerate(blocks):
+            mid = f"msg_{n}"
+            c.process(_added(_msg_item(mid), n, 10 * n + 1))
+            c.process(_part_added(mid, 10 * n + 2))
+            c.process(_delta(mid, text, 10 * n + 3))
+            c.process(_done(_msg_item(mid, status="completed", text=text), n, 10 * n + 4))
+        c.process(_completed(99))
+        msg = c.result()
+        assert [(type(b).__name__, getattr(b, "name", None)) for b in msg.content] == [
+            ("ToolUseContent", "timbal__get_preview_logs"),
+            ("ToolUseContent", "list_background_tasks"),
+        ]
+
+    def test_prose_before_the_first_leak_is_kept_and_was_streamed(self):
+        c = self._collector()
+        c.process(_added(_msg_item("msg_0", phase="commentary"), 0, 1))
+        c.process(_part_added("msg_0", 2))
+        assert isinstance(c.process(_delta("msg_0", "Probing the UI build now.", 3)), Text)
+        c.process(_done(_msg_item("msg_0", phase="commentary", status="completed", text="Probing the UI build now."), 0, 4))
+        leak = ' to=functions.timbal__get_preview_logs  code:\n{"component":"ui"}'
+        c.process(_added(_msg_item("msg_1"), 1, 5))
+        c.process(_part_added("msg_1", 6))
+        c.process(_delta("msg_1", leak, 7))
+        c.process(_done(_msg_item("msg_1", status="completed", text=leak), 1, 8))
+        c.process(_completed(9))
+        msg = c.result()
+        assert [type(b).__name__ for b in msg.content] == ["TextContent", "ToolUseContent"]
+        assert msg.content[0].phase == "commentary"
+        items = msg.to_openai_responses_input()
+        assert [i.get("type") or i.get("phase") for i in items] == ["commentary", "function_call"]

--- a/python/tests/collectors/test_openai_collector.py
+++ b/python/tests/collectors/test_openai_collector.py
@@ -478,8 +478,9 @@ class TestResponseCollectorText:
             part=text_part,
             sequence_number=1,
         ))
-        assert isinstance(item, Text)
-        assert item.id == item_id
+        # An empty part is held until the first characters show it is prose, not a
+        # leaked `to=functions.…` call (see TestResponseCollectorLeakedToolCalls).
+        assert item is None
 
         item = collector.process(ResponseTextDeltaEvent(
             type="response.output_text.delta",
@@ -490,8 +491,21 @@ class TestResponseCollectorText:
             logprobs=[],
             sequence_number=2,
         ))
+        assert isinstance(item, Text)
+        assert item.id == item_id
+        assert item.text == "Hello"
+
+        item = collector.process(ResponseTextDeltaEvent(
+            type="response.output_text.delta",
+            item_id=item_id,
+            output_index=0,
+            content_index=0,
+            delta=" there",
+            logprobs=[],
+            sequence_number=2,
+        ))
         assert isinstance(item, TimbalTextDelta)
-        assert item.text_delta == "Hello"
+        assert item.text_delta == " there"
 
         result = collector.process(ResponseTextDoneEvent(
             type="response.output_text.done",
@@ -2040,3 +2054,193 @@ class TestResponseCollectorEncryptedReasoning:
             ("reasoning", "rs_1"), ("function_call", "call_1"), ("reasoning", "rs_2"), ("function_call", "call_2"),
         ]
         assert [i["encrypted_content"] for i in items if i["type"] == "reasoning"] == ["enc-1", "enc-2"]
+
+
+# ---------------------------------------------------------------------------
+# OpenAI Responses: assistant `phase` and leaked tool-call recovery
+# ---------------------------------------------------------------------------
+
+def _msg_item(item_id: str, *, phase: str | None = None, status: str = "in_progress", text: str | None = None):
+    content = [ResponseOutputText(type="output_text", text=text, annotations=[])] if text is not None else []
+    kwargs = {"phase": phase} if phase else {}
+    return ResponseOutputMessage(id=item_id, type="message", role="assistant", content=content, status=status, **kwargs)
+
+
+def _part_added(item_id: str, seq: int):
+    return ResponseContentPartAddedEvent(
+        type="response.content_part.added", item_id=item_id, output_index=0, content_index=0,
+        part=ResponseOutputText(type="output_text", text="", annotations=[]), sequence_number=seq,
+    )
+
+
+def _delta(item_id: str, delta: str, seq: int):
+    return ResponseTextDeltaEvent(
+        type="response.output_text.delta", item_id=item_id, output_index=0, content_index=0,
+        delta=delta, logprobs=[], sequence_number=seq,
+    )
+
+
+class TestResponseCollectorPhase:
+    def _collector(self):
+        _make_context()
+        c = ResponseCollector(async_gen=_empty_gen(), start=time.perf_counter())
+        c.process(ResponseCreatedEvent(type="response.created", response=_make_response(model="gpt-5.6-luna"), sequence_number=0))
+        return c
+
+    def test_phase_from_added_lands_on_text_content(self):
+        c = self._collector()
+        c.process(_added(_msg_item("msg_1", phase="commentary"), 0, 1))
+        c.process(_part_added("msg_1", 2))
+        c.process(_delta("msg_1", "Checking first.", 3))
+        c.process(_done(_msg_item("msg_1", phase="commentary", status="completed", text="Checking first."), 0, 4))
+        c.process(_completed(5))
+        msg = c.result()
+        assert [type(b).__name__ for b in msg.content] == ["TextContent"]
+        assert msg.content[0].phase == "commentary"
+        assert msg.to_openai_responses_input()[0]["phase"] == "commentary"
+
+    def test_phase_only_on_done_is_still_captured(self):
+        c = self._collector()
+        c.process(_added(_msg_item("msg_1"), 0, 1))
+        c.process(_part_added("msg_1", 2))
+        c.process(_delta("msg_1", "Done.", 3))
+        c.process(_done(_msg_item("msg_1", phase="final_answer", status="completed", text="Done."), 0, 4))
+        c.process(_completed(5))
+        assert c.result().content[0].phase == "final_answer"
+
+    def test_no_phase_means_none(self):
+        c = self._collector()
+        c.process(_added(_msg_item("msg_1"), 0, 1))
+        c.process(_part_added("msg_1", 2))
+        c.process(_delta("msg_1", "Hello", 3))
+        c.process(_done(_msg_item("msg_1", status="completed", text="Hello"), 0, 4))
+        c.process(_completed(5))
+        assert c.result().content[0].phase is None
+
+
+class TestResponseCollectorLeakedToolCalls:
+    """A `message` whose text is a Harmony-form tool call becomes the tool call."""
+
+    def _collector(self):
+        _make_context()
+        c = ResponseCollector(async_gen=_empty_gen(), start=time.perf_counter())
+        c.process(ResponseCreatedEvent(type="response.created", response=_make_response(model="gpt-5.6-luna"), sequence_number=0))
+        return c
+
+    def test_prose_is_held_until_decided_then_released_with_what_accumulated(self):
+        c = self._collector()
+        c.process(_added(_msg_item("msg_1"), 0, 1))
+        assert c.process(_part_added("msg_1", 2)) is None            # empty: undecided
+        assert c.process(_delta("msg_1", "t", 3)) is None            # prefix of `to=functions.`
+        assert c.process(_delta("msg_1", "o", 4)) is None
+        started = c.process(_delta("msg_1", "morrow", 5))            # diverged: prose
+        assert isinstance(started, Text) and started.id == "msg_1" and started.text == "tomorrow"
+        nxt = c.process(_delta("msg_1", " then", 6))
+        assert isinstance(nxt, TimbalTextDelta) and nxt.text_delta == " then"
+        assert isinstance(c.process(_done(_msg_item("msg_1", status="completed", text="tomorrow then"), 0, 7)), ContentBlockStop)
+        c.process(_completed(8))
+        assert c.result().content[0].text == "tomorrow then"
+
+    def test_clean_text_releases_on_the_first_delta(self):
+        c = self._collector()
+        c.process(_added(_msg_item("msg_1"), 0, 1))
+        c.process(_part_added("msg_1", 2))
+        started = c.process(_delta("msg_1", "Hello", 3))
+        assert isinstance(started, Text) and started.text == "Hello"
+
+    def test_short_undecided_text_is_released_at_done_with_its_stop(self):
+        c = self._collector()
+        c.process(_added(_msg_item("msg_1"), 0, 1))
+        c.process(_part_added("msg_1", 2))
+        assert c.process(_delta("msg_1", "to", 3)) is None
+        first = c.process(_done(_msg_item("msg_1", status="completed", text="to"), 0, 4))
+        assert isinstance(first, Text) and first.text == "to"
+        assert isinstance(c.pop_pending_stream_item(), ContentBlockStop)
+        c.process(_completed(5))
+        assert c.result().content[0].text == "to"
+
+    def test_leak_is_never_streamed_and_becomes_a_tool_call(self):
+        leak = ' to=functions.timbal__get_preview_logs  (json 恒一\n{"service":"ui"}ંалда'
+        c = self._collector()
+        c.process(_added(_msg_item("msg_1", phase="final_answer"), 0, 1))
+        c.process(_part_added("msg_1", 2))
+        emitted = [c.process(_delta("msg_1", ch, 3 + i)) for i, ch in enumerate(leak)]
+        assert all(e is None for e in emitted), "leaked text must not reach the stream"
+        assert c.process(_done(_msg_item("msg_1", phase="final_answer", status="completed", text=leak), 0, 99)) is None
+        c.process(_completed(100))
+        msg = c.result()
+        assert [type(b).__name__ for b in msg.content] == ["ToolUseContent"]
+        call = msg.content[0]
+        assert call.name == "timbal__get_preview_logs"
+        assert call.input == {"service": "ui"}
+        assert call.id.startswith("call_leak_")
+        assert msg.to_openai_responses_input()[0]["type"] == "function_call"
+
+    def test_repeated_leaked_calls_collapse_and_the_fake_summary_is_dropped(self):
+        leak = (
+            ' to=functions.wait_for_background_tasks  code:\n{"task_ids":["x"],"timeout_seconds":120}\n\n'
+            ' to=functions.wait_for_background_tasks  code:\n{"task_ids":["x"],"timeout_seconds":120}\n\n'
+            "Invoice Triage is built.\n- Knowledge base: 5 vendors"
+        )
+        c = self._collector()
+        c.process(_added(_msg_item("msg_1"), 0, 1))
+        c.process(_part_added("msg_1", 2))
+        c.process(_delta("msg_1", leak, 3))
+        c.process(_done(_msg_item("msg_1", status="completed", text=leak), 0, 4))
+        c.process(_completed(5))
+        msg = c.result()
+        assert [type(b).__name__ for b in msg.content] == ["ToolUseContent"]
+        assert msg.content[0].input == {"task_ids": ["x"], "timeout_seconds": 120}
+        assert "Invoice Triage" not in msg.collect_text()
+
+    def test_leak_after_prose_keeps_the_prose_and_recovers_the_call(self):
+        text = 'Wave 3 dependency check:\n- UI → ready.\n\n\n to=functions.builder  code:\n{"title":"UI","run_in_background":true}'
+        c = self._collector()
+        c.process(_added(_msg_item("msg_1", phase="commentary"), 0, 1))
+        c.process(_part_added("msg_1", 2))
+        c.process(_delta("msg_1", text, 3))  # streams (it starts as prose) — history is still cleaned
+        c.process(_done(_msg_item("msg_1", phase="commentary", status="completed", text=text), 0, 4))
+        c.process(_completed(5))
+        msg = c.result()
+        assert [type(b).__name__ for b in msg.content] == ["TextContent", "ToolUseContent"]
+        assert msg.content[0].text == "Wave 3 dependency check:\n- UI → ready."
+        assert msg.content[0].phase == "commentary"
+        assert msg.content[1].name == "builder"
+
+    def test_leak_next_to_a_structured_call_is_dropped_not_duplicated(self):
+        c = self._collector()
+        c.process(_added(_fn_call("fc_1", "call_1", name="search"), 0, 1))
+        c.process(_done(_fn_call("fc_1", "call_1", name="search", arguments='{"q":"x"}', status="completed"), 0, 2))
+        leak = ' to=functions.search json\n{"q":"x"}'
+        c.process(_added(_msg_item("msg_1"), 1, 3))
+        c.process(_part_added("msg_1", 4))
+        c.process(_delta("msg_1", leak, 5))
+        c.process(_done(_msg_item("msg_1", status="completed", text=leak), 1, 6))
+        c.process(_completed(7))
+        msg = c.result()
+        assert [type(b).__name__ for b in msg.content] == ["ToolUseContent"]
+        assert msg.content[0].id == "call_1"
+
+    def test_unparseable_leak_is_dropped_leaving_no_garbage(self):
+        leak = " to=functions.wait_for_background_tasks  code: 亚洲AV"
+        c = self._collector()
+        c.process(_added(_msg_item("msg_1"), 0, 1))
+        c.process(_part_added("msg_1", 2))
+        c.process(_delta("msg_1", leak, 3))
+        c.process(_done(_msg_item("msg_1", status="completed", text=leak), 0, 4))
+        c.process(_completed(5))
+        assert c.result().content == []
+
+    def test_recovered_count_is_recorded_in_usage(self):
+        ctx = _make_context()
+        c = ResponseCollector(async_gen=_empty_gen(), start=time.perf_counter())
+        c.process(ResponseCreatedEvent(type="response.created", response=_make_response(model="gpt-5.6-luna"), sequence_number=0))
+        leak = ' to=functions.a json\n{}\n to=functions.b json\n{"k":1}'
+        c.process(_added(_msg_item("msg_1"), 0, 1))
+        c.process(_part_added("msg_1", 2))
+        c.process(_delta("msg_1", leak, 3))
+        c.process(_done(_msg_item("msg_1", status="completed", text=leak), 0, 4))
+        c.process(_completed(5))
+        msg = c.result()
+        assert [b.name for b in msg.content] == ["a", "b"]
+        assert ctx.current_span().usage.get("recovered_tool_calls") == 2

--- a/python/tests/collectors/test_openai_collector.py
+++ b/python/tests/collectors/test_openai_collector.py
@@ -1849,3 +1849,194 @@ class TestResponseCollectorResult:
 
         msg = collector.result()
         assert len(msg.content) == 0  # server_tool_use skipped
+
+
+# ---------------------------------------------------------------------------
+# OpenAI Responses: reasoning items carry `id` + `encrypted_content` into memory
+# ---------------------------------------------------------------------------
+
+def _reasoning(item_id: str, *, status: str = "in_progress", encrypted: str | None = None, summary: list[str] | None = None):
+    from openai.types.responses.response_reasoning_item import Summary
+
+    return ResponseReasoningItem(
+        type="reasoning",
+        id=item_id,
+        status=status,
+        summary=[Summary(type="summary_text", text=t) for t in (summary or [])],
+        encrypted_content=encrypted,
+    )
+
+
+def _fn_call(item_id: str, call_id: str, name: str = "search", arguments: str = "", status: str = "in_progress"):
+    return ResponseFunctionToolCall(
+        type="function_call", id=item_id, call_id=call_id, name=name, arguments=arguments, status=status,
+    )
+
+
+def _added(item, index: int, seq: int):
+    return ResponseOutputItemAddedEvent(type="response.output_item.added", output_index=index, item=item, sequence_number=seq)
+
+
+def _done(item, index: int, seq: int):
+    return ResponseOutputItemDoneEvent(type="response.output_item.done", output_index=index, item=item, sequence_number=seq)
+
+
+def _completed(seq: int):
+    resp = _make_response(model="gpt-5.6-luna", status="completed")
+    resp.usage = _make_response_usage()
+    return ResponseCompletedEvent(type="response.completed", response=resp, sequence_number=seq)
+
+
+class TestResponseCollectorEncryptedReasoning:
+    """The chain of thought a reasoning model needs back on the next call of a tool loop."""
+
+    def _collector(self):
+        _make_context()
+        c = ResponseCollector(async_gen=_empty_gen(), start=time.perf_counter())
+        c.process(ResponseCreatedEvent(type="response.created", response=_make_response(model="gpt-5.6-luna"), sequence_number=0))
+        return c
+
+    def test_encrypted_content_from_done_lands_on_thinking_content(self):
+        c = self._collector()
+        c.process(_added(_reasoning("rs_1"), 0, 1))
+        c.process(_done(_reasoning("rs_1", status="completed", encrypted="enc-1"), 0, 2))
+        c.process(_completed(3))
+
+        msg = c.result()
+        assert len(msg.content) == 1
+        block = msg.content[0]
+        assert isinstance(block, ThinkingContent)
+        assert block.id == "rs_1"
+        assert block.encrypted_content == "enc-1"
+        assert block.thinking == ""
+        assert block.is_openai_reasoning_item
+
+    def test_reasoning_precedes_the_function_call_it_produced(self):
+        """Order in memory is order on the wire: reasoning item, then its function_call."""
+        c = self._collector()
+        c.process(_added(_reasoning("rs_1"), 0, 1))
+        c.process(_done(_reasoning("rs_1", status="completed", encrypted="enc-1"), 0, 2))
+        c.process(_added(_fn_call("fc_1", "call_1"), 1, 3))
+        c.process(ResponseFunctionCallArgumentsDeltaEvent(
+            type="response.function_call_arguments.delta", item_id="fc_1", output_index=1, delta='{"q":"x"}', sequence_number=4,
+        ))
+        c.process(_done(_fn_call("fc_1", "call_1", arguments='{"q":"x"}', status="completed"), 1, 5))
+        c.process(_completed(6))
+
+        msg = c.result()
+        assert [type(b).__name__ for b in msg.content] == ["ThinkingContent", "ToolUseContent"]
+        assert msg.content[0].encrypted_content == "enc-1"
+        assert msg.content[1].id == "call_1"
+        # …and that message replays as [reasoning, function_call] with the same ids.
+        items = msg.to_openai_responses_input()
+        assert [i["type"] for i in items] == ["reasoning", "function_call"]
+        assert items[0]["id"] == "rs_1" and items[0]["encrypted_content"] == "enc-1"
+        assert items[1]["call_id"] == "call_1"
+
+    def test_reasoning_without_payload_or_summary_is_not_kept(self):
+        """`include` not requested (or a non-reasoning model): nothing to replay, no empty block."""
+        c = self._collector()
+        c.process(_added(_reasoning("rs_1"), 0, 1))
+        c.process(_done(_reasoning("rs_1", status="completed"), 0, 2))
+        c.process(_added(_fn_call("fc_1", "call_1"), 1, 3))
+        c.process(_done(_fn_call("fc_1", "call_1", arguments="{}", status="completed"), 1, 4))
+        c.process(_completed(5))
+
+        msg = c.result()
+        assert [type(b).__name__ for b in msg.content] == ["ToolUseContent"]
+        assert msg.to_openai_responses_input()[0]["type"] == "function_call"
+
+    def test_streamed_summary_and_encrypted_content_both_kept(self):
+        from openai.types.responses.response_reasoning_summary_part_added_event import Part as ReasoningSummaryPart
+
+        c = self._collector()
+        c.process(_added(_reasoning("rs_1"), 0, 1))
+        c.process(ResponseReasoningSummaryPartAddedEvent(
+            type="response.reasoning_summary_part.added", item_id="rs_1", output_index=0, summary_index=0,
+            part=ReasoningSummaryPart(type="summary_text", text=""), sequence_number=2,
+        ))
+        c.process(ResponseReasoningSummaryTextDeltaEvent(
+            type="response.reasoning_summary_text.delta", item_id="rs_1", output_index=0, summary_index=0,
+            delta="Need the schema first.", sequence_number=3,
+        ))
+        c.process(_done(_reasoning("rs_1", status="completed", encrypted="enc-1", summary=["Need the schema first."]), 0, 4))
+        c.process(_completed(5))
+
+        block = c.result().content[0]
+        assert block.thinking == "Need the schema first."
+        assert block.encrypted_content == "enc-1"
+        assert block.to_openai_responses_input(role="assistant")["summary"] == [
+            {"type": "summary_text", "text": "Need the schema first."}
+        ]
+
+    def test_multiple_summary_parts_join_as_paragraphs(self):
+        from openai.types.responses.response_reasoning_summary_part_added_event import Part as ReasoningSummaryPart
+
+        c = self._collector()
+        c.process(_added(_reasoning("rs_1"), 0, 1))
+        for idx, text in enumerate(["first", "second"]):
+            c.process(ResponseReasoningSummaryPartAddedEvent(
+                type="response.reasoning_summary_part.added", item_id="rs_1", output_index=0, summary_index=idx,
+                part=ReasoningSummaryPart(type="summary_text", text=""), sequence_number=2 + 2 * idx,
+            ))
+            c.process(ResponseReasoningSummaryTextDeltaEvent(
+                type="response.reasoning_summary_text.delta", item_id="rs_1", output_index=0, summary_index=idx,
+                delta=text, sequence_number=3 + 2 * idx,
+            ))
+        c.process(_done(_reasoning("rs_1", status="completed", encrypted="enc-1", summary=["first", "second"]), 0, 6))
+        c.process(_completed(7))
+        assert c.result().content[0].thinking == "first\n\nsecond"
+
+    def test_summary_only_on_done_is_used_when_nothing_streamed(self):
+        c = self._collector()
+        c.process(_added(_reasoning("rs_1"), 0, 1))
+        c.process(_done(_reasoning("rs_1", status="completed", encrypted="enc-1", summary=["late summary"]), 0, 2))
+        c.process(_completed(3))
+        assert c.result().content[0].thinking == "late summary"
+
+    def test_summary_without_encrypted_content_keeps_legacy_thinking(self):
+        """Summary text but no payload (include not requested): visible thinking, not a reasoning item."""
+        c = self._collector()
+        c.process(_added(_reasoning("rs_1"), 0, 1))
+        c.process(_done(_reasoning("rs_1", status="completed", summary=["visible"]), 0, 2))
+        c.process(_completed(3))
+        block = c.result().content[0]
+        assert block.thinking == "visible"
+        assert block.encrypted_content is None
+        assert block.id is None
+        assert not block.is_openai_reasoning_item
+
+    def test_done_without_added_still_records_the_item(self):
+        """A `.done` for an item whose `.added` was missed must not raise or lose the payload."""
+        c = self._collector()
+        item = c.process(_done(_reasoning("rs_orphan", status="completed", encrypted="enc-o"), 0, 1))
+        assert item is None  # no content block was opened, so no stop event
+        c.process(_completed(2))
+        block = c.result().content[0]
+        assert block.id == "rs_orphan" and block.encrypted_content == "enc-o"
+
+    def test_added_and_done_emit_stream_events_as_before(self):
+        c = self._collector()
+        started = c.process(_added(_reasoning("rs_1"), 0, 1))
+        assert isinstance(started, Thinking) and started.id == "rs_1"
+        stopped = c.process(_done(_reasoning("rs_1", status="completed", encrypted="enc-1"), 0, 2))
+        assert isinstance(stopped, ContentBlockStop) and stopped.id == "rs_1"
+
+    def test_two_steps_two_reasoning_items(self):
+        """Parallel tool calls in one response: each reasoning item keeps its own payload."""
+        c = self._collector()
+        c.process(_added(_reasoning("rs_1"), 0, 1))
+        c.process(_done(_reasoning("rs_1", status="completed", encrypted="enc-1"), 0, 2))
+        c.process(_added(_fn_call("fc_1", "call_1", name="a"), 1, 3))
+        c.process(_done(_fn_call("fc_1", "call_1", name="a", arguments="{}", status="completed"), 1, 4))
+        c.process(_added(_reasoning("rs_2"), 2, 5))
+        c.process(_done(_reasoning("rs_2", status="completed", encrypted="enc-2"), 2, 6))
+        c.process(_added(_fn_call("fc_2", "call_2", name="b"), 3, 7))
+        c.process(_done(_fn_call("fc_2", "call_2", name="b", arguments="{}", status="completed"), 3, 8))
+        c.process(_completed(9))
+
+        items = c.result().to_openai_responses_input()
+        assert [(i["type"], i.get("id") or i.get("call_id")) for i in items] == [
+            ("reasoning", "rs_1"), ("function_call", "call_1"), ("reasoning", "rs_2"), ("function_call", "call_2"),
+        ]
+        assert [i["encrypted_content"] for i in items if i["type"] == "reasoning"] == ["enc-1", "enc-2"]

--- a/python/tests/core/llm/test_responses_reasoning_replay.py
+++ b/python/tests/core/llm/test_responses_reasoning_replay.py
@@ -476,3 +476,59 @@ class TestAgentToolLoopReplaysReasoning:
         kinds = [(i.get("type") or i.get("role")) for i in second]
         assert kinds == ["user", "function_call", "function_call_output"], kinds
         assert [type(c).__name__ for c in result.output.content] == ["TextContent"]
+
+
+# ---------------------------------------------------------------------------
+# Leaked tool calls (Harmony text) run like real ones; `phase` survives the loop
+# ---------------------------------------------------------------------------
+
+
+def _text_turn_with_phase(rs_id: str, encrypted: str, text: str, phase: str | None):
+    """`_text_turn` whose message items carry a `phase` (GPT-5.4+)."""
+    events = _text_turn(rs_id, encrypted, text)
+    out = []
+    for e in events:
+        item = getattr(e, "item", None)
+        if isinstance(item, ResponseOutputMessage) and phase:
+            e = e.model_copy(update={"item": item.model_copy(update={"phase": phase})})
+        out.append(e)
+    return out
+
+
+class TestAgentRecoversLeakedToolCalls:
+    @pytest.mark.asyncio
+    async def test_leaked_call_text_runs_the_tool_and_the_loop_continues(self):
+        """Turn 1 is a `message` that says ` to=functions.search json {"q":"x"}` instead of a
+        function_call item. The tool must run and turn 2 must see a real function_call +
+        output in its input — never the leaked text as assistant prose."""
+        leak = ' to=functions.search  (json 恒一\n{"q":"x"}ંалда'
+        scripted = _ScriptedResponses(
+            [
+                _text_turn("rs_1", "enc-1", leak),
+                _text_turn("rs_2", "enc-2", "Done: x"),
+            ]
+        )
+        result, calls = await _run_agent(scripted)
+
+        assert calls == [{"q": "x"}]
+        assert result.output.content[-1].text == "Done: x"
+        second = scripted.requests[1]["input"]
+        kinds = [(i.get("type") or i.get("role")) for i in second]
+        assert kinds == ["user", "reasoning", "function_call", "function_call_output"], kinds
+        assert second[2]["name"] == "search"
+        assert second[2]["call_id"].startswith("call_leak_")
+        assert second[3]["call_id"] == second[2]["call_id"]
+        assert not any("to=functions" in str(i) for i in second)
+
+    @pytest.mark.asyncio
+    async def test_assistant_phase_is_replayed_on_the_next_request(self):
+        scripted = _ScriptedResponses(
+            [
+                _text_turn_with_phase("rs_1", "enc-1", "One moment.", "commentary"),
+            ]
+        )
+        result, _ = await _run_agent(scripted)
+        assert result.output.content[-1].phase == "commentary"
+        # A follow-up turn replays the assistant message with its phase intact.
+        items = result.output.to_openai_responses_input()
+        assert items[-1] == {"role": "assistant", "content": [{"type": "output_text", "text": "One moment."}], "phase": "commentary"}

--- a/python/tests/core/llm/test_responses_reasoning_replay.py
+++ b/python/tests/core/llm/test_responses_reasoning_replay.py
@@ -532,3 +532,39 @@ class TestAgentRecoversLeakedToolCalls:
         # A follow-up turn replays the assistant message with its phase intact.
         items = result.output.to_openai_responses_input()
         assert items[-1] == {"role": "assistant", "content": [{"type": "output_text", "text": "One moment."}], "phase": "commentary"}
+
+
+class TestAgentRetriesUnrecoverableLeak:
+    @pytest.mark.asyncio
+    async def test_leak_without_arguments_is_re_requested_and_the_loop_completes(self):
+        """Turn 1 leaks `to=functions.search (json…` with no JSON: nothing to run. The agent
+        must re-request (nudge appended, empty assistant turn not kept), turn 2 calls the
+        tool properly, turn 3 answers."""
+        scripted = _ScriptedResponses(
+            [
+                _text_turn("rs_1", "enc-1", " to=functions.search  (jsonеиҳәеит?)\n"),
+                _tool_call_turn("rs_2", "enc-2", "call_1", "fc_1", "search", '{"q": "x"}'),
+                _text_turn("rs_3", "enc-3", "Done: x"),
+            ]
+        )
+        result, calls = await _run_agent(scripted)
+
+        assert calls == [{"q": "x"}]
+        assert result.output.content[-1].text == "Done: x"
+        assert len(scripted.requests) == 3
+        second = scripted.requests[1]["input"]
+        kinds = [(i.get("type") or i.get("role")) for i in second]
+        # user prompt, then the runtime nudge — no dangling reasoning item, no empty assistant message
+        assert kinds == ["user", "user"], kinds
+        assert "emitted as text" in second[1]["content"][0]["text"]
+        assert not any(i.get("type") == "reasoning" for i in second)
+
+    @pytest.mark.asyncio
+    async def test_retry_budget_is_bounded(self):
+        leak = " to=functions.search  (json\n"
+        scripted = _ScriptedResponses([_text_turn(f"rs_{n}", f"enc-{n}", leak) for n in range(1, 5)])
+        result, calls = await _run_agent(scripted)
+        assert calls == []
+        # 1 original + 2 retries (max_leaked_tool_call_retries) = 3 requests; then the turn ends
+        assert len(scripted.requests) == 3
+        assert result.output.metadata.get("kind") == "leaked_tool_call_unrecovered"

--- a/python/tests/core/llm/test_responses_reasoning_replay.py
+++ b/python/tests/core/llm/test_responses_reasoning_replay.py
@@ -1,0 +1,478 @@
+"""OpenAI Responses: request `include` for encrypted reasoning, and replay across a tool loop.
+
+Reasoning models (GPT-5.x, o-series, codex) keep no chain of thought between the calls
+of a tool loop unless every request (a) asks for `reasoning.encrypted_content` and (b)
+replays the `reasoning` items it got back, ahead of the function_call each one produced.
+With `store: false` that is the only mechanism. Without it the model degrades with loop
+depth — up to emitting tool calls as plain text (`to=functions.…`) and ending the turn.
+
+These tests run entirely offline against a fake `client.responses.create` that yields
+real SDK event objects, so they exercise collector → memory → serializer → next request.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from openai.types.responses import (
+    Response,
+    ResponseCompletedEvent,
+    ResponseContentPartAddedEvent,
+    ResponseCreatedEvent,
+    ResponseFunctionCallArgumentsDeltaEvent,
+    ResponseFunctionToolCall,
+    ResponseOutputItemAddedEvent,
+    ResponseOutputItemDoneEvent,
+    ResponseOutputMessage,
+    ResponseOutputText,
+    ResponseReasoningItem,
+    ResponseTextDeltaEvent,
+)
+from openai.types.responses.response_reasoning_item import Summary
+from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails, ResponseUsage
+from timbal.core.llm.responses import (
+    REASONING_ENCRYPTED_CONTENT_INCLUDE,
+    prepare_responses_request,
+    supports_encrypted_reasoning,
+)
+from timbal.types.content import ThinkingContent, ToolUseContent
+from timbal.types.message import Message
+
+
+@pytest.fixture(autouse=True)
+def clean_context():
+    from timbal.state import _call_id, _run_context_var
+
+    token_ctx = _run_context_var.set(None)
+    token_cid = _call_id.set(None)
+    yield
+    _run_context_var.reset(token_ctx)
+    _call_id.reset(token_cid)
+
+
+# ---------------------------------------------------------------------------
+# Request preparation
+# ---------------------------------------------------------------------------
+
+
+class TestSupportsEncryptedReasoning:
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gpt-5.6-luna",
+            "gpt-5",
+            "gpt-5-mini",
+            "gpt-5.1-codex",
+            "GPT-5.6-luna",
+            "gpt-6-astra",
+            "o3",
+            "o3-mini",
+            "o4-mini",
+            "o1",
+            "codex-mini-latest",
+        ],
+    )
+    def test_reasoning_models(self, model):
+        assert supports_encrypted_reasoning(model)
+
+    @pytest.mark.parametrize(
+        "model", ["gpt-4o", "gpt-4o-mini", "gpt-4.1", "gpt-4.1-nano", "grok-4.6", "grok-3", "", "   "]
+    )
+    def test_non_reasoning_models_and_xai(self, model):
+        assert not supports_encrypted_reasoning(model)
+
+
+def _prepare(model_name: str, provider_params: dict | None = None, messages: list[Message] | None = None):
+    client = MagicMock()
+    _, _ = prepare_responses_request(
+        client=client,
+        model_name=model_name,
+        request_headers={},
+        system_prompt=None,
+        messages=messages or [Message.validate("hi")],
+        tools=None,
+        max_tokens=None,
+        temperature=None,
+        output_model=None,
+        provider_params=provider_params or {},
+    )
+    # prepare returns a stream factory; grab the kwargs it will send by calling it.
+    return client
+
+
+async def _kwargs_sent(
+    model_name: str, provider_params: dict | None = None, messages: list[Message] | None = None
+) -> dict:
+    captured: dict = {}
+
+    async def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _empty_stream()
+
+    client = MagicMock()
+    client.responses.create = fake_create
+    create_stream, _ = prepare_responses_request(
+        client=client,
+        model_name=model_name,
+        request_headers={},
+        system_prompt=None,
+        messages=messages or [Message.validate("hi")],
+        tools=None,
+        max_tokens=None,
+        temperature=None,
+        output_model=None,
+        provider_params=provider_params or {},
+    )
+    async for _ in create_stream():
+        pass
+    return captured
+
+
+async def _empty_stream():
+    return
+    yield
+
+
+class TestPrepareResponsesRequestInclude:
+    @pytest.mark.asyncio
+    async def test_reasoning_model_requests_encrypted_content(self):
+        kwargs = await _kwargs_sent("gpt-5.6-luna")
+        assert kwargs["store"] is False
+        assert REASONING_ENCRYPTED_CONTENT_INCLUDE in kwargs["include"]
+        assert "web_search_call.action.sources" in kwargs["include"]
+
+    @pytest.mark.asyncio
+    async def test_non_reasoning_model_does_not(self):
+        kwargs = await _kwargs_sent("gpt-4.1-mini")
+        assert kwargs["include"] == ["web_search_call.action.sources"]
+
+    @pytest.mark.asyncio
+    async def test_xai_model_does_not(self):
+        kwargs = await _kwargs_sent("grok-4.6")
+        assert REASONING_ENCRYPTED_CONTENT_INCLUDE not in kwargs["include"]
+
+    @pytest.mark.asyncio
+    async def test_caller_include_is_merged_not_clobbered(self):
+        kwargs = await _kwargs_sent("gpt-5.6-luna", provider_params={"include": ["message.output_text.logprobs"]})
+        assert kwargs["include"] == [
+            "web_search_call.action.sources",
+            REASONING_ENCRYPTED_CONTENT_INCLUDE,
+            "message.output_text.logprobs",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_caller_include_deduped(self):
+        kwargs = await _kwargs_sent("gpt-5.6-luna", provider_params={"include": [REASONING_ENCRYPTED_CONTENT_INCLUDE]})
+        assert kwargs["include"].count(REASONING_ENCRYPTED_CONTENT_INCLUDE) == 1
+
+    @pytest.mark.asyncio
+    async def test_other_provider_params_still_forwarded(self):
+        kwargs = await _kwargs_sent("gpt-5.6-luna", provider_params={"reasoning": {"effort": "high"}})
+        assert kwargs["reasoning"] == {"effort": "high"}
+
+    @pytest.mark.asyncio
+    async def test_memory_with_reasoning_items_is_serialized_top_level(self):
+        memory = [
+            Message.validate("find x"),
+            Message(
+                role="assistant",
+                content=[
+                    ThinkingContent(thinking="", id="rs_1", encrypted_content="enc-1"),
+                    ToolUseContent(id="call_1", name="search", input={"q": "x"}),
+                ],
+            ),
+        ]
+        kwargs = await _kwargs_sent("gpt-5.6-luna", messages=memory)
+        types = [i.get("type") or i.get("role") for i in kwargs["input"]]
+        assert types == ["user", "reasoning", "function_call"]
+        assert kwargs["input"][1] == {"type": "reasoning", "id": "rs_1", "encrypted_content": "enc-1", "summary": []}
+
+
+# ---------------------------------------------------------------------------
+# Agent tool loop, offline
+# ---------------------------------------------------------------------------
+
+
+def _usage(inp=20, out=5):
+    return ResponseUsage(
+        input_tokens=inp,
+        output_tokens=out,
+        total_tokens=inp + out,
+        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+    )
+
+
+def _response(model="gpt-5.6-luna", status="in_progress", usage=None):
+    return Response(
+        id="resp_001",
+        created_at=1,
+        model=model,
+        object="response",
+        output=[],
+        parallel_tool_calls=True,
+        tool_choice="auto",
+        tools=[],
+        status=status,
+        usage=usage,
+        incomplete_details=None,
+        instructions=None,
+        metadata={},
+        error=None,
+        temperature=1.0,
+        top_p=1.0,
+        max_output_tokens=None,
+        text=None,
+        truncation="disabled",
+    )
+
+
+def _tool_call_turn(
+    rs_id: str, encrypted: str, call_id: str, fn_item: str, name: str, arguments: str, *, summary: str = ""
+):
+    """Events for one model response: reasoning (with payload) → function_call."""
+    seq = iter(range(100))
+    reasoning_done = ResponseReasoningItem(
+        type="reasoning",
+        id=rs_id,
+        status="completed",
+        summary=[Summary(type="summary_text", text=summary)] if summary else [],
+        encrypted_content=encrypted,
+    )
+    return [
+        ResponseCreatedEvent(type="response.created", response=_response(), sequence_number=next(seq)),
+        ResponseOutputItemAddedEvent(
+            type="response.output_item.added",
+            output_index=0,
+            sequence_number=next(seq),
+            item=ResponseReasoningItem(type="reasoning", id=rs_id, status="in_progress", summary=[]),
+        ),
+        ResponseOutputItemDoneEvent(
+            type="response.output_item.done", output_index=0, item=reasoning_done, sequence_number=next(seq)
+        ),
+        ResponseOutputItemAddedEvent(
+            type="response.output_item.added",
+            output_index=1,
+            sequence_number=next(seq),
+            item=ResponseFunctionToolCall(
+                type="function_call", id=fn_item, call_id=call_id, name=name, arguments="", status="in_progress"
+            ),
+        ),
+        ResponseFunctionCallArgumentsDeltaEvent(
+            type="response.function_call_arguments.delta",
+            item_id=fn_item,
+            output_index=1,
+            delta=arguments,
+            sequence_number=next(seq),
+        ),
+        ResponseOutputItemDoneEvent(
+            type="response.output_item.done",
+            output_index=1,
+            sequence_number=next(seq),
+            item=ResponseFunctionToolCall(
+                type="function_call", id=fn_item, call_id=call_id, name=name, arguments=arguments, status="completed"
+            ),
+        ),
+        ResponseCompletedEvent(
+            type="response.completed", response=_response(status="completed", usage=_usage()), sequence_number=next(seq)
+        ),
+    ]
+
+
+def _text_turn(rs_id: str, encrypted: str, text: str):
+    """Events for the final model response: reasoning → assistant text."""
+    seq = iter(range(100))
+    return [
+        ResponseCreatedEvent(type="response.created", response=_response(), sequence_number=next(seq)),
+        ResponseOutputItemAddedEvent(
+            type="response.output_item.added",
+            output_index=0,
+            sequence_number=next(seq),
+            item=ResponseReasoningItem(type="reasoning", id=rs_id, status="in_progress", summary=[]),
+        ),
+        ResponseOutputItemDoneEvent(
+            type="response.output_item.done",
+            output_index=0,
+            sequence_number=next(seq),
+            item=ResponseReasoningItem(
+                type="reasoning", id=rs_id, status="completed", summary=[], encrypted_content=encrypted
+            ),
+        ),
+        ResponseOutputItemAddedEvent(
+            type="response.output_item.added",
+            output_index=1,
+            sequence_number=next(seq),
+            item=ResponseOutputMessage(type="message", id="msg_1", role="assistant", status="in_progress", content=[]),
+        ),
+        ResponseContentPartAddedEvent(
+            type="response.content_part.added",
+            item_id="msg_1",
+            output_index=1,
+            content_index=0,
+            sequence_number=next(seq),
+            part=ResponseOutputText(type="output_text", text="", annotations=[]),
+        ),
+        ResponseTextDeltaEvent(
+            type="response.output_text.delta",
+            item_id="msg_1",
+            output_index=1,
+            content_index=0,
+            delta=text,
+            logprobs=[],
+            sequence_number=next(seq),
+        ),
+        ResponseOutputItemDoneEvent(
+            type="response.output_item.done",
+            output_index=1,
+            sequence_number=next(seq),
+            item=ResponseOutputMessage(
+                type="message",
+                id="msg_1",
+                role="assistant",
+                status="completed",
+                content=[ResponseOutputText(type="output_text", text=text, annotations=[])],
+            ),
+        ),
+        ResponseCompletedEvent(
+            type="response.completed", response=_response(status="completed", usage=_usage()), sequence_number=next(seq)
+        ),
+    ]
+
+
+class _ScriptedResponses:
+    """`client.responses.create` that plays one scripted event list per call and records every request."""
+
+    def __init__(self, turns):
+        self.turns = list(turns)
+        self.requests: list[dict] = []
+
+    async def create(self, **kwargs):
+        self.requests.append(kwargs)
+        events = self.turns.pop(0)
+
+        async def gen():
+            for e in events:
+                yield e
+
+        return gen()
+
+
+async def _run_agent(scripted: _ScriptedResponses, *, prompt: str = "look it up"):
+    """Run a one-tool Agent against the scripted client; return (OutputEvent, tool calls made).
+
+    Everything — including `collect()` — runs inside the patches: the collector is lazy,
+    so returning it and awaiting outside would hit the real network.
+    """
+    from timbal import Agent
+
+    calls: list[dict] = []
+
+    def search(q: str) -> str:
+        """Search for a query."""
+        calls.append({"q": q})
+        return f"result for {q}"
+
+    agent = Agent(name="agent", model="openai/gpt-5.6-luna", tools=[search])
+    client = MagicMock()
+    client.responses.create = scripted.create
+    with patch("timbal.core.llm.router._resolve_client", return_value=(client, None)):
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "key"}):
+            with patch("timbal.core.llm.router.TIMBAL_OPENAI_API", "responses"):
+                result = await agent(prompt=prompt).collect()
+    assert result.error is None, result.error
+    return result, calls
+
+
+class TestAgentToolLoopReplaysReasoning:
+    @pytest.mark.asyncio
+    async def test_second_request_carries_first_steps_reasoning_item(self):
+        scripted = _ScriptedResponses(
+            [
+                _tool_call_turn("rs_1", "enc-1", "call_1", "fc_1", "search", '{"q": "x"}'),
+                _text_turn("rs_2", "enc-2", "Done: x"),
+            ]
+        )
+        result, calls = await _run_agent(scripted)
+
+        assert calls == [{"q": "x"}]
+        assert isinstance(result.output, Message)
+        assert result.output.content[-1].text == "Done: x"
+        assert len(scripted.requests) == 2
+
+        first, second = scripted.requests
+        for req in (first, second):
+            assert REASONING_ENCRYPTED_CONTENT_INCLUDE in req["include"]
+            assert req["store"] is False
+
+        # Second request replays: user → reasoning(rs_1) → function_call(call_1) → function_call_output.
+        kinds = [(i.get("type") or i.get("role")) for i in second["input"]]
+        assert kinds == ["user", "reasoning", "function_call", "function_call_output"], kinds
+        reasoning = second["input"][1]
+        assert reasoning == {"type": "reasoning", "id": "rs_1", "encrypted_content": "enc-1", "summary": []}
+        assert second["input"][2]["call_id"] == "call_1"
+        assert second["input"][3]["call_id"] == "call_1"
+        # The reasoning payload is never leaked as visible assistant text.
+        assert not any(i.get("role") == "assistant" for i in second["input"])
+
+    @pytest.mark.asyncio
+    async def test_three_step_loop_accumulates_every_reasoning_item(self):
+        scripted = _ScriptedResponses(
+            [
+                _tool_call_turn("rs_1", "enc-1", "call_1", "fc_1", "search", '{"q": "a"}', summary="step one"),
+                _tool_call_turn("rs_2", "enc-2", "call_2", "fc_2", "search", '{"q": "b"}'),
+                _text_turn("rs_3", "enc-3", "a and b"),
+            ]
+        )
+        _, calls = await _run_agent(scripted)
+
+        assert calls == [{"q": "a"}, {"q": "b"}]
+        third = scripted.requests[2]["input"]
+        kinds = [(i.get("type") or i.get("role")) for i in third]
+        assert kinds == [
+            "user",
+            "reasoning",
+            "function_call",
+            "function_call_output",
+            "reasoning",
+            "function_call",
+            "function_call_output",
+        ], kinds
+        assert [i["id"] for i in third if i.get("type") == "reasoning"] == ["rs_1", "rs_2"]
+        assert [i["encrypted_content"] for i in third if i.get("type") == "reasoning"] == ["enc-1", "enc-2"]
+        assert third[1]["summary"] == [{"type": "summary_text", "text": "step one"}]
+        # Every reasoning item sits directly before the function_call it produced.
+        for idx, item in enumerate(third):
+            if item.get("type") == "reasoning":
+                assert third[idx + 1]["type"] == "function_call"
+
+    @pytest.mark.asyncio
+    async def test_final_memory_keeps_reasoning_items_for_the_next_turn(self):
+        scripted = _ScriptedResponses(
+            [
+                _tool_call_turn("rs_1", "enc-1", "call_1", "fc_1", "search", '{"q": "x"}'),
+                _text_turn("rs_2", "enc-2", "Done"),
+            ]
+        )
+        result, _ = await _run_agent(scripted)
+        final = result.output
+        # The last assistant message carries its own reasoning item too, so a follow-up
+        # user turn replays the complete chain.
+        assert [type(c).__name__ for c in final.content] == ["ThinkingContent", "TextContent"]
+        assert final.content[0].id == "rs_2" and final.content[0].encrypted_content == "enc-2"
+        assert final.to_openai_responses_input()[0]["type"] == "reasoning"
+
+    @pytest.mark.asyncio
+    async def test_without_encrypted_content_nothing_is_replayed_and_nothing_breaks(self):
+        """A server that returns no payload (include ignored) must not produce empty items."""
+        scripted = _ScriptedResponses(
+            [
+                _tool_call_turn("rs_1", None, "call_1", "fc_1", "search", '{"q": "x"}'),
+                _text_turn("rs_2", None, "Done"),
+            ]
+        )
+        result, calls = await _run_agent(scripted)
+        assert calls == [{"q": "x"}]
+        second = scripted.requests[1]["input"]
+        kinds = [(i.get("type") or i.get("role")) for i in second]
+        assert kinds == ["user", "function_call", "function_call_output"], kinds
+        assert [type(c).__name__ for c in result.output.content] == ["TextContent"]

--- a/python/tests/core/llm/test_responses_reasoning_replay.py
+++ b/python/tests/core/llm/test_responses_reasoning_replay.py
@@ -568,3 +568,44 @@ class TestAgentRetriesUnrecoverableLeak:
         # 1 original + 2 retries (max_leaked_tool_call_retries) = 3 requests; then the turn ends
         assert len(scripted.requests) == 3
         assert result.output.metadata.get("kind") == "leaked_tool_call_unrecovered"
+
+
+# ---------------------------------------------------------------------------
+# Cross-provider replay: reasoning payloads and `phase` are OpenAI-reasoning-only
+# ---------------------------------------------------------------------------
+
+
+def _history_from_a_reasoning_model() -> list[Message]:
+    from timbal.types.content import TextContent
+
+    return [
+        Message.validate({"role": "user", "content": "hi"}),
+        Message(
+            role="assistant",
+            content=[
+                ThinkingContent(thinking="", id="rs_1", encrypted_content="enc-1"),
+                ToolUseContent(id="call_1", name="search", input={"q": "x"}),
+                TextContent(text="Done.", phase="final_answer"),
+            ],
+        ),
+    ]
+
+
+class TestCrossProviderReplayScrub:
+    @pytest.mark.asyncio
+    async def test_reasoning_model_keeps_reasoning_and_phase(self):
+        kw = await _kwargs_sent(model_name="gpt-5.6-luna", messages=_history_from_a_reasoning_model())
+        kinds = [(i.get("type") or i.get("role")) for i in kw["input"]]
+        assert kinds == ["user", "reasoning", "function_call", "assistant"], kinds
+        assert kw["input"][-1]["phase"] == "final_answer"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("model", ["gpt-4.1", "grok-4"])
+    async def test_other_target_gets_neither(self, model):
+        """FallbackModel to xAI, or a gpt-4.1 follow-up on a gpt-5 history: the function_call
+        stays, the encrypted reasoning item and the phase do not."""
+        kw = await _kwargs_sent(model_name=model, messages=_history_from_a_reasoning_model())
+        kinds = [(i.get("type") or i.get("role")) for i in kw["input"]]
+        assert kinds == ["user", "function_call", "assistant"], (model, kinds)
+        assert "phase" not in kw["input"][-1]
+        assert kw["input"][-1]["content"] == [{"type": "output_text", "text": "Done."}]

--- a/python/tests/types/content/test_text.py
+++ b/python/tests/types/content/test_text.py
@@ -19,3 +19,19 @@ def test_text_to_openai_chat_completions_input() -> None:
 def test_text_to_anthropic_input() -> None:
     text_content = TextContent(text="Hello, World!")
     assert text_content.to_anthropic_input() == {"type": "text", "text": "Hello, World!"}
+
+
+def test_text_phase_round_trips_through_the_factory() -> None:
+    content = content_factory({"type": "text", "text": "One sec.", "phase": "commentary"})
+    assert isinstance(content, TextContent)
+    assert content.phase == "commentary"
+    assert content_factory({"type": "text", "text": "x"}).phase is None
+    assert content_factory("plain").phase is None
+
+
+def test_text_phase_stays_off_other_providers() -> None:
+    content = TextContent(text="x", phase="final_answer")
+    assert content.to_openai_chat_completions_input() == {"type": "text", "text": "x"}
+    assert content.to_anthropic_input() == {"type": "text", "text": "x"}
+    # the part itself is unchanged; the phase belongs on the enclosing message item
+    assert content.to_openai_responses_input(role="assistant") == {"type": "output_text", "text": "x"}

--- a/python/tests/types/content/test_thinking.py
+++ b/python/tests/types/content/test_thinking.py
@@ -1,0 +1,116 @@
+"""ThinkingContent: Anthropic signature vs OpenAI Responses reasoning item replay."""
+
+from timbal.types.content import ThinkingContent, content_factory
+from timbal.types.message import Message
+
+
+class TestOpenAIResponsesReplay:
+    def test_assistant_reasoning_item_with_summary(self):
+        c = ThinkingContent(thinking="plan the tool call", id="rs_1", encrypted_content="enc-1")
+        assert c.is_openai_reasoning_item
+        assert c.to_openai_responses_input(role="assistant") == {
+            "type": "reasoning",
+            "id": "rs_1",
+            "encrypted_content": "enc-1",
+            "summary": [{"type": "summary_text", "text": "plan the tool call"}],
+        }
+
+    def test_assistant_reasoning_item_without_summary_has_empty_summary_list(self):
+        """`summary` is required by the API; no visible text means `[]`, never a fake entry."""
+        c = ThinkingContent(thinking="", id="rs_1", encrypted_content="enc-1")
+        item = c.to_openai_responses_input(role="assistant")
+        assert item["type"] == "reasoning"
+        assert item["summary"] == []
+        assert item["encrypted_content"] == "enc-1"
+
+    def test_encrypted_content_without_id_is_not_a_reasoning_item(self):
+        """A reasoning item needs its `rs_…` id; without it fall back to the text behaviour."""
+        c = ThinkingContent(thinking="visible", encrypted_content="enc-1")
+        assert not c.is_openai_reasoning_item
+        assert c.to_openai_responses_input(role="assistant") == {"type": "output_text", "text": "visible"}
+
+    def test_id_without_encrypted_content_is_not_a_reasoning_item(self):
+        c = ThinkingContent(thinking="visible", id="rs_1")
+        assert not c.is_openai_reasoning_item
+        assert c.to_openai_responses_input(role="assistant") == {"type": "output_text", "text": "visible"}
+
+    def test_legacy_assistant_text_preserved(self):
+        c = ThinkingContent(thinking="raw reasoning text")
+        assert c.to_openai_responses_input(role="assistant") == {"type": "output_text", "text": "raw reasoning text"}
+
+    def test_legacy_user_text_preserved(self):
+        c = ThinkingContent(thinking="raw reasoning text")
+        assert c.to_openai_responses_input(role="user") == {"type": "input_text", "text": "raw reasoning text"}
+
+    def test_empty_legacy_thinking_is_dropped(self):
+        """An empty text part would be rejected upstream; return None so the message skips it."""
+        assert ThinkingContent(thinking="").to_openai_responses_input(role="assistant") is None
+        assert ThinkingContent(thinking="").to_openai_responses_input(role="user") is None
+
+    def test_user_role_never_emits_a_reasoning_item(self):
+        """Reasoning items are model output; a user-role block with the fields stays a text part."""
+        c = ThinkingContent(thinking="t", id="rs_1", encrypted_content="enc-1")
+        assert c.to_openai_responses_input(role="user") == {"type": "input_text", "text": "t"}
+
+
+class TestOtherProvidersUnaffected:
+    def test_anthropic_input_ignores_openai_fields(self):
+        c = ThinkingContent(thinking="t", signature="sig", id="rs_1", encrypted_content="enc-1")
+        assert c.to_anthropic_input() == {"type": "thinking", "thinking": "t", "signature": "sig"}
+
+    def test_anthropic_input_drops_thinking_without_a_signature(self):
+        """A cross-provider fallback (OpenAI → Anthropic) must not send an unverifiable block."""
+        assert ThinkingContent(thinking="t", id="rs_1", encrypted_content="enc-1").to_anthropic_input() is None
+        assert ThinkingContent(thinking="raw xai reasoning").to_anthropic_input() is None
+
+    def test_anthropic_message_skips_openai_reasoning_items(self):
+        from timbal.types.content import TextContent, ToolUseContent
+
+        msg = Message(
+            role="assistant",
+            content=[
+                ThinkingContent(thinking="", id="rs_1", encrypted_content="enc-1"),
+                ToolUseContent(id="call_1", name="search", input={"q": "x"}),
+                TextContent(text="ok"),
+            ],
+        )
+        blocks = msg.to_anthropic_input()["content"]
+        assert [b["type"] for b in blocks] == ["tool_use", "text"]
+
+    def test_anthropic_message_keeps_signed_thinking(self):
+        msg = Message(role="assistant", content=[ThinkingContent(thinking="t", signature="sig")])
+        assert msg.to_anthropic_input()["content"] == [{"type": "thinking", "thinking": "t", "signature": "sig"}]
+
+    def test_chat_completions_input_is_none(self):
+        c = ThinkingContent(thinking="t", id="rs_1", encrypted_content="enc-1")
+        assert c.to_openai_chat_completions_input() is None
+
+
+class TestPersistence:
+    def test_content_factory_round_trip_keeps_reasoning_fields(self):
+        original = ThinkingContent(thinking="t", signature="sig", id="rs_1", encrypted_content="enc-1")
+        rebuilt = content_factory(original.model_dump())
+        assert rebuilt == original
+
+    def test_content_factory_defaults(self):
+        rebuilt = content_factory({"type": "thinking", "thinking": "t"})
+        assert rebuilt == ThinkingContent(thinking="t")
+        assert rebuilt.id is None and rebuilt.encrypted_content is None
+
+    def test_content_factory_missing_thinking_becomes_empty_string(self):
+        rebuilt = content_factory({"type": "thinking", "id": "rs_1", "encrypted_content": "enc-1"})
+        assert rebuilt.thinking == ""
+        assert rebuilt.is_openai_reasoning_item
+
+    def test_message_json_round_trip(self):
+        """Memory is persisted as JSON (traces, sessions); a reload must keep the payload."""
+        from pydantic import TypeAdapter
+
+        adapter = TypeAdapter(Message)
+        msg = Message(
+            role="assistant",
+            content=[ThinkingContent(thinking="t", id="rs_1", encrypted_content="enc-1")],
+        )
+        reloaded = adapter.validate_json(adapter.dump_json(msg))
+        assert reloaded.content[0] == msg.content[0]
+        assert reloaded.to_openai_responses_input()[0]["type"] == "reasoning"

--- a/python/tests/types/test_message.py
+++ b/python/tests/types/test_message.py
@@ -379,6 +379,83 @@ def test_thinking_only_message_drops_turn_for_chat_completions() -> None:
     }
 
 
+def test_openai_reasoning_item_is_top_level_and_precedes_its_function_call() -> None:
+    """An assistant turn `reasoning → function_call` replays as two top-level items in that
+    order — the shape OpenAI's reasoning models need to keep their chain of thought across a
+    tool loop. Nothing is wrapped in a `message`."""
+    message = Message(
+        role="assistant",
+        content=[
+            ThinkingContent(thinking="", id="rs_1", encrypted_content="enc-1"),
+            ToolUseContent(id="call_1", name="search", input={"q": "x"}),
+        ],
+    )
+    items = message.to_openai_responses_input()
+    assert [i["type"] for i in items] == ["reasoning", "function_call"]
+    assert items[0] == {"type": "reasoning", "id": "rs_1", "encrypted_content": "enc-1", "summary": []}
+    assert items[1]["call_id"] == "call_1"
+
+
+def test_openai_reasoning_item_with_text_keeps_text_in_a_message() -> None:
+    message = Message(
+        role="assistant",
+        content=[
+            ThinkingContent(thinking="thought", id="rs_1", encrypted_content="enc-1"),
+            TextContent(text="Here you go."),
+        ],
+    )
+    items = message.to_openai_responses_input()
+    assert items[0]["type"] == "reasoning"
+    assert items[0]["summary"] == [{"type": "summary_text", "text": "thought"}]
+    assert items[1] == {"role": "assistant", "content": [{"type": "output_text", "text": "Here you go."}]}
+
+
+def test_openai_reasoning_items_one_per_step_all_replayed() -> None:
+    """Parallel tool calls: each reasoning item stays adjacent to the call it produced."""
+    message = Message(
+        role="assistant",
+        content=[
+            ThinkingContent(thinking="", id="rs_1", encrypted_content="enc-1"),
+            ToolUseContent(id="call_1", name="a", input={}),
+            ThinkingContent(thinking="", id="rs_2", encrypted_content="enc-2"),
+            ToolUseContent(id="call_2", name="b", input={}),
+        ],
+    )
+    items = message.to_openai_responses_input()
+    assert [(i["type"], i.get("id") or i.get("call_id")) for i in items] == [
+        ("reasoning", "rs_1"),
+        ("function_call", "call_1"),
+        ("reasoning", "rs_2"),
+        ("function_call", "call_2"),
+    ]
+
+
+def test_legacy_thinking_without_payload_still_rides_inside_the_message() -> None:
+    """No id/encrypted payload (xAI raw reasoning, pre-fix memory): historical behaviour."""
+    message = Message(
+        role="assistant",
+        content=[ThinkingContent(thinking="raw"), TextContent(text="answer")],
+    )
+    assert message.to_openai_responses_input() == [
+        {"role": "assistant", "content": [{"type": "output_text", "text": "raw"}, {"type": "output_text", "text": "answer"}]}
+    ]
+
+
+def test_empty_legacy_thinking_does_not_produce_an_empty_text_part() -> None:
+    message = Message(role="assistant", content=[ThinkingContent(thinking=""), TextContent(text="answer")])
+    assert message.to_openai_responses_input() == [
+        {"role": "assistant", "content": [{"type": "output_text", "text": "answer"}]}
+    ]
+
+
+def test_reasoning_only_assistant_turn_replays_as_just_the_reasoning_item() -> None:
+    """A turn that was cut off after reasoning (max_tokens) must not become an empty message."""
+    message = Message(role="assistant", content=[ThinkingContent(thinking="", id="rs_1", encrypted_content="enc-1")])
+    assert message.to_openai_responses_input() == [
+        {"type": "reasoning", "id": "rs_1", "encrypted_content": "enc-1", "summary": []}
+    ]
+
+
 def test_server_tool_blocks_preserved_in_anthropic_input() -> None:
     result = _anthropic_server_tool_message().to_anthropic_input()
     assert result["content"][0] == {

--- a/python/tests/types/test_message.py
+++ b/python/tests/types/test_message.py
@@ -456,6 +456,65 @@ def test_reasoning_only_assistant_turn_replays_as_just_the_reasoning_item() -> N
     ]
 
 
+# --- assistant `phase` and wire order (GPT-5.4+ preambles) ----------------------------
+
+
+def test_assistant_text_phase_rides_on_the_message_item() -> None:
+    message = Message(role="assistant", content=[TextContent(text="Done.", phase="final_answer")])
+    assert message.to_openai_responses_input() == [
+        {"role": "assistant", "content": [{"type": "output_text", "text": "Done."}], "phase": "final_answer"}
+    ]
+
+
+def test_user_text_never_carries_a_phase() -> None:
+    message = Message(role="user", content=[TextContent(text="hi", phase="final_answer")])
+    assert message.to_openai_responses_input() == [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}]
+
+
+def test_preamble_replays_before_the_function_call_it_introduced() -> None:
+    """Wire order is content order: `message(commentary) → reasoning → function_call →
+    message(final_answer)`, not "all function_calls, then one message with every text"."""
+    message = Message(
+        role="assistant",
+        content=[
+            TextContent(text="Checking the schema first.", phase="commentary"),
+            ThinkingContent(thinking="", id="rs_1", encrypted_content="enc-1"),
+            ToolUseContent(id="call_1", name="get_schema", input={}),
+            TextContent(text="Here is the schema.", phase="final_answer"),
+        ],
+    )
+    items = message.to_openai_responses_input()
+    assert [i.get("type") or i.get("phase") for i in items] == ["commentary", "reasoning", "function_call", "final_answer"]
+    assert items[0] == {"role": "assistant", "content": [{"type": "output_text", "text": "Checking the schema first."}], "phase": "commentary"}
+    assert items[3] == {"role": "assistant", "content": [{"type": "output_text", "text": "Here is the schema."}], "phase": "final_answer"}
+
+
+def test_adjacent_text_with_the_same_phase_shares_one_message() -> None:
+    message = Message(
+        role="assistant",
+        content=[TextContent(text="a", phase="final_answer"), TextContent(text="b", phase="final_answer")],
+    )
+    assert message.to_openai_responses_input() == [
+        {"role": "assistant", "content": [{"type": "output_text", "text": "a"}, {"type": "output_text", "text": "b"}], "phase": "final_answer"}
+    ]
+
+
+def test_adjacent_text_with_different_phases_splits_into_two_messages() -> None:
+    message = Message(
+        role="assistant",
+        content=[TextContent(text="one sec", phase="commentary"), TextContent(text="done", phase="final_answer")],
+    )
+    items = message.to_openai_responses_input()
+    assert [i["phase"] for i in items] == ["commentary", "final_answer"]
+
+
+def test_text_without_phase_replays_as_before() -> None:
+    message = Message(role="assistant", content=[TextContent(text="plain"), ToolUseContent(id="c", name="t", input={})])
+    items = message.to_openai_responses_input()
+    assert items[0] == {"role": "assistant", "content": [{"type": "output_text", "text": "plain"}]}
+    assert items[1]["type"] == "function_call"
+
+
 def test_server_tool_blocks_preserved_in_anthropic_input() -> None:
     result = _anthropic_server_tool_message().to_anthropic_input()
     assert result["content"][0] == {

--- a/python/timbal/collectors/harmony_leak.py
+++ b/python/timbal/collectors/harmony_leak.py
@@ -43,7 +43,14 @@ LEAKED_TOOL_CALL_UNRECOVERED = "leaked_tool_call_unrecovered"
 # The recipient header. A tool name is what the Responses API allows for a function
 # name plus the dots timbal uses for namespaced tools (``timbal__codegen`` has none,
 # but MCP-style ``server.tool`` names exist elsewhere).
-_HEADER_RE = re.compile(r"to=(?:functions\.([A-Za-z0-9_][A-Za-z0-9_.\-]*)|(multi_tool_use\.parallel))")
+# `functions.` is usually present; the bare form (`to=timbal__codegen code: {…}`) shows up
+# too. A bare name is accepted only when a JSON object follows it (see the parser) — the
+# agent's unknown-tool path answers a wrong name with an error the model can act on.
+_HEADER_RE = re.compile(
+    r"to=(?:(multi_tool_use\.parallel)|(?:functions\.)?([A-Za-z_][A-Za-z0-9_.\-]*))(?![A-Za-z0-9_.\-])"
+)
+_BARE_HEAD_RE = re.compile(r"^to=[A-Za-z_][A-Za-z0-9_.\-]*(?:\s|\()")
+_BARE_TYPING_RE = re.compile(r"^to=[A-Za-z_]?[A-Za-z0-9_.\-]*$")
 
 LeakState = Literal["undecided", "leak", "clean"]
 
@@ -61,6 +68,12 @@ def leak_state(text: str) -> LeakState:
     if any(head.startswith(m) for m in LEAK_MARKERS):
         return "leak"
     if any(m.startswith(head) for m in LEAK_MARKERS):
+        return "undecided"
+    # Bare recipient (`to=timbal__codegen …`): a leak once the name is complete; while
+    # the name is still being typed, undecided. Prose does not start with `to=`.
+    if _BARE_HEAD_RE.match(head) and not head.startswith("to=functions.") and not head.startswith("to=multi_tool_use."):
+        return "leak"
+    if _BARE_TYPING_RE.match(head):
         return "undecided"
     return "clean"
 
@@ -142,7 +155,7 @@ def parse_leaked_tool_calls(text: str) -> tuple[str, list[tuple[str, dict]]]:
             continue
         if not isinstance(args, dict):
             continue
-        expanded = _expand_parallel(args) if m.group(2) else [(m.group(1), args)]
+        expanded = _expand_parallel(args) if m.group(1) else [(m.group(2), args)]
         for name, a in expanded:
             key = (name, json.dumps(a, sort_keys=True))
             if key in seen:

--- a/python/timbal/collectors/harmony_leak.py
+++ b/python/timbal/collectors/harmony_leak.py
@@ -36,6 +36,10 @@ LEAK_MARKER = "to=functions."
 PARALLEL_MARKER = "to=multi_tool_use.parallel"
 LEAK_MARKERS = (LEAK_MARKER, PARALLEL_MARKER)
 
+# `Message.metadata["kind"]` the collector sets when a leak carried no runnable call —
+# the agent loop re-requests instead of ending the turn with nothing.
+LEAKED_TOOL_CALL_UNRECOVERED = "leaked_tool_call_unrecovered"
+
 # The recipient header. A tool name is what the Responses API allows for a function
 # name plus the dots timbal uses for namespaced tools (``timbal__codegen`` has none,
 # but MCP-style ``server.tool`` names exist elsewhere).

--- a/python/timbal/collectors/harmony_leak.py
+++ b/python/timbal/collectors/harmony_leak.py
@@ -31,11 +31,15 @@ import re
 from typing import Literal
 
 LEAK_MARKER = "to=functions."
+# The model's parallel-call wrapper leaks too:
+#   to=multi_tool_use.parallel … {"tool_uses":[{"recipient_name":"functions.X","parameters":{…}}, …]}
+PARALLEL_MARKER = "to=multi_tool_use.parallel"
+LEAK_MARKERS = (LEAK_MARKER, PARALLEL_MARKER)
 
 # The recipient header. A tool name is what the Responses API allows for a function
 # name plus the dots timbal uses for namespaced tools (``timbal__codegen`` has none,
 # but MCP-style ``server.tool`` names exist elsewhere).
-_HEADER_RE = re.compile(r"to=functions\.([A-Za-z0-9_][A-Za-z0-9_.\-]*)")
+_HEADER_RE = re.compile(r"to=(?:functions\.([A-Za-z0-9_][A-Za-z0-9_.\-]*)|(multi_tool_use\.parallel))")
 
 LeakState = Literal["undecided", "leak", "clean"]
 
@@ -50,15 +54,29 @@ def leak_state(text: str) -> LeakState:
     head = text.lstrip()
     if not head:
         return "undecided"
-    if head.startswith(LEAK_MARKER):
+    if any(head.startswith(m) for m in LEAK_MARKERS):
         return "leak"
-    if LEAK_MARKER.startswith(head):
+    if any(m.startswith(head) for m in LEAK_MARKERS):
         return "undecided"
     return "clean"
 
 
 def contains_leak(text: str) -> bool:
     return bool(_HEADER_RE.search(text or ""))
+
+
+def _expand_parallel(args: dict) -> list[tuple[str, dict]]:
+    """``{"tool_uses": [{"recipient_name": "functions.X", "parameters": {…}}, …]}`` → calls."""
+    out: list[tuple[str, dict]] = []
+    for use in args.get("tool_uses") or []:
+        if not isinstance(use, dict):
+            continue
+        name = str(use.get("recipient_name") or "")
+        name = name.split("functions.", 1)[1] if "functions." in name else name
+        params = use.get("parameters")
+        if name and isinstance(params, dict):
+            out.append((name, params))
+    return out
 
 
 def _extract_json_object(text: str, start: int) -> tuple[str, int] | None:
@@ -120,9 +138,11 @@ def parse_leaked_tool_calls(text: str) -> tuple[str, list[tuple[str, dict]]]:
             continue
         if not isinstance(args, dict):
             continue
-        key = (m.group(1), json.dumps(args, sort_keys=True))
-        if key in seen:
-            continue
-        seen.add(key)
-        calls.append((m.group(1), args))
+        expanded = _expand_parallel(args) if m.group(2) else [(m.group(1), args)]
+        for name, a in expanded:
+            key = (name, json.dumps(a, sort_keys=True))
+            if key in seen:
+                continue
+            seen.add(key)
+            calls.append((name, a))
     return prefix, calls

--- a/python/timbal/collectors/harmony_leak.py
+++ b/python/timbal/collectors/harmony_leak.py
@@ -1,0 +1,128 @@
+"""Recover tool calls that GPT-5.x leaks into assistant text.
+
+GPT-5.x on the Responses API occasionally fails to emit a structured ``function_call``
+item and instead writes the Harmony wire form of the call into a ``message`` item::
+
+     to=functions.wait_for_background_tasks  (json 恒一
+    {"task_ids":["o20s53ln5l51"],"timeout_seconds":120}
+
+``to=functions.<name>`` is the recipient header; the junk between it and the JSON
+is where the ``<|constrain|>json<|message|>`` control tokens should have been
+(decoded as text they surface as high-frequency training tokens — CJK spam, stray
+Cyrillic). The name and the JSON object are intact in every sample we have; the
+framing is what broke. Known across the ecosystem (livekit/agents-js#1632,
+openclaw#30441, hermes-agent ``codex_responses_adapter``); this module is the
+recovery every serious runtime ends up shipping.
+
+Two entry points:
+
+- :func:`leak_state` — for the streaming hold-back. While a text block is short and
+  still a prefix of the marker (`` to=fun``) it is *undecided* and must not be
+  emitted; once it either matches or diverges the collector knows whether to stream
+  it or swallow it.
+- :func:`parse_leaked_tool_calls` — for the collected block. Returns the clean text
+  that preceded the first marker and every ``(name, arguments)`` it could parse, in
+  order and deduplicated (the model tends to repeat the same call several times).
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import Literal
+
+LEAK_MARKER = "to=functions."
+
+# The recipient header. A tool name is what the Responses API allows for a function
+# name plus the dots timbal uses for namespaced tools (``timbal__codegen`` has none,
+# but MCP-style ``server.tool`` names exist elsewhere).
+_HEADER_RE = re.compile(r"to=functions\.([A-Za-z0-9_][A-Za-z0-9_.\-]*)")
+
+LeakState = Literal["undecided", "leak", "clean"]
+
+
+def leak_state(text: str) -> LeakState:
+    """Whether the text so far *starts* a leaked tool call.
+
+    Leading whitespace is ignored (the leak arrives as `` to=functions.…``). Only a
+    leak at the very start of the block is decidable while streaming; a marker after
+    real prose is found by :func:`parse_leaked_tool_calls` once the block is complete.
+    """
+    head = text.lstrip()
+    if not head:
+        return "undecided"
+    if head.startswith(LEAK_MARKER):
+        return "leak"
+    if LEAK_MARKER.startswith(head):
+        return "undecided"
+    return "clean"
+
+
+def contains_leak(text: str) -> bool:
+    return bool(_HEADER_RE.search(text or ""))
+
+
+def _extract_json_object(text: str, start: int) -> tuple[str, int] | None:
+    """The first balanced ``{…}`` at or after ``start``; ``(json_text, end_index)``.
+
+    Tracks string literals so braces inside argument strings do not end the scan.
+    """
+    i = text.find("{", start)
+    if i < 0:
+        return None
+    depth = 0
+    in_str = False
+    esc = False
+    for j in range(i, len(text)):
+        ch = text[j]
+        if in_str:
+            if esc:
+                esc = False
+            elif ch == "\\":
+                esc = True
+            elif ch == '"':
+                in_str = False
+            continue
+        if ch == '"':
+            in_str = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[i : j + 1], j + 1
+    return None
+
+
+def parse_leaked_tool_calls(text: str) -> tuple[str, list[tuple[str, dict]]]:
+    """Split a text block into the prose before the first leak and the calls it carries.
+
+    Each header is paired with the first balanced JSON object that follows it and
+    precedes the next header; a header without a parseable object is skipped (there
+    is nothing to run). Identical ``(name, arguments)`` pairs collapse into one call.
+    Text *between* or *after* the calls is dropped: it is either control-token debris
+    or a summary the model wrote believing the calls had run.
+    """
+    matches = list(_HEADER_RE.finditer(text or ""))
+    if not matches:
+        return text, []
+    prefix = text[: matches[0].start()].rstrip()
+    calls: list[tuple[str, dict]] = []
+    seen: set[tuple[str, str]] = set()
+    for k, m in enumerate(matches):
+        limit = matches[k + 1].start() if k + 1 < len(matches) else len(text)
+        found = _extract_json_object(text[:limit], m.end())
+        if found is None:
+            continue
+        raw, _ = found
+        try:
+            args = json.loads(raw)
+        except ValueError:
+            continue
+        if not isinstance(args, dict):
+            continue
+        key = (m.group(1), json.dumps(args, sort_keys=True))
+        if key in seen:
+            continue
+        seen.add(key)
+        calls.append((m.group(1), args))
+    return prefix, calls

--- a/python/timbal/collectors/harmony_leak.py
+++ b/python/timbal/collectors/harmony_leak.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import json
 import re
+import unicodedata
 from typing import Literal
 
 LEAK_MARKER = "to=functions."
@@ -79,7 +80,8 @@ def leak_state(text: str) -> LeakState:
 
 
 def contains_leak(text: str) -> bool:
-    return bool(_HEADER_RE.search(text or ""))
+    """A leak header that counts: at a line start, outside code fences."""
+    return bool(_leak_headers(text or ""))
 
 
 def _expand_parallel(args: dict) -> list[tuple[str, dict]]:
@@ -128,6 +130,54 @@ def _extract_json_object(text: str, start: int) -> tuple[str, int] | None:
     return None
 
 
+def _fenced_ranges(text: str) -> list[tuple[int, int]]:
+    """Spans of ``` fenced code blocks — a header inside one is being *quoted*, not issued."""
+    spans: list[tuple[int, int]] = []
+    start: int | None = None
+    for m in re.finditer(r"^[ \t]*```", text, re.M):
+        if start is None:
+            start = m.start()
+        else:
+            spans.append((start, m.end()))
+            start = None
+    if start is not None:
+        spans.append((start, len(text)))
+    return spans
+
+
+def _at_line_start(text: str, pos: int) -> bool:
+    """The header begins a line (after optional indentation). Leaks always do; a header
+    embedded mid-sentence is someone describing the syntax."""
+    line_start = text.rfind("\n", 0, pos) + 1
+    return text[line_start:pos].strip() == ""
+
+
+def _leak_headers(text: str) -> list[re.Match]:
+    fenced = _fenced_ranges(text)
+    return [
+        m for m in _HEADER_RE.finditer(text or "")
+        if _at_line_start(text, m.start()) and not any(a <= m.start() < b for a, b in fenced)
+    ]
+
+
+def _looks_corrupted(raw: str) -> bool:
+    """Control-token debris landed *inside* the JSON.
+
+    The debris is what the decoder makes of special tokens: private-use, unassigned and
+    replacement code points (``\\U0004e7ff``, ``񟿿``, ``￼``, ``\\ufffd``). Real text — in
+    any script — does not contain those, so their presence means the arguments cannot
+    be trusted (a `builder` prompt with a garbage line in it would still parse). Such
+    a call is not recovered; with nothing else runnable the step is re-requested.
+    """
+    for ch in raw:
+        if ch in ("\ufffc", "\ufffd"):
+            return True
+        cat = unicodedata.category(ch)
+        if cat in ("Co", "Cn", "Cs"):
+            return True
+    return False
+
+
 def parse_leaked_tool_calls(text: str) -> tuple[str, list[tuple[str, dict]]]:
     """Split a text block into the prose before the first leak and the calls it carries.
 
@@ -136,8 +186,11 @@ def parse_leaked_tool_calls(text: str) -> tuple[str, list[tuple[str, dict]]]:
     is nothing to run). Identical ``(name, arguments)`` pairs collapse into one call.
     Text *between* or *after* the calls is dropped: it is either control-token debris
     or a summary the model wrote believing the calls had run.
+
+    A header only counts when it starts a line and sits outside a ``` fence; an
+    object carrying decoder debris (see ``_looks_corrupted``) is not recovered.
     """
-    matches = list(_HEADER_RE.finditer(text or ""))
+    matches = _leak_headers(text or "")
     if not matches:
         return text, []
     prefix = text[: matches[0].start()].rstrip()
@@ -149,6 +202,8 @@ def parse_leaked_tool_calls(text: str) -> tuple[str, list[tuple[str, dict]]]:
         if found is None:
             continue
         raw, _ = found
+        if _looks_corrupted(raw):
+            continue
         try:
             args = json.loads(raw)
         except ValueError:

--- a/python/timbal/collectors/impl/openai.py
+++ b/python/timbal/collectors/impl/openai.py
@@ -52,6 +52,7 @@ from ...core.models import (
 )
 from ...state import get_billing_id, get_run_context
 from ...types.content.text import TextContent
+from ..harmony_leak import contains_leak, leak_state, parse_leaked_tool_calls
 from ...types.content.thinking import ThinkingContent
 from ...types.content.tool_use import ToolUseContent
 from ...types.events.delta import (
@@ -488,11 +489,35 @@ class ResponseCollector(BaseCollector):
         self._stop_reason: str | None = None
         self.content_blocks: set[str] = set()
         self.content: dict[str, dict[str, Any]] = {}
+        # `phase` per message item id (`commentary` / `final_answer`), from the
+        # item's `.added` / `.done`; the text block is keyed by the same id.
+        self._message_phase: dict[str, str | None] = {}
+        # A `.done` that has to flush held text emits two items; see `_emit_stream_items`.
+        self._pending_stream_items: deque[Any] = deque()
 
     @classmethod
     @override
     def can_handle(cls, event: Any) -> bool:
         return isinstance(event, ResponseEvent)
+
+    def pop_pending_stream_item(self) -> Any | None:
+        if self._pending_stream_items:
+            return self._pending_stream_items.popleft()
+        return None
+
+    async def __anext__(self):
+        pending = self.pop_pending_stream_item()
+        if pending is not None:
+            return pending
+        return await super().__anext__()
+
+    def _emit_stream_items(self, items: list[Any]) -> Any:
+        filtered = [item for item in items if item is not None]
+        if not filtered:
+            return None
+        first, *rest = filtered
+        self._pending_stream_items.extend(rest)
+        return first
 
     @override
     def process(self, event: ResponseEvent) -> Any:
@@ -579,6 +604,7 @@ class ResponseCollector(BaseCollector):
                 is_server_tool_use=False,
             )
         elif isinstance(event.item, ResponseOutputMessage):
+            self._message_phase[event.item.id] = getattr(event.item, "phase", None)
             return None
         elif isinstance(event.item, ResponseFunctionWebSearch):
             # TODO We should add this to the messages history
@@ -615,26 +641,55 @@ class ResponseCollector(BaseCollector):
             logger.warning("Unhandled output item added event", response_output_item_added_event=event)
 
     def _handle_content_part_added(self, event: ResponseContentPartAddedEvent) -> None:
-        """Handle content part added events from OpenAI."""
+        """Handle content part added events from OpenAI.
+
+        The text block is *held* until its first characters show whether it is prose
+        or a leaked tool call (`` to=functions.…``, see ``harmony_leak``). Prose is
+        released as one ``Text`` carrying what accumulated meanwhile; a leak is never
+        streamed — it is recovered as a tool call in ``result()``.
+        """
         if isinstance(event.part, ResponseOutputText):
             self.content[event.item_id] = {
                 "type": "text",
                 "citations": [],
                 "text": event.part.text,
+                "phase": self._message_phase.get(event.item_id),
+                "held": True,
+                "leak": False,
             }
-            content_block_id = event.item_id
-            self.content_blocks.add(content_block_id)
-            return TimbalText(
-                id=content_block_id,
-                text=event.part.text,
-            )
+            return self._release_text_if_decided(event.item_id)
         else:
             logger.warning("Unhandled content part added event", response_content_part_added_event=event)
 
+    def _release_text_if_decided(self, item_id: str, *, force: bool = False) -> TimbalText | None:
+        """Start the stream block for a held text once it is known not to be a leak.
+
+        ``force`` settles an undecided block (the item ended while still a prefix of
+        the marker, e.g. a message that is just ``"to"``) as prose.
+        """
+        entry = self.content[item_id]
+        if not entry.get("held"):
+            return None
+        state = leak_state(entry["text"])
+        if state == "leak":
+            entry["leak"] = True
+            entry["held"] = False
+            return None
+        if state == "undecided" and not force:
+            return None
+        entry["held"] = False
+        self.content_blocks.add(item_id)
+        return TimbalText(id=item_id, text=entry["text"])
+
     def _handle_text_delta(self, event: ResponseTextDeltaEvent) -> None:
         """Handle text delta events from OpenAI."""
-        self.content[event.item_id]["text"] += event.delta
+        entry = self.content[event.item_id]
+        entry["text"] += event.delta
         content_block_id = event.item_id
+        if entry.get("held"):
+            return self._release_text_if_decided(content_block_id)
+        if entry.get("leak"):
+            return None
         assert content_block_id in self.content_blocks, "Text delta event without content block start event"
         return TimbalTextDelta(
             id=content_block_id,
@@ -743,7 +798,21 @@ class ResponseCollector(BaseCollector):
                 return TimbalContentBlockStop(id=content_block_id)
             else:
                 return None
-        elif isinstance(event.item, ResponseFunctionToolCall | ResponseOutputMessage):
+        elif isinstance(event.item, ResponseOutputMessage):
+            content_block_id = event.item.id
+            phase = getattr(event.item, "phase", None)
+            if phase:
+                self._message_phase[content_block_id] = phase
+                if content_block_id in self.content:
+                    self.content[content_block_id]["phase"] = phase
+            released = None
+            if content_block_id in self.content:
+                # A block still held at the end (too short to decide) is prose.
+                released = self._release_text_if_decided(content_block_id, force=True)
+            if content_block_id in self.content_blocks:
+                return self._emit_stream_items([released, TimbalContentBlockStop(id=content_block_id)])
+            return None
+        elif isinstance(event.item, ResponseFunctionToolCall):
             content_block_id = event.item.id
             if content_block_id in self.content_blocks:
                 return TimbalContentBlockStop(id=content_block_id)
@@ -820,6 +889,11 @@ class ResponseCollector(BaseCollector):
         span.metadata["tps"] = tps
 
         content = []
+        # Leaked tool calls are recovered only when the response produced no structured
+        # one: next to real function_calls the leaked text is a duplicate or a
+        # hallucination, and running it would double the action.
+        has_structured_tool_use = any(b["type"] == "tool_use" for b in self.content.values())
+        recovered = 0
         for content_block in self.content.values():  # Python dicts are ordered
             if content_block["type"] == "tool_use":
                 content.append(
@@ -850,11 +924,32 @@ class ResponseCollector(BaseCollector):
                 )
             elif content_block["type"] == "text":
                 text = content_block["text"]
+                phase = content_block.get("phase")
                 # e.g. {'type': 'url_citation', 'end_index': 2538, 'start_index': 2403, 'title': 'Weather Forecast and Conditions for Barcelona, Barcelona, Spain - The Weather Channel | Weather.com', 'url': 'https://weather.com/weather/today/l/b3b13a74649dd0a2a0aada41e1bf764de39e5dacf21d062ef18ecdeb09796ba0?utm_source=openai'}
                 # Openai annotations are already formatted into the text
-                content.append(TextContent(text=text))
+                if content_block.get("leak") or contains_leak(text):
+                    # A tool call written as text (see harmony_leak). Keep the prose
+                    # before it; turn what parses into real tool calls; drop the rest
+                    # — surfacing it would hand the user a summary of work nobody did.
+                    prefix, calls = parse_leaked_tool_calls(text)
+                    if prefix:
+                        content.append(TextContent(text=prefix, phase=phase))
+                    if has_structured_tool_use:
+                        logger.warning("Leaked tool-call text alongside structured tool calls; dropped",
+                                       names=[n for n, _ in calls], text=text[:300])
+                        continue
+                    for name, args in calls:
+                        recovered += 1
+                        content.append(ToolUseContent(id=f"call_leak_{uuid7(as_type='hex')}", name=name, input=args))
+                    if not calls:
+                        logger.warning("Leaked tool-call text with no parseable call; dropped", text=text[:300])
+                    continue
+                content.append(TextContent(text=text, phase=phase))
             else:
                 # Unreachable
                 raise AssertionError(f"Unknown content block type: {content_block['type']}")
+        if recovered:
+            logger.warning("Recovered tool calls from leaked assistant text", count=recovered, model=getattr(self, "model", None))
+            get_run_context().update_usage("recovered_tool_calls", recovered)
 
         return Message(role="assistant", content=content, stop_reason=self._stop_reason)

--- a/python/timbal/collectors/impl/openai.py
+++ b/python/timbal/collectors/impl/openai.py
@@ -53,7 +53,7 @@ from ...core.models import (
 )
 from ...state import get_billing_id, get_run_context
 from ...types.content.text import TextContent
-from ..harmony_leak import contains_leak, leak_state, parse_leaked_tool_calls
+from ..harmony_leak import LEAKED_TOOL_CALL_UNRECOVERED, contains_leak, leak_state, parse_leaked_tool_calls
 from ...types.content.thinking import ThinkingContent
 from ...types.content.tool_use import ToolUseContent
 from ...types.events.delta import (
@@ -977,5 +977,18 @@ class ResponseCollector(BaseCollector):
         if recovered:
             logger.warning("Recovered tool calls from leaked assistant text", count=recovered, model=getattr(self, "model", None))
             get_run_context().update_usage("recovered_tool_calls", recovered)
+        metadata: dict[str, Any] | None = None
+        if leak_recovered_here and not has_structured_tool_use:
+            # Debris-adjacent empty text parts carry nothing; they would only replay as
+            # empty `output_text` items around the recovered calls.
+            content = [c for c in content if not (isinstance(c, TextContent) and not c.text)]
+            if not recovered and not any(isinstance(c, TextContent) for c in content):
+                # A leak whose call never got its arguments (`to=functions.builder (json…`
+                # and then nothing): nothing to run, nothing to say. The agent loop
+                # re-requests on this flag instead of ending the turn empty.
+                metadata = {"source": "runtime", "kind": LEAKED_TOOL_CALL_UNRECOVERED}
+                logger.warning("Leaked tool call with no recoverable arguments; turn needs a retry",
+                               model=getattr(self, "model", None))
+                get_run_context().update_usage("unrecovered_tool_call_leaks", 1)
 
-        return Message(role="assistant", content=content, stop_reason=self._stop_reason)
+        return Message(role="assistant", content=content, stop_reason=self._stop_reason, metadata=metadata)

--- a/python/timbal/collectors/impl/openai.py
+++ b/python/timbal/collectors/impl/openai.py
@@ -592,10 +592,13 @@ class ResponseCollector(BaseCollector):
             )
         elif isinstance(event.item, ResponseReasoningItem):
             content_block_id = event.item.id
+            # Register the block now so it keeps its position ahead of the function_call
+            # it produced; the encrypted payload (and any summary) land on `.done`.
+            self._reasoning_entry(event.item)
             self.content_blocks.add(content_block_id)
             return TimbalThinking(
                 id=content_block_id,
-                thinking="",  # TODO Review this
+                thinking="",
             )
         elif isinstance(event.item, ResponseCustomToolCall):
             # Server-side custom tools (e.g. xAI's x_keyword_search, web_fetch).
@@ -654,12 +657,36 @@ class ResponseCollector(BaseCollector):
             input_delta=event.delta,
         )
 
+    def _reasoning_entry(self, item: ResponseReasoningItem | None = None, item_id: str | None = None) -> dict[str, Any]:
+        """The content block for a reasoning item, created on first sight.
+
+        Carries the item id and, once `.done` delivers it, the `encrypted_content` the
+        request asked for via `include: ["reasoning.encrypted_content"]`. Both are what
+        `ThinkingContent` needs to replay this step's chain of thought on the next call.
+        """
+        key = item.id if item is not None else item_id
+        entry = self.content.get(key)
+        if entry is None:
+            entry = {"type": "thinking", "thinking": "", "id": key, "encrypted_content": None}
+            self.content[key] = entry
+        if item is not None:
+            entry["id"] = item.id
+            if item.encrypted_content:
+                entry["encrypted_content"] = item.encrypted_content
+            # The final item carries the complete summary; prefer it over what streamed
+            # in (identical when parts streamed, filled in when they did not).
+            summary = "\n\n".join(part.text for part in (item.summary or []) if getattr(part, "text", ""))
+            if summary:
+                entry["thinking"] = summary
+        return entry
+
     def _handle_reasoning_summary_part_added(self, event: ResponseReasoningSummaryPartAddedEvent) -> None:
         """Handle reasoning summary part added events from OpenAI."""
-        self.content[event.item_id] = {
-            "type": "thinking",
-            "thinking": event.part.text,  # Usually empty string from the beginning
-        }
+        entry = self._reasoning_entry(item_id=event.item_id)
+        # Several summary parts make one thinking block; separate them like paragraphs.
+        if entry["thinking"]:
+            entry["thinking"] += "\n\n"
+        entry["thinking"] += event.part.text  # Usually empty string from the beginning
         content_block_id = event.item_id
         self.content_blocks.add(content_block_id)
         return TimbalThinking(
@@ -669,7 +696,7 @@ class ResponseCollector(BaseCollector):
 
     def _handle_reasoning_summary_text_delta(self, event: ResponseReasoningSummaryTextDeltaEvent) -> None:
         """Handle reasoning summary text delta events from OpenAI."""
-        self.content[event.item_id]["thinking"] += event.delta
+        self._reasoning_entry(item_id=event.item_id)["thinking"] += event.delta
         content_block_id = event.item_id
         assert content_block_id in self.content_blocks, (
             "Reasoning summary text delta event without content block start event"
@@ -681,12 +708,7 @@ class ResponseCollector(BaseCollector):
 
     def _handle_reasoning_text_delta(self, event: ResponseReasoningTextDeltaEvent) -> None:
         """Handle raw reasoning text delta events (e.g. from xAI)."""
-        if event.item_id not in self.content:
-            self.content[event.item_id] = {
-                "type": "thinking",
-                "thinking": "",
-            }
-        self.content[event.item_id]["thinking"] += event.delta
+        self._reasoning_entry(item_id=event.item_id)["thinking"] += event.delta
         content_block_id = event.item_id
         if content_block_id not in self.content_blocks:
             self.content_blocks.add(content_block_id)
@@ -713,7 +735,15 @@ class ResponseCollector(BaseCollector):
                 return TimbalContentBlockStop(id=content_block_id)
             else:
                 return None
-        elif isinstance(event.item, ResponseFunctionToolCall | ResponseOutputMessage | ResponseReasoningItem):
+        elif isinstance(event.item, ResponseReasoningItem):
+            # `.done` is where `encrypted_content` (and the full summary) arrive.
+            self._reasoning_entry(event.item)
+            content_block_id = event.item.id
+            if content_block_id in self.content_blocks:
+                return TimbalContentBlockStop(id=content_block_id)
+            else:
+                return None
+        elif isinstance(event.item, ResponseFunctionToolCall | ResponseOutputMessage):
             content_block_id = event.item.id
             if content_block_id in self.content_blocks:
                 return TimbalContentBlockStop(id=content_block_id)
@@ -804,7 +834,20 @@ class ResponseCollector(BaseCollector):
             elif content_block["type"] == "server_tool_result":
                 continue
             elif content_block["type"] == "thinking":
-                content.append(ThinkingContent(thinking=content_block["thinking"]))
+                thinking = content_block.get("thinking") or ""
+                encrypted = content_block.get("encrypted_content")
+                if not thinking and not encrypted:
+                    # A reasoning item with neither a summary nor an encrypted payload
+                    # (`include` not requested) carries nothing to replay; an empty
+                    # thinking block would only serialize as an empty text part.
+                    continue
+                content.append(
+                    ThinkingContent(
+                        thinking=thinking,
+                        id=content_block.get("id") if encrypted else None,
+                        encrypted_content=encrypted,
+                    )
+                )
             elif content_block["type"] == "text":
                 text = content_block["text"]
                 # e.g. {'type': 'url_citation', 'end_index': 2538, 'start_index': 2403, 'title': 'Weather Forecast and Conditions for Barcelona, Barcelona, Spain - The Weather Channel | Weather.com', 'url': 'https://weather.com/weather/today/l/b3b13a74649dd0a2a0aada41e1bf764de39e5dacf21d062ef18ecdeb09796ba0?utm_source=openai'}

--- a/python/timbal/collectors/impl/openai.py
+++ b/python/timbal/collectors/impl/openai.py
@@ -1,3 +1,4 @@
+import json
 import time
 from collections import deque
 from typing import Any
@@ -492,6 +493,11 @@ class ResponseCollector(BaseCollector):
         # `phase` per message item id (`commentary` / `final_answer`), from the
         # item's `.added` / `.done`; the text block is keyed by the same id.
         self._message_phase: dict[str, str | None] = {}
+        # Once a text block is a leaked tool call, every later text block of this
+        # response is the model narrating work that never ran ("Invoice Triage is
+        # built…"). It is neither streamed nor kept; the real answer comes after
+        # the recovered call has actually run.
+        self._leak_seen: bool = False
         # A `.done` that has to flush held text emits two items; see `_emit_stream_items`.
         self._pending_stream_items: deque[Any] = deque()
 
@@ -670,10 +676,15 @@ class ResponseCollector(BaseCollector):
         entry = self.content[item_id]
         if not entry.get("held"):
             return None
+        if self._leak_seen:
+            entry["after_leak"] = True
+            entry["held"] = False
+            return None
         state = leak_state(entry["text"])
         if state == "leak":
             entry["leak"] = True
             entry["held"] = False
+            self._leak_seen = True
             return None
         if state == "undecided" and not force:
             return None
@@ -688,7 +699,7 @@ class ResponseCollector(BaseCollector):
         content_block_id = event.item_id
         if entry.get("held"):
             return self._release_text_if_decided(content_block_id)
-        if entry.get("leak"):
+        if entry.get("leak") or entry.get("after_leak"):
             return None
         assert content_block_id in self.content_blocks, "Text delta event without content block start event"
         return TimbalTextDelta(
@@ -894,6 +905,8 @@ class ResponseCollector(BaseCollector):
         # hallucination, and running it would double the action.
         has_structured_tool_use = any(b["type"] == "tool_use" for b in self.content.values())
         recovered = 0
+        recovered_keys: set[tuple[str, str]] = set()
+        leak_recovered_here = False  # a leaked block has been seen in this response (content order)
         for content_block in self.content.values():  # Python dicts are ordered
             if content_block["type"] == "tool_use":
                 content.append(
@@ -927,7 +940,15 @@ class ResponseCollector(BaseCollector):
                 phase = content_block.get("phase")
                 # e.g. {'type': 'url_citation', 'end_index': 2538, 'start_index': 2403, 'title': 'Weather Forecast and Conditions for Barcelona, Barcelona, Spain - The Weather Channel | Weather.com', 'url': 'https://weather.com/weather/today/l/b3b13a74649dd0a2a0aada41e1bf764de39e5dacf21d062ef18ecdeb09796ba0?utm_source=openai'}
                 # Openai annotations are already formatted into the text
+                if (content_block.get("after_leak") or leak_recovered_here) and not contains_leak(text):
+                    # Prose after a leaked call in the same response: the model's
+                    # account of work that never ran. Replaying it puts a "final
+                    # answer" between the recovered function_call and its output,
+                    # and the next turn answers as if it were already done.
+                    logger.warning("Dropped assistant text following a leaked tool call", text=text[:200])
+                    continue
                 if content_block.get("leak") or contains_leak(text):
+                    leak_recovered_here = True
                     # A tool call written as text (see harmony_leak). Keep the prose
                     # before it; turn what parses into real tool calls; drop the rest
                     # — surfacing it would hand the user a summary of work nobody did.
@@ -939,6 +960,11 @@ class ResponseCollector(BaseCollector):
                                        names=[n for n, _ in calls], text=text[:300])
                         continue
                     for name, args in calls:
+                        # The model repeats the same call across message items; one run each.
+                        key = (name, json.dumps(args, sort_keys=True))
+                        if key in recovered_keys:
+                            continue
+                        recovered_keys.add(key)
                         recovered += 1
                         content.append(ToolUseContent(id=f"call_leak_{uuid7(as_type='hex')}", name=name, input=args))
                     if not calls:

--- a/python/timbal/core/agent.py
+++ b/python/timbal/core/agent.py
@@ -51,6 +51,7 @@ from ..state.background import (
     current_background_store,
     format_background_completion_notice,
 )
+from ..collectors.harmony_leak import LEAKED_TOOL_CALL_UNRECOVERED
 from ..types.content import (
     CustomContent,
     FileContent,
@@ -301,6 +302,12 @@ class Agent(Runnable):
     max_guardrail_retries: int = 2
     """Budget for guardrail "retry" verdicts per turn (the reask loop). Exhaustion blocks
     with the last rejection reason."""
+    max_leaked_tool_call_retries: int = 2
+    """GPT-5.x on the Responses API occasionally writes a tool call as text instead of a
+    `function_call` item (`to=functions.x …`). The collector runs what it can parse; when
+    the call never got its arguments there is nothing to run and nothing to show, so the
+    step is re-requested — with the model's reasoning items kept — up to this many times
+    per turn instead of ending the turn empty. 0 disables."""
     temperature: float | None = None
     """Sampling temperature for the LLM response."""
     output_model: type[BaseModel] | None = None
@@ -1581,6 +1588,8 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
         _llm_memory_saved = False
         # Guardrail "retry" verdicts consumed this turn (bounded by max_guardrail_retries).
         guardrail_retry_count = 0
+        # Re-requests after a leaked, unrecoverable tool call (max_leaked_tool_call_retries).
+        leaked_call_retry_count = 0
         # Token usage reported by the previous LLM call this turn — the live signal for
         # mid-loop compaction. None until the first LLM call completes.
         last_llm_usage: dict | None = None
@@ -1778,6 +1787,41 @@ If the file is relevant for the user query, USE the `read_skill` tool to get its
                                 )
                         delta_scrubbers.clear()
                         last_delta_events.clear()
+
+                        # A tool call leaked as text whose arguments never arrived: the
+                        # collector could neither run nor show anything. Re-request the
+                        # step. The empty message is not kept (a reasoning item with no
+                        # following item is rejected on replay); a runtime nudge tells the
+                        # model why it is being asked again.
+                        if (
+                            not interrupted
+                            and event.output.metadata.get("kind") == LEAKED_TOOL_CALL_UNRECOVERED
+                            and leaked_call_retry_count < self.max_leaked_tool_call_retries
+                            and i < self.max_iter - 1
+                        ):
+                            leaked_call_retry_count += 1
+                            logger.warning(
+                                "Re-requesting step after a leaked tool call with no arguments",
+                                agent_path=self._path,
+                                attempt=leaked_call_retry_count,
+                            )
+                            await _append_memory(
+                                Message(
+                                    role="user",
+                                    content=[TextContent(text=(
+                                        "Your previous response ended before the tool call was issued "
+                                        "(the call was emitted as text, without arguments, and nothing ran). "
+                                        "Issue the tool call now as a proper function call."
+                                    ))],
+                                    metadata={"source": "runtime", "kind": "leaked_tool_call_retry"},
+                                )
+                            )
+                            _llm_memory_saved = True
+                            last_llm_usage = event.usage
+                            buffered_events.clear()
+                            i += 1
+                            need_retry = True
+                            break
 
                         # model_step rails run on every assistant message; model_output
                         # rails on the final one (no tool calls). Both run BEFORE the

--- a/python/timbal/core/llm/responses.py
+++ b/python/timbal/core/llm/responses.py
@@ -55,7 +55,18 @@ def prepare_responses_request(
     if system_prompt:
         responses_kwargs["instructions"] = system_prompt
 
-    responses_kwargs["input"] = sum([message.to_openai_responses_input() for message in messages], [])
+    input_items = sum([message.to_openai_responses_input() for message in messages], [])
+    if not supports_encrypted_reasoning(model_name):
+        # History written by an OpenAI reasoning model, replayed to something else
+        # (FallbackModel to xAI, a gpt-4.1 follow-up): `reasoning` items with another
+        # model's encrypted payload and the assistant `phase` field are not accepted
+        # there. The function_call each reasoning item preceded stays.
+        input_items = [
+            {k: v for k, v in item.items() if k != "phase"}
+            for item in input_items
+            if not (item.get("type") == "reasoning" and item.get("encrypted_content"))
+        ]
+    responses_kwargs["input"] = input_items
 
     if tools:
         responses_tools = [tool.openai_responses_schema for tool in tools]

--- a/python/timbal/core/llm/responses.py
+++ b/python/timbal/core/llm/responses.py
@@ -1,5 +1,6 @@
 """OpenAI Responses API request adapter (openai, xai)."""
 
+import re
 from collections.abc import AsyncIterator, Callable
 from typing import TYPE_CHECKING, Any
 
@@ -10,6 +11,21 @@ if TYPE_CHECKING:
     from pydantic import BaseModel
 
     from ..runnable import Runnable
+
+
+# OpenAI reasoning models: the `o` series, GPT-5.x, GPT-6.x and the codex line. With
+# `store: false` these only keep their chain of thought across a tool loop if every
+# request asks for `reasoning.encrypted_content` and replays the items it gets back.
+# Non-reasoning models (gpt-4o, gpt-4.1) and xAI's Responses-compatible endpoint
+# are left alone so an unsupported `include` value can never 400 a request.
+_ENCRYPTED_REASONING_MODEL_RE = re.compile(r"^(?:o\d|gpt-5|gpt-6|codex)", re.IGNORECASE)
+
+REASONING_ENCRYPTED_CONTENT_INCLUDE = "reasoning.encrypted_content"
+
+
+def supports_encrypted_reasoning(model_name: str) -> bool:
+    """Whether `include: ["reasoning.encrypted_content"]` should be requested for this model."""
+    return bool(_ENCRYPTED_REASONING_MODEL_RE.match((model_name or "").strip()))
 
 
 def prepare_responses_request(
@@ -26,11 +42,14 @@ def prepare_responses_request(
     provider_params: dict[str, Any],
 ) -> tuple[Callable[[], AsyncIterator[Any]], str]:
     """Build the Responses API kwargs and return (create_stream, context_label)."""
+    include = ["web_search_call.action.sources"]
+    if supports_encrypted_reasoning(model_name):
+        include.append(REASONING_ENCRYPTED_CONTENT_INCLUDE)
     responses_kwargs = {
         "model": model_name,
         "stream": True,
         "store": False,
-        "include": ["web_search_call.action.sources"],
+        "include": include,
     }
 
     if system_prompt:
@@ -65,6 +84,11 @@ def prepare_responses_request(
     # letting dict.update clobber the generated list.
     provider_params = dict(provider_params)
     extra_tools = provider_params.pop("tools", None)
+    # A caller-supplied `include` extends ours rather than replacing it: dropping
+    # `reasoning.encrypted_content` silently would reintroduce the lost-chain-of-thought bug.
+    extra_include = provider_params.pop("include", None)
+    if extra_include:
+        responses_kwargs["include"] = list(dict.fromkeys([*responses_kwargs["include"], *extra_include]))
     responses_kwargs.update(provider_params)
     if extra_tools:
         responses_kwargs["tools"] = [*responses_kwargs.get("tools", []), *extra_tools]

--- a/python/timbal/types/content/__init__.py
+++ b/python/timbal/types/content/__init__.py
@@ -23,7 +23,7 @@ def content_factory(value: Any) -> BaseContent:
         if content_type == "custom":
             return CustomContent(value=value.get("value"))
         elif content_type == "text":
-            return TextContent(text=value.get("text"))
+            return TextContent(text=value.get("text"), phase=value.get("phase"))
         elif content_type == "thinking":
             return ThinkingContent(
                 thinking=value.get("thinking") or "",

--- a/python/timbal/types/content/__init__.py
+++ b/python/timbal/types/content/__init__.py
@@ -26,8 +26,10 @@ def content_factory(value: Any) -> BaseContent:
             return TextContent(text=value.get("text"))
         elif content_type == "thinking":
             return ThinkingContent(
-                thinking=value.get("thinking"),
+                thinking=value.get("thinking") or "",
                 signature=value.get("signature"),
+                id=value.get("id"),
+                encrypted_content=value.get("encrypted_content"),
             )
         elif content_type == "file":
             return FileContent(file=File(value.get("file")), name=value.get("name"))

--- a/python/timbal/types/content/text.py
+++ b/python/timbal/types/content/text.py
@@ -10,13 +10,23 @@ from .base import BaseContent
 
 
 class TextContent(BaseContent):
-    """Text content type for chat messages."""
+    """Text content type for chat messages.
+
+    ``phase`` is the OpenAI Responses assistant-message phase (``"commentary"`` for a
+    preamble before tool calls, ``"final_answer"`` for the completed answer). GPT-5.4+
+    emit it on every ``message`` output item and want it back verbatim when the
+    history is replayed manually — a dropped phase makes a preamble read as a final
+    answer and the model stops early or garbles the next tool call. ``None`` for text
+    from any other source; it never reaches other providers.
+    """
     type: Literal["text"] = "text"
-    text: str 
+    text: str
+    phase: str | None = None
 
     @override
     def to_openai_responses_input(self, role: str, **kwargs: Any) -> dict[str, Any]:
-        """See base class."""
+        """See base class. The phase belongs on the enclosing ``message`` item, which
+        ``Message.to_openai_responses_input`` builds — see there."""
         type = "output_text" if role == "assistant" else "input_text"
         return {
             "type": type,

--- a/python/timbal/types/content/thinking.py
+++ b/python/timbal/types/content/thinking.py
@@ -10,19 +10,52 @@ from .base import BaseContent
 
 
 class ThinkingContent(BaseContent):
-    """Thinking content type for chat messages."""
+    """Thinking content type for chat messages.
+
+    Two provider-specific carriers ride along with the (possibly empty) visible text:
+
+    - ``signature`` — Anthropic's signed thinking block. Replayed verbatim through
+      ``to_anthropic_input`` so multi-step tool loops keep their chain of thought.
+    - ``id`` + ``encrypted_content`` — OpenAI Responses reasoning item (``rs_…``),
+      populated when the request asked for ``include: ["reasoning.encrypted_content"]``.
+      Replayed as a top-level ``{"type": "reasoning", …}`` input item. OpenAI's
+      reasoning models expect these back on every subsequent call of a tool loop;
+      without them the model loses the chain of thought between steps and tool
+      calling degrades (up to emitting tool calls as plain text).
+    """
+
     type: Literal["thinking"] = "thinking"
-    thinking: str 
-    signature: str | None = None # TODO Review openai
+    thinking: str
+    signature: str | None = None
+    id: str | None = None
+    encrypted_content: str | None = None
+
+    @property
+    def is_openai_reasoning_item(self) -> bool:
+        """True when this block can be replayed as an OpenAI Responses ``reasoning`` item."""
+        return bool(self.id and self.encrypted_content)
 
     @override
-    def to_openai_responses_input(self, role: str, **kwargs: Any) -> dict[str, Any]:
-        """See base class."""
+    def to_openai_responses_input(self, role: str, **kwargs: Any) -> dict[str, Any] | None:
+        """See base class.
+
+        Assistant thinking that carries an OpenAI reasoning id + encrypted payload becomes a
+        ``reasoning`` item (the caller places it at the top level of ``input``, not inside a
+        message). Anything else keeps the historical behaviour — the visible text as a text
+        part — except that an empty text part is dropped rather than sent as ``""``.
+        """
+        if role == "assistant" and self.is_openai_reasoning_item:
+            item: dict[str, Any] = {
+                "type": "reasoning",
+                "id": self.id,
+                "encrypted_content": self.encrypted_content,
+                "summary": [{"type": "summary_text", "text": self.thinking}] if self.thinking else [],
+            }
+            return item
+        if not self.thinking:
+            return None
         type = "output_text" if role == "assistant" else "input_text"
-        return {
-            "type": type,
-            "text": self.thinking
-        }
+        return {"type": type, "text": self.thinking}
 
     @override
     def to_openai_chat_completions_input(self, **kwargs: Any) -> None:
@@ -34,10 +67,14 @@ class ThinkingContent(BaseContent):
         return None
 
     @override
-    def to_anthropic_input(self, **kwargs: Any) -> dict[str, Any]:
-        """See base class."""
-        return {
-            "type": "thinking", 
-            "thinking": self.thinking,
-            "signature": self.signature
-        }
+    def to_anthropic_input(self, **kwargs: Any) -> dict[str, Any] | None:
+        """See base class.
+
+        Anthropic verifies replayed thinking against its signature and rejects a block
+        without one. Thinking that came from another provider (an OpenAI reasoning item,
+        raw xAI reasoning text) has no Anthropic signature, so on a cross-provider
+        fallback it is dropped rather than sent as an invalid block.
+        """
+        if not self.signature:
+            return None
+        return {"type": "thinking", "thinking": self.thinking, "signature": self.signature}

--- a/python/timbal/types/content/tool_result.py
+++ b/python/timbal/types/content/tool_result.py
@@ -52,7 +52,7 @@ class ToolResultContent(BaseContent):
         nested: list[dict[str, Any]] = []
         for item in self.content:
             block = item.to_anthropic_input()
-            if block.get("type") == "text" and not block.get("text"):
+            if block is None or (block.get("type") == "text" and not block.get("text")):
                 continue
             nested.append(block)
         return {

--- a/python/timbal/types/message.py
+++ b/python/timbal/types/message.py
@@ -27,7 +27,10 @@ BACKGROUND_TASK_COMPLETED_KIND = "background_task_completed"
 def _append_anthropic_content_blocks(
     target: list[dict[str, Any]], anthropic_input: dict[str, Any] | list[dict[str, Any]]
 ) -> None:
-    """Append Anthropic content blocks, dropping empty text (API rejects text: '')."""
+    """Append Anthropic content blocks, dropping empty text (API rejects text: '') and
+    blocks a content type declined to serialize (``None``)."""
+    if anthropic_input is None:
+        return
     if isinstance(anthropic_input, list):
         for block in anthropic_input:
             _append_anthropic_content_blocks(target, block)
@@ -116,6 +119,17 @@ class Message:
                 item_input = content_item.to_openai_responses_input()
                 if item_input is not None:
                     inputs.append(item_input)
+            elif isinstance(content_item, ThinkingContent):
+                item_input = content_item.to_openai_responses_input(role=self.role)
+                if item_input is None:
+                    continue
+                # An OpenAI reasoning item (`rs_…` + encrypted payload) is a top-level
+                # input item like a function_call, not a part of a `message`. It must
+                # precede the function_call it produced, which content order guarantees.
+                if item_input.get("type") == "reasoning":
+                    inputs.append(item_input)
+                else:
+                    message_content.append(item_input)
             else:
                 item_input = content_item.to_openai_responses_input(role=self.role)
                 if item_input is not None:

--- a/python/timbal/types/message.py
+++ b/python/timbal/types/message.py
@@ -111,13 +111,42 @@ class Message:
         return md is not None and md.get("source") == RUNTIME_SOURCE
 
     def to_openai_responses_input(self) -> list[dict[str, Any]]:
-        """Convert the message to OpenAI's responses api expected input format."""
-        inputs = []
-        message_content = []
+        """Convert the message to OpenAI's responses api expected input format.
+
+        Content order is wire order: a ``message`` item is flushed whenever a top-level
+        item (``reasoning``, ``function_call``, ``function_call_output``) follows it, so
+        an assistant preamble replays *before* the tool call it introduced instead of
+        after every call of the turn. Assistant text also splits into one ``message``
+        per ``phase`` (``commentary`` / ``final_answer``) and carries it — GPT-5.4+
+        read a dropped phase as "this preamble was the final answer".
+        """
+        inputs: list[dict[str, Any]] = []
+        message_content: list[dict[str, Any]] = []
+        message_phase: str | None = None
+
+        def flush() -> None:
+            nonlocal message_content, message_phase
+            if message_content:
+                # Role here should only be 'user' or 'assistant'
+                item: dict[str, Any] = {"role": self.role, "content": message_content}
+                if self.role == "assistant" and message_phase:
+                    item["phase"] = message_phase
+                inputs.append(item)
+            message_content = []
+            message_phase = None
+
+        def add_part(part: dict[str, Any], phase: str | None) -> None:
+            nonlocal message_phase
+            if message_content and phase != message_phase:
+                flush()
+            message_phase = phase
+            message_content.append(part)
+
         for content_item in self.content:
             if isinstance(content_item, ToolUseContent | ToolResultContent):
                 item_input = content_item.to_openai_responses_input()
                 if item_input is not None:
+                    flush()
                     inputs.append(item_input)
             elif isinstance(content_item, ThinkingContent):
                 item_input = content_item.to_openai_responses_input(role=self.role)
@@ -127,16 +156,16 @@ class Message:
                 # input item like a function_call, not a part of a `message`. It must
                 # precede the function_call it produced, which content order guarantees.
                 if item_input.get("type") == "reasoning":
+                    flush()
                     inputs.append(item_input)
                 else:
-                    message_content.append(item_input)
+                    add_part(item_input, None)
             else:
                 item_input = content_item.to_openai_responses_input(role=self.role)
                 if item_input is not None:
-                    message_content.append(item_input)
-        if message_content:
-            # Role here should only be 'user' or 'assistant'
-            inputs.append({"role": self.role, "content": message_content})
+                    phase = getattr(content_item, "phase", None) if self.role == "assistant" else None
+                    add_part(item_input, phase)
+        flush()
         return inputs
 
     def to_openai_chat_completions_input(


### PR DESCRIPTION
## Summary

OpenAI Responses path, GPT-5.x tool loops. Six commits, all defensive: nothing changes for a model that behaves.

1. **`fix(openai): replay reasoning items across Responses tool loops`** — request `include: ["reasoning.encrypted_content"]` for reasoning models, keep `id` + `encrypted_content` on the collected thinking block, replay it as a top-level `reasoning` item ahead of the `function_call` it produced. With `store: false` this is the only way the model keeps its chain of thought between the calls of a tool loop; without it, tool calling degrades with loop depth.
2. **`fix(openai): recover leaked Harmony tool calls; replay assistant phase`** — see below.
3. **`fix(openai): drop assistant text written after a leaked tool call`**
4. **`fix(openai): recover leaked multi_tool_use.parallel wrappers too`**
5. **`fix(agent): re-request a step whose leaked tool call had no arguments`**
6. **`fix(openai): recover bare to=<tool> {json} leaks`**

## The leak

GPT-5.x — every 5.6-family sample we have is `gpt-5.6-luna` — occasionally fails to emit a structured `function_call` item and writes the call's Harmony wire form into a `message` item instead:

```
 to=functions.timbal__get_preview_logs  (json 恒一
{"service":"ui"}ંалда
```

The debris (CJK spam, stray Cyrillic) sits exactly where `<|constrain|>json<|message|>` should be: control tokens decoded as text. Nothing runs; the model then narrates the result it never got. In a recorded sample of 12 deep bootstraps (~35 messages, ~60 input items, 8-way parallel probes) it happened in 3–4 runs, on requests we verified to be well-formed — every prior turn replaying as `reasoning → function_call → function_call_output`, no assistant text in history. It is the model, not the request: the same signature is reported by livekit/agents-js#1632 (gpt-5.4), openclaw#30441 (gpt-5.3-codex), johnib/copilot-api-issues#12 (gpt-5.6-sol) and handled in hermes-agent's `codex_responses_adapter.py`.

We tested Codex's request-side setting for this family, `parallel_tool_calls: false`: on the same 12 runs it went from 3 dumps / 11 passed to **9 dumps / 0 passed** — the model wants batched calls and, denied them structurally, writes the batch as text. Codex only survives it through code-mode `exec`. Not applied.

## What the collector does now (`ResponseCollector`)

- **Hold-back.** A text block is held until its first characters settle prose vs leak (`harmony_leak.leak_state`). Prose is released as one `Text` carrying what accumulated; a leak is never streamed. Normal text is delayed by at most the length of the marker (`to=functions.`).
- **Recover.** In `result()`, a leaked block becomes real `ToolUseContent` (`call_leak_<uuid7>`): name and JSON arguments are intact in every sample. Handles `to=functions.X {json}`, bare `to=X {json}`, and the parallel wrapper `to=multi_tool_use.parallel {"tool_uses":[{"recipient_name":"functions.X","parameters":{…}}]}`. Identical `(name, args)` collapse to one call per response; prose before the first marker is kept; text *after* a leak in the same response (the model's account of work that never ran) is neither streamed nor kept. Next to a structured `function_call`, leaked text is dropped, not duplicated. Counted as `recovered_tool_calls` in usage.
- **Re-request.** A leak whose arguments never arrived (`to=functions.builder (jsonеиҳәеит?` and nothing) has nothing to run and nothing to show. The collector tags the message (`metadata.kind = leaked_tool_call_unrecovered`); the Agent loop drops it (a reasoning item with no following item is rejected on replay), appends a runtime user nudge, and re-requests — `Agent.max_leaked_tool_call_retries` (default 2), same shape as the `output_model` validation retry.

## `phase` and wire order

OpenAI's reasoning guide: *"If you replay assistant history manually, preserve each original `phase` value. Missing or dropped `phase` can cause preambles to be treated as final answers."* We dropped it, and we gathered every text part of a turn into one `message` appended **after** all of the turn's `function_call`s. Now: `TextContent.phase` captured from the message item; `Message.to_openai_responses_input` emits in content order (a message is flushed before any top-level item that follows it) and one assistant `message` per phase, carrying it. Other providers never see `phase`.

## Tests

- `tests/collectors/test_harmony_leak.py` — parser on verbatim samples, all three shapes, brace-balanced JSON, dedupe, prose untouched (`"the functions.search helper"`, `"to=30 seconds"`).
- `tests/collectors/test_openai_collector.py` — hold-back/release/leak on the stream, recovery, text-after-leak suppression, phase capture, encrypted reasoning.
- `tests/types/test_message.py`, `tests/types/content/test_text.py` — phase grouping, wire order, replay of reasoning items.
- `tests/core/llm/test_responses_reasoning_replay.py` — offline Agent loop against scripted SDK events: reasoning replayed across 2- and 3-step loops; a leaked turn runs the tool and the next request carries a real `function_call` + output; a no-arguments leak is re-requested and the loop completes; retry budget bounded.

Full suite green. One behaviour change in an existing test: an empty `content_part.added` no longer emits `Text` immediately — the first decisive delta does (`test_text_message_flow`).

## Field results

Composer bootstrap evals on `gpt-5.6-luna`, same 12 runs, request/response recorded:

| wheel | dumps | passed |
|---|---|---|
| 2.7.13 | 4 | fake summaries, nothing ran |
| + reasoning replay | 3 | 1 empty turn, 2 fake summaries |
| + this PR | 3 | 11/12 — every dump recovered, real summary followed; the miss is unrelated |

## Rollback

`Agent.max_leaked_tool_call_retries=0` disables the re-request. The hold-back and recovery have no switch; they only trigger on `to=<name>` followed by a JSON object, which prose does not produce.
