### PR TITLE
fix(voice): skip dest-box onnx/LiveKit when platform owns media

### DIFF
--- a/python/tests/server/test_livekit_session.py
+++ b/python/tests/server/test_livekit_session.py
@@ -54,19 +54,28 @@ def _reassemble(chunks: list[dict]) -> dict:
 class TestMaybeStart:
     def test_off_when_transport_unset(self, monkeypatch) -> None:
         monkeypatch.delenv("TIMBAL_VOICE_TRANSPORT", raising=False)
+        monkeypatch.delenv("TIMBAL_VOICE_MEDIA_OWNER", raising=False)
         assert maybe_start_livekit_session(SimpleNamespace()) is None
 
     def test_off_when_transport_is_webrtc(self, monkeypatch) -> None:
+        monkeypatch.delenv("TIMBAL_VOICE_MEDIA_OWNER", raising=False)
         monkeypatch.setenv("TIMBAL_VOICE_TRANSPORT", "webrtc")
         assert maybe_start_livekit_session(SimpleNamespace()) is None
 
     async def test_starts_a_task_when_livekit(self, monkeypatch) -> None:
+        monkeypatch.delenv("TIMBAL_VOICE_MEDIA_OWNER", raising=False)
         monkeypatch.setenv("TIMBAL_VOICE_TRANSPORT", "livekit")
         task = maybe_start_livekit_session(SimpleNamespace(state=SimpleNamespace(runnable=None)))
         assert task is not None
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await task
+
+    def test_off_when_platform_owns_media(self, monkeypatch) -> None:
+        """Leftover TIMBAL_VOICE_TRANSPORT=livekit on a headless dest box."""
+        monkeypatch.setenv("TIMBAL_VOICE_TRANSPORT", "livekit")
+        monkeypatch.setenv("TIMBAL_VOICE_MEDIA_OWNER", "platform")
+        assert maybe_start_livekit_session(SimpleNamespace()) is None
 
 
 class TestCallerIdentity:

--- a/python/tests/server/test_voice_config.py
+++ b/python/tests/server/test_voice_config.py
@@ -73,6 +73,28 @@ class TestVoiceWarmupIntended:
         r.voice_config = {"stt_provider": "elevenlabs"}  # even a voice app
         assert voice_routes.voice_warmup_intended(r) is False
 
+    def test_platform_media_owner_skips_warmup(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Headless dest box: sidecar owns media. voice_config must not load onnx."""
+        self._clear_warmup_env(monkeypatch)
+        monkeypatch.setenv("TIMBAL_VOICE_MEDIA_OWNER", "platform")
+        r = self._Runnable()
+        r.voice_config = {"stt_provider": "elevenlabs"}
+        assert voice_routes.voice_warmup_intended(r) is False
+
+    def test_platform_media_owner_beats_warmup_force_on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._clear_warmup_env(monkeypatch)
+        monkeypatch.setenv("TIMBAL_VOICE_MEDIA_OWNER", "platform")
+        monkeypatch.setenv("TIMBAL_VOICE_WARMUP", "1")
+        r = self._Runnable()
+        r.voice_config = {"stt_provider": "elevenlabs"}
+        assert voice_routes.voice_warmup_intended(r) is False
+
+    def test_platform_media_owner_is_not_a_warmup_signal(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Informational owner env must not trip the any(TIMBAL_VOICE_*) heuristic."""
+        self._clear_warmup_env(monkeypatch)
+        monkeypatch.setenv("TIMBAL_VOICE_MEDIA_OWNER", "platform")
+        assert voice_routes.voice_warmup_intended(self._Runnable()) is False
+
 
 class TestVoiceOnnxWarmupIntended:
     """Flux / provider EOU must not pull Smart Turn + Namo + Silero at boot."""

--- a/python/timbal/server/livekit_session.py
+++ b/python/timbal/server/livekit_session.py
@@ -74,7 +74,12 @@ import structlog
 
 from ..voice.config import VoiceConfig
 from .capacity import acquire_session_slot, max_concurrent_sessions, release_session_slot
-from .voice import build_voice_session, event_to_payloads, merge_client_voice_overrides
+from .voice import (
+    build_voice_session,
+    event_to_payloads,
+    merge_client_voice_overrides,
+    voice_media_owned_by_platform,
+)
 
 logger = structlog.get_logger("timbal.server.livekit_session")
 
@@ -215,7 +220,14 @@ def _sessions(app: Any) -> dict[str, asyncio.Task]:
 
 
 def maybe_start_livekit_session(app: Any) -> asyncio.Task | None:
-    """Lifespan hook: start the dial-out driver when the transport is LiveKit."""
+    """Lifespan hook: start the dial-out driver when the transport is LiveKit.
+
+    No-op when ``TIMBAL_VOICE_MEDIA_OWNER=platform``: STT/TTS run in the
+    sidecar and this process is headless ``/stream``. A leftover ProjectVar
+    ``TIMBAL_VOICE_TRANSPORT=livekit`` must not join a room from here.
+    """
+    if voice_media_owned_by_platform():
+        return None
     if os.environ.get("TIMBAL_VOICE_TRANSPORT", "").strip().lower() != "livekit":
         return None
     return asyncio.create_task(_run_livekit_session(app), name="voice-livekit-session")

--- a/python/timbal/server/voice.py
+++ b/python/timbal/server/voice.py
@@ -438,6 +438,11 @@ def client_parent_run_id(config: dict[str, Any]) -> str | None:
     return raw.strip()
 
 
+def voice_media_owned_by_platform() -> bool:
+    """Sidecar owns STT/TTS/VAD; this process is headless ``/stream`` only."""
+    return os.environ.get("TIMBAL_VOICE_MEDIA_OWNER", "").strip().lower() == "platform"
+
+
 def voice_warmup_intended(runnable: Any) -> bool:
     """Whether server boot should pre-import the voice stack and pre-load ONNX models.
 
@@ -448,13 +453,21 @@ def voice_warmup_intended(runnable: Any) -> bool:
 
     Policy, in order:
 
-    1. ``TIMBAL_VOICE_WARMUP`` env: truthy forces warmup (the playground
+    1. ``TIMBAL_VOICE_MEDIA_OWNER=platform``: never. Media is the sidecar;
+       loading onnxruntime here is the dest-box SIGSEGV inside bwrap.
+       Beats ``TIMBAL_VOICE_WARMUP=1`` — a leftover playground/ProjectVar
+       must not turn a headless box back into a media process.
+    2. ``TIMBAL_VOICE_WARMUP`` env: truthy forces warmup (the playground
        launcher sets this for its child servers), falsy disables it.
-    2. The runnable declares ``voice_config`` — clearly a voice app.
-    3. Any ``TIMBAL_VOICE_*`` / ``ELEVENLABS_VOICE_ID`` env is set — the
-       deployment is voice-configured even if the runnable isn't.
-    4. Otherwise: no warmup.
+    3. The runnable declares ``voice_config`` — clearly a voice app.
+    4. Any *other* ``TIMBAL_VOICE_*`` / ``ELEVENLABS_VOICE_ID`` env is set —
+       the deployment is voice-configured even if the runnable isn't.
+       ``TIMBAL_VOICE_WARMUP`` and ``TIMBAL_VOICE_MEDIA_OWNER`` themselves
+       are not media-intent (they are this function's inputs).
+    5. Otherwise: no warmup.
     """
+    if voice_media_owned_by_platform():
+        return False
     override = os.environ.get("TIMBAL_VOICE_WARMUP", "").strip().lower()
     if override in _TRUTHY:
         return True
@@ -464,7 +477,10 @@ def voice_warmup_intended(runnable: Any) -> bool:
         return True
     if os.environ.get("ELEVENLABS_VOICE_ID"):
         return True
-    return any(k.startswith("TIMBAL_VOICE_") for k in os.environ)
+    return any(
+        k.startswith("TIMBAL_VOICE_") and k not in ("TIMBAL_VOICE_WARMUP", "TIMBAL_VOICE_MEDIA_OWNER")
+        for k in os.environ
+    )
 
 
 def voice_onnx_warmup_intended(voice_config: VoiceConfig) -> bool:


### PR DESCRIPTION
## Summary
- `TIMBAL_VOICE_MEDIA_OWNER=platform` now skips voice warmup (onnx/Silero/Smart Turn), even when the runnable has `voice_config` or `TIMBAL_VOICE_WARMUP=1`.
- `maybe_start_livekit_session` is a no-op under the same flag, so leftover `TIMBAL_VOICE_TRANSPORT=livekit` ProjectVars cannot join a room from a headless `/stream` box.
- `TIMBAL_VOICE_MEDIA_OWNER` / `TIMBAL_VOICE_WARMUP` are no longer treated as warmup-intent by the `any(TIMBAL_VOICE_*)` heuristic.

Dest boxes under platform-owned media only serve `/stream`. STT/TTS/VAD run in the sidecar. Without this, a voice Agent still imported onnxruntime at boot (SIGSEGV inside bwrap).

Does not help already-pinned customer venvs until they bump. Monolith already sets `TIMBAL_VOICE_WARMUP=0` as the old-pin backstop.

## Test plan
- [x] `PYTHONPATH=python python -m pytest python/tests/server/test_voice_config.py::TestVoiceWarmupIntended python/tests/server/test_livekit_session.py::TestMaybeStart`
- [ ] After pin: dest box with `TIMBAL_VOICE_MEDIA_OWNER=platform` does not log `voice_models_warmed` / import onnx
- [ ] After pin: dest box with leftover `TIMBAL_VOICE_TRANSPORT=livekit` does not join the LiveKit room