### PR TITLE
feat(server/telephony): public Media Streams bridge for embedding hosts

### DIFF
--- a/python/tests/server/test_voice_telephony.py
+++ b/python/tests/server/test_voice_telephony.py
@@ -13,6 +13,7 @@ import asyncio
 import base64
 import hashlib
 import hmac
+import json
 from collections.abc import AsyncIterator
 from pathlib import Path
 
@@ -565,24 +566,27 @@ class TestEmbeddedBridge:
     def test_host_supplies_defaults_and_observes_the_session(self, monkeypatch, tmp_path) -> None:
         pytest.importorskip("av")
         from timbal.server import telephony as tel
-        from timbal.voice.config import VoiceConfig
+        from timbal.voice.config import RecordingConfig, VoiceConfig
 
         stt_cls = _make_stt_class([TranscriptEvent(type="committed", text="Hello")])
         # Same adapter mocks; the app under test is NOT timbal.server — it is
         # a host that never sets ``app.state.voice_config``.
         runnable = _host_runnable(monkeypatch, tmp_path, stt_cls, _make_tts_class(_TTS_CHUNK))
         seen: dict = {}
+        rec_dir = tmp_path / "recordings"
 
         host = FastAPI()
 
         @host.websocket("/media/{provider}")
         async def media(ws: WebSocket, provider: str) -> None:
             await ws.accept()
-            defaults = VoiceConfig(language="es")
+            defaults = VoiceConfig(language="es", recording=RecordingConfig(dir=str(rec_dir)))
 
             def observe(session, meta):
                 seen["session"] = session
                 seen["meta_keys"] = set(meta)
+                seen["generated_id"] = session.session_id
+                seen["meta_session_id_before"] = meta.get("session_id")
                 session.session_id = "platform-0001"
                 meta["org_id"] = "781"
                 meta["transport"] = f"{provider}-via-host"
@@ -598,14 +602,22 @@ class TestEmbeddedBridge:
 
         assert [f for f in frames if f["event"] == "media"], "bridge produced no downlink"
         session = seen["session"]
-        assert session.session_id == "platform-0001"
+        assert seen["generated_id"] and seen["generated_id"] != "platform-0001"
+        assert seen["meta_session_id_before"] == seen["generated_id"]
+        assert session.session_id == session.recording_meta["session_id"] == "platform-0001"
         # The observer saw the final meta and its edits landed on the session.
         assert {"transport", "call_id", "from", "to"} <= seen["meta_keys"]
         assert session.recording_meta["org_id"] == "781"
         assert session.recording_meta["transport"] == "telnyx-via-host"
         assert session.recording_meta["from"] == "+13120000001"
-        # The host's config was the one built from, not a box default.
-        assert session.recording_meta.get("language", "es") == "es"
+        # Host VoiceConfig actually reached the session (language is never in
+        # recording_meta — a `.get("language", "es")` would always pass).
+        assert session.audio_input.language == "es"
+        # Recorder opened under the generated id, then followed the pin.
+        assert (rec_dir / "platform-0001.mp3").exists()
+        assert list(rec_dir.glob("*.mp3")) == [rec_dir / "platform-0001.mp3"]
+        manifest = json.loads((rec_dir / "platform-0001.json").read_text())
+        assert manifest["session_id"] == "platform-0001"
 
     def test_a_failing_observer_never_ends_the_call(self, monkeypatch, tmp_path) -> None:
         pytest.importorskip("av")

--- a/python/tests/server/test_voice_telephony.py
+++ b/python/tests/server/test_voice_telephony.py
@@ -146,7 +146,7 @@ def _setup_app(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, stt_cls, tts_cls
     return create_app()
 
 
-def _host_runnable(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, stt_cls, tts_cls):
+def _host_runnable(monkeypatch: pytest.MonkeyPatch, stt_cls, tts_cls):
     """An Agent for a host that is not ``timbal.server`` (no lifespan, no
     ``TIMBAL_RUNNABLE``), with the same adapter mocks as ``_setup_app``."""
     from timbal import Agent
@@ -156,7 +156,6 @@ def _host_runnable(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, stt_cls, tts
         monkeypatch.delenv(k, raising=False)
     monkeypatch.setattr("timbal.voice.elevenlabs.ElevenLabsRealtimeSTT", stt_cls)
     monkeypatch.setattr("timbal.voice.elevenlabs.ElevenLabsStreamTTS", tts_cls)
-    del tmp_path
     return Agent(name="phone_host", model=TestModel(responses=["Hi there!"]), tools=[])
 
 
@@ -571,7 +570,7 @@ class TestEmbeddedBridge:
         stt_cls = _make_stt_class([TranscriptEvent(type="committed", text="Hello")])
         # Same adapter mocks; the app under test is NOT timbal.server — it is
         # a host that never sets ``app.state.voice_config``.
-        runnable = _host_runnable(monkeypatch, tmp_path, stt_cls, _make_tts_class(_TTS_CHUNK))
+        runnable = _host_runnable(monkeypatch, stt_cls, _make_tts_class(_TTS_CHUNK))
         seen: dict = {}
         rec_dir = tmp_path / "recordings"
 
@@ -582,7 +581,9 @@ class TestEmbeddedBridge:
             await ws.accept()
             defaults = VoiceConfig(language="es", recording=RecordingConfig(dir=str(rec_dir)))
 
-            def observe(session, meta):
+            # Async observer: a sidecar resolves tenant identity with I/O.
+            async def observe(session, meta):
+                await asyncio.sleep(0)
                 seen["session"] = session
                 seen["meta_keys"] = set(meta)
                 seen["generated_id"] = session.session_id
@@ -619,12 +620,50 @@ class TestEmbeddedBridge:
         manifest = json.loads((rec_dir / "platform-0001.json").read_text())
         assert manifest["session_id"] == "platform-0001"
 
-    def test_a_failing_observer_never_ends_the_call(self, monkeypatch, tmp_path) -> None:
+    def test_a_refused_pin_keeps_the_generated_id_everywhere(self, monkeypatch, tmp_path) -> None:
+        """A pin the recorder cannot carry onto the file must not split the id
+        across the session, the manifest and the file: it is refused (the
+        hook's error is logged) and the generated uuid7 stays in force."""
+        pytest.importorskip("av")
+        from timbal.server import telephony as tel
+        from timbal.voice.config import RecordingConfig, VoiceConfig
+
+        stt_cls = _make_stt_class([TranscriptEvent(type="committed", text="Hello")])
+        runnable = _host_runnable(monkeypatch, stt_cls, _make_tts_class(_TTS_CHUNK))
+        seen: dict = {}
+        rec_dir = tmp_path / "recordings"
+        host = FastAPI()
+
+        @host.websocket("/media")
+        async def media(ws: WebSocket) -> None:
+            await ws.accept()
+            defaults = VoiceConfig(recording=RecordingConfig(dir=str(rec_dir)))
+
+            def pin_badly(session, meta):  # noqa: ARG001 - the hook shape
+                seen["session"] = session
+                session.session_id = "../escape"
+
+            await tel.serve_media_ws(ws, runnable, tel.TWILIO, defaults=defaults, on_session_built=pin_badly)
+
+        with TestClient(host) as client, client.websocket_connect("/media") as ws:
+            ws.send_json(_twilio_start_frame())
+            frames = _collect_frames(ws)
+
+        assert [f for f in frames if f["event"] == "media"], "bridge produced no downlink"
+        session = seen["session"]
+        generated = session.session_id
+        assert generated != "../escape"
+        assert session.recording_meta["session_id"] == generated
+        assert [p.name for p in sorted(rec_dir.iterdir())] == [f"{generated}.json", f"{generated}.mp3"]
+        manifest = json.loads((rec_dir / f"{generated}.json").read_text())
+        assert manifest["session_id"] == generated
+
+    def test_a_failing_observer_never_ends_the_call(self, monkeypatch) -> None:
         pytest.importorskip("av")
         from timbal.server import telephony as tel
 
         stt_cls = _make_stt_class([TranscriptEvent(type="committed", text="Hello")])
-        runnable = _host_runnable(monkeypatch, tmp_path, stt_cls, _make_tts_class(_TTS_CHUNK))
+        runnable = _host_runnable(monkeypatch, stt_cls, _make_tts_class(_TTS_CHUNK))
         host = FastAPI()
 
         @host.websocket("/media")

--- a/python/tests/server/test_voice_telephony.py
+++ b/python/tests/server/test_voice_telephony.py
@@ -17,6 +17,7 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 
 import pytest
+from fastapi import FastAPI, WebSocket
 from fastapi.testclient import TestClient
 from timbal.server.http import create_app
 from timbal.voice import (
@@ -142,6 +143,20 @@ def _setup_app(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, stt_cls, tts_cls
     monkeypatch.setattr("timbal.voice.elevenlabs.ElevenLabsRealtimeSTT", stt_cls)
     monkeypatch.setattr("timbal.voice.elevenlabs.ElevenLabsStreamTTS", tts_cls)
     return create_app()
+
+
+def _host_runnable(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, stt_cls, tts_cls):
+    """An Agent for a host that is not ``timbal.server`` (no lifespan, no
+    ``TIMBAL_RUNNABLE``), with the same adapter mocks as ``_setup_app``."""
+    from timbal import Agent
+    from timbal.core.test_model import TestModel
+
+    for k in VOICE_ENV_KEYS:
+        monkeypatch.delenv(k, raising=False)
+    monkeypatch.setattr("timbal.voice.elevenlabs.ElevenLabsRealtimeSTT", stt_cls)
+    monkeypatch.setattr("timbal.voice.elevenlabs.ElevenLabsStreamTTS", tts_cls)
+    del tmp_path
+    return Agent(name="phone_host", model=TestModel(responses=["Hi there!"]), tools=[])
 
 
 def _collect_frames(ws) -> list[dict]:
@@ -526,6 +541,93 @@ class TestUlawWire:
         # Resampler ramps in, but the steady-state must sit near 16000.
         steady = values[len(values) // 2 :]
         assert sum(steady) / len(steady) > 10_000
+
+
+class TestEmbeddedBridge:
+    """``serve_media_ws`` as a library: a host that owns the socket and the
+    runnable (a platform media sidecar) runs the same bridge with its own
+    ``VoiceConfig`` and an ``on_session_built`` observer."""
+
+    def test_public_names_and_aliases(self) -> None:
+        from timbal.server import telephony as tel
+
+        assert tel.dialect_for("twilio") is tel.TWILIO
+        assert tel.dialect_for(" Telnyx ") is tel.TELNYX
+        with pytest.raises(KeyError):
+            tel.dialect_for("vonage")
+        assert isinstance(tel.TWILIO, tel.TwilioDialect)
+        assert isinstance(tel.TELNYX, tel.TelnyxDialect)
+        # Pre-2.7.17 spellings still resolve to the same objects.
+        assert tel._TWILIO is tel.TWILIO and tel._TELNYX is tel.TELNYX
+        assert tel._TwilioDialect is tel.TwilioDialect
+        assert tel._serve_media_ws is tel.serve_media_ws
+
+    def test_host_supplies_defaults_and_observes_the_session(self, monkeypatch, tmp_path) -> None:
+        pytest.importorskip("av")
+        from timbal.server import telephony as tel
+        from timbal.voice.config import VoiceConfig
+
+        stt_cls = _make_stt_class([TranscriptEvent(type="committed", text="Hello")])
+        # Same adapter mocks; the app under test is NOT timbal.server — it is
+        # a host that never sets ``app.state.voice_config``.
+        runnable = _host_runnable(monkeypatch, tmp_path, stt_cls, _make_tts_class(_TTS_CHUNK))
+        seen: dict = {}
+
+        host = FastAPI()
+
+        @host.websocket("/media/{provider}")
+        async def media(ws: WebSocket, provider: str) -> None:
+            await ws.accept()
+            defaults = VoiceConfig(language="es")
+
+            def observe(session, meta):
+                seen["session"] = session
+                seen["meta_keys"] = set(meta)
+                session.session_id = "platform-0001"
+                meta["org_id"] = "781"
+                meta["transport"] = f"{provider}-via-host"
+
+            await tel.serve_media_ws(
+                ws, runnable, tel.dialect_for(provider), defaults=defaults, on_session_built=observe
+            )
+
+        with TestClient(host) as client, client.websocket_connect("/media/telnyx") as ws:
+            ws.send_json({"event": "connected"})
+            ws.send_json(_telnyx_start_frame())
+            frames = _collect_frames(ws)
+
+        assert [f for f in frames if f["event"] == "media"], "bridge produced no downlink"
+        session = seen["session"]
+        assert session.session_id == "platform-0001"
+        # The observer saw the final meta and its edits landed on the session.
+        assert {"transport", "call_id", "from", "to"} <= seen["meta_keys"]
+        assert session.recording_meta["org_id"] == "781"
+        assert session.recording_meta["transport"] == "telnyx-via-host"
+        assert session.recording_meta["from"] == "+13120000001"
+        # The host's config was the one built from, not a box default.
+        assert session.recording_meta.get("language", "es") == "es"
+
+    def test_a_failing_observer_never_ends_the_call(self, monkeypatch, tmp_path) -> None:
+        pytest.importorskip("av")
+        from timbal.server import telephony as tel
+
+        stt_cls = _make_stt_class([TranscriptEvent(type="committed", text="Hello")])
+        runnable = _host_runnable(monkeypatch, tmp_path, stt_cls, _make_tts_class(_TTS_CHUNK))
+        host = FastAPI()
+
+        @host.websocket("/media")
+        async def media(ws: WebSocket) -> None:
+            await ws.accept()
+
+            def boom(session, meta):  # noqa: ARG001 - the hook shape, deliberately failing
+                raise RuntimeError("observer bug")
+
+            await tel.serve_media_ws(ws, runnable, tel.TWILIO, on_session_built=boom)
+
+        with TestClient(host) as client, client.websocket_connect("/media") as ws:
+            ws.send_json(_twilio_start_frame())
+            frames = _collect_frames(ws)
+        assert [f for f in frames if f["event"] == "media"]
 
 
 class TestCallContext:

--- a/python/tests/voice/test_recording.py
+++ b/python/tests/voice/test_recording.py
@@ -162,6 +162,24 @@ class TestRobustness:
         with pytest.raises(ValueError, match="layout"):
             CallRecorder(tmp_path / "call.mp3", layout="both")  # type: ignore[arg-type]
 
+    def test_retarget_renames_output_before_any_samples(self, tmp_path: Path) -> None:
+        old = tmp_path / "generated.mp3"
+        rec = CallRecorder(old, sample_rate=SR)
+        rec.retarget(tmp_path / "pinned.mp3")
+        rec.add_mic(_silence(0.1))
+        result = rec.close()
+        assert result is not None
+        assert result.audio_path == tmp_path / "pinned.mp3"
+        assert (tmp_path / "pinned.mp3").exists()
+        assert not old.exists()
+
+    def test_retarget_after_samples_raises(self, tmp_path: Path) -> None:
+        rec = CallRecorder(tmp_path / "a.mp3", sample_rate=SR)
+        rec.add_mic(_silence(0.1))
+        with pytest.raises(RuntimeError, match="after audio"):
+            rec.retarget(tmp_path / "b.mp3")
+        rec.close()
+
 
 class TestSessionIntegration:
     async def test_session_writes_recording_manifest_and_fires_on_saved(self, tmp_path: Path) -> None:

--- a/python/tests/voice/test_recording.py
+++ b/python/tests/voice/test_recording.py
@@ -180,6 +180,70 @@ class TestRobustness:
             rec.retarget(tmp_path / "b.mp3")
         rec.close()
 
+    def test_retarget_failed_open_leaves_recorder_untouched(self, tmp_path: Path, monkeypatch) -> None:
+        """A failed reopen must not strand the recorder at a path that was never
+        created while it keeps encoding into a closed container."""
+        old = tmp_path / "generated.mp3"
+        rec = CallRecorder(old, sample_rate=SR)
+
+        def boom(*_a, **_k):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(av, "open", boom)
+        with pytest.raises(OSError, match="disk full"):
+            rec.retarget(tmp_path / "pinned.mp3")
+        monkeypatch.undo()
+
+        assert rec.audio_path == old
+        rec.add_mic(_silence(0.1))
+        result = rec.close(manifest={"session_id": "generated"})
+        assert result is not None
+        assert result.audio_path == old
+        assert sorted(p.name for p in tmp_path.iterdir()) == ["generated.json", "generated.mp3"]
+
+    async def test_session_id_setter_pins_recorder_and_refuses_bad_ids(self, tmp_path: Path) -> None:
+        from timbal import Agent
+        from timbal.core.test_model import TestModel
+        from timbal.voice import VoiceSession
+
+        from .test_session import DelayedMockSTT, MockTTS
+
+        def _session(rec):
+            return VoiceSession(
+                agent=Agent(name="rec", model=TestModel(responses=["x"]), tools=[]),
+                stt=DelayedMockSTT(),
+                tts=MockTTS(chunk=b"\x00\x00", num_chunks=1),
+                recorder=rec,
+                session_id="generated",
+                turn_detector="heuristic",
+            )
+
+        rec = CallRecorder(tmp_path / "generated.mp3", sample_rate=SR)
+        session = _session(rec)
+        session.session_id = "platform-0001"
+        assert session.session_id == "platform-0001"
+        assert rec.audio_path == tmp_path / "platform-0001.mp3"
+
+        # Refused pins leave both the id and the file alone.
+        for bad in ("", "a/b", "../x", "x" * 129, "with space"):
+            with pytest.raises(ValueError, match="session_id"):
+                session.session_id = bad
+        assert session.session_id == "platform-0001"
+        assert rec.audio_path == tmp_path / "platform-0001.mp3"
+
+        # After audio the pin cannot be carried onto the file → refused, not split.
+        rec.add_mic(_silence(0.1))
+        with pytest.raises(RuntimeError, match="after audio"):
+            session.session_id = "platform-0002"
+        assert session.session_id == "platform-0001"
+        assert rec.audio_path.stem == "platform-0001"
+        rec.close()
+
+        # No recorder: the id is just a string.
+        free = _session(None)
+        free.session_id = "no-recorder"
+        assert free.session_id == "no-recorder"
+
 
 class TestSessionIntegration:
     async def test_session_writes_recording_manifest_and_fires_on_saved(self, tmp_path: Path) -> None:

--- a/python/tests/voice/test_recording.py
+++ b/python/tests/voice/test_recording.py
@@ -201,6 +201,61 @@ class TestRobustness:
         assert result.audio_path == old
         assert sorted(p.name for p in tmp_path.iterdir()) == ["generated.json", "generated.mp3"]
 
+    def test_retarget_old_file_cleanup_failure_does_not_undo_the_swap(self, tmp_path: Path, monkeypatch) -> None:
+        """Once the new encoder is open the swap is committed: a failing unlink
+        of the old file is logged, not raised — a raise here would leave the
+        caller's id on the generated name while the file is on the pinned one."""
+        old = tmp_path / "generated.mp3"
+        rec = CallRecorder(old, sample_rate=SR)
+
+        real_unlink = Path.unlink
+
+        def deny(self: Path, *a, **k):
+            if self == old:
+                raise PermissionError("held open")
+            return real_unlink(self, *a, **k)
+
+        monkeypatch.setattr(Path, "unlink", deny)
+        rec.retarget(tmp_path / "pinned.mp3")  # must not raise
+        monkeypatch.undo()
+
+        assert rec.audio_path == tmp_path / "pinned.mp3"
+        rec.add_mic(_silence(0.1))
+        result = rec.close(manifest={"session_id": "pinned"})
+        assert result is not None
+        assert result.audio_path == tmp_path / "pinned.mp3"
+        assert (tmp_path / "pinned.json").exists()
+
+    async def test_session_id_pin_survives_old_file_cleanup_failure(self, tmp_path: Path, monkeypatch) -> None:
+        from timbal import Agent
+        from timbal.core.test_model import TestModel
+        from timbal.voice import VoiceSession
+
+        from .test_session import DelayedMockSTT, MockTTS
+
+        old = tmp_path / "generated.mp3"
+        rec = CallRecorder(old, sample_rate=SR)
+        session = VoiceSession(
+            agent=Agent(name="rec", model=TestModel(responses=["x"]), tools=[]),
+            stt=DelayedMockSTT(),
+            tts=MockTTS(chunk=b"\x00\x00", num_chunks=1),
+            recorder=rec,
+            session_id="generated",
+            turn_detector="heuristic",
+        )
+        real_unlink = Path.unlink
+        monkeypatch.setattr(
+            Path,
+            "unlink",
+            lambda self, *a, **k: (_ for _ in ()).throw(PermissionError("held")) if self == old else real_unlink(self, *a, **k),
+        )
+        session.session_id = "platform-0001"
+        monkeypatch.undo()
+        # Identity is one string across the session and the file.
+        assert session.session_id == "platform-0001"
+        assert rec.audio_path.stem == "platform-0001"
+        rec.close()
+
     async def test_session_id_setter_pins_recorder_and_refuses_bad_ids(self, tmp_path: Path) -> None:
         from timbal import Agent
         from timbal.core.test_model import TestModel

--- a/python/timbal/server/telephony.py
+++ b/python/timbal/server/telephony.py
@@ -12,6 +12,12 @@ Routes (per provider ``{p}`` in ``twilio`` | ``telnyx``):
   TwiML/TeXML that connects the call to the media WebSocket below.
 - ``WS /voice/{p}/stream`` — the bidirectional media stream.
 
+Embedding the bridge elsewhere: :func:`serve_media_ws` (with
+:func:`dialect_for` / :data:`TWILIO` / :data:`TELNYX`) runs one call against
+a caller-supplied runnable and :class:`VoiceConfig`, with an
+``on_session_built`` seam — for a process that terminates the carrier
+socket for many tenants and owns the media on their behalf.
+
 The two providers speak near-identical protocols with different spellings
 (Twilio camelCase / ``streamSid``; Telnyx snake_case / ``stream_id``), so one
 handler runs both via a small dialect table.
@@ -31,6 +37,7 @@ import hmac
 import json
 import os
 import time
+from collections.abc import Callable
 from contextlib import aclosing
 from typing import Any
 from urllib.parse import parse_qsl
@@ -95,7 +102,7 @@ _MIN_MEDIA_BYTES = 160  # 20ms of mulaw @ 8kHz
 # ---------------------------------------------------------------------------
 
 
-class _TwilioDialect:
+class TwilioDialect:
     """Twilio Media Streams: camelCase frames keyed by ``streamSid``."""
 
     name = "twilio"
@@ -142,7 +149,7 @@ class _TwilioDialect:
         return {"event": "clear", "streamSid": stream_id}
 
 
-class _TelnyxDialect:
+class TelnyxDialect:
     """Telnyx bidirectional streaming: snake_case frames keyed by ``stream_id``.
 
     Client → Telnyx frames carry no stream id (one stream per socket).
@@ -190,8 +197,25 @@ class _TelnyxDialect:
         return {"event": "clear"}
 
 
-_TWILIO = _TwilioDialect()
-_TELNYX = _TelnyxDialect()
+TWILIO = TwilioDialect()
+TELNYX = TelnyxDialect()
+
+#: Provider name → dialect. Public so a platform that terminates the carrier
+#: socket elsewhere (and only knows the provider by name) can pick one.
+DIALECTS: dict[str, Any] = {TWILIO.name: TWILIO, TELNYX.name: TELNYX}
+
+
+def dialect_for(provider: str) -> Any:
+    """The dialect for ``"twilio"`` / ``"telnyx"``; ``KeyError`` otherwise."""
+    return DIALECTS[provider.strip().lower()]
+
+
+# Pre-2.7.17 spellings. Same objects; kept so out-of-tree callers that
+# reached for the underscored names keep working.
+_TwilioDialect = TwilioDialect
+_TelnyxDialect = TelnyxDialect
+_TWILIO = TWILIO
+_TELNYX = TELNYX
 
 
 # ---------------------------------------------------------------------------
@@ -358,12 +382,12 @@ async def telnyx_incoming(request: Request) -> Response:
 
 @router.websocket("/twilio/stream")
 async def twilio_stream(ws: WebSocket) -> None:
-    await _media_ws(ws, _TWILIO)
+    await _media_ws(ws, TWILIO)
 
 
 @router.websocket("/telnyx/stream")
 async def telnyx_stream(ws: WebSocket) -> None:
-    await _media_ws(ws, _TELNYX)
+    await _media_ws(ws, TELNYX)
 
 
 async def _media_ws(ws: WebSocket, dialect: Any) -> None:
@@ -390,7 +414,7 @@ async def _media_ws(ws: WebSocket, dialect: Any) -> None:
     guard = getattr(ws.app.state, "single_session_guard", None)
     if guard is None:
         try:
-            await _serve_media_ws(ws, runnable, dialect)
+            await serve_media_ws(ws, runnable, dialect)
         finally:
             release_session_slot()
         return
@@ -402,7 +426,7 @@ async def _media_ws(ws: WebSocket, dialect: Any) -> None:
         return
     guard.mark_connected()
     try:
-        await _serve_media_ws(ws, runnable, dialect)
+        await serve_media_ws(ws, runnable, dialect)
     finally:
         release_session_slot()
         await guard.finish()
@@ -416,8 +440,31 @@ async def _safe_close(ws: WebSocket, code: int, reason: str) -> None:
         pass
 
 
-async def _serve_media_ws(ws: WebSocket, runnable: Any, dialect: Any) -> None:
-    """One phone call: start frame → session → μ-law media both ways, until stop."""
+async def serve_media_ws(
+    ws: WebSocket,
+    runnable: Any,
+    dialect: Any,
+    *,
+    defaults: VoiceConfig | None = None,
+    on_session_built: Callable[[Any, dict[str, Any]], None] | None = None,
+) -> None:
+    """One phone call: start frame → session → μ-law media both ways, until stop.
+
+    Public so a process that terminates the carrier socket for many tenants
+    (a platform media sidecar) can run the bridge itself:
+
+    - ``ws`` must already be accepted. Capacity / single-session gating is
+      the caller's job (this server does it in ``_media_ws``).
+    - ``defaults`` is the :class:`VoiceConfig` the session is built from.
+      ``None`` reads ``ws.app.state.voice_config`` — the one-agent-per-box
+      layout — so existing callers are unchanged.
+    - ``on_session_built(session, meta)`` runs once the :class:`VoiceSession`
+      exists and before it runs, with the *final* ``meta`` (``transport``,
+      ``call_id``, ``from``, ``to`` plus the build's). Mutate ``meta`` in
+      place to shape what lands on ``session.recording_meta``; set
+      ``session.session_id`` to pin your own identity. Exceptions are logged
+      and ignored — an observer must never end a call.
+    """
     try:
         from ..voice import AgentTextDone, AudioOutput, FillerSpoken, SessionEnded, TurnMetricsEvent
         from ..voice.telephony import (
@@ -478,7 +525,8 @@ async def _serve_media_ws(ws: WebSocket, runnable: Any, dialect: Any) -> None:
     client_config = {k: v for k, v in custom.items() if k in _CONFIG_PARAM_KEYS and isinstance(v, str) and v}
     call_context = _call_context_from_start(info, custom)
 
-    defaults: VoiceConfig = getattr(ws.app.state, "voice_config", None) or VoiceConfig()
+    if defaults is None:
+        defaults = getattr(ws.app.state, "voice_config", None) or VoiceConfig()
     session_rate = int(merge_client_voice_overrides(defaults, client_config).sample_rate)
 
     audio_queue: asyncio.Queue[bytes] = asyncio.Queue()
@@ -529,6 +577,11 @@ async def _serve_media_ws(ws: WebSocket, runnable: Any, dialect: Any) -> None:
         "to": info.get("to"),
         **meta,
     }
+    if on_session_built is not None:
+        try:
+            on_session_built(session, meta)
+        except Exception as e:  # noqa: BLE001 - an observer must never end a call
+            logger.error("telephony_session_hook_failed", provider=dialect.name, error=str(e), exc_info=True)
     session.recording_meta = meta
 
     up_resampler = PcmResampler(line_rate, session_rate) if line_rate != session_rate else None
@@ -648,3 +701,7 @@ async def _serve_media_ws(ws: WebSocket, runnable: Any, dialect: Any) -> None:
         except Exception:
             pass
         logger.info("telephony_ws_disconnected", provider=dialect.name)
+
+
+# Pre-2.7.17 spelling; same coroutine.
+_serve_media_ws = serve_media_ws

--- a/python/timbal/server/telephony.py
+++ b/python/timbal/server/telephony.py
@@ -34,10 +34,11 @@ import asyncio
 import base64
 import hashlib
 import hmac
+import inspect
 import json
 import os
 import time
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from contextlib import aclosing
 from typing import Any
 from urllib.parse import parse_qsl
@@ -50,6 +51,17 @@ from ..voice.config import VoiceConfig
 from .capacity import acquire_session_slot, release_session_slot
 
 logger = structlog.get_logger("timbal.server.telephony")
+
+__all__ = [
+    "DIALECTS",
+    "TELNYX",
+    "TWILIO",
+    "TelnyxDialect",
+    "TwilioDialect",
+    "dialect_for",
+    "router",
+    "serve_media_ws",
+]
 
 router = APIRouter(prefix="/voice", tags=["telephony"])
 
@@ -200,12 +212,14 @@ class TelnyxDialect:
 TWILIO = TwilioDialect()
 TELNYX = TelnyxDialect()
 
+Dialect = TwilioDialect | TelnyxDialect
+
 #: Provider name → dialect. Public so a platform that terminates the carrier
 #: socket elsewhere (and only knows the provider by name) can pick one.
-DIALECTS: dict[str, Any] = {TWILIO.name: TWILIO, TELNYX.name: TELNYX}
+DIALECTS: dict[str, Dialect] = {TWILIO.name: TWILIO, TELNYX.name: TELNYX}
 
 
-def dialect_for(provider: str) -> Any:
+def dialect_for(provider: str) -> Dialect:
     """The dialect for ``"twilio"`` / ``"telnyx"``; ``KeyError`` otherwise."""
     return DIALECTS[provider.strip().lower()]
 
@@ -390,7 +404,7 @@ async def telnyx_stream(ws: WebSocket) -> None:
     await _media_ws(ws, TELNYX)
 
 
-async def _media_ws(ws: WebSocket, dialect: Any) -> None:
+async def _media_ws(ws: WebSocket, dialect: Dialect) -> None:
     from ..core.agent import Agent
 
     await ws.accept()
@@ -443,28 +457,38 @@ async def _safe_close(ws: WebSocket, code: int, reason: str) -> None:
 async def serve_media_ws(
     ws: WebSocket,
     runnable: Any,
-    dialect: Any,
+    dialect: Dialect,
     *,
     defaults: VoiceConfig | None = None,
-    on_session_built: Callable[[Any, dict[str, Any]], None] | None = None,
+    on_session_built: Callable[[Any, dict[str, Any]], Awaitable[None] | None] | None = None,
 ) -> None:
     """One phone call: start frame → session → μ-law media both ways, until stop.
 
     Public so a process that terminates the carrier socket for many tenants
     (a platform media sidecar) can run the bridge itself:
 
-    - ``ws`` must already be accepted. Capacity / single-session gating is
-      the caller's job (this server does it in ``_media_ws``).
+    - ``ws`` must already be accepted. Capacity / single-session gating and
+      the "runnable is an :class:`~timbal.core.agent.Agent`" check are the
+      caller's job (this server does both in ``_media_ws``).
     - ``defaults`` is the :class:`VoiceConfig` the session is built from.
       ``None`` reads ``ws.app.state.voice_config`` — the one-agent-per-box
       layout — so existing callers are unchanged.
-    - ``on_session_built(session, meta)`` runs once the :class:`VoiceSession`
-      exists and before it runs, with the *final* ``meta`` (``transport``,
-      ``call_id``, ``from``, ``to`` plus the build's). Mutate ``meta`` in
-      place to shape what lands on ``session.recording_meta``; set
-      ``session.session_id`` to pin your own identity (the recorder file,
-      ``meta["session_id"]``, and the upload path follow). Exceptions are
-      logged and ignored — an observer must never end a call.
+    - ``on_session_built(session, meta)`` (sync or async) runs once the
+      :class:`VoiceSession` exists and before it runs, with the *final*
+      ``meta`` (``transport``, ``call_id``, ``from``, ``to`` plus the
+      build's). Mutate ``meta`` in place to shape what lands on
+      ``session.recording_meta``; set ``session.session_id`` to pin your own
+      identity — the recording file stem and ``meta["session_id"]`` follow
+      (ids: ``[A-Za-z0-9_-]{1,128}``). Exceptions are logged and ignored — an
+      observer must never end a call — and a refused pin leaves the
+      generated id in force everywhere.
+
+    Recording *destination* identity does not come from ``meta``: the env
+    knobs ``build_voice_session`` reads (``TIMBAL_VOICE_RECORDING_*``,
+    ``TIMBAL_ORG_ID`` / ``TIMBAL_PROJECT_ID`` for the platform upload path)
+    are process-wide. A multi-tenant host must carry them per call through
+    ``defaults.recording`` (``dir`` and an ``on_saved`` hook that knows the
+    tenant) and leave ``TIMBAL_VOICE_RECORDING_UPLOAD`` unset.
     """
     try:
         from ..voice import AgentTextDone, AudioOutput, FillerSpoken, SessionEnded, TurnMetricsEvent
@@ -580,13 +604,15 @@ async def serve_media_ws(
     }
     if on_session_built is not None:
         try:
-            on_session_built(session, meta)
+            result = on_session_built(session, meta)
+            if inspect.isawaitable(result):
+                await result
         except Exception as e:  # noqa: BLE001 - an observer must never end a call
             logger.error("telephony_session_hook_failed", provider=dialect.name, error=str(e), exc_info=True)
     # The hook may pin ``session.session_id`` after the recorder already
-    # opened under a generated uuid7. ``VoiceSession.session_id`` retargets
-    # the file; copy it onto meta *after* the hook so recording_meta, the
-    # manifest, and any upload path share that id.
+    # opened under a generated uuid7. The setter retargets the file (or
+    # raises and leaves the id alone), so stamping *after* the hook keeps
+    # recording_meta, the manifest, and the upload path (file stem) equal.
     meta["session_id"] = session.session_id
     session.recording_meta = meta
 

--- a/python/timbal/server/telephony.py
+++ b/python/timbal/server/telephony.py
@@ -462,8 +462,9 @@ async def serve_media_ws(
       exists and before it runs, with the *final* ``meta`` (``transport``,
       ``call_id``, ``from``, ``to`` plus the build's). Mutate ``meta`` in
       place to shape what lands on ``session.recording_meta``; set
-      ``session.session_id`` to pin your own identity. Exceptions are logged
-      and ignored — an observer must never end a call.
+      ``session.session_id`` to pin your own identity (the recorder file,
+      ``meta["session_id"]``, and the upload path follow). Exceptions are
+      logged and ignored — an observer must never end a call.
     """
     try:
         from ..voice import AgentTextDone, AudioOutput, FillerSpoken, SessionEnded, TurnMetricsEvent
@@ -582,6 +583,11 @@ async def serve_media_ws(
             on_session_built(session, meta)
         except Exception as e:  # noqa: BLE001 - an observer must never end a call
             logger.error("telephony_session_hook_failed", provider=dialect.name, error=str(e), exc_info=True)
+    # The hook may pin ``session.session_id`` after the recorder already
+    # opened under a generated uuid7. ``VoiceSession.session_id`` retargets
+    # the file; copy it onto meta *after* the hook so recording_meta, the
+    # manifest, and any upload path share that id.
+    meta["session_id"] = session.session_id
     session.recording_meta = meta
 
     up_resampler = PcmResampler(line_rate, session_rate) if line_rate != session_rate else None

--- a/python/timbal/voice/recording.py
+++ b/python/timbal/voice/recording.py
@@ -161,11 +161,17 @@ class CallRecorder:
             self._path, self._container, self._stream, self._fifo = old
             new_path.unlink(missing_ok=True)
             raise
+        # From here the swap has happened and must be reported as such: the
+        # caller sets its id only if we return. Closing / unlinking the old
+        # (empty) file is cleanup, never a reason to leave the identity split.
         try:
             old[1].close()
         except Exception as e:
             logger.warning("recording_retarget_close_failed", error=str(e))
-        old[0].unlink(missing_ok=True)
+        try:
+            old[0].unlink(missing_ok=True)
+        except OSError as e:
+            logger.warning("recording_retarget_unlink_failed", path=str(old[0]), error=str(e))
 
     # -- Feed points -----------------------------------------------------------
 

--- a/python/timbal/voice/recording.py
+++ b/python/timbal/voice/recording.py
@@ -93,12 +93,7 @@ class CallRecorder:
         self.meta = meta
 
         self._channel_layout = "mono" if layout == "mixed" else "stereo"
-        self._container = av.open(str(self._path), mode="w")
-        self._stream = self._container.add_stream("libmp3lame", rate=sample_rate)
-        self._stream.codec_context.layout = self._channel_layout
-        self._stream.codec_context.format = "s16p"
-        self._stream.codec_context.bit_rate = bitrate_kbps * 1000
-        self._fifo = av.AudioFifo()
+        self._open_container()
 
         # Sample alignment: chunks may split an s16 sample across calls.
         self._mic_rem = b""
@@ -136,6 +131,32 @@ class CallRecorder:
     @property
     def duration_secs(self) -> float:
         return self._samples_written / self._sample_rate
+
+    def retarget(self, path: str | Path) -> None:
+        """Reopen the encoder at ``path``. Only valid before any samples are written.
+
+        ``build_voice_session`` mints a uuid7 and opens the MP3 under that
+        name *before* a host ``on_session_built`` hook can pin
+        ``session.session_id``. Call this (or assign ``session.session_id``,
+        which does it) so the file stem, the manifest, and the upload path
+        share the pinned id.
+        """
+        if self._closed or self._failed:
+            raise RuntimeError("cannot retarget a closed or failed recorder")
+        if self._samples_written or self._mic_bytes or self._agent_bytes or self._agent_pending or self._mic_rem:
+            raise RuntimeError("cannot retarget after audio has been written")
+        new_path = Path(path)
+        if new_path == self._path:
+            return
+        new_path.parent.mkdir(parents=True, exist_ok=True)
+        old_path = self._path
+        try:
+            self._container.close()
+        except Exception as e:
+            logger.warning("recording_retarget_close_failed", error=str(e))
+        self._path = new_path
+        self._open_container()
+        old_path.unlink(missing_ok=True)
 
     # -- Feed points -----------------------------------------------------------
 
@@ -248,6 +269,14 @@ class CallRecorder:
         return self._result
 
     # -- Internal ---------------------------------------------------------------
+
+    def _open_container(self) -> None:
+        self._container = av.open(str(self._path), mode="w")
+        self._stream = self._container.add_stream("libmp3lame", rate=self._sample_rate)
+        self._stream.codec_context.layout = self._channel_layout
+        self._stream.codec_context.format = "s16p"
+        self._stream.codec_context.bit_rate = self._bitrate_kbps * 1000
+        self._fifo = av.AudioFifo()
 
     def _write(self, mic: bytes, agent: bytes) -> None:
         """Encode one span (equal-length mic/agent PCM16 mono) onto the timeline."""

--- a/python/timbal/voice/recording.py
+++ b/python/timbal/voice/recording.py
@@ -149,14 +149,23 @@ class CallRecorder:
         if new_path == self._path:
             return
         new_path.parent.mkdir(parents=True, exist_ok=True)
-        old_path = self._path
+        # Open the new encoder *before* letting go of the old one, so a failed
+        # open leaves the recorder exactly as it was (still writable, still at
+        # the old path) rather than pointing at a file that was never created
+        # while encoding into a closed container.
+        old = (self._path, self._container, self._stream, self._fifo)
+        self._path = new_path
         try:
-            self._container.close()
+            self._open_container()
+        except Exception:
+            self._path, self._container, self._stream, self._fifo = old
+            new_path.unlink(missing_ok=True)
+            raise
+        try:
+            old[1].close()
         except Exception as e:
             logger.warning("recording_retarget_close_failed", error=str(e))
-        self._path = new_path
-        self._open_container()
-        old_path.unlink(missing_ok=True)
+        old[0].unlink(missing_ok=True)
 
     # -- Feed points -----------------------------------------------------------
 

--- a/python/timbal/voice/session.py
+++ b/python/timbal/voice/session.py
@@ -84,6 +84,10 @@ if TYPE_CHECKING:
 
 logger = structlog.get_logger("timbal.voice.session")
 
+# Platform session-id contract (see server/recording_upload.py): the id is a
+# file stem and a URL path segment, so no separators and a bounded length.
+_SESSION_ID_RE = re.compile(r"[A-Za-z0-9_-]{1,128}")
+
 # Wall-clock cap on a single agent turn (LLM stream + in-turn TTS drains).
 # Without this a hung provider leaves the caller in silence forever.
 DEFAULT_TURN_TIMEOUT_SECS = 60.0
@@ -455,20 +459,25 @@ class VoiceSession:
 
     @session_id.setter
     def session_id(self, value: str) -> None:
-        """Pin identity. Retargets an already-opened recorder onto ``{id}.mp3``."""
-        self._session_id = value
+        """Pin identity. Retargets an already-opened recorder onto ``{id}.mp3``.
+
+        Only valid before any audio has been recorded (a host's
+        ``on_session_built`` hook is the intended caller). Raises rather than
+        half-applying: the recording file stem, the manifest ``session_id``
+        and the platform upload path must all be the same string, so a pin
+        that cannot be carried onto the file is refused and the previous id
+        stays in force. Ids follow the platform contract ``[A-Za-z0-9_-]{1,128}``.
+        """
+        if not isinstance(value, str) or not _SESSION_ID_RE.fullmatch(value):
+            raise ValueError(f"session_id must match [A-Za-z0-9_-]{{1,128}}, got {value!r}")
         recorder = self._recorder
-        if recorder is None:
-            return
-        current = recorder.audio_path
-        if current.stem == value:
-            return
-        try:
-            recorder.retarget(current.with_name(f"{value}{current.suffix}"))
-        except Exception as e:
-            # Keep the pinned id even if the file stays under the generated
-            # name — an observer must never fail a call over a rename.
-            logger.error("recording_retarget_failed", error=str(e), session_id=value, exc_info=True)
+        if recorder is not None:
+            current = recorder.audio_path
+            if current.stem != value:
+                # Raises on a closed/failed recorder, after audio, or on a
+                # failed reopen — in all cases the recorder is left as it was.
+                recorder.retarget(current.with_name(f"{value}{current.suffix}"))
+        self._session_id = value
 
     @property
     def transcript(self) -> list[TranscriptEntry]:

--- a/python/timbal/voice/session.py
+++ b/python/timbal/voice/session.py
@@ -426,7 +426,7 @@ class VoiceSession:
         self._output_audio_chunks: list[bytes] = []
         # Persistent call recording (MP3 + manifest; see voice/recording.py).
         # Distinct from the in-memory record_audio seam above.
-        self.session_id = session_id or uuid7(as_type="hex")
+        self._session_id = session_id or uuid7(as_type="hex")
         self._recorder = recorder
         #: Wall-clock session start (set when run() begins); transcript offsets
         #: in the recording manifest and session_transcript are relative to it.
@@ -448,6 +448,27 @@ class VoiceSession:
         self._turn_audio_bytes = 0
 
     # -- Public: session recording ------------------------------------------
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    @session_id.setter
+    def session_id(self, value: str) -> None:
+        """Pin identity. Retargets an already-opened recorder onto ``{id}.mp3``."""
+        self._session_id = value
+        recorder = self._recorder
+        if recorder is None:
+            return
+        current = recorder.audio_path
+        if current.stem == value:
+            return
+        try:
+            recorder.retarget(current.with_name(f"{value}{current.suffix}"))
+        except Exception as e:
+            # Keep the pinned id even if the file stays under the generated
+            # name — an observer must never fail a call over a rename.
+            logger.error("recording_retarget_failed", error=str(e), session_id=value, exc_info=True)
 
     @property
     def transcript(self) -> list[TranscriptEntry]:


### PR DESCRIPTION
## Why

The platform is moving all workforce voice media into one sidecar process (browser and SIP via LiveKit; Twilio/Telnyx keep the carrier WebSocket but its media end is the sidecar). Today the sidecar has to import `_serve_media_ws` / `_TwilioDialect` / `_TelnyxDialect`, wrap the socket in a fake-`app` proxy so the bridge reads the right `voice_config`, and monkeypatch `timbal.server.voice.build_voice_session` to observe the session. This makes that a supported surface.

## What

`timbal/server/telephony.py`:

- `serve_media_ws(ws, runnable, dialect, *, defaults=None, on_session_built=None)` — public.
  - `defaults`: the `VoiceConfig` to build the session from. `None` → today's `ws.app.state.voice_config` read; `timbal.server`'s own routes are unchanged.
  - `on_session_built(session, meta)`: runs once the `VoiceSession` exists, with the **final** `meta` (`transport`, `call_id`, `from`, `to` + the build's), before `recording_meta` is stamped and before `run()`. Mutate `meta` in place / set `session.session_id` to pin the host's identity. Exceptions are logged (`telephony_session_hook_failed`) and never end the call.
- `TwilioDialect`, `TelnyxDialect`, `TWILIO`, `TELNYX`, `DIALECTS`, `dialect_for("twilio"|"telnyx")`.
- Underscored spellings kept as aliases to the same objects.

No behaviour change for `POST /voice/{p}/incoming` / `WS /voice/{p}/stream`.

## Tests

`TestEmbeddedBridge` in `python/tests/server/test_voice_telephony.py`: public names + aliases; a non-`timbal.server` FastAPI host runs the bridge with its own `VoiceConfig`, observes the session, and its `meta` edits land on `recording_meta`; a failing observer doesn't end the call.

`python/tests/server` + `python/tests/voice`: 1126 passed, 4 skipped.

Formatting: both files were already `ruff format`-dirty on `main`; left as-is to keep the diff reviewable.
