### PR TITLE
feat(server): GET /voice_config — agent's declared voice config for remote media hosts

### DIFF
--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -140,6 +140,28 @@ class TestFastAPIApp:
         response = tool_client.get("/healthcheck")
         assert response.status_code == 204
 
+    def test_voice_config_endpoint_reports_the_agents_declaration(self, agent_app, agent_client):
+        """``GET /voice_config`` hands a remote media host the agent's own
+        ``voice_config`` — sparse, JSON-safe, server-only keys withheld."""
+        # Nothing declared → empty block, still 200 (the caller merges over it).
+        r = agent_client.get("/voice_config")
+        assert r.status_code == 200
+        assert r.json() == {"voice_config": {}}
+
+        agent_app.state.runnable.voice_config = {
+            "language": "es",
+            "greeting": {"text": "Hola, ¿en qué te ayudo?", "interruptible": False},
+            "recording": {"dir": "/var/lib/rec"},
+        }
+        r = agent_client.get("/voice_config")
+        assert r.status_code == 200
+        assert r.json() == {
+            "voice_config": {
+                "language": "es",
+                "greeting": {"text": "Hola, ¿en qué te ayudo?", "interruptible": False},
+            }
+        }
+
     def test_params_model_schema_endpoint_tool(self, tool_client):
         """Test /params_model_schema endpoint returns correct schema for tool."""
         response = tool_client.get("/params_model_schema")

--- a/python/tests/server/test_voice_config.py
+++ b/python/tests/server/test_voice_config.py
@@ -582,3 +582,68 @@ class TestVoiceServerScript:
         runn = os.environ["TIMBAL_RUNNABLE"]
         assert runn.endswith("::agent")
         assert "voice_server.py" in runn
+
+
+@pytest.mark.usefixtures("clear_voice_env")
+class TestDeclaredVoiceConfig:
+    """``declared_voice_config`` — the wire form behind ``GET /voice_config``.
+
+    A platform sidecar that joins the room on the agent's behalf reads this to
+    honour the agent's opener / language / voice. It must be *what the agent
+    set*, not the box's env-merged defaults, and never a server-only knob.
+    """
+
+    def test_nothing_declared_is_empty(self):
+        class R:
+            voice_config = None
+
+        assert voice_routes.declared_voice_config(R()) == {}
+        assert voice_routes.declared_voice_config(object()) == {}
+
+    def test_dict_is_sparse_and_json_safe(self):
+        class R:
+            voice_config = {
+                "language": "es",
+                "greeting": {"text": "Hola, soy el copiloto.", "interruptible": False, "model": object()},
+                "filler": {"delay_secs": 0.8, "model": "groq/llama"},
+                "turn_detector": lambda: None,
+                "model": None,
+                "recording": {"dir": "/var/lib/rec", "on_saved": lambda r: None},
+                "ambient": {"source": "/etc/passwd"},
+            }
+
+        out = voice_routes.declared_voice_config(R())
+        assert out == {
+            "language": "es",
+            "greeting": {"text": "Hola, soy el copiloto.", "interruptible": False},
+            "filler": {"delay_secs": 0.8, "model": "groq/llama"},
+        }
+        json.dumps(out)  # wire-safe by construction
+
+    def test_voice_config_instance_only_reports_fields_the_agent_set(self):
+        class R:
+            voice_config = VoiceConfig(language="ca", greeting="Bon dia")
+
+        out = voice_routes.declared_voice_config(R())
+        assert out["language"] == "ca"
+        assert out["greeting"] == {"text": "Bon dia"}
+        # Defaults the agent never touched are not "declared".
+        assert "stt_provider" not in out and "voice" not in out and "sample_rate" not in out
+
+    def test_callable_is_resolved(self):
+        class R:
+            @staticmethod
+            def voice_config():
+                return {"voice": "abc123", "turn_detector": "lexical"}
+
+        assert voice_routes.declared_voice_config(R()) == {"voice": "abc123", "turn_detector": "lexical"}
+
+    def test_merge_still_sees_the_same_declaration(self, monkeypatch):
+        """Refactor guard: ``merge_voice_config`` and ``declared_voice_config``
+        read the declaration through one normalizer."""
+
+        class R:
+            voice_config = VoiceConfig(language="es", greeting="Hola")
+
+        merged = voice_routes.merge_voice_config(R())
+        assert merged.language == "es" and merged.greeting is not None and merged.greeting.text == "Hola"

--- a/python/tests/server/test_voice_config.py
+++ b/python/tests/server/test_voice_config.py
@@ -17,7 +17,7 @@ from timbal import __version__ as timbal_version
 from timbal.server import voice as voice_routes
 from timbal.server.http import create_app, lifespan
 from timbal.utils import ImportSpec
-from timbal.voice.config import DEFAULT_VOICE_ID, FillerConfig, RecordingConfig, VoiceConfig
+from timbal.voice.config import DEFAULT_VOICE_ID, FillerConfig, GreetingConfig, RecordingConfig, VoiceConfig
 
 from .voice_env import VOICE_ENV_KEYS
 
@@ -629,6 +629,43 @@ class TestDeclaredVoiceConfig:
         assert out["greeting"] == {"text": "Bon dia"}
         # Defaults the agent never touched are not "declared".
         assert "stt_provider" not in out and "voice" not in out and "sample_rate" not in out
+
+    def test_model_instances_inside_a_dict_are_reported_sparsely(self):
+        """Regression: a ``GreetingConfig`` / ``FillerConfig`` *inside a dict*
+        used to be dropped by the JSON pass while ``merge_voice_config`` still
+        honoured it — the box spoke the opener, the endpoint said there was none."""
+
+        class R:
+            voice_config = {
+                "language": "es",
+                "greeting": GreetingConfig(text="Hola", delay_ms=300),
+                "filler": FillerConfig(delay_secs=0.8),
+            }
+
+        declared = voice_routes.declared_voice_config(R())
+        assert declared == {
+            "language": "es",
+            "greeting": {"text": "Hola", "delay_ms": 300},  # sparse: only what was set
+            "filler": {"delay_secs": 0.8},
+        }
+        merged = voice_routes.merge_voice_config(R())
+        assert merged.greeting is not None and merged.greeting.text == "Hola" and merged.greeting.delay_ms == 300
+        assert merged.filler is not None and merged.filler.delay_secs == 0.8
+
+    def test_voice_config_instance_keeps_nested_blocks_sparse_too(self, monkeypatch):
+        """The ``VoiceConfig`` spelling must not clobber env-supplied nested
+        values with the nested model's *defaults* (the original reason for the
+        sparse redo), and must report the same shape as the dict spelling."""
+        monkeypatch.setenv("TIMBAL_VOICE_GREETING", "Env opener")
+
+        class R:
+            voice_config = VoiceConfig(greeting=GreetingConfig(delay_ms=250, instructions="be brief"))
+
+        declared = voice_routes.declared_voice_config(R())
+        assert declared == {"greeting": {"delay_ms": 250, "instructions": "be brief"}}
+        merged = voice_routes.merge_voice_config(R())
+        # Env text survives the agent's partial greeting block.
+        assert merged.greeting is not None and merged.greeting.text == "Env opener" and merged.greeting.delay_ms == 250
 
     def test_callable_is_resolved(self):
         class R:

--- a/python/timbal/server/http.py
+++ b/python/timbal/server/http.py
@@ -142,6 +142,22 @@ def create_app() -> FastAPI:
     async def healthcheck() -> Response:
         return Response(status_code=204)
 
+    @app.get("/voice_config")
+    async def voice_config() -> Response:
+        """The agent's declared ``voice_config``, sparse and JSON-safe.
+
+        For a host that runs the voice session on this agent's behalf (a
+        platform media sidecar in the same room) and needs the agent's own
+        greeting / language / voice rather than this box's env defaults. See
+        :func:`timbal.server.voice.declared_voice_config` for what is withheld.
+        """
+        from .voice import declared_voice_config
+
+        return JSONResponse(
+            status_code=200,
+            content={"voice_config": declared_voice_config(app.state.runnable)},
+        )
+
     @app.get("/params_model_schema")
     async def params_model_schema() -> Response:
         params_model_schema = app.state.runnable.params_model_schema

--- a/python/timbal/server/voice.py
+++ b/python/timbal/server/voice.py
@@ -113,13 +113,13 @@ _RECORDING_IDENTITY_ENV = (
 )
 
 
-def merge_voice_config(runnable: Any) -> VoiceConfig:
-    """Env defaults, then optional ``runnable.voice_config`` (dict, callable, or ``VoiceConfig``).
+def _normalize_declared_voice_config(runnable: Any) -> dict[str, Any] | None:
+    """``runnable.voice_config`` as the sparse dict the agent actually set.
 
-    Validated strictly: an unknown key or bad value raises at server boot
-    instead of silently falling back to defaults on the first call.
+    Accepts a dict, a zero-arg callable returning one, or a ``VoiceConfig``
+    (dumped by ``model_fields_set`` so defaults the agent never touched do not
+    masquerade as choices). ``None`` when the runnable declares nothing.
     """
-    base = default_voice_config_from_env()
     vc = getattr(runnable, "voice_config", None)
     if callable(vc):
         vc = vc()
@@ -132,7 +132,75 @@ def merge_voice_config(runnable: Any) -> VoiceConfig:
         if isinstance(vc.greeting, GreetingConfig):
             dumped["greeting"] = vc.greeting.model_dump(include=vc.greeting.model_fields_set)
         vc = dumped
-    if not isinstance(vc, dict):
+    return vc if isinstance(vc, dict) else None
+
+
+#: ``VoiceConfig`` keys that stay on this box when the config is served over
+#: HTTP (:func:`declared_voice_config`). ``recording`` carries a directory and
+#: an ``on_saved`` callable; ``ambient.source`` may be a local file path. Both
+#: are this process's business, never a remote media host's.
+_VOICE_CONFIG_SERVER_ONLY = frozenset({"recording", "ambient"})
+
+_DROP = object()
+
+
+def _json_safe(value: Any) -> Any:
+    """Keep JSON scalars / lists / dicts; drop everything else (callables,
+    ``TestModel`` instances, ``TurnDetector`` factories, …)."""
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, (list, tuple)):
+        out = [_json_safe(v) for v in value]
+        return [v for v in out if v is not _DROP]
+    if isinstance(value, dict):
+        out = {}
+        for k, v in value.items():
+            if not isinstance(k, str):
+                continue
+            sv = _json_safe(v)
+            if sv is not _DROP:
+                out[k] = sv
+        return out
+    return _DROP
+
+
+def declared_voice_config(runnable: Any) -> dict[str, Any]:
+    """What ``runnable.voice_config`` says, JSON-safe, minus server-only keys.
+
+    This is the wire form for ``GET /voice_config``: a host that runs the
+    media session *for* this agent elsewhere (a platform sidecar joining the
+    room on the agent's behalf) needs the agent's own opener, language, voice
+    and turn policy — and must not inherit this box's env defaults, which is
+    why the result is sparse (declared keys only) rather than the merged
+    :class:`VoiceConfig`. Nested ``filler`` / ``greeting`` lose their ``model``
+    unless it is a plain ``"provider/model"`` string.
+    """
+    vc = _normalize_declared_voice_config(runnable)
+    if not vc:
+        return {}
+    out = _json_safe({k: v for k, v in vc.items() if k not in _VOICE_CONFIG_SERVER_ONLY})
+    if out is _DROP:
+        return {}
+    for nested in ("filler", "greeting"):
+        block = out.get(nested)
+        if isinstance(block, dict) and "model" in block and not isinstance(block["model"], str):
+            block.pop("model")
+    if "turn_detector" in out and not isinstance(out["turn_detector"], str):
+        out.pop("turn_detector")
+    if "model" in out and not isinstance(out["model"], str):
+        out.pop("model")
+    return out
+
+
+def merge_voice_config(runnable: Any) -> VoiceConfig:
+    """Env defaults, then optional ``runnable.voice_config`` (dict, callable, or ``VoiceConfig``).
+
+    Validated strictly: an unknown key or bad value raises at server boot
+    instead of silently falling back to defaults on the first call.
+    """
+    base = default_voice_config_from_env()
+    vc = _normalize_declared_voice_config(runnable)
+    if vc is None:
         return base
     skip = frozenset({"stt_extra", "tts_extra", "filler", "greeting"})
     data = {

--- a/python/timbal/server/voice.py
+++ b/python/timbal/server/voice.py
@@ -119,20 +119,32 @@ def _normalize_declared_voice_config(runnable: Any) -> dict[str, Any] | None:
     Accepts a dict, a zero-arg callable returning one, or a ``VoiceConfig``
     (dumped by ``model_fields_set`` so defaults the agent never touched do not
     masquerade as choices). ``None`` when the runnable declares nothing.
+
+    Nested ``filler`` / ``greeting`` come back as sparse dicts whichever way
+    the agent spelled them — a ``FillerConfig`` / ``GreetingConfig`` instance
+    inside a plain dict is as common as a ``VoiceConfig`` — so every consumer
+    (:func:`merge_voice_config`, :func:`declared_voice_config`) sees one shape.
     """
     vc = getattr(runnable, "voice_config", None)
     if callable(vc):
         vc = vc()
     if isinstance(vc, VoiceConfig):
+        # Top-level ``include`` dumps nested models in full (unset fields and
+        # all); put the instances back so the sparse redo below applies to
+        # them exactly as it does to instances the agent placed in a dict.
         dumped = vc.model_dump(include=vc.model_fields_set)
-        # Top-level ``include`` dumps nested models in full; redo filler and
-        # greeting sparsely so unset fields don't clobber env values below.
-        if isinstance(vc.filler, FillerConfig):
-            dumped["filler"] = vc.filler.model_dump(include=vc.filler.model_fields_set)
-        if isinstance(vc.greeting, GreetingConfig):
-            dumped["greeting"] = vc.greeting.model_dump(include=vc.greeting.model_fields_set)
+        for key in ("filler", "greeting"):
+            if key in dumped:
+                dumped[key] = getattr(vc, key)
         vc = dumped
-    return vc if isinstance(vc, dict) else None
+    if not isinstance(vc, dict):
+        return None
+    out = dict(vc)
+    for key, model_type in (("filler", FillerConfig), ("greeting", GreetingConfig)):
+        nested = out.get(key)
+        if isinstance(nested, model_type):
+            out[key] = nested.model_dump(include=nested.model_fields_set)
+    return out
 
 
 #: ``VoiceConfig`` keys that stay on this box when the config is served over
@@ -211,17 +223,15 @@ def merge_voice_config(runnable: Any) -> VoiceConfig:
         data["stt_extra"] = {**base.stt_extra, **vc["stt_extra"]}
     if isinstance(vc.get("tts_extra"), dict):
         data["tts_extra"] = {**base.tts_extra, **vc["tts_extra"]}
+    # ``filler`` / ``greeting`` arrive as sparse dicts (or ``None`` / ``""``)
+    # from the normalizer, however the agent spelled them.
     filler = vc.get("filler")
-    if isinstance(filler, FillerConfig):
-        filler = filler.model_dump(include=filler.model_fields_set)
     if isinstance(filler, dict):
         base_filler = base.filler.model_dump(include=base.filler.model_fields_set) if base.filler else {}
         data["filler"] = {**base_filler, **filler}
     elif filler is not None:
         data["filler"] = filler
     greeting = vc.get("greeting")
-    if isinstance(greeting, GreetingConfig):
-        greeting = greeting.model_dump(include=greeting.model_fields_set)
     if isinstance(greeting, dict):
         # Same deep merge as filler: an agent tweaking ``delay_ms`` must not drop
         # the text TIMBAL_VOICE_GREETING supplied (and lose the whole opener to a


### PR DESCRIPTION
## Why

A platform that runs the voice session *for* an agent (media sidecar joins the LiveKit room / terminates the carrier socket; the agent box is headless behind `/stream`) has no way to read the agent's own `voice_config`. The framework's `merge_voice_config` evaluates it inside the box and keeps it on `app.state`.

Measured on a live PSTN call today (livekit-sip → platform sidecar): the agent had declared nothing the sidecar could see → caller hears dead air → says "hola, hola" → first reply takes 4 s and is barged in by the caller's next sentence → abandoned at 20 s. Exactly the failure `GreetingConfig`'s docstring describes; the fix (greeting + filler) exists in `VoiceConfig` but never reached the process that needed it.

## What

- `GET /voice_config` → `{"voice_config": {...}}` — the **sparse** dict the agent actually declared (dict, zero-arg callable, or `VoiceConfig` dumped by `model_fields_set`), JSON-safe.
- Withheld: `recording`, `ambient` (server-only: paths / callables), and any non-string `model` / `turn_detector` (incl. nested `filler.model` / `greeting.model`).
- Sparse on purpose: a remote host layers this over *its own* env defaults; the box's env-merged `VoiceConfig` must not leak across (`stt_provider`, `voice`, `sample_rate`…).
- `merge_voice_config` and `declared_voice_config` share `_normalize_declared_voice_config`, so the two views can't drift.

## Tests

`tests/server/test_voice_config.py::TestDeclaredVoiceConfig`, `tests/server/test_http.py::…::test_voice_config_endpoint_reports_the_agents_declaration`. `pytest tests/server/test_voice_config.py tests/server/test_http.py` → 94 passed. No new ruff findings (the pre-existing ones in `voice.py` are untouched, same as #165).

## Consumer

Platform sidecar fetches this from the headless box at dial time and merges it under the per-session knobs it already receives. Follow-up to #165.