### PR TITLE
fix(server/livekit): answer a SIP call listening — skip the hello window, connect STT/TTS before publish

### DIFF
--- a/python/tests/server/test_livekit_session.py
+++ b/python/tests/server/test_livekit_session.py
@@ -724,11 +724,13 @@ class TestSipRuntime:
         class _Session:
             recording_meta: dict | None = None
             session_id = "s"
+            closed = False
 
             async def prepare(self) -> None:
                 order.append("prepare")
 
             async def close(self) -> None:
+                self.closed = True
                 order.append("close")
 
             async def run(self, _audio_in: object):
@@ -831,9 +833,11 @@ class TestSipRuntime:
         room, guard, _log, app = driver_env
         built: list[object] = []
         closed: list[object] = []
+        published: list[object] = []
 
         class _Session:
             recording_meta: dict | None = None
+            closed = False
 
             async def prepare(self) -> None:
                 # Hold here long enough for the abandon timer to fire, the way
@@ -841,12 +845,25 @@ class TestSipRuntime:
                 await asyncio.sleep(0.2)
 
             async def close(self) -> None:
+                # The real path: once session_holder is set, the abandon goes
+                # through close(), not _abort() — the gate must see this.
+                self.closed = True
                 closed.append(True)
 
         def _capture(*_args: object, **_kwargs: object):
             built.append(True)
             return _Session(), {}
 
+        async def _publish(*_args: object, **_kwargs: object) -> None:
+            published.append(True)
+
+        room.local_participant.publish_track = _publish  # type: ignore[method-assign]
+        fake_rtc = sys.modules["livekit"].rtc
+        monkeypatch.setattr(
+            fake_rtc, "LocalAudioTrack", SimpleNamespace(create_audio_track=lambda *_args: object()), raising=False
+        )
+        monkeypatch.setattr(fake_rtc, "TrackPublishOptions", lambda **_kwargs: _kwargs, raising=False)
+        monkeypatch.setattr(fake_rtc, "TrackSource", SimpleNamespace(SOURCE_MICROPHONE=1), raising=False)
         monkeypatch.setenv("TIMBAL_VOICE_SIP_ABANDON_SECS", "0.05")
         monkeypatch.setattr("timbal.server.livekit_session.build_voice_session", _capture)
         task = asyncio.create_task(_run_livekit_session(app))
@@ -862,7 +879,8 @@ class TestSipRuntime:
         done, _ = await asyncio.wait({task}, timeout=2.0)
         assert task in done
         assert built == [True]
-        assert closed == [True]  # built, then torn down — never published, never ran
+        assert closed  # built, then torn down by the abandon
+        assert published == []  # a hung-up caller is never answered (Bugbot, PR 170)
         assert guard.finished
 
     async def test_late_media_after_sip_bye_does_not_build(

--- a/python/tests/server/test_livekit_session.py
+++ b/python/tests/server/test_livekit_session.py
@@ -8,6 +8,7 @@ tests inject a fake ``livekit`` module.
 from __future__ import annotations
 
 import asyncio
+import time
 import base64
 import contextlib
 import json
@@ -582,6 +583,111 @@ class TestSipRuntime:
         with contextlib.suppress(asyncio.CancelledError):
             await task
 
+    async def test_sip_caller_does_not_wait_for_a_hello(
+        self,
+        driver_env: tuple[_FakeRoom, _FakeGuard, _LogRecorder, object],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A phone has no data channel to send a config hello on, so the
+        2s hello window can only expire — measured live as 2.0s of dead air
+        between the agent joining and the session being built. For a SIP
+        caller the build must follow the mic subscribe immediately."""
+        room, _guard, _log, app = driver_env
+        built_at: dict[str, float] = {}
+
+        def _capture(runnable: object, defaults: object, config: dict, **kwargs: object):
+            built_at["t"] = time.monotonic()
+            raise RuntimeError("stop")
+
+        monkeypatch.setattr("timbal.server.livekit_session.build_voice_session", _capture)
+        task = asyncio.create_task(_run_livekit_session(app))
+        await asyncio.wait_for(room.connected.wait(), timeout=1.0)
+        await asyncio.sleep(0)
+        subscribed_at = time.monotonic()
+        _subscribe_caller(room, identity="+34111", kind="PARTICIPANT_KIND_SIP")  # no hello, ever
+        done, _ = await asyncio.wait({task}, timeout=1.0)
+        assert task in done, "build waited on the hello window for a SIP caller"
+        assert built_at["t"] - subscribed_at < 0.5
+
+    async def test_browser_caller_still_gets_the_hello_window(
+        self,
+        driver_env: tuple[_FakeRoom, _FakeGuard, _LogRecorder, object],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Contrast: a standard participant without a hello is waited on —
+        the playground's dropdowns ride that hello."""
+        room, _guard, _log, app = driver_env
+        monkeypatch.setattr("timbal.server.livekit_session._HELLO_WAIT_SECS", 0.4)
+
+        def _capture(runnable: object, defaults: object, config: dict, **kwargs: object):
+            raise RuntimeError("stop")
+
+        monkeypatch.setattr("timbal.server.livekit_session.build_voice_session", _capture)
+        task = asyncio.create_task(_run_livekit_session(app))
+        await asyncio.wait_for(room.connected.wait(), timeout=1.0)
+        await asyncio.sleep(0)
+        _subscribe_caller(room)  # browser, no hello
+        done, _ = await asyncio.wait({task}, timeout=0.15)
+        assert task not in done  # still inside the window
+        done, _ = await asyncio.wait({task}, timeout=1.0)
+        assert task in done
+
+    async def test_sip_session_is_listening_before_the_track_is_published(
+        self,
+        driver_env: tuple[_FakeRoom, _FakeGuard, _LogRecorder, object],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Our published track is what makes livekit-sip send the 200 OK, so
+        for a phone "answered" must mean STT/TTS are already connected."""
+        room, _guard, _log, app = driver_env
+        order: list[str] = []
+
+        class _Session:
+            recording_meta: dict | None = None
+            session_id = "s"
+
+            async def prepare(self) -> None:
+                order.append("prepare")
+
+            async def close(self) -> None:
+                order.append("close")
+
+            async def run(self, _audio_in: object):
+                order.append("run")
+                await asyncio.Event().wait()
+                yield  # pragma: no cover - never reached
+
+        monkeypatch.setattr(
+            "timbal.server.livekit_session.build_voice_session",
+            lambda *_args, **_kwargs: (_Session(), {}),
+        )
+        original_publish = room.local_participant.publish_track
+
+        async def _publish(*args: object, **kwargs: object) -> None:
+            order.append("publish")
+            await original_publish(*args, **kwargs)
+
+        room.local_participant.publish_track = _publish  # type: ignore[method-assign]
+        # No other test reaches publish, so the fake rtc has no track types.
+        fake_rtc = sys.modules["livekit"].rtc
+        monkeypatch.setattr(
+            fake_rtc, "LocalAudioTrack", SimpleNamespace(create_audio_track=lambda *_args: object()), raising=False
+        )
+        monkeypatch.setattr(fake_rtc, "TrackPublishOptions", lambda **_kwargs: _kwargs, raising=False)
+        monkeypatch.setattr(fake_rtc, "TrackSource", SimpleNamespace(SOURCE_MICROPHONE=1), raising=False)
+        task = asyncio.create_task(_run_livekit_session(app))
+        await asyncio.wait_for(room.connected.wait(), timeout=1.0)
+        await asyncio.sleep(0)
+        _subscribe_caller(room, identity="+34111", kind="PARTICIPANT_KIND_SIP")
+        for _ in range(50):
+            if "publish" in order:
+                break
+            await asyncio.sleep(0.02)
+        assert order[:2] == ["prepare", "publish"], order
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
     async def test_sip_path_applies_phone_tuned_config(
         self,
         driver_env: tuple[_FakeRoom, _FakeGuard, _LogRecorder, object],
@@ -637,14 +743,30 @@ class TestSipRuntime:
         driver_env: tuple[_FakeRoom, _FakeGuard, _LogRecorder, object],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Short-abandon after media but before session_holder must abort
-        the hello wait — not tear the room and then still build_voice_session."""
+        """A SIP caller gets no hello window (see
+        ``test_sip_caller_does_not_wait_for_a_hello``), so a blip right after
+        media lands *after* the build: the session is built at once, the
+        short-abandon then tears it down through finish(). What must not
+        happen is a build that outlives the abandon — the driver's post-build
+        abort check is what this pins."""
         room, guard, _log, app = driver_env
         built: list[object] = []
+        closed: list[object] = []
 
-        def _capture(*_args: object, **_kwargs: object) -> None:
+        class _Session:
+            recording_meta: dict | None = None
+
+            async def prepare(self) -> None:
+                # Hold here long enough for the abandon timer to fire, the way
+                # a real STT/TTS connect would.
+                await asyncio.sleep(0.2)
+
+            async def close(self) -> None:
+                closed.append(True)
+
+        def _capture(*_args: object, **_kwargs: object):
             built.append(True)
-            raise RuntimeError("should not build after short-abandon")
+            return _Session(), {}
 
         monkeypatch.setenv("TIMBAL_VOICE_SIP_ABANDON_SECS", "0.05")
         monkeypatch.setattr("timbal.server.livekit_session.build_voice_session", _capture)
@@ -660,7 +782,8 @@ class TestSipRuntime:
         room.handlers["participant_disconnected"](participant)
         done, _ = await asyncio.wait({task}, timeout=2.0)
         assert task in done
-        assert built == []
+        assert built == [True]
+        assert closed == [True]  # built, then torn down — never published, never ran
         assert guard.finished
 
     async def test_late_media_after_sip_bye_does_not_build(

--- a/python/tests/server/test_livekit_session.py
+++ b/python/tests/server/test_livekit_session.py
@@ -609,6 +609,46 @@ class TestSipRuntime:
         assert task in done, "build waited on the hello window for a SIP caller"
         assert built_at["t"] - subscribed_at < 0.5
 
+    def test_hello_window_is_env_tunable_per_caller_kind(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from timbal.server.livekit_session import hello_wait_secs
+
+        monkeypatch.delenv("TIMBAL_VOICE_HELLO_WAIT_SECS", raising=False)
+        monkeypatch.delenv("TIMBAL_VOICE_SIP_HELLO_WAIT_SECS", raising=False)
+        assert hello_wait_secs(caller_is_sip=False) == 2.0
+        assert hello_wait_secs(caller_is_sip=True) == 0.0
+        monkeypatch.setenv("TIMBAL_VOICE_HELLO_WAIT_SECS", "0.75")
+        monkeypatch.setenv("TIMBAL_VOICE_SIP_HELLO_WAIT_SECS", "0.3")
+        assert hello_wait_secs(caller_is_sip=False) == 0.75
+        assert hello_wait_secs(caller_is_sip=True) == 0.3
+        # Garbage and negatives never break a call: fall back / clamp.
+        monkeypatch.setenv("TIMBAL_VOICE_HELLO_WAIT_SECS", "soon")
+        monkeypatch.setenv("TIMBAL_VOICE_SIP_HELLO_WAIT_SECS", "-4")
+        assert hello_wait_secs(caller_is_sip=False) == 2.0
+        assert hello_wait_secs(caller_is_sip=True) == 0.0
+
+    async def test_sip_hello_window_can_be_reopened_from_env(
+        self,
+        driver_env: tuple[_FakeRoom, _FakeGuard, _LogRecorder, object],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A deployment whose SIP bridge does send a hello (or wants a settle
+        beat) sets TIMBAL_VOICE_SIP_HELLO_WAIT_SECS; the driver then waits."""
+        room, _guard, _log, app = driver_env
+        monkeypatch.setenv("TIMBAL_VOICE_SIP_HELLO_WAIT_SECS", "0.4")
+
+        def _capture(*_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("stop")
+
+        monkeypatch.setattr("timbal.server.livekit_session.build_voice_session", _capture)
+        task = asyncio.create_task(_run_livekit_session(app))
+        await asyncio.wait_for(room.connected.wait(), timeout=1.0)
+        await asyncio.sleep(0)
+        _subscribe_caller(room, identity="+34111", kind="PARTICIPANT_KIND_SIP")
+        done, _ = await asyncio.wait({task}, timeout=0.15)
+        assert task not in done  # inside the reopened window
+        done, _ = await asyncio.wait({task}, timeout=1.0)
+        assert task in done
+
     async def test_browser_caller_still_gets_the_hello_window(
         self,
         driver_env: tuple[_FakeRoom, _FakeGuard, _LogRecorder, object],

--- a/python/tests/server/test_livekit_session.py
+++ b/python/tests/server/test_livekit_session.py
@@ -609,8 +609,10 @@ class TestSipRuntime:
         assert task in done, "build waited on the hello window for a SIP caller"
         assert built_at["t"] - subscribed_at < 0.5
 
-    def test_hello_window_is_env_tunable_per_caller_kind(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_hello_window_is_tunable_per_caller_kind(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """agent voice_config > env > default, separately for browser and SIP."""
         from timbal.server.livekit_session import hello_wait_secs
+        from timbal.voice.config import VoiceConfig
 
         monkeypatch.delenv("TIMBAL_VOICE_HELLO_WAIT_SECS", raising=False)
         monkeypatch.delenv("TIMBAL_VOICE_SIP_HELLO_WAIT_SECS", raising=False)
@@ -620,11 +622,48 @@ class TestSipRuntime:
         monkeypatch.setenv("TIMBAL_VOICE_SIP_HELLO_WAIT_SECS", "0.3")
         assert hello_wait_secs(caller_is_sip=False) == 0.75
         assert hello_wait_secs(caller_is_sip=True) == 0.3
-        # Garbage and negatives never break a call: fall back / clamp.
+        # What agent.py / `codegen set-config voice_config` wrote beats env.
+        declared = VoiceConfig(hello_wait_secs=1.25, sip_hello_wait_secs=0.5)
+        assert hello_wait_secs(caller_is_sip=False, defaults=declared) == 1.25
+        assert hello_wait_secs(caller_is_sip=True, defaults=declared) == 0.5
+        # An agent that sets only one leaves the other to env.
+        assert hello_wait_secs(caller_is_sip=True, defaults=VoiceConfig(hello_wait_secs=1.0)) == 0.3
+        # Garbage and negatives in env never break a call: fall back / clamp.
         monkeypatch.setenv("TIMBAL_VOICE_HELLO_WAIT_SECS", "soon")
         monkeypatch.setenv("TIMBAL_VOICE_SIP_HELLO_WAIT_SECS", "-4")
         assert hello_wait_secs(caller_is_sip=False) == 2.0
         assert hello_wait_secs(caller_is_sip=True) == 0.0
+        # In config the model refuses a negative outright (ge=0) — a typo
+        # fails at boot, not on the first call.
+        with pytest.raises(ValueError):
+            VoiceConfig(sip_hello_wait_secs=-1)
+
+    async def test_agent_voice_config_reopens_the_sip_hello_window(
+        self,
+        driver_env: tuple[_FakeRoom, _FakeGuard, _LogRecorder, object],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The driver reads the window off the agent's merged voice_config
+        (``app.state.voice_config``) — the same object the box builds from
+        ``agent.py`` — so a Python-side ``sip_hello_wait_secs`` is honoured."""
+        from timbal.voice.config import VoiceConfig
+
+        room, _guard, _log, app = driver_env
+        monkeypatch.delenv("TIMBAL_VOICE_SIP_HELLO_WAIT_SECS", raising=False)
+        app.state.voice_config = VoiceConfig(sip_hello_wait_secs=0.4)
+
+        def _capture(*_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("stop")
+
+        monkeypatch.setattr("timbal.server.livekit_session.build_voice_session", _capture)
+        task = asyncio.create_task(_run_livekit_session(app))
+        await asyncio.wait_for(room.connected.wait(), timeout=1.0)
+        await asyncio.sleep(0)
+        _subscribe_caller(room, identity="+34111", kind="PARTICIPANT_KIND_SIP")
+        done, _ = await asyncio.wait({task}, timeout=0.15)
+        assert task not in done
+        done, _ = await asyncio.wait({task}, timeout=1.0)
+        assert task in done
 
     async def test_sip_hello_window_can_be_reopened_from_env(
         self,

--- a/python/tests/server/test_voice_config.py
+++ b/python/tests/server/test_voice_config.py
@@ -608,7 +608,7 @@ class TestDeclaredVoiceConfig:
                 "filler": {"delay_secs": 0.8, "model": "groq/llama"},
                 "turn_detector": lambda: None,
                 "model": None,
-                "recording": {"dir": "/var/lib/rec", "on_saved": lambda r: None},
+                "recording": {"dir": "/var/lib/rec", "on_saved": lambda *_args: None},
                 "ambient": {"source": "/etc/passwd"},
             }
 
@@ -675,7 +675,7 @@ class TestDeclaredVoiceConfig:
 
         assert voice_routes.declared_voice_config(R()) == {"voice": "abc123", "turn_detector": "lexical"}
 
-    def test_merge_still_sees_the_same_declaration(self, monkeypatch):
+    def test_merge_still_sees_the_same_declaration(self):
         """Refactor guard: ``merge_voice_config`` and ``declared_voice_config``
         read the declaration through one normalizer."""
 

--- a/python/tests/voice/test_session.py
+++ b/python/tests/voice/test_session.py
@@ -303,6 +303,43 @@ class TestVoiceSessionLifecycle:
         await session.close()
         await session.close()
 
+    async def test_prepare_then_run_connects_once(self) -> None:
+        """A transport may open STT/TTS ahead of run() (SIP answers only once
+        our track is published — we must be listening by then); run() must not
+        reconnect on top."""
+        session, stt, tts = _make_session(stt_script=[])
+        await session.prepare()
+        assert stt._connected and tts._connected
+        stt._connected = False  # would flip back to True on a second connect
+        events = await _collect_events(session)
+        assert events[0].type == "session_started"
+        assert stt._connected is False
+        assert stt._closed and tts._closed  # run()'s finally still cleans up
+
+    async def test_close_after_prepare_without_run_closes_the_adapters(self) -> None:
+        """prepare() opened the provider sockets; if run() never starts (BYE
+        during the connects, publish failure, cancellation) close() is the
+        only teardown left — it must not leak them (Bugbot, PR 170)."""
+        session, stt, tts = _make_session(stt_script=[])
+        await session.prepare()
+        assert stt._connected and not stt._closed
+        await session.close()
+        assert stt._closed and tts._closed
+        assert session.closed
+        await session.close()  # still idempotent
+
+    async def test_half_open_prepare_closes_what_it_opened(self) -> None:
+        session, stt, tts = _make_session(stt_script=[])
+
+        async def _boom(_config: object) -> None:
+            raise RuntimeError("tts down")
+
+        tts.connect = _boom  # type: ignore[method-assign]
+        with pytest.raises(RuntimeError):
+            await session.prepare()
+        assert stt._connected and stt._closed  # STT was opened, then closed again
+        assert not session._prepared
+
     async def test_call_context_seeded_into_session_bag(self) -> None:
         """Empty-``_trace`` reuse: turn 1's callable reads the session bag."""
         session, _, _ = _make_session(stt_script=[])

--- a/python/timbal/server/livekit_session.py
+++ b/python/timbal/server/livekit_session.py
@@ -845,12 +845,20 @@ async def _run_livekit_session(
         # already consume is waited out here — usually nothing, because the
         # hello rides the data channel the moment the caller connects while
         # the mic subscribe takes a getUserMedia + publish round trip.
-        seen_at = caller_seen_at.get("t")
-        hello_wait = (
-            max(0.0, _HELLO_WAIT_SECS - (time.monotonic() - seen_at))
-            if seen_at is not None
-            else _HELLO_WAIT_SECS
-        )
+        #
+        # A SIP caller has no data channel to say hello on, so for a phone the
+        # window can only ever expire: measured live on an inbound PSTN call,
+        # 2.0s of dead air between "agent joined" and "session built", before
+        # a single byte of STT or greeting. Skip it outright.
+        if caller_is_sip:
+            hello_wait = 0.0
+        else:
+            seen_at = caller_seen_at.get("t")
+            hello_wait = (
+                max(0.0, _HELLO_WAIT_SECS - (time.monotonic() - seen_at))
+                if seen_at is not None
+                else _HELLO_WAIT_SECS
+            )
         await _wait_event_or_abort(hello_event, timeout=hello_wait)
         if session_aborted.is_set():
             _release_if_never_connected()
@@ -899,6 +907,26 @@ async def _run_livekit_session(
             **meta,
         }
         session.recording_meta = {**(session.recording_meta or {}), **meta}
+
+        if caller_is_sip:
+            # Publishing our track is what makes livekit-sip send the 200 OK,
+            # so on a phone call "answered" must mean "listening". Open the
+            # STT/TTS connections first (idempotent; ``run()`` skips them) —
+            # otherwise the callee hears the line go live ~0.5s before the
+            # first word can be heard, and the first "hola" is lost.
+            try:
+                await session.prepare()
+            except BaseException:
+                with contextlib.suppress(BaseException):
+                    await session.close()
+                raise
+            # The connects took real time; a BYE / short-abandon may have
+            # landed meanwhile. Same gate as after build: never publish (and
+            # so never answer) a call whose caller is already gone.
+            if session_aborted.is_set():
+                with contextlib.suppress(BaseException):
+                    await session.close()
+                return
 
         track = rtc.LocalAudioTrack.create_audio_track("agent", downlink.source)
         await room.local_participant.publish_track(

--- a/python/timbal/server/livekit_session.py
+++ b/python/timbal/server/livekit_session.py
@@ -31,6 +31,9 @@ Env contract for the boot-env path (all platform-owned):
   Session identity, not a voice knob: it is read here (and off the dial body
   on the per-request path), never off the data-channel hello.
 * ``TIMBAL_VOICE_ABANDON_SECS`` — default 45; see ``SingleSessionGuard``
+* ``TIMBAL_VOICE_HELLO_WAIT_SECS`` / ``TIMBAL_VOICE_SIP_HELLO_WAIT_SECS`` —
+  the config-hello window for browser (default 2) and SIP (default 0) callers;
+  see ``hello_wait_secs``.
 
 Env contract for the per-request path (both optional, both recommended on
 anything long-lived — the dial tells the process where to connect and what to
@@ -91,6 +94,30 @@ _EVENTS_TOPIC = "timbal.events"
 # still being published — anchoring it after the mic subscribe instead would
 # put a flat 2s on top of every hello-less call's setup.
 _HELLO_WAIT_SECS = 2.0
+# A SIP caller has no data channel to say hello on, so the window can only
+# expire for them: measured live, 2.0s of dead air on every inbound PSTN call.
+# Zero by default; a deployment whose SIP bridge does deliver a hello (or that
+# wants a settle beat before build) can raise it.
+_SIP_HELLO_WAIT_SECS = 0.0
+
+
+def hello_wait_secs(*, caller_is_sip: bool) -> float:
+    """The config-hello window for this caller, from env or the defaults above.
+
+    ``TIMBAL_VOICE_HELLO_WAIT_SECS`` (browser / standard participants, default
+    2.0) and ``TIMBAL_VOICE_SIP_HELLO_WAIT_SECS`` (SIP, default 0). Read per
+    call, not at import, so an operator can tune a running deployment's next
+    call and tests can set the env. A bad value logs and falls back.
+    """
+    name = "TIMBAL_VOICE_SIP_HELLO_WAIT_SECS" if caller_is_sip else "TIMBAL_VOICE_HELLO_WAIT_SECS"
+    default = _SIP_HELLO_WAIT_SECS if caller_is_sip else _HELLO_WAIT_SECS
+    raw = os.environ.get(name, "").strip()
+    if raw:
+        try:
+            return max(0.0, float(raw))
+        except ValueError:
+            logger.warning("livekit_bad_hello_wait_secs", env=name, value=raw)
+    return default
 
 # How long a per-request join may take before the caller gets a 504. The SFU is
 # in the same VPC, so this covers the FFI import on a cold process, not a WAN
@@ -846,19 +873,13 @@ async def _run_livekit_session(
         # hello rides the data channel the moment the caller connects while
         # the mic subscribe takes a getUserMedia + publish round trip.
         #
-        # A SIP caller has no data channel to say hello on, so for a phone the
-        # window can only ever expire: measured live on an inbound PSTN call,
-        # 2.0s of dead air between "agent joined" and "session built", before
-        # a single byte of STT or greeting. Skip it outright.
-        if caller_is_sip:
-            hello_wait = 0.0
-        else:
-            seen_at = caller_seen_at.get("t")
-            hello_wait = (
-                max(0.0, _HELLO_WAIT_SECS - (time.monotonic() - seen_at))
-                if seen_at is not None
-                else _HELLO_WAIT_SECS
-            )
+        # For a SIP caller the window is 0 by default (see ``hello_wait_secs``):
+        # a phone has no data channel to say hello on, so it could only expire
+        # — measured live as 2.0s of dead air between "agent joined" and
+        # "session built", before a single byte of STT or greeting.
+        window = hello_wait_secs(caller_is_sip=caller_is_sip)
+        seen_at = caller_seen_at.get("t")
+        hello_wait = max(0.0, window - (time.monotonic() - seen_at)) if seen_at is not None else window
         await _wait_event_or_abort(hello_event, timeout=hello_wait)
         if session_aborted.is_set():
             _release_if_never_connected()

--- a/python/timbal/server/livekit_session.py
+++ b/python/timbal/server/livekit_session.py
@@ -101,14 +101,20 @@ _HELLO_WAIT_SECS = 2.0
 _SIP_HELLO_WAIT_SECS = 0.0
 
 
-def hello_wait_secs(*, caller_is_sip: bool) -> float:
-    """The config-hello window for this caller, from env or the defaults above.
+def hello_wait_secs(*, caller_is_sip: bool, defaults: Any = None) -> float:
+    """The config-hello window for this caller.
 
-    ``TIMBAL_VOICE_HELLO_WAIT_SECS`` (browser / standard participants, default
-    2.0) and ``TIMBAL_VOICE_SIP_HELLO_WAIT_SECS`` (SIP, default 0). Read per
-    call, not at import, so an operator can tune a running deployment's next
-    call and tests can set the env. A bad value logs and falls back.
+    Precedence: the agent's own ``voice_config`` (``hello_wait_secs`` /
+    ``sip_hello_wait_secs`` on ``defaults`` — what ``agent.py`` or
+    ``codegen set-config`` wrote), then env ``TIMBAL_VOICE_HELLO_WAIT_SECS`` /
+    ``TIMBAL_VOICE_SIP_HELLO_WAIT_SECS`` (operator tuning, read per call, not
+    at import), then 2.0 for browser callers and 0 for SIP. A bad env value
+    logs and falls back.
     """
+    field = "sip_hello_wait_secs" if caller_is_sip else "hello_wait_secs"
+    declared = getattr(defaults, field, None)
+    if declared is not None:
+        return max(0.0, float(declared))
     name = "TIMBAL_VOICE_SIP_HELLO_WAIT_SECS" if caller_is_sip else "TIMBAL_VOICE_HELLO_WAIT_SECS"
     default = _SIP_HELLO_WAIT_SECS if caller_is_sip else _HELLO_WAIT_SECS
     raw = os.environ.get(name, "").strip()
@@ -877,7 +883,8 @@ async def _run_livekit_session(
         # a phone has no data channel to say hello on, so it could only expire
         # — measured live as 2.0s of dead air between "agent joined" and
         # "session built", before a single byte of STT or greeting.
-        window = hello_wait_secs(caller_is_sip=caller_is_sip)
+        defaults = getattr(app.state, "voice_config", None) or VoiceConfig()
+        window = hello_wait_secs(caller_is_sip=caller_is_sip, defaults=defaults)
         seen_at = caller_seen_at.get("t")
         hello_wait = max(0.0, window - (time.monotonic() - seen_at)) if seen_at is not None else window
         await _wait_event_or_abort(hello_event, timeout=hello_wait)
@@ -895,7 +902,6 @@ async def _run_livekit_session(
                 attrs = dict(getattr(caller_participant, "attributes", None) or {})
                 sip_ctx = sip_call_context(attrs)
                 sip_meta.update(sip_recording_meta(attrs))
-        defaults = getattr(app.state, "voice_config", None) or VoiceConfig()
         sample_rate = int(merge_client_voice_overrides(defaults, config).sample_rate)
 
         downlink = LkPacedSource(sample_rate=sample_rate)

--- a/python/timbal/server/livekit_session.py
+++ b/python/timbal/server/livekit_session.py
@@ -922,7 +922,7 @@ async def _run_livekit_session(
             parent_run_id=dial.parent_id or None,
         )
         session_holder["s"] = session
-        if session_aborted.is_set():
+        if session_aborted.is_set() or session.closed:
             with contextlib.suppress(BaseException):
                 await session.close()
             return
@@ -948,9 +948,11 @@ async def _run_livekit_session(
                     await session.close()
                 raise
             # The connects took real time; a BYE / short-abandon may have
-            # landed meanwhile. Same gate as after build: never publish (and
-            # so never answer) a call whose caller is already gone.
-            if session_aborted.is_set():
+            # landed meanwhile. Once ``session_holder`` is set that path goes
+            # through ``session.close()`` rather than ``_abort()``, so check
+            # both: never publish (and so never answer) a call whose caller is
+            # already gone.
+            if session_aborted.is_set() or session.closed:
                 with contextlib.suppress(BaseException):
                     await session.close()
                 return

--- a/python/timbal/voice/config.py
+++ b/python/timbal/voice/config.py
@@ -206,6 +206,16 @@ class VoiceConfig(BaseModel):
     """Per-session LLM override ("provider/model")."""
     turn_timeout_secs: float | None = None
     """None → ``VoiceSession`` default."""
+    hello_wait_secs: float | None = Field(default=None, ge=0.0)
+    """LiveKit transport: how long to hold the session build for a browser
+    caller's config hello (STT/TTS/turn-detector picks on the data channel).
+    None → ``TIMBAL_VOICE_HELLO_WAIT_SECS``, else 2.0. Server-side only — the
+    hello is the thing being waited for, so it cannot carry this."""
+    sip_hello_wait_secs: float | None = Field(default=None, ge=0.0)
+    """Same window for a SIP caller. None → ``TIMBAL_VOICE_SIP_HELLO_WAIT_SECS``,
+    else 0: a phone has no data channel to say hello on, so the window can
+    only expire — measured live as 2s of dead air before the first word. Raise
+    it only for a SIP bridge that does deliver a hello, or for a settle beat."""
     turn_timeout_fallback: str | None = None
     """None → ``VoiceSession`` default; "" → no spoken apology on timeout."""
     recording: RecordingConfig | None = None

--- a/python/timbal/voice/session.py
+++ b/python/timbal/voice/session.py
@@ -567,9 +567,30 @@ class VoiceSession:
         """
         if self._prepared:
             return
-        await self.stt.connect(self.audio_input)
-        await self.tts.connect(self.audio_output)
+        try:
+            await self.stt.connect(self.audio_input)
+            await self.tts.connect(self.audio_output)
+        except BaseException:
+            # A half-open pair (STT up, TTS failed) has no ``run()`` finally
+            # coming to close it.
+            await self._close_prepared_adapters()
+            raise
         self._prepared = True
+
+    @property
+    def closed(self) -> bool:
+        """``True`` once :meth:`close` ran — the caller hung up or the host
+        tore the session down. A transport that answers the far end only after
+        its own setup (SIP: the 200 OK follows our published track) checks this
+        before answering; a closed session must never be put on the air."""
+        return self._closed
+
+    async def _close_prepared_adapters(self) -> None:
+        for closer in (self.stt.close, self.tts.close):
+            try:
+                await closer()
+            except Exception as e:  # noqa: BLE001 - teardown must finish
+                logger.debug("voice_prepared_adapter_close_failed", error=str(e))
 
     async def run(self, audio_in: AsyncIterable[bytes]) -> AsyncIterator[VoiceSessionEvent]:
         """Main loop.  Yields events until the session is closed or errors out."""
@@ -761,6 +782,10 @@ class VoiceSession:
             self._greeting_task.cancel()
         await self.interrupt(truncate_completed=False)
         await self._emit(None)  # sentinel stops the run() iterator
+        if self._prepared and self.started_at is None:
+            # ``prepare()`` opened the provider sockets but ``run()`` never
+            # started, so its ``finally`` (``_cleanup``) will never close them.
+            await self._close_prepared_adapters()
 
     # -- Internal: first-reply warmup -----------------------------------------
 

--- a/python/timbal/voice/session.py
+++ b/python/timbal/voice/session.py
@@ -345,6 +345,8 @@ class VoiceSession:
         self._current_turn_task: asyncio.Task | None = None
         self._is_speaking = False
         self._closed = False
+        #: STT/TTS connections opened (``prepare()``), so ``run()`` skips them.
+        self._prepared = False
         self._held_user_text: str | None = None
         self._hold_task: asyncio.Task | None = None
         self._hold_armed_timeout_secs: float | None = None
@@ -553,13 +555,28 @@ class VoiceSession:
             await self._begin_user_turn(text, replace_user_entry=False)
             return True
 
+    async def prepare(self) -> None:
+        """Open the STT and TTS connections ahead of :meth:`run`.
+
+        Optional and idempotent: ``run()`` does this itself when it has not
+        been done. A transport that signals "answered" to the far end only
+        once the agent's media is published (SIP via LiveKit: the 200 OK
+        follows our track) calls this first, so the moment the callee hears
+        the line go live we are already listening — without it the first
+        ~half second of the call is dead, and the first word is lost.
+        """
+        if self._prepared:
+            return
+        await self.stt.connect(self.audio_input)
+        await self.tts.connect(self.audio_output)
+        self._prepared = True
+
     async def run(self, audio_in: AsyncIterable[bytes]) -> AsyncIterator[VoiceSessionEvent]:
         """Main loop.  Yields events until the session is closed or errors out."""
         try:
             self.started_at = time.time()
             self._start_llm_warmup()
-            await self.stt.connect(self.audio_input)
-            await self.tts.connect(self.audio_output)
+            await self.prepare()
             await self.turn_detector.start(self.audio_input)
             await self._maybe_start_endpointer()
             await self._emit(SessionStarted())


### PR DESCRIPTION
## Measured (inbound PSTN → livekit-sip → platform media sidecar)

| T | |
|---|---|
| 0.00 | agent joined the room |
| **2.00** | `build_voice_session` |
| 2.47 | Deepgram Flux connected |

Between join and build: nothing. That is `_HELLO_WAIT_SECS = 2.0` — the driver waits for the browser's config hello on the data channel before building. A phone has no data channel, so for a SIP caller the window can only ever expire.

Then STT/TTS connect inside `run()`, which starts after `publish_track` — and our published track is what makes livekit-sip send the 200 OK. So the callee hears the line go live ~0.5 s before we're listening. On the live call the first "hola" was lost; the caller repeated it 6 s later.

## Change

- **Skip the hello window for SIP callers.** `caller_is_sip` is set in the participant handler before `caller_ready` fires, so at the wait it's known. Browser callers are unchanged.
- **`VoiceSession.prepare()`** — opens STT + TTS ahead of `run()`, idempotent (`run()` calls it too). The LiveKit driver awaits it for SIP callers *before* `publish_track`, with the same `session_aborted` gate afterwards as after build: a BYE during the connects must not produce an answered call with nobody on it.

Net for a phone: agent-joined → listening goes from ~2.5 s to the STT/TTS connect time (~0.5 s), and "answered" now means "listening".

## Tests

`TestSipRuntime`: SIP caller builds within 0.5 s of media with no hello; a standard participant still gets the window; for SIP, `prepare` precedes `publish`. `test_sip_blip_during_hello_does_not_build_session` re-asserts the new contract (built at once, torn down by the abandon, never published).

`test_livekit_session` + `test_livekit_sip` + `test_voice_ws` + `test_voice_greeting` + `test_voice_filler` + `tests/voice`: **799 passed, 4 skipped**. No new ruff findings; also clears two nits #169 left in `test_voice_config.py`. The three touched source/test files were already `ruff format`-dirty on main and are left as they were.

Follow-up to #165 / #169.