### PR TITLE
feat(server/voice): carry ambient presets on GET /voice_config

### DIFF
--- a/python/tests/server/test_voice_config.py
+++ b/python/tests/server/test_voice_config.py
@@ -667,6 +667,33 @@ class TestDeclaredVoiceConfig:
         # Env text survives the agent's partial greeting block.
         assert merged.greeting is not None and merged.greeting.text == "Env opener" and merged.greeting.delay_ms == 250
 
+    def test_ambient_travels_as_a_preset_but_never_as_a_path(self):
+        """The first platform-media PSTN call with an agent that asked for the
+        café bed got silence behind the voice: ``ambient`` was withheld
+        wholesale. A preset name is portable (same CDN asset on any host); a
+        file path names this box's disk and stays here."""
+        from timbal.voice.config import AmbientAudioConfig
+
+        class Preset:
+            voice_config = {"ambient": {"source": "Cafe", "volume": 0.3}}
+
+        assert voice_routes.declared_voice_config(Preset()) == {"ambient": {"source": "cafe", "volume": 0.3}}
+
+        class Instance:
+            voice_config = {"ambient": AmbientAudioConfig(source="office")}
+
+        assert voice_routes.declared_voice_config(Instance()) == {"ambient": {"source": "office"}}
+
+        class Path_:
+            voice_config = {"language": "es", "ambient": {"source": "/srv/beds/lobby.ogg", "volume": 0.2}}
+
+        assert voice_routes.declared_voice_config(Path_()) == {"language": "es"}
+
+        class Garbage:
+            voice_config = {"ambient": {"source": "cafe", "volume": "loud"}}
+
+        assert voice_routes.declared_voice_config(Garbage()) == {"ambient": {"source": "cafe"}}
+
     def test_callable_is_resolved(self):
         class R:
             @staticmethod

--- a/python/tests/server/test_voice_config.py
+++ b/python/tests/server/test_voice_config.py
@@ -684,6 +684,11 @@ class TestDeclaredVoiceConfig:
 
         assert voice_routes.declared_voice_config(Instance()) == {"ambient": {"source": "office"}}
 
+        class Top:  # VoiceConfig spelling must be just as sparse (Bugbot: default volume leaked)
+            voice_config = VoiceConfig(ambient=AmbientAudioConfig(source="office"))
+
+        assert voice_routes.declared_voice_config(Top()) == {"ambient": {"source": "office"}}
+
         class Path_:
             voice_config = {"language": "es", "ambient": {"source": "/srv/beds/lobby.ogg", "volume": 0.2}}
 

--- a/python/timbal/server/voice.py
+++ b/python/timbal/server/voice.py
@@ -31,6 +31,7 @@ from ..voice.ambience import PRESETS as AMBIENT_PRESETS
 from ..voice.ambience import ensure_ambient_source
 from ..voice.config import (
     DEFAULT_VOICE_ID,
+    AmbientAudioConfig,
     FillerConfig,
     GreetingConfig,
     RecordingConfig,
@@ -149,9 +150,31 @@ def _normalize_declared_voice_config(runnable: Any) -> dict[str, Any] | None:
 
 #: ``VoiceConfig`` keys that stay on this box when the config is served over
 #: HTTP (:func:`declared_voice_config`). ``recording`` carries a directory and
-#: an ``on_saved`` callable; ``ambient.source`` may be a local file path. Both
-#: are this process's business, never a remote media host's.
-_VOICE_CONFIG_SERVER_ONLY = frozenset({"recording", "ambient"})
+#: an ``on_saved`` callable — this process's business, never a remote media
+#: host's. ``ambient`` is handled separately: a *preset* name is portable (the
+#: remote host fetches the same CDN asset), a file path is not.
+_VOICE_CONFIG_SERVER_ONLY = frozenset({"recording"})
+
+
+def _portable_ambient(block: Any) -> dict[str, Any] | None:
+    """The agent's ``ambient`` block if a remote media host can honour it.
+
+    Only a preset name travels — a file path names something on *this* box's
+    disk, and the first PSTN call on platform media showed why this matters
+    the other way too: withholding ``ambient`` wholesale meant an agent that
+    asked for the café bed got silence behind its voice.
+    """
+    if isinstance(block, AmbientAudioConfig):
+        block = block.model_dump(include=block.model_fields_set)
+    if not isinstance(block, dict):
+        return None
+    source = block.get("source")
+    if not isinstance(source, str) or source.strip().lower() not in AMBIENT_PRESETS:
+        return None
+    out: dict[str, Any] = {"source": source.strip().lower()}
+    if isinstance(block.get("volume"), (int, float)) and not isinstance(block["volume"], bool):
+        out["volume"] = float(block["volume"])
+    return out
 
 _DROP = object()
 
@@ -185,14 +208,18 @@ def declared_voice_config(runnable: Any) -> dict[str, Any]:
     and turn policy — and must not inherit this box's env defaults, which is
     why the result is sparse (declared keys only) rather than the merged
     :class:`VoiceConfig`. Nested ``filler`` / ``greeting`` lose their ``model``
-    unless it is a plain ``"provider/model"`` string.
+    unless it is a plain ``"provider/model"`` string; ``ambient`` travels only
+    as a preset name (see :func:`_portable_ambient`).
     """
     vc = _normalize_declared_voice_config(runnable)
     if not vc:
         return {}
-    out = _json_safe({k: v for k, v in vc.items() if k not in _VOICE_CONFIG_SERVER_ONLY})
+    ambient = _portable_ambient(vc.get("ambient"))
+    out = _json_safe({k: v for k, v in vc.items() if k not in _VOICE_CONFIG_SERVER_ONLY and k != "ambient"})
     if out is _DROP:
         return {}
+    if ambient is not None:
+        out["ambient"] = ambient
     for nested in ("filler", "greeting"):
         block = out.get(nested)
         if isinstance(block, dict) and "model" in block and not isinstance(block["model"], str):

--- a/python/timbal/server/voice.py
+++ b/python/timbal/server/voice.py
@@ -121,9 +121,9 @@ def _normalize_declared_voice_config(runnable: Any) -> dict[str, Any] | None:
     (dumped by ``model_fields_set`` so defaults the agent never touched do not
     masquerade as choices). ``None`` when the runnable declares nothing.
 
-    Nested ``filler`` / ``greeting`` come back as sparse dicts whichever way
-    the agent spelled them — a ``FillerConfig`` / ``GreetingConfig`` instance
-    inside a plain dict is as common as a ``VoiceConfig`` — so every consumer
+    Nested ``filler`` / ``greeting`` / ``ambient`` come back as sparse dicts
+    whichever way the agent spelled them — a model instance inside a plain
+    dict is as common as a ``VoiceConfig`` — so every consumer
     (:func:`merge_voice_config`, :func:`declared_voice_config`) sees one shape.
     """
     vc = getattr(runnable, "voice_config", None)
@@ -134,18 +134,27 @@ def _normalize_declared_voice_config(runnable: Any) -> dict[str, Any] | None:
         # all); put the instances back so the sparse redo below applies to
         # them exactly as it does to instances the agent placed in a dict.
         dumped = vc.model_dump(include=vc.model_fields_set)
-        for key in ("filler", "greeting"):
+        for key, _ in _SPARSE_NESTED:
             if key in dumped:
                 dumped[key] = getattr(vc, key)
         vc = dumped
     if not isinstance(vc, dict):
         return None
     out = dict(vc)
-    for key, model_type in (("filler", FillerConfig), ("greeting", GreetingConfig)):
+    for key, model_type in _SPARSE_NESTED:
         nested = out.get(key)
         if isinstance(nested, model_type):
             out[key] = nested.model_dump(include=nested.model_fields_set)
     return out
+
+
+#: Nested ``VoiceConfig`` blocks that are re-dumped by ``model_fields_set`` so a
+#: default the agent never touched is not reported (or merged) as a choice.
+_SPARSE_NESTED: tuple[tuple[str, type], ...] = (
+    ("filler", FillerConfig),
+    ("greeting", GreetingConfig),
+    ("ambient", AmbientAudioConfig),
+)
 
 
 #: ``VoiceConfig`` keys that stay on this box when the config is served over


### PR DESCRIPTION
## Why

#169 withheld `ambient` from `GET /voice_config` as server-only, because `source` may be a local file path. Measured on the next PSTN call through the platform media sidecar: an agent declaring `ambient: {source: "cafe", volume: 0.3}` got no background bed at all — the config never left its box.

## What

`_portable_ambient`: `ambient` travels when `source` is a known preset (`office`, `cafe`, `city`, `typing` — normalised to lower case; `volume` kept when numeric). A file path still stays on the box. `recording` remains server-only.

## Tests

`test_ambient_travels_as_a_preset_but_never_as_a_path`: preset dict, `AmbientAudioConfig` instance, path (dropped, siblings kept), non-numeric volume (dropped). `test_voice_config` + `test_http` + `test_voice_ambience`: 125 passed. No new lint findings beyond the file's existing `class R: voice_config = {...}` idiom.

Follow-up to #169 / #170.