### PR TITLE
feat(voice): call edges — outbound opener, wait-for-pickup, user idle/hang-up, and a playground that covers voice_config

### DIFF
--- a/examples/voice_playground_agents.py
+++ b/examples/voice_playground_agents.py
@@ -1,0 +1,193 @@
+"""Agents for exercising every voice_config knob in the /voice playground.
+
+One module, several agents — pick one with the import spec's ``::name``. All
+run on Groq (``qwen3.8-27b`` — fast enough that TTS never waits on the LLM),
+override with ``TIMBAL_VOICE_DEMO_MODEL``. Keys come from the repo-root ``.env``
+(the server ``load_dotenv()``s its cwd): ``GROQ_API_KEY`` + ``ELEVENLABS_API_KEY``
+minimum; ``DEEPGRAM_API_KEY`` to A/B Flux from the playground.
+
+From the repo root::
+
+    uv run python -m timbal.server --import_spec examples/voice_playground_agents.py::plain --port 4444
+    # then open http://127.0.0.1:4444/voice
+
+or drive several at once from the standalone launcher (Target panel → Agent
+field takes ``examples/voice_playground_agents.py::tools``, Start spawns it)::
+
+    uv run python -m timbal.server.playground
+
+Agents:
+
+  plain      no thinking, no tools. Inbound + outbound openers, user-idle
+             re-engagement, hang-up on a dead line. Flip *Simulate* to hear
+             the two openers; go quiet after a reply to hear the check-in.
+  thinking   reasoning ON, one slow tool — hear what 1–2s of silent thinking
+             does to first audio (nothing covers it: the filler is
+             tool-triggered; ask for the time to hear both stack up).
+  tools      a 3–5s tool and a fast one, spoken filler with a follow-up,
+             non-interruptible opener with a settle beat.
+  outbound   an outbound campaign shape: silent on inbound (``greeting=""``),
+             waits for the callee's "hello?" before opening, hangs up after
+             25s of silence (voicemail). Use *Simulate → Outbound*.
+  bare       declares no voice_config at all — the playground with nothing
+             to show as "server default"; every knob comes from the browser.
+
+Every value here is deliberately *declared* (not left default) so the Agent
+panel lists it and each field's placeholder shows it. Override any of them
+from the right-hand panel; ``Server default`` puts it back.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import random
+from datetime import UTC, datetime
+
+from timbal import Agent
+from timbal.core.tool import Tool
+
+_MODEL = os.environ.get("TIMBAL_VOICE_DEMO_MODEL", "groq/qwen/qwen3.8-27b")
+_QWEN = "qwen" in _MODEL
+
+# Groq's Qwen3 thinks by default; ``reasoning_effort`` is how it is switched.
+# Other providers: ``model_params`` passes through untouched, so for Anthropic
+# use {"thinking": {"type": "enabled", "budget_tokens": 1024}} and for OpenAI
+# {"reasoning_effort": "low"} — set TIMBAL_VOICE_DEMO_MODEL accordingly.
+_NO_THINKING = {"reasoning_effort": "none"} if _QWEN else {}
+_THINKING = {"reasoning_effort": "default"} if _QWEN else {}
+
+_STYLE = (
+    "You are a warm, concise voice assistant on a phone call. One or two short spoken "
+    "sentences per reply — no lists, no markdown, no emoji. Match the caller's language."
+)
+
+
+async def get_datetime() -> str:
+    """Current UTC date and time. Slow on purpose — long enough for a spoken filler."""
+    await asyncio.sleep(random.uniform(3.0, 5.0))
+    return datetime.now(UTC).strftime("%A %d %B %Y, %H:%M UTC")
+
+
+def roll_dice(sides: int = 6) -> int:
+    """Roll a die with ``sides`` sides. Instant — no filler should fire for this."""
+    return random.randint(1, max(2, sides))
+
+
+# ---------------------------------------------------------------------------
+
+plain = Agent(
+    name="voice_plain",
+    model=_MODEL,
+    max_tokens=512,
+    model_params=_NO_THINKING,
+    system_prompt=f"{_STYLE} You are Sam from Northwind Dental.",
+    tools=[],
+    voice_config={
+        "language": "en",
+        "greeting": {
+            "text": "Northwind Dental, this is Sam. How can I help you today?",
+            "interruptible": True,
+        },
+        "outbound_greeting": {
+            "text": "Hi, it's Sam from Northwind Dental calling about your appointment. Is now a good time?",
+            "delay_ms": 300,
+            "after_user_silence_secs": 2.0,
+        },
+        "user_idle": {
+            "timeout_secs": 6.0,
+            "text": ["Are you still there?", "Take your time — I'm here when you're ready."],
+            "max_count": 2,
+            "hangup_after_secs": 40.0,
+        },
+    },
+)
+
+thinking = Agent(
+    name="voice_thinking",
+    model=_MODEL,
+    max_tokens=1024,
+    model_params=_THINKING,
+    system_prompt=(
+        f"{_STYLE} You are a thoughtful tutor; reason carefully before answering. "
+        "For date or time questions call get_datetime."
+    ),
+    tools=[Tool(handler=get_datetime, description="Return the current UTC date and time.")],
+    voice_config={
+        "language": "en",
+        "greeting": "Hi, I'm your tutor. Ask me anything and I'll think it through with you.",
+        # Thinking is dead air until first audio and nothing covers it — the
+        # filler is tool-triggered (ask for the time to hear it fire on top of
+        # the thinking). A turn timeout keeps a runaway think from stalling
+        # the call.
+        "filler": {"delay_secs": 1.2, "repeat_secs": 4.0, "model": "groq/qwen/qwen3.8-27b"},
+        "turn_timeout_secs": 30.0,
+        "turn_timeout_fallback": "Sorry, that one's taking me too long — let's try again.",
+    },
+)
+
+tools = Agent(
+    name="voice_tools",
+    model=_MODEL,
+    max_tokens=512,
+    model_params=_NO_THINKING,
+    system_prompt=(
+        f"{_STYLE} For any date or time question you MUST call get_datetime and then speak "
+        "the result. For anything about dice, luck or random numbers call roll_dice. "
+        "Never claim you cannot do these."
+    ),
+    tools=[
+        Tool(handler=get_datetime, description="Return the current UTC date and time. Always use for date/time."),
+        Tool(handler=roll_dice, description="Roll a die. Use for dice, luck, or picking a random number."),
+    ],
+    voice_config={
+        "language": "en",
+        "greeting": {
+            "text": "Hello, this is the concierge line. I can tell you the time or roll a die for you.",
+            "interruptible": False,
+            "delay_ms": 400,
+        },
+        "filler": {
+            "delay_secs": 0.8,
+            "repeat_secs": 2.5,
+            "max_per_turn": 3,
+            "model": "groq/qwen/qwen3.8-27b",
+        },
+        "user_idle": {"timeout_secs": 8.0, "instructions": "Ask if they still need anything, in one short line."},
+    },
+)
+
+outbound = Agent(
+    name="voice_outbound",
+    model=_MODEL,
+    max_tokens=512,
+    model_params=_NO_THINKING,
+    system_prompt=(
+        f"{_STYLE} You are Alex from Riverside Clinic, calling to confirm tomorrow's 10am appointment. "
+        "Confirm, reschedule, or take a message — then wrap up politely."
+    ),
+    tools=[],
+    voice_config={
+        "language": "en",
+        # Nothing to say if someone dials *in* to this number...
+        "greeting": "",
+        # ...but on a call we placed: let them pick up first, open only if they don't.
+        "outbound_greeting": {
+            "text": "Hi, this is Alex from Riverside Clinic — I'm calling to confirm your appointment tomorrow at ten.",
+            "interruptible": False,
+            "delay_ms": 500,
+            "after_user_silence_secs": 2.5,
+        },
+        # Voicemail / dead line: one nudge, then hang up.
+        "user_idle": {"timeout_secs": 5.0, "text": "Hello? Can you hear me?", "max_count": 1, "hangup_after_secs": 25.0},
+    },
+)
+
+bare = Agent(
+    name="voice_bare",
+    model=_MODEL,
+    max_tokens=512,
+    model_params=_NO_THINKING,
+    system_prompt=_STYLE,
+    tools=[],
+)

--- a/python/tests/server/test_voice_config.py
+++ b/python/tests/server/test_voice_config.py
@@ -699,6 +699,41 @@ class TestDeclaredVoiceConfig:
 
         assert voice_routes.declared_voice_config(Garbage()) == {"ambient": {"source": "cafe"}}
 
+    def test_outbound_greeting_is_declared_sparsely_and_resolved_by_direction(self):
+        """``greeting`` is the inbound opener; ``outbound_greeting`` says what to
+        do on a call we placed — a different line, or ``""`` for silence. The
+        session never knows the direction, so the resolver is for the host."""
+        from timbal.voice.config import greeting_for_direction
+
+        class Both:
+            voice_config = {
+                "greeting": "Hey, this is your calorie coach. What have you eaten today?",
+                "outbound_greeting": {"text": "Hi, it's your coach checking in — got a minute?", "delay_ms": 500},
+            }
+
+        declared = voice_routes.declared_voice_config(Both())
+        # A bare string travels as written (the consumer coerces, like ``""``); a block stays sparse.
+        assert declared["greeting"] == "Hey, this is your calorie coach. What have you eaten today?"
+        assert declared["outbound_greeting"] == {"text": "Hi, it's your coach checking in — got a minute?", "delay_ms": 500}
+        merged = voice_routes.merge_voice_config(Both())
+        assert greeting_for_direction(merged, outbound=False).text.startswith("Hey")
+        assert greeting_for_direction(merged, outbound=True).text.startswith("Hi, it's")
+
+        class Quiet:  # inbound opener, silence on outbound
+            voice_config = {"greeting": "Thanks for calling.", "outbound_greeting": ""}
+
+        assert voice_routes.declared_voice_config(Quiet()) == {"greeting": "Thanks for calling.", "outbound_greeting": ""}
+        merged = voice_routes.merge_voice_config(Quiet())
+        assert greeting_for_direction(merged, outbound=False).text == "Thanks for calling."
+        assert greeting_for_direction(merged, outbound=True) is None
+
+        class OnlyInbound:  # unset → the one opener serves both directions
+            voice_config = {"greeting": "Hello there."}
+
+        merged = voice_routes.merge_voice_config(OnlyInbound())
+        assert greeting_for_direction(merged, outbound=True).text == "Hello there."
+        assert "outbound_greeting" not in voice_routes.declared_voice_config(OnlyInbound())
+
     def test_callable_is_resolved(self):
         class R:
             @staticmethod

--- a/python/tests/server/test_voice_filler.py
+++ b/python/tests/server/test_voice_filler.py
@@ -272,8 +272,11 @@ class TestFillerRepeat:
             prompts.append(messages[-1].collect_text())
             return f"Filler {len(prompts)}."
 
+        # Generous tool time: the follow-up only fires after ``repeat_secs`` of
+        # silence *since the first filler finished*, and a loaded CI runner can
+        # take most of 0.5s just to produce that first one (seen: 1 >= 2).
         session = _make_session(
-            tool_sleep=0.5,
+            tool_sleep=1.5,
             filler={"model": TestModel(handler=handler), "delay_secs": 0.0, "repeat_secs": 0.08},
         )
         await session._run_turn("what is the answer?")

--- a/python/tests/server/test_voice_greeting.py
+++ b/python/tests/server/test_voice_greeting.py
@@ -464,6 +464,42 @@ class TestGreetingSpoken:
         ]
         assert session._greeting_text == ""
 
+    async def test_after_user_silence_speaks_the_opener_only_when_the_line_stays_quiet(self) -> None:
+        """Wait-for-pickup (Retell ``begin_after_user_silence_ms``, ElevenLabs
+        ``initial_wait_time``): on a call we placed the callee's "hello?" opens
+        turn one; only a silent line gets the opener."""
+        stt = _OpenSTT()
+        session = _make_session(greeting={"text": GREETING, "after_user_silence_secs": 0.3}, stt=stt)
+        silent_at_150ms: list[bool] = []
+
+        async def drive(events: list[VoiceSessionEvent]) -> None:
+            await asyncio.sleep(0.15)
+            silent_at_150ms.append(not any(isinstance(e, AudioOutput) for e in events))
+            while not any(isinstance(e, AgentTextDone) for e in events):
+                await asyncio.sleep(0.01)
+
+        await _run(session, stt, drive=drive)
+        assert silent_at_150ms == [True]
+        assert [(e.role, e.text) for e in session.transcript] == [("assistant", GREETING)]
+
+    async def test_after_user_silence_yields_to_a_callee_who_speaks_first(self) -> None:
+        stt = _OpenSTT()
+        session = _make_session(greeting={"text": GREETING, "after_user_silence_secs": 0.4}, stt=stt)
+
+        async def drive(events: list[VoiceSessionEvent]) -> None:
+            await asyncio.sleep(0.05)
+            await stt.inject(TranscriptEvent(type="committed", text="Yes, hello?"))
+            while not any(isinstance(e, AgentTextDone) for e in events):
+                await asyncio.sleep(0.01)
+            await asyncio.sleep(0.5)  # outlive the window we skipped
+
+        await _run(session, stt, drive=drive)
+        assert [(e.role, e.text) for e in session.transcript] == [
+            ("user", "Yes, hello?"),
+            ("assistant", REPLY),
+        ]
+        assert session._greeting_text == ""
+
     async def test_generated_greeting_uses_instructions_and_agent_prompt(self) -> None:
         stt = _OpenSTT()
         seen: list[str] = []

--- a/python/tests/server/test_voice_greeting.py
+++ b/python/tests/server/test_voice_greeting.py
@@ -394,6 +394,86 @@ class TestClientGreetingOverrides:
         assert out.greeting.text == GREETING
 
 
+class TestClientOutboundGreetingAndDirection:
+    """The playground (or a dial) says which side placed the call; the server picks the opener."""
+
+    def test_outbound_greeting_is_client_settable(self) -> None:
+        assert "outbound_greeting" in voice_routes.CLIENT_SETTABLE_VOICE_FIELDS
+
+    def test_direction_is_read_off_the_hello(self) -> None:
+        assert voice_routes.client_call_direction({"direction": "outbound"}) == "outbound"
+        assert voice_routes.client_call_direction({"direction": " Inbound "}) == "inbound"
+        assert voice_routes.client_call_direction({"direction": "sideways"}) is None
+        assert voice_routes.client_call_direction({}) is None
+        assert voice_routes.client_call_direction({"direction": 3}) is None
+
+    def test_direction_is_not_reported_as_ignored(self, caplog) -> None:
+        with caplog.at_level("INFO"):
+            voice_routes.merge_client_voice_overrides(VoiceConfig(), {"direction": "outbound"})
+        assert "voice_client_config_ignored" not in caplog.text
+
+    def test_client_outbound_block_merges_over_declared_outbound(self) -> None:
+        base = VoiceConfig(greeting=GREETING, outbound_greeting={"text": "out", "delay_ms": 400})
+        out = voice_routes.merge_client_voice_overrides(base, {"outbound_greeting": {"after_user_silence_secs": 2}})
+        assert out.outbound_greeting.text == "out"
+        assert out.outbound_greeting.delay_ms == 400
+        assert out.outbound_greeting.after_user_silence_secs == 2
+        assert out.greeting.text == GREETING
+
+    def test_client_outbound_block_falls_back_to_inbound_base(self) -> None:
+        """No declared outbound → the patch is applied over ``greeting``, the opener outbound would use."""
+        base = VoiceConfig(greeting={"text": GREETING, "interruptible": True})
+        out = voice_routes.merge_client_voice_overrides(base, {"outbound_greeting": {"delay_ms": 250}})
+        assert out.outbound_greeting.text == GREETING
+        assert out.outbound_greeting.interruptible is True
+        assert out.outbound_greeting.delay_ms == 250
+
+    def test_client_empty_string_silences_outbound_only(self) -> None:
+        from timbal.voice.config import greeting_for_direction
+
+        base = VoiceConfig(greeting=GREETING)
+        out = voice_routes.merge_client_voice_overrides(base, {"outbound_greeting": ""})
+        assert "outbound_greeting" in out.model_fields_set
+        assert greeting_for_direction(out, outbound=True) is None
+        assert greeting_for_direction(out, outbound=False).text == GREETING
+
+    def test_unset_outbound_inherits_after_client_merge(self) -> None:
+        from timbal.voice.config import greeting_for_direction
+
+        base = VoiceConfig(greeting=GREETING)
+        out = voice_routes.merge_client_voice_overrides(base, {"greeting": {"delay_ms": 100}})
+        assert "outbound_greeting" not in out.model_fields_set
+        assert greeting_for_direction(out, outbound=True).delay_ms == 100
+
+    def test_build_voice_session_picks_opener_by_direction(self, monkeypatch) -> None:
+        captured: dict = {}
+
+        class FakeSession:
+            def __init__(self, **kw):
+                captured.update(kw)
+                self.session_id = "s"
+                self.parent_run_id = None
+
+        import timbal.voice as voice_pkg
+
+        monkeypatch.setattr(voice_pkg, "VoiceSession", FakeSession)
+        base = VoiceConfig(greeting="in line", outbound_greeting="out line")
+        agent = Agent(name="a", model=TestModel(responses=["x"]), tools=[])
+
+        _, meta = voice_routes.build_voice_session(agent, base, {"direction": "outbound"})
+        assert captured["greeting"].text == "out line"
+        assert meta["direction"] == "outbound"
+
+        captured.clear()
+        _, meta = voice_routes.build_voice_session(agent, base, {})
+        assert captured["greeting"].text == "in line"
+        assert meta["direction"] is None
+
+        captured.clear()
+        voice_routes.build_voice_session(agent, base, {"direction": "outbound", "outbound_greeting": ""})
+        assert "greeting" not in captured
+
+
 # ---------------------------------------------------------------------------
 # Speaking it
 # ---------------------------------------------------------------------------

--- a/python/tests/server/test_voice_user_idle.py
+++ b/python/tests/server/test_voice_user_idle.py
@@ -1,0 +1,163 @@
+"""``VoiceConfig.user_idle`` — re-engage a silent user, hang up on a dead line.
+
+Same harness as the greeting tests: an STT that stays open until told to
+finish, a tiny fake TTS, a ``TestModel`` agent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pydantic import ValidationError
+from timbal import Agent
+from timbal.core.test_model import TestModel
+from timbal.voice import (
+    AgentTextDone,
+    SessionEnded,
+    TranscriptEvent,
+    UserIdleConfig,
+    VoiceConfig,
+    VoiceSession,
+    VoiceSessionEvent,
+)
+
+from .test_voice_greeting import GREETING, REPLY, _OpenSTT, _run
+from .test_voice_ws import _make_tts_class
+
+
+def _session(stt: _OpenSTT, **user_idle: object) -> VoiceSession:
+    agent = Agent(name="idle_test", model=TestModel(responses=[REPLY]), tools=[])
+    return VoiceSession(agent, stt, _make_tts_class()(), turn_detector="heuristic", user_idle=user_idle or None)
+
+
+class TestUserIdleConfig:
+    def test_defaults_and_rotation(self) -> None:
+        cfg = UserIdleConfig(text=["Still there?", "Hello?"])
+        assert cfg.timeout_secs == 8.0 and cfg.max_count == 2 and cfg.hangup_after_secs is None
+        assert [cfg.line_for(i) for i in range(3)] == ["Still there?", "Hello?", "Still there?"]
+        assert UserIdleConfig(text="One line").line_for(5) == "One line"
+        assert UserIdleConfig(instructions="check in").line_for(0) is None  # → generated
+
+    def test_rejects_configs_that_do_nothing(self) -> None:
+        with pytest.raises(ValidationError):
+            UserIdleConfig()  # no line, prompts enabled
+        with pytest.raises(ValidationError):
+            UserIdleConfig(max_count=0)  # nothing to say and nothing to hang up on
+        UserIdleConfig(max_count=0, hangup_after_secs=30)  # hang-up only: fine
+        with pytest.raises(ValidationError):
+            UserIdleConfig(text="x", timeout_secs=0)
+        with pytest.raises(ValidationError):
+            VoiceConfig(user_idle={"text": "x", "unknown": 1})
+
+    def test_rides_voice_config(self) -> None:
+        cfg = VoiceConfig(user_idle={"text": "Are you still there?", "timeout_secs": 6, "hangup_after_secs": 30})
+        assert isinstance(cfg.user_idle, UserIdleConfig)
+        assert cfg.user_idle.hangup_after_secs == 30
+        assert VoiceConfig().user_idle is None  # status quo: wait forever
+
+
+class TestUserIdleBehaviour:
+    async def test_prompts_after_silence_then_stops_at_max_count(self) -> None:
+        stt = _OpenSTT()
+        session = _session(stt, timeout_secs=0.2, text=["Still there?", "Hello?"], max_count=2)
+
+        async def drive(_events: list[VoiceSessionEvent]) -> None:
+            # Long enough for four timeouts; only two prompts may be spoken.
+            await asyncio.sleep(1.4)
+
+        events = await _run(session, stt, drive=drive)
+        spoken = [e.text for e in events if isinstance(e, AgentTextDone)]
+        assert spoken == ["Still there?", "Hello?"]
+        assert [(e.role, e.text) for e in session.transcript] == [
+            ("assistant", "Still there?"),
+            ("assistant", "Hello?"),
+        ]
+        assert session.metrics == []  # prompts are not turns
+
+    async def test_user_speech_resets_the_clock(self) -> None:
+        stt = _OpenSTT()
+        session = _session(stt, timeout_secs=0.3, text="Still there?", max_count=1)
+
+        async def drive(events: list[VoiceSessionEvent]) -> None:
+            await asyncio.sleep(0.2)
+            await stt.inject(TranscriptEvent(type="committed", text="One sec."))
+            while not any(isinstance(e, AgentTextDone) for e in events):
+                await asyncio.sleep(0.01)
+            await asyncio.sleep(0.15)  # < timeout since the reply drained → no prompt yet
+
+        events = await _run(session, stt, drive=drive)
+        spoken = [e.text for e in events if isinstance(e, AgentTextDone)]
+        assert spoken == [REPLY]
+
+    async def test_hangup_after_secs_ends_the_session(self) -> None:
+        stt = _OpenSTT()
+        session = _session(stt, timeout_secs=0.15, text="Still there?", max_count=1, hangup_after_secs=0.6)
+
+        async def drive(events: list[VoiceSessionEvent]) -> None:
+            # Do not finish the STT ourselves: the hang-up must end the session.
+            while not any(isinstance(e, SessionEnded) for e in events):
+                await asyncio.sleep(0.02)
+
+        events = await _run(session, stt, drive=drive, timeout=3.0)
+        spoken = [e.text for e in events if isinstance(e, AgentTextDone)]
+        assert spoken == ["Still there?"]  # one prompt, then the line was dead
+        assert session.closed
+        assert isinstance(events[-1], SessionEnded)
+
+    async def test_our_own_prompt_does_not_reset_the_hangup_clock(self) -> None:
+        """Two prompts at 0.15s cadence would keep an agent-speech-reset clock
+        alive forever; the hang-up counts from the user's last word."""
+        stt = _OpenSTT()
+        session = _session(stt, timeout_secs=0.15, text="Hello?", max_count=5, hangup_after_secs=0.7)
+
+        async def drive(events: list[VoiceSessionEvent]) -> None:
+            while not any(isinstance(e, SessionEnded) for e in events):
+                await asyncio.sleep(0.02)
+
+        events = await _run(session, stt, drive=drive, timeout=3.0)
+        assert session.closed
+        assert len([e for e in events if isinstance(e, AgentTextDone)]) <= 4
+
+    async def test_generated_prompt_uses_instructions(self) -> None:
+        stt = _OpenSTT()
+        agent = Agent(name="idle_test", model=TestModel(responses=[REPLY]), tools=[])
+        session = VoiceSession(
+            agent,
+            stt,
+            _make_tts_class()(),
+            turn_detector="heuristic",
+            user_idle={
+                "timeout_secs": 0.2,
+                "instructions": "Ask if they are still there.",
+                "model": TestModel(responses=["Are you still with me?"]),
+                "max_count": 1,
+            },
+        )
+
+        async def drive(events: list[VoiceSessionEvent]) -> None:
+            while not any(isinstance(e, AgentTextDone) for e in events):
+                await asyncio.sleep(0.02)
+
+        events = await _run(session, stt, drive=drive)
+        assert [e.text for e in events if isinstance(e, AgentTextDone)] == ["Are you still with me?"]
+
+    async def test_greeting_and_idle_compose(self) -> None:
+        """Opener first; the idle clock starts only once it has drained."""
+        stt = _OpenSTT()
+        agent = Agent(name="idle_test", model=TestModel(responses=[REPLY]), tools=[])
+        session = VoiceSession(
+            agent,
+            stt,
+            _make_tts_class()(),
+            turn_detector="heuristic",
+            greeting=GREETING,
+            user_idle={"timeout_secs": 0.2, "text": "Still there?", "max_count": 1},
+        )
+
+        async def drive(events: list[VoiceSessionEvent]) -> None:
+            while len([e for e in events if isinstance(e, AgentTextDone)]) < 2:
+                await asyncio.sleep(0.02)
+
+        events = await _run(session, stt, drive=drive)
+        assert [e.text for e in events if isinstance(e, AgentTextDone)] == [GREETING, "Still there?"]

--- a/python/tests/server/test_voice_user_idle.py
+++ b/python/tests/server/test_voice_user_idle.py
@@ -57,6 +57,37 @@ class TestUserIdleConfig:
         assert VoiceConfig().user_idle is None  # status quo: wait forever
 
 
+class TestClientUserIdleOverrides:
+    """Playground / hello: tune or switch off the idle watcher for one call."""
+
+    def test_is_client_settable(self) -> None:
+        from timbal.server import voice as voice_routes
+
+        assert "user_idle" in voice_routes.CLIENT_SETTABLE_VOICE_FIELDS
+
+    def test_dict_deep_merges_and_validates(self) -> None:
+        from timbal.server import voice as voice_routes
+
+        base = VoiceConfig(user_idle={"text": "Still there?", "timeout_secs": 6})
+        out = voice_routes.merge_client_voice_overrides(base, {"user_idle": {"hangup_after_secs": 30, "text": ["a", "b"]}})
+        assert out.user_idle.timeout_secs == 6
+        assert out.user_idle.hangup_after_secs == 30
+        assert out.user_idle.line_for(1) == "b"
+        # Invalid patch → server's block is kept, not dropped.
+        out = voice_routes.merge_client_voice_overrides(base, {"user_idle": {"nope": 1}})
+        assert out.user_idle.text == "Still there?"
+        # Enables from nothing when the patch is complete on its own.
+        out = voice_routes.merge_client_voice_overrides(VoiceConfig(), {"user_idle": {"instructions": "check in"}})
+        assert out.user_idle.instructions == "check in"
+
+    def test_empty_string_switches_off(self) -> None:
+        from timbal.server import voice as voice_routes
+
+        base = VoiceConfig(user_idle={"text": "Still there?"})
+        assert voice_routes.merge_client_voice_overrides(base, {"user_idle": ""}).user_idle is None
+        assert voice_routes.merge_client_voice_overrides(base, {"user_idle": 7}).user_idle.text == "Still there?"
+
+
 class TestUserIdleBehaviour:
     async def test_prompts_after_silence_then_stops_at_max_count(self) -> None:
         stt = _OpenSTT()

--- a/python/tests/server/test_voice_user_idle.py
+++ b/python/tests/server/test_voice_user_idle.py
@@ -15,6 +15,7 @@ from timbal.core.test_model import TestModel
 from timbal.voice import (
     AgentTextDone,
     SessionEnded,
+    SessionInterrupted,
     TranscriptEvent,
     UserIdleConfig,
     VoiceConfig,
@@ -22,7 +23,7 @@ from timbal.voice import (
     VoiceSessionEvent,
 )
 
-from .test_voice_greeting import GREETING, REPLY, _OpenSTT, _run
+from .test_voice_greeting import GREETING, REPLY, _drain_queue, _OpenSTT, _PacedTTS, _run, _spoken
 from .test_voice_ws import _make_tts_class
 
 
@@ -88,6 +89,69 @@ class TestClientUserIdleOverrides:
         assert voice_routes.merge_client_voice_overrides(base, {"user_idle": 7}).user_idle.text == "Still there?"
 
 
+PROMPT = "Are you still there? I can wait, or we can pick this up another time."
+
+
+class TestUserIdlePromptBargeIn:
+    """The prompt is interruptible like an interruptible opener: cut to what was heard, bubble sealed."""
+
+    def _session(self, tts: _PacedTTS) -> VoiceSession:
+        agent = Agent(name="idle_test", model=TestModel(responses=[REPLY]), tools=[])
+        return VoiceSession(agent, _OpenSTT(), tts, turn_detector="heuristic", user_idle={"text": PROMPT})
+
+    async def test_prompt_counts_as_active_before_playback_reports_anything(self) -> None:
+        """A callee answering in the prompt's first ~100ms must still barge in.
+
+        Regression: the prompt used to be invisible to ``interrupt()`` until
+        the client acked playback — it returned ``not_active`` and left the
+        prompt talking over the user.
+        """
+        session = self._session(_PacedTTS(num_chunks=40, every_secs=0.05))
+        speak = asyncio.create_task(session._speak_idle_prompt(PROMPT))
+        await asyncio.sleep(0.01)  # synthesis started, nothing played yet
+        assert session._assistant_active is True
+
+        await session.interrupt()
+        await asyncio.gather(speak, return_exceptions=True)
+
+        assert session._idle_prompt_speaking is False
+        assert session._is_speaking is False
+        assert session._idle_record is None
+        assert session.transcript == []  # nothing heard → it was never said
+        events = _drain_queue(session)
+        [interrupted] = [e for e in events if isinstance(e, SessionInterrupted)]
+        assert interrupted.heard_text == ""
+        assert _spoken(events) == [""]  # bubble sealed, not left hanging
+
+    async def test_prompt_is_cut_to_what_was_heard(self) -> None:
+        session = self._session(_PacedTTS(num_chunks=4))
+        speak = asyncio.create_task(session._speak_idle_prompt(PROMPT))
+        await asyncio.sleep(0.12)  # ~2 of 4 chunks out, playback far behind
+
+        await session.interrupt()
+        await asyncio.gather(speak, return_exceptions=True)
+
+        [entry] = session.transcript
+        assert entry.role == "assistant"
+        assert entry.text != PROMPT
+        assert PROMPT.startswith(entry.text)
+        events = _drain_queue(session)
+        [interrupted] = [e for e in events if isinstance(e, SessionInterrupted)]
+        assert interrupted.heard_text == entry.text
+        assert _spoken(events) == [entry.text]
+
+    async def test_prompt_does_not_touch_the_opener_record(self) -> None:
+        """Regression: the prompt used to synthesize as ``greeting=True`` and
+        overwrite ``_greeting_record``, so a barge-in rewrote the opener's entry."""
+        session = self._session(_PacedTTS(num_chunks=2, every_secs=0.0))
+        session._greeting_record = [GREETING, 32_000]
+        await session._speak_idle_prompt(PROMPT)
+        assert session._greeting_record == [GREETING, 32_000]
+        assert session.metrics == []  # not a turn
+        assert [e.text for e in session.transcript] == [PROMPT]
+        assert _spoken(_drain_queue(session)) == [PROMPT]
+
+
 class TestUserIdleBehaviour:
     async def test_prompts_after_silence_then_stops_at_max_count(self) -> None:
         stt = _OpenSTT()
@@ -108,14 +172,18 @@ class TestUserIdleBehaviour:
 
     async def test_user_speech_resets_the_clock(self) -> None:
         stt = _OpenSTT()
-        session = _session(stt, timeout_secs=0.3, text="Still there?", max_count=1)
+        # Wide margin on purpose: the idle clock starts when the reply's audio
+        # has drained (after AgentTextDone), the watcher polls at 100ms, and
+        # teardown after ``drive`` returns is not free on a loaded CI runner —
+        # 0.15s of slack against a 0.3s timeout produced a phantom prompt.
+        session = _session(stt, timeout_secs=1.5, text="Still there?", max_count=1)
 
         async def drive(events: list[VoiceSessionEvent]) -> None:
             await asyncio.sleep(0.2)
             await stt.inject(TranscriptEvent(type="committed", text="One sec."))
             while not any(isinstance(e, AgentTextDone) for e in events):
                 await asyncio.sleep(0.01)
-            await asyncio.sleep(0.15)  # < timeout since the reply drained → no prompt yet
+            await asyncio.sleep(0.3)  # < timeout since the reply drained → no prompt yet
 
         events = await _run(session, stt, drive=drive)
         spoken = [e.text for e in events if isinstance(e, AgentTextDone)]

--- a/python/tests/voice/test_elevenlabs.py
+++ b/python/tests/voice/test_elevenlabs.py
@@ -1,0 +1,76 @@
+"""ElevenLabs adapters: what actually goes on the wire."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+from timbal.voice import elevenlabs as el
+from timbal.voice.providers import AudioInputConfig
+
+
+class _IdleWs:
+    """A socket that never yields and accepts sends — enough to let ``connect`` return."""
+
+    def __init__(self) -> None:
+        self.sent: list[Any] = []
+        self.closed = False
+
+    def __aiter__(self) -> _IdleWs:
+        return self
+
+    async def __anext__(self) -> str:
+        raise StopAsyncIteration
+
+    async def send(self, data: Any) -> None:
+        self.sent.append(data)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+async def _connect_uri(monkeypatch: pytest.MonkeyPatch, config: AudioInputConfig) -> dict[str, list[str]]:
+    seen: dict[str, str] = {}
+
+    async def fake_connect(uri: str, **_kw: Any) -> _IdleWs:
+        seen["uri"] = uri
+        return _IdleWs()
+
+    monkeypatch.setattr(el, "ws_connect", fake_connect)
+    stt = el.ElevenLabsRealtimeSTT(api_key="test-key")
+    await stt.connect(config)
+    try:
+        return parse_qs(urlsplit(seen["uri"]).query, keep_blank_values=True)
+    finally:
+        await stt.close()
+
+
+class TestScribeRealtimeQuery:
+    async def test_list_extras_become_repeated_params(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``keyterms`` is the one vocabulary-biasing knob Scribe has, and the
+        API only reads it as ``keyterms=a&keyterms=b``. A stringified list
+        (``keyterms=['a', 'b']``) silently biases towards one bogus term."""
+        q = await _connect_uri(
+            monkeypatch,
+            AudioInputConfig(extra={"keyterms": ["Acme", "Timbal AI"], "secondary_languages": ["es", "fr"]}),
+        )
+        assert q["keyterms"] == ["Acme", "Timbal AI"]
+        assert q["secondary_languages"] == ["es", "fr"]
+        assert q["model_id"] == [el._DEFAULT_STT_MODEL]
+        assert q["commit_strategy"] == ["vad"]
+
+    async def test_scalars_and_booleans_are_wire_spelled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        q = await _connect_uri(
+            monkeypatch,
+            AudioInputConfig(
+                language="en",
+                extra={"vad_threshold": 0.4, "include_timestamps": True, "no_verbatim": False, "_private": "x"},
+            ),
+        )
+        assert q["language_code"] == ["en"]
+        assert q["vad_threshold"] == ["0.4"]
+        assert q["include_timestamps"] == ["true"]
+        assert q["no_verbatim"] == ["false"]
+        assert "_private" not in q
+        assert "stt_host" not in q

--- a/python/tests/voice/test_session.py
+++ b/python/tests/voice/test_session.py
@@ -953,6 +953,26 @@ class TestTurnMetrics:
         assert m.speech_end_to_transcript_ms is not None
         assert 150 <= m.speech_end_to_transcript_ms <= 600
 
+    async def test_ignored_commits_do_not_steal_the_pending_asr_latency(self) -> None:
+        """A noise commit the detector IGNOREs (mid-HOLD, say) must not overwrite
+        the measurement of the utterance that will actually open the turn."""
+
+        class _Ignoring(TurnDetector):
+            async def on_partial(self, text, state):
+                return None
+
+            async def on_committed(self, text, state):
+                return CommitDecision(action=CommitAction.IGNORE, text=text, reason="noise")
+
+        agent = Agent(name="t", model=TestModel(responses=["Hi!"]), tools=[])
+        session = VoiceSession(agent=agent, stt=DelayedMockSTT(), tts=MockTTS(), turn_detector=_Ignoring())
+        session._pending_stt_latency = (123.0, "partial")  # from an accepted (held) commit
+        session._last_partial_at = session._last_commit_at + 0.05  # something to measure from
+
+        await session._handle_committed("uh")
+
+        assert session._pending_stt_latency == (123.0, "partial")
+
     async def test_final_metrics_persisted_by_serializing_provider(self, tmp_path) -> None:
         """Regression: the agent run's trace is saved (provider put) when the
         generator exhausts — before the turn's finally builds final metrics.

--- a/python/tests/voice/test_session.py
+++ b/python/tests/voice/test_session.py
@@ -926,6 +926,32 @@ class TestTurnMetrics:
         assert m.audio_bytes == len(chunk) * 2
 
         assert session.metrics == [m]
+        # Commit with no partial before it and no local VAD: nothing to measure from.
+        assert m.speech_end_to_transcript_ms is None and m.speech_end_source is None
+
+    async def test_asr_latency_is_measured_from_the_last_partial_without_a_vad(self) -> None:
+        """Per-user-message ASR latency: end of speech → committed transcript.
+        Without a local Silero VAD the STT's last interim is the stand-in for
+        end of speech, flagged as ``partial`` so a dashboard can label it."""
+        stt = DelayedMockSTT()
+        agent = Agent(name="t", model=TestModel(responses=["Hi!"]), tools=[])
+        session = VoiceSession(agent=agent, stt=stt, tts=MockTTS(), turn_detector="heuristic")
+
+        async def drive() -> None:
+            await asyncio.sleep(0.05)
+            await stt.inject(TranscriptEvent(type="partial", text="hel"))
+            await asyncio.sleep(0.2)  # the transcriber taking its time to finalize
+            await stt.inject(TranscriptEvent(type="committed", text="hello"))
+            await asyncio.sleep(0.3)
+            await stt.finish()
+
+        driver = asyncio.create_task(drive())
+        events = await _collect_events(session)
+        await driver
+        m = next(e for e in events if isinstance(e, TurnMetricsEvent)).metrics
+        assert m.speech_end_source == "partial"
+        assert m.speech_end_to_transcript_ms is not None
+        assert 150 <= m.speech_end_to_transcript_ms <= 600
 
     async def test_final_metrics_persisted_by_serializing_provider(self, tmp_path) -> None:
         """Regression: the agent run's trace is saved (provider put) when the

--- a/python/timbal/server/README.md
+++ b/python/timbal/server/README.md
@@ -78,6 +78,7 @@ A run whose process dies has nothing to replay. A replayable log is a ring: defa
 
 - **Embedded** (served by a running agent): `GET /voice` on a `timbal.server` — auto-dials that agent; the page injects the runnable meta at serve time.
 - **Standalone** (no agent required): `python -m timbal.server.playground` — serves the same HTML raw and opens a Target panel. Local target: enter an agent path (`path/to/agent.py::object`, optional fixed port) and press Start — the launcher spawns `uv run python -m timbal.server --import_spec …` from the agent file's directory, waits for the healthcheck, and the page dials it (changing agent/port respawns on the next Start). Platform target: a deployed workforce (`api.dev.timbal.ai` / `api.timbal.ai`) via ticket-authenticated WS / bearer-authenticated RTC. Fields persist in `localStorage`.
+- **What it exposes:** every client-settable `VoiceConfig` knob (pipeline, turn taking, greeting + outbound greeting, filler, user idle, `stt_extra` / `tts_extra` JSON) and nothing else — the page is a voice-config playground, not an agent override surface (there is no LLM picker; `model` stays client-settable on the wire for other clients). The Agent panel lists what the agent's own `voice_config` declares (`/voice/meta` → `voice_config`, same wire form as `GET /voice_config`), and each field's placeholder shows that declared value as its "server default". *Simulate* (inbound / outbound) sends `direction` on the hello so the outbound opener can be heard without placing a call.
 
 ---
 
@@ -131,7 +132,9 @@ Whether acks were received is reported per turn in `metrics.playback_acks_receiv
 
 Optional **first** text frame: a JSON object merged on top of `app.state.voice_config`, which is built at startup from environment defaults and optional `runnable.voice_config` on the loaded agent (`http` lifespan). Server-side `voice_config` (a dict, zero-arg callable, or `timbal.voice.VoiceConfig`) is validated strictly at startup — an unknown key fails server boot instead of being silently ignored.
 
-Only send keys you need; omitted keys keep server defaults. Client keys are allowlist-filtered (`CLIENT_SETTABLE_VOICE_FIELDS`): the table below plus `model` (per-session LLM override, `"provider/model"`), `turn_timeout_secs`, and `turn_timeout_fallback` (`""` disables the spoken apology). Anything else — notably `recording` — is server policy and is ignored with a log line.
+Only send keys you need; omitted keys keep server defaults. Client keys are allowlist-filtered (`CLIENT_SETTABLE_VOICE_FIELDS`): the table below plus `model` (per-session LLM override, `"provider/model"`), `turn_timeout_secs`, `turn_timeout_fallback` (`""` disables the spoken apology), and the nested blocks `filler`, `greeting`, `outbound_greeting` and `user_idle`. Nested blocks are deep-merged over the server's block and validated (an invalid patch keeps the server's); a bare string on `greeting` / `outbound_greeting` is a text override, and `""` on any of them switches that block off for this call (`filler` uses `{"enabled": false}`). Anything else — notably `recording` — is server policy and is ignored with a log line.
+
+Two hello keys are read by the transport rather than merged into `VoiceConfig`: `turn_detector` (below) and `direction` — `"inbound"` (default) or `"outbound"`, which tells the session who placed the call so it can pick `outbound_greeting` over `greeting` (`timbal.voice.config.greeting_for_direction`). The session cannot know this itself; the host that dialled or answered does (a LiveKit dial's `client_config`, or the playground's *Simulate* control). `session_started` echoes it back as `direction`.
 
 | Key           | Description |
 |---------------|-------------|

--- a/python/timbal/server/telephony.py
+++ b/python/timbal/server/telephony.py
@@ -80,6 +80,10 @@ _CONFIG_PARAM_KEYS = (
     "language",
     "voice",
     "greeting",
+    "outbound_greeting",
+    # Who placed the call — the webhook that dialled knows, the session does
+    # not; ``build_voice_session`` reads it to pick the outbound opener.
+    "direction",
 )
 
 # First-party identity on *our* incoming URL — not Telnyx-logged PII (name,

--- a/python/timbal/server/voice.html
+++ b/python/timbal/server/voice.html
@@ -199,15 +199,46 @@
     cursor: not-allowed;
     opacity: 0.65;
   }
-  .model-picker {
+  /* Read-only view of the agent's declared voice_config (from /voice/meta).
+     Key above value — the panel is 220px, too narrow for two columns once
+     keys like outbound_greeting.after_user_silence_secs show up. Nested
+     blocks are flattened to dotted keys so a greeting.delay_ms is one entry. */
+  .declared-list {
     display: flex;
     flex-direction: column;
-    gap: 0.55rem;
+    gap: 0.4rem;
+    margin: 0;
+    font-size: 0.6875rem;
+    line-height: 1.35;
   }
-  .model-count {
-    font-size: 0.65625rem;
+  .declared-list[hidden] { display: none !important; }
+  .declared-list dt {
     color: var(--text-muted);
-    margin-top: -0.15rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.625rem;
+    overflow-wrap: anywhere;
+  }
+  .declared-list dd {
+    margin: 0 0 0 0.5rem;
+    min-width: 0;
+    overflow-wrap: anywhere;
+    color: var(--text);
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  .declared-list dd.declared-empty { color: var(--text-muted); font-style: italic; }
+  /* Greeting sections: the one the simulated direction will not use is dimmed
+     (still editable — its values are sent, the server just picks the other). */
+  .panel-section.direction-idle { opacity: 0.55; }
+  .panel-section.direction-idle:hover,
+  .panel-section.direction-idle:focus-within { opacity: 1; }
+  .direction-tag {
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: 0;
+    margin-left: 0.35rem;
   }
   .panel-note {
     font-size: 0.6875rem;
@@ -236,8 +267,9 @@
     .panel { flex-basis: 220px; }
     .panel--session { flex-basis: 600px; }
     /* Explicit 2-track grid, not CSS columns: pairing is by section (pipeline
-       next to greeting, filler next to ambience) so the tops line up instead
-       of packing by height and leaving a ragged right edge. */
+       next to turn taking, inbound next to outbound greeting, filler next to
+       user idle, ambience next to advanced) so the tops line up instead of
+       packing by height and leaving a ragged right edge. */
     .panel-sections {
       display: grid;
       grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
@@ -740,23 +772,9 @@
             <span id="conn-runnable-spec" class="conn-runnable-spec" hidden></span>
           </div>
         </div>
-        <div class="model-picker" title="Agent LLM — applied on the next Start. Needs the matching provider API key on the server.">
-          <label class="field">
-            <span class="field-label">Provider</span>
-            <select id="model-provider-select" aria-label="LLM provider">
-              <option value="">All providers</option>
-            </select>
-          </label>
-          <label class="field">
-            <span class="field-label">Model</span>
-            <select id="model-select" aria-label="LLM model">
-              <option value="">Agent default</option>
-            </select>
-          </label>
-          <span id="model-count" class="model-count"></span>
-        </div>
+        <dl id="conn-declared" class="declared-list" hidden aria-label="Agent voice_config"></dl>
       </section>
-      <p class="panel-note">Changes apply on the next session Start. Model overrides need the matching provider API key on the server.</p>
+      <p class="panel-note">The agent's own <code>voice_config</code> is listed above. Every knob on the right that says “Server default” defers to it; set one to override it for the next Start only.</p>
     </aside>
 
     <main id="card" class="card">
@@ -803,6 +821,13 @@
             <option value="ws">WebSocket (PCM)</option>
             <option value="webrtc">WebRTC (Opus)</option>
             <option value="livekit">LiveKit (SFU)</option>
+          </select>
+        </label>
+        <label class="field">
+          <span class="field-label">Simulate</span>
+          <select id="direction-select" aria-label="Call direction" title="Which side placed the call — applied on the next Start. Inbound: you dialled in, the agent answers with its greeting. Outbound: the agent called you, so it uses outbound_greeting (falling back to greeting when the agent declares none, staying silent when it declares ''). Only the opener changes; the rest of the session is identical.">
+            <option value="inbound">Inbound call</option>
+            <option value="outbound">Outbound call</option>
           </select>
         </label>
       </div>
@@ -853,14 +878,55 @@
                 <option value="">Server default</option>
               </select>
             </label>
+            <label class="field">
+              <span class="field-label">Language</span>
+              <input type="text" id="language-input" aria-label="Language" placeholder="auto" data-vc="language"
+                     title="ISO code passed to STT and TTS (en, es, ar…). Empty = server default; the agent's default is provider auto-detect.">
+            </label>
+            <label class="field">
+              <span class="field-label">Voice ID</span>
+              <input type="text" id="voice-input" aria-label="TTS voice id" placeholder="Server default" data-vc="voice"
+                     title="Provider voice id for TTS (ElevenLabs voice id, Fish reference id…). Applied on the next Start.">
+            </label>
           </div>
         </section>
-        <section class="panel-section" aria-label="Greeting">
-          <h3 class="panel-section-title">Greeting</h3>
+        <section class="panel-section" aria-label="Turn taking">
+          <h3 class="panel-section-title">Turn taking</h3>
+          <div class="panel-grid">
+            <label class="field">
+              <span class="field-label">VAD endpointing</span>
+              <select id="vad-select" aria-label="VAD endpointing" title="Local Silero VAD fast path that commits the STT on silence — applied on the next Start. Auto = on when the turn detector has an audio EOU model. Always off for Flux/Munsit (they own end-of-turn).">
+                <option value="">Server default (auto)</option>
+                <option value="on">On</option>
+                <option value="off">Off</option>
+              </select>
+            </label>
+            <label class="field">
+              <span class="field-label">Turn timeout (s)</span>
+              <input type="number" id="turn-timeout" min="1" max="600" step="1" aria-label="Turn timeout" placeholder="Server default" data-vc="turn_timeout_secs"
+                     title="Wall-clock budget for one agent turn (LLM + tools). Past it the turn is cancelled and the fallback line is spoken.">
+            </label>
+            <label class="field">
+              <span class="field-label">Timeout apology</span>
+              <select id="turn-fallback-select" aria-label="Turn timeout fallback" title="What the agent says when a turn times out. Off = cancel silently; Custom = the line on the right.">
+                <option value="">Server default</option>
+                <option value="off">Off (silent)</option>
+                <option value="custom">Custom line</option>
+              </select>
+            </label>
+            <label class="field">
+              <span class="field-label">Apology text</span>
+              <input type="text" id="turn-fallback-text" aria-label="Turn timeout fallback text" placeholder="Server default" data-vc="turn_timeout_fallback"
+                     title="Spoken when a turn times out. Only used when the apology is set to Custom.">
+            </label>
+          </div>
+        </section>
+        <section class="panel-section" id="greeting-section" aria-label="Greeting (inbound)">
+          <h3 class="panel-section-title">Greeting <span class="direction-tag" id="greeting-tag"></span></h3>
           <div class="panel-grid">
             <label class="field">
               <span class="field-label">Enabled</span>
-              <select id="greeting-select" aria-label="Greeting" title="Agent speaks first, before you say anything. 'Server default' uses whatever the agent's voice_config sets; 'Off' silences the opener for this call only. Applied on the next Start.">
+              <select id="greeting-select" aria-label="Greeting" title="Agent speaks first, before you say anything. 'Server default' uses whatever the agent's voice_config sets; 'Off' silences the opener for this call only. Applied on the next Start. On an outbound call this block is the fallback when no outbound greeting is declared.">
                 <option value="">Server default</option>
                 <option value="off">Off</option>
                 <option value="on">On</option>
@@ -876,18 +942,74 @@
             </label>
             <label class="field">
               <span class="field-label">Delay (ms)</span>
-              <input type="number" id="greeting-delay" min="0" max="10000" step="100" aria-label="Greeting delay" placeholder="0"
+              <input type="number" id="greeting-delay" min="0" max="10000" step="100" aria-label="Greeting delay" placeholder="0" data-vc="greeting.delay_ms"
                      title="Silence held before the opener speaks. Mimics a carrier connecting the media stream before the callee has the handset up.">
             </label>
             <label class="field">
+              <span class="field-label">Wait for them (s)</span>
+              <input type="number" id="greeting-wait" min="0" max="30" step="0.5" aria-label="Greeting after user silence" placeholder="off" data-vc="greeting.after_user_silence_secs"
+                     title="Let the other side speak first: hold the opener this long after the delay, and skip it if they say anything (their words open turn one). Speak it anyway when the line stays silent — hesitant callee, voicemail beep. Empty = speak the opener right after the delay.">
+            </label>
+            <label class="field">
               <span class="field-label">Text</span>
-              <input type="text" id="greeting-text" aria-label="Greeting text" placeholder="Server default"
+              <input type="text" id="greeting-text" aria-label="Greeting text" placeholder="Server default" data-vc="greeting.text"
                      title="Exact words to say — straight to TTS, no LLM turn (~300ms to first audio). Wins over Instructions when both are set.">
+            </label>
+            <label class="field">
+              <span class="field-label">Generator model</span>
+              <input type="text" id="greeting-model" aria-label="Greeting generator model" placeholder="Session LLM" data-vc="greeting.model"
+                     title="provider/model used to write the opener from Instructions. Empty = the session's own LLM. Unused when Text is set.">
             </label>
             <label class="field field-wide">
               <span class="field-label">Instructions</span>
-              <input type="text" id="greeting-instructions" aria-label="Greeting instructions" placeholder="e.g. greet them by name and say why you are calling"
+              <input type="text" id="greeting-instructions" aria-label="Greeting instructions" placeholder="e.g. greet them by name and say why you are calling" data-vc="greeting.instructions"
                      title="Brief for an LLM-authored opener, written against the agent's own system prompt (~1.5s to first audio). Ignored when Text is set.">
+            </label>
+          </div>
+        </section>
+        <section class="panel-section" id="outbound-section" aria-label="Greeting (outbound)">
+          <h3 class="panel-section-title">Outbound greeting <span class="direction-tag" id="outbound-tag"></span></h3>
+          <div class="panel-grid">
+            <label class="field">
+              <span class="field-label">Enabled</span>
+              <select id="outbound-select" aria-label="Outbound greeting" title="Opener for calls the agent placed — only used when Simulate is set to Outbound. 'Server default' = the agent's outbound_greeting, or its greeting when none is declared. 'Off' = say nothing and wait for the callee's hello. 'On' = the fields below, deep-merged over that default.">
+                <option value="">Server default</option>
+                <option value="off">Off (wait for hello)</option>
+                <option value="on">On</option>
+              </select>
+            </label>
+            <label class="field">
+              <span class="field-label">Interruptible</span>
+              <select id="outbound-interruptible" aria-label="Outbound greeting interruptible" title="No = talking over the opener will not cut it off. Yes = barge-in truncates it like any reply.">
+                <option value="">Server default</option>
+                <option value="no">No (hold)</option>
+                <option value="yes">Yes (barge-in)</option>
+              </select>
+            </label>
+            <label class="field">
+              <span class="field-label">Delay (ms)</span>
+              <input type="number" id="outbound-delay" min="0" max="10000" step="100" aria-label="Outbound greeting delay" placeholder="0" data-vc="outbound_greeting.delay_ms"
+                     title="Silence held before the opener speaks — the beat between the carrier answering and the callee having the handset up.">
+            </label>
+            <label class="field">
+              <span class="field-label">Wait for them (s)</span>
+              <input type="number" id="outbound-wait" min="0" max="30" step="0.5" aria-label="Outbound greeting after user silence" placeholder="off" data-vc="outbound_greeting.after_user_silence_secs"
+                     title="The normal outbound pickup: hold the opener and let the callee's 'hello?' open turn one; speak the opener only if they stay silent this long (voicemail, hesitation).">
+            </label>
+            <label class="field">
+              <span class="field-label">Text</span>
+              <input type="text" id="outbound-text" aria-label="Outbound greeting text" placeholder="Server default" data-vc="outbound_greeting.text"
+                     title="Exact words to say — straight to TTS. Wins over Instructions when both are set.">
+            </label>
+            <label class="field">
+              <span class="field-label">Generator model</span>
+              <input type="text" id="outbound-model" aria-label="Outbound greeting generator model" placeholder="Session LLM" data-vc="outbound_greeting.model"
+                     title="provider/model used to write the opener from Instructions. Empty = the session's own LLM.">
+            </label>
+            <label class="field field-wide">
+              <span class="field-label">Instructions</span>
+              <input type="text" id="outbound-instructions" aria-label="Outbound greeting instructions" placeholder="e.g. say who you are and why you are calling, then ask if now is a good time" data-vc="outbound_greeting.instructions"
+                     title="Brief for an LLM-authored opener. Ignored when Text is set.">
             </label>
           </div>
         </section>
@@ -904,23 +1026,76 @@
             </label>
             <label class="field">
               <span class="field-label">Delay (s)</span>
-              <input type="number" id="filler-delay" min="0" max="10" step="0.1" aria-label="Filler grace delay" placeholder="1.0"
+              <input type="number" id="filler-delay" min="0" max="10" step="0.1" aria-label="Filler grace delay" placeholder="1.0" data-vc="filler.delay_secs"
                      title="Grace period before the filler speaks — tools that finish sooner stay silent. Only used when filler speech is On.">
             </label>
             <label class="field">
               <span class="field-label">Repeat (s)</span>
-              <input type="number" id="filler-repeat" min="0" max="60" step="0.5" aria-label="Filler repeat interval" placeholder="off"
+              <input type="number" id="filler-repeat" min="0" max="60" step="0.5" aria-label="Filler repeat interval" placeholder="off" data-vc="filler.repeat_secs"
                      title="If the agent is still working this long after the previous filler with nothing spoken, say a short follow-up ('still on it…'). Empty or 0 = one filler max. Only used when filler speech is On.">
             </label>
             <label class="field">
               <span class="field-label">Max per turn</span>
-              <input type="number" id="filler-max" min="1" max="10" step="1" aria-label="Max fillers per turn" placeholder="3"
+              <input type="number" id="filler-max" min="1" max="10" step="1" aria-label="Max fillers per turn" placeholder="3" data-vc="filler.max_per_turn"
                      title="Hard cap on fillers per turn when repeating. Only used when filler speech is On.">
+            </label>
+            <label class="field">
+              <span class="field-label">Gen. timeout (s)</span>
+              <input type="number" id="filler-timeout" min="0.5" max="30" step="0.5" aria-label="Filler generation timeout" placeholder="5.0" data-vc="filler.timeout_secs"
+                     title="Deadline for the filler LLM after the grace delay; past it the filler is skipped silently. Only used when filler speech is On.">
+            </label>
+            <label class="field">
+              <span class="field-label">Generator model</span>
+              <input type="text" id="filler-model" aria-label="Filler generator model" placeholder="Session LLM" data-vc="filler.model"
+                     title="provider/model that writes the filler phrase — something fast and cheap is best. Empty = the session's own LLM. Only used when filler speech is On.">
             </label>
             <label class="field field-wide">
               <span class="field-label">Generator prompt</span>
-              <input type="text" id="filler-prompt" aria-label="Filler generator prompt" placeholder="Built-in generator prompt"
+              <input type="text" id="filler-prompt" aria-label="Filler generator prompt" placeholder="Built-in generator prompt" data-vc="filler.system_prompt"
                      title="System prompt for the filler-generating LLM. Empty keeps the server's prompt (or the built-in one). Only used when filler speech is On.">
+            </label>
+          </div>
+        </section>
+        <section class="panel-section" aria-label="User idle">
+          <h3 class="panel-section-title">User idle</h3>
+          <div class="panel-grid">
+            <label class="field">
+              <span class="field-label">Enabled</span>
+              <select id="idle-select" aria-label="User idle re-engagement" title="What happens when you stop talking after the agent finishes: a spoken check-in ('still there?') after a silence, and optionally a hang-up. 'Server default' uses the agent's voice_config; 'Off' waits forever for this call. Applied on the next Start.">
+                <option value="">Server default</option>
+                <option value="off">Off (wait forever)</option>
+                <option value="on">On</option>
+              </select>
+            </label>
+            <label class="field">
+              <span class="field-label">Silence (s)</span>
+              <input type="number" id="idle-timeout" min="1" max="120" step="0.5" aria-label="User idle timeout" placeholder="8" data-vc="user_idle.timeout_secs"
+                     title="Seconds of your silence — counted from when the agent's last audio drained — before it speaks a prompt. Re-arms after each prompt.">
+            </label>
+            <label class="field">
+              <span class="field-label">Max prompts</span>
+              <input type="number" id="idle-max" min="0" max="10" step="1" aria-label="User idle max prompts" placeholder="2" data-vc="user_idle.max_count"
+                     title="Prompts per call, then silence. 0 = never prompt, only hang up (needs Hang up after).">
+            </label>
+            <label class="field">
+              <span class="field-label">Hang up after (s)</span>
+              <input type="number" id="idle-hangup" min="1" max="600" step="1" aria-label="User idle hang-up" placeholder="never" data-vc="user_idle.hangup_after_secs"
+                     title="Seconds since your last word (or since the call started) after which the session ends. The agent's own prompts do not reset it. Empty = never hang up on silence.">
+            </label>
+            <label class="field field-wide">
+              <span class="field-label">Text (| separates rotating lines)</span>
+              <input type="text" id="idle-text" aria-label="User idle text" placeholder="Server default" data-vc="user_idle.text"
+                     title="Static line(s) to say. Separate several with | to rotate through them in order. Wins over Instructions when set.">
+            </label>
+            <label class="field">
+              <span class="field-label">Instructions</span>
+              <input type="text" id="idle-instructions" aria-label="User idle instructions" placeholder="e.g. ask if they are still there" data-vc="user_idle.instructions"
+                     title="Brief for an LLM-authored check-in, in the agent's own voice and language. Ignored when Text is set.">
+            </label>
+            <label class="field">
+              <span class="field-label">Generator model</span>
+              <input type="text" id="idle-model" aria-label="User idle generator model" placeholder="Session LLM" data-vc="user_idle.model"
+                     title="provider/model that writes the check-in from Instructions. Empty = the session's own LLM.">
             </label>
           </div>
         </section>
@@ -942,6 +1117,26 @@
             <label class="field field-inline field-wide">
               <input type="checkbox" id="thinking-sound" aria-label="Thinking sound">
               <span class="field-label">Thinking sound while tools run</span>
+            </label>
+          </div>
+        </section>
+        <section class="panel-section" aria-label="Advanced">
+          <h3 class="panel-section-title">Advanced</h3>
+          <div class="panel-grid">
+            <label class="field field-wide">
+              <span class="field-label">STT model</span>
+              <input type="text" id="stt-model-input" aria-label="STT model" placeholder="Server default" data-vc="stt_model"
+                     title="Provider model id (scribe_v2_realtime, nova-3, flux-general-en…). Must match the selected STT provider — a foreign id falls back to the provider's default.">
+            </label>
+            <label class="field field-wide">
+              <span class="field-label">STT extra (JSON)</span>
+              <input type="text" id="stt-extra-input" aria-label="STT extra" placeholder='{"vad_silence_threshold_secs": 0.8}'
+                     title="Tuning knobs merged over the server's stt_extra — allow-listed server-side (VAD thresholds, endpointing, keyterms…); hosts and callbacks are dropped.">
+            </label>
+            <label class="field field-wide">
+              <span class="field-label">TTS extra (JSON)</span>
+              <input type="text" id="tts-extra-input" aria-label="TTS extra" placeholder='{"speed": 1.1, "stability": 0.5}'
+                     title="Tuning knobs merged over the server's tts_extra — allow-listed server-side (speed, stability, dialect, auto_mode…).">
             </label>
           </div>
         </section>
@@ -1004,72 +1199,276 @@ tdSelect.onchange = () => {
   localStorage.setItem(TD_STORAGE_KEY, tdSelect.value);
 };
 
-// Tool-call filler override — sent in the session config, applied on the next
-// Start. '' defers entirely to the server's voice_config.
+// --- Voice-config overrides -------------------------------------------------
+// Every control below maps onto a VoiceConfig key the server lets a client
+// set (CLIENT_SETTABLE_VOICE_FIELDS). They are sent in the session hello and
+// applied on the next Start; '' / empty always means "defer to the server's
+// voice_config", never "clear it" — the one exception is the explicit 'off'
+// option on nested blocks, which sends '' so the server drops its default.
+
+/** Restore an input/select from localStorage under `key` and save it on every change (`onChange` runs after each save). */
+function persist(el, key, onChange) {
+  el.value = localStorage.getItem(key) || '';
+  if (el.tagName === 'SELECT' && ![...el.options].some((o) => o.value === el.value)) el.value = '';
+  el.addEventListener('change', () => {
+    localStorage.setItem(key, el.value);
+    if (onChange) onChange();
+  });
+}
+function numOrNull(el, { min = -Infinity, integer = false } = {}) {
+  const raw = el.value.trim();
+  if (!raw) return null;
+  const n = integer ? parseInt(raw, 10) : parseFloat(raw);
+  return Number.isFinite(n) && n >= min ? n : null;
+}
+function jsonObjectOrNull(el) {
+  const raw = el.value.trim();
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
+  } catch (_) {
+    return null;
+  }
+}
+/** Red border + hint on a JSON field that will not be sent. */
+function markJson(el, okTitle) {
+  const bad = el.value.trim() && !jsonObjectOrNull(el);
+  el.style.borderColor = bad ? 'var(--danger)' : '';
+  el.title = bad ? 'Not a JSON object — this will not be sent.' : okTitle;
+}
+
+// Pipeline: language + TTS voice id (plain VoiceConfig scalars).
+const languageInput = document.getElementById('language-input');
+const voiceInput = document.getElementById('voice-input');
+persist(languageInput, 'timbal-voice-language');
+persist(voiceInput, 'timbal-voice-voice-id');
+
+// Turn taking: vad_endpointing / turn_timeout_secs / turn_timeout_fallback.
+const vadSelect = document.getElementById('vad-select');
+const turnTimeoutInput = document.getElementById('turn-timeout');
+const turnFallbackSelect = document.getElementById('turn-fallback-select');
+const turnFallbackText = document.getElementById('turn-fallback-text');
+persist(vadSelect, 'timbal-voice-vad-endpointing');
+persist(turnTimeoutInput, 'timbal-voice-turn-timeout');
+persist(turnFallbackSelect, 'timbal-voice-turn-fallback-mode', syncTurnInputs);
+persist(turnFallbackText, 'timbal-voice-turn-fallback-text');
+function syncTurnInputs() {
+  turnFallbackText.disabled = turnFallbackSelect.value !== 'custom';
+}
+syncTurnInputs();
+
+// Tool-call filler override.
 const fillerSelect = document.getElementById('filler-select');
 const fillerPrompt = document.getElementById('filler-prompt');
 const fillerDelay = document.getElementById('filler-delay');
 const fillerRepeat = document.getElementById('filler-repeat');
 const fillerMax = document.getElementById('filler-max');
-const FILLER_MODE_STORAGE_KEY = 'timbal-voice-filler-mode';
-const FILLER_PROMPT_STORAGE_KEY = 'timbal-voice-filler-prompt';
-const FILLER_DELAY_STORAGE_KEY = 'timbal-voice-filler-delay';
-const FILLER_REPEAT_STORAGE_KEY = 'timbal-voice-filler-repeat';
-const FILLER_MAX_STORAGE_KEY = 'timbal-voice-filler-max';
-fillerSelect.value = localStorage.getItem(FILLER_MODE_STORAGE_KEY) || '';
-fillerPrompt.value = localStorage.getItem(FILLER_PROMPT_STORAGE_KEY) || '';
-fillerDelay.value = localStorage.getItem(FILLER_DELAY_STORAGE_KEY) || '';
-fillerRepeat.value = localStorage.getItem(FILLER_REPEAT_STORAGE_KEY) || '';
-fillerMax.value = localStorage.getItem(FILLER_MAX_STORAGE_KEY) || '';
+const fillerTimeout = document.getElementById('filler-timeout');
+const fillerModel = document.getElementById('filler-model');
+const FILLER_INPUTS = [fillerPrompt, fillerDelay, fillerRepeat, fillerMax, fillerTimeout, fillerModel];
+persist(fillerSelect, 'timbal-voice-filler-mode', syncFillerInputs);
+persist(fillerPrompt, 'timbal-voice-filler-prompt');
+persist(fillerDelay, 'timbal-voice-filler-delay');
+persist(fillerRepeat, 'timbal-voice-filler-repeat');
+persist(fillerMax, 'timbal-voice-filler-max');
+persist(fillerTimeout, 'timbal-voice-filler-timeout');
+persist(fillerModel, 'timbal-voice-filler-model');
 function syncFillerInputs() {
   const on = fillerSelect.value === 'on';
-  for (const el of [fillerPrompt, fillerDelay, fillerRepeat, fillerMax]) el.disabled = !on;
+  for (const el of FILLER_INPUTS) el.disabled = !on;
 }
 syncFillerInputs();
-fillerSelect.onchange = () => {
-  localStorage.setItem(FILLER_MODE_STORAGE_KEY, fillerSelect.value);
-  syncFillerInputs();
-};
-fillerPrompt.onchange = () => localStorage.setItem(FILLER_PROMPT_STORAGE_KEY, fillerPrompt.value);
-fillerDelay.onchange = () => localStorage.setItem(FILLER_DELAY_STORAGE_KEY, fillerDelay.value);
-fillerRepeat.onchange = () => localStorage.setItem(FILLER_REPEAT_STORAGE_KEY, fillerRepeat.value);
-fillerMax.onchange = () => localStorage.setItem(FILLER_MAX_STORAGE_KEY, fillerMax.value);
 
-// Greeting override — the agent-speaks-first opener. Same lifecycle as the
-// filler block: sent in the session config, applied on the next Start, ''
-// defers to the server's voice_config.
-const greetingSelect = document.getElementById('greeting-select');
-const greetingText = document.getElementById('greeting-text');
-const greetingInstructions = document.getElementById('greeting-instructions');
-const greetingInterruptible = document.getElementById('greeting-interruptible');
-const greetingDelay = document.getElementById('greeting-delay');
-const GREETING_FIELDS = [
-  [greetingSelect, 'timbal-voice-greeting-mode'],
-  [greetingText, 'timbal-voice-greeting-text'],
-  [greetingInstructions, 'timbal-voice-greeting-instructions'],
-  [greetingInterruptible, 'timbal-voice-greeting-interruptible'],
-  [greetingDelay, 'timbal-voice-greeting-delay'],
-];
-for (const [el, key] of GREETING_FIELDS) {
-  el.value = localStorage.getItem(key) || '';
-  el.onchange = () => {
-    localStorage.setItem(key, el.value);
-    syncGreetingInputs();
+// Greeting overrides — one block per call direction. `greeting` is the
+// inbound opener (and the outbound fallback); `outbound_greeting` is the
+// opener for calls the agent placed. Which one the server uses is decided by
+// the Simulate control, sent as `direction` on the hello.
+function greetingBlock(prefix, storagePrefix, defaultInstructions) {
+  const b = {
+    select: document.getElementById(`${prefix}-select`),
+    text: document.getElementById(`${prefix}-text`),
+    instructions: document.getElementById(`${prefix}-instructions`),
+    interruptible: document.getElementById(`${prefix}-interruptible`),
+    delay: document.getElementById(`${prefix}-delay`),
+    wait: document.getElementById(`${prefix}-wait`),
+    model: document.getElementById(`${prefix}-model`),
   };
+  b.inputs = [b.text, b.instructions, b.interruptible, b.delay, b.wait, b.model];
+  const sync = () => {
+    const on = b.select.value === 'on';
+    for (const el of b.inputs) el.disabled = !on;
+    // text wins over instructions server-side — say so rather than letting a
+    // filled-in brief look like it is being used.
+    b.instructions.placeholder = (on && b.text.value.trim()) ? 'Ignored — Text takes precedence' : defaultInstructions;
+    b.model.placeholder = (on && b.text.value.trim()) ? 'Unused — Text needs no LLM' : 'Session LLM';
+  };
+  persist(b.select, `${storagePrefix}-mode`, sync);
+  persist(b.text, `${storagePrefix}-text`, sync);
+  persist(b.instructions, `${storagePrefix}-instructions`);
+  persist(b.interruptible, `${storagePrefix}-interruptible`);
+  persist(b.delay, `${storagePrefix}-delay`);
+  persist(b.wait, `${storagePrefix}-wait`);
+  persist(b.model, `${storagePrefix}-model`);
+  b.text.addEventListener('input', sync);
+  sync();
+  /** Hello value for this block: '' (off), a sparse patch (on), or undefined (server default). */
+  b.payload = () => {
+    if (b.select.value === 'off') return ''; // the only spelling that subtracts a nested default
+    if (b.select.value !== 'on') return undefined;
+    // Deep-merged over the server's block, so empty fields keep its values. A
+    // server with nothing declared needs text or instructions here, otherwise
+    // the patch fails validation and the server keeps its default.
+    const g = {};
+    if (b.text.value.trim()) g.text = b.text.value.trim();
+    if (b.instructions.value.trim()) g.instructions = b.instructions.value.trim();
+    if (b.interruptible.value) g.interruptible = b.interruptible.value === 'yes';
+    const delay = numOrNull(b.delay, { min: 0, integer: true });
+    if (delay !== null) g.delay_ms = delay;
+    const wait = numOrNull(b.wait, { min: 0 });
+    if (wait !== null && wait > 0) g.after_user_silence_secs = wait;
+    if (b.model.value.trim().includes('/')) g.model = b.model.value.trim();
+    return g;
+  };
+  return b;
 }
-function syncGreetingInputs() {
-  const on = greetingSelect.value === 'on';
-  for (const el of [greetingText, greetingInstructions, greetingInterruptible, greetingDelay]) {
-    el.disabled = !on;
+const greeting = greetingBlock('greeting', 'timbal-voice-greeting', 'e.g. greet them by name and say why you are calling');
+const outbound = greetingBlock('outbound', 'timbal-voice-outbound-greeting', 'e.g. say who you are and why you are calling, then ask if now is a good time');
+
+// Simulated call direction. The session itself never knows who placed the
+// call; the host does, and in the playground that host is this page.
+const directionSelect = document.getElementById('direction-select');
+persist(directionSelect, 'timbal-voice-direction', syncDirection);
+if (!directionSelect.value) directionSelect.value = 'inbound';
+function syncDirection() {
+  const out = directionSelect.value === 'outbound';
+  document.getElementById('greeting-section').classList.toggle('direction-idle', out);
+  document.getElementById('outbound-section').classList.toggle('direction-idle', !out);
+  // Say which block the next Start will actually speak. Outbound falls back
+  // to the inbound block unless outbound_greeting is declared somewhere.
+  const outboundDeclared = outbound.select.value !== '' || (declaredVoiceConfig && 'outbound_greeting' in declaredVoiceConfig);
+  document.getElementById('greeting-tag').textContent = out
+    ? (outboundDeclared ? '— not used on outbound' : '— used: no outbound greeting declared')
+    : '— used on this call';
+  document.getElementById('outbound-tag').textContent = out
+    ? (outboundDeclared ? '— used on this call' : '— nothing declared, inbound block applies')
+    : '— not used on inbound';
+}
+outbound.select.addEventListener('change', syncDirection);
+
+// User idle re-engagement (`user_idle`). Same lifecycle as filler/greeting:
+// 'off' sends '' so the server drops its default for this call.
+const idleSelect = document.getElementById('idle-select');
+const idleTimeout = document.getElementById('idle-timeout');
+const idleMax = document.getElementById('idle-max');
+const idleHangup = document.getElementById('idle-hangup');
+const idleText = document.getElementById('idle-text');
+const idleInstructions = document.getElementById('idle-instructions');
+const idleModel = document.getElementById('idle-model');
+const IDLE_INPUTS = [idleTimeout, idleMax, idleHangup, idleText, idleInstructions, idleModel];
+persist(idleSelect, 'timbal-voice-idle-mode', syncIdleInputs);
+persist(idleTimeout, 'timbal-voice-idle-timeout');
+persist(idleMax, 'timbal-voice-idle-max');
+persist(idleHangup, 'timbal-voice-idle-hangup');
+persist(idleText, 'timbal-voice-idle-text', syncIdleInputs);
+persist(idleInstructions, 'timbal-voice-idle-instructions');
+persist(idleModel, 'timbal-voice-idle-model');
+function syncIdleInputs() {
+  const on = idleSelect.value === 'on';
+  for (const el of IDLE_INPUTS) el.disabled = !on;
+  idleInstructions.placeholder = (on && idleText.value.trim()) ? 'Ignored — Text takes precedence' : 'e.g. ask if they are still there';
+}
+idleText.addEventListener('input', syncIdleInputs);
+syncIdleInputs();
+function userIdlePayload() {
+  if (idleSelect.value === 'off') return '';
+  if (idleSelect.value !== 'on') return undefined;
+  const u = {};
+  const timeout = numOrNull(idleTimeout, { min: 0 });
+  if (timeout !== null && timeout > 0) u.timeout_secs = timeout;
+  const maxCount = numOrNull(idleMax, { min: 0, integer: true });
+  if (maxCount !== null) u.max_count = maxCount;
+  const hangup = numOrNull(idleHangup, { min: 0 });
+  if (hangup !== null && hangup > 0) u.hangup_after_secs = hangup;
+  const lines = idleText.value.split('|').map((s) => s.trim()).filter(Boolean);
+  if (lines.length === 1) u.text = lines[0];
+  else if (lines.length > 1) u.text = lines;
+  if (idleInstructions.value.trim()) u.instructions = idleInstructions.value.trim();
+  if (idleModel.value.trim().includes('/')) u.model = idleModel.value.trim();
+  return u;
+}
+
+// Advanced: stt_model + allow-listed stt_extra / tts_extra tuning.
+const sttModelInput = document.getElementById('stt-model-input');
+const sttExtraInput = document.getElementById('stt-extra-input');
+const ttsExtraInput = document.getElementById('tts-extra-input');
+persist(sttModelInput, 'timbal-voice-stt-model');
+persist(sttExtraInput, 'timbal-voice-stt-extra');
+persist(ttsExtraInput, 'timbal-voice-tts-extra');
+const STT_EXTRA_TITLE = sttExtraInput.title;
+const TTS_EXTRA_TITLE = ttsExtraInput.title;
+sttExtraInput.addEventListener('input', () => markJson(sttExtraInput, STT_EXTRA_TITLE));
+ttsExtraInput.addEventListener('input', () => markJson(ttsExtraInput, TTS_EXTRA_TITLE));
+markJson(sttExtraInput, STT_EXTRA_TITLE);
+markJson(ttsExtraInput, TTS_EXTRA_TITLE);
+
+// The agent's declared voice_config (from meta) — drives placeholders and the
+// read-only list in the Agent panel. null until a server answers.
+let declaredVoiceConfig = null;
+/** Flatten {greeting: {text: 'x'}} → [['greeting.text', 'x'], …] for display and placeholders. */
+function flattenDeclared(obj, prefix = '') {
+  const out = [];
+  for (const [k, v] of Object.entries(obj || {})) {
+    const key = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === 'object' && !Array.isArray(v)) out.push(...flattenDeclared(v, key));
+    else out.push([key, v]);
   }
-  // text wins over instructions server-side — say so rather than letting a
-  // filled-in brief look like it is being used.
-  greetingInstructions.placeholder = (on && greetingText.value.trim())
-    ? 'Ignored — Text takes precedence'
-    : 'e.g. greet them by name and say why you are calling';
+  return out;
 }
-syncGreetingInputs();
-greetingText.oninput = syncGreetingInputs;
+function declaredLabel(v) {
+  if (v === null || v === undefined) return 'none';
+  if (v === '') return '"" (off)';
+  if (Array.isArray(v)) return v.map(String).join(' | ');
+  if (typeof v === 'boolean') return v ? 'true' : 'false';
+  return String(v);
+}
+function applyDeclaredVoiceConfig(vc) {
+  declaredVoiceConfig = vc && typeof vc === 'object' ? { ...vc } : null;
+  // A bare string is the agent's shorthand for {text: …}; '' declares silence.
+  for (const k of ['greeting', 'outbound_greeting']) {
+    if (declaredVoiceConfig && typeof declaredVoiceConfig[k] === 'string') {
+      declaredVoiceConfig[k] = declaredVoiceConfig[k].trim() ? { text: declaredVoiceConfig[k] } : '';
+    }
+  }
+  const flat = flattenDeclared(declaredVoiceConfig);
+  const byKey = new Map(flat);
+  // Placeholders: every input tagged data-vc shows the agent's own value as
+  // its "server default", so the label is a fact instead of a shrug.
+  for (const el of document.querySelectorAll('[data-vc]')) {
+    if (!el.dataset.defaultPlaceholder) el.dataset.defaultPlaceholder = el.placeholder;
+    const has = byKey.has(el.dataset.vc);
+    el.placeholder = has ? declaredLabel(byKey.get(el.dataset.vc)) : el.dataset.defaultPlaceholder;
+  }
+  const list = document.getElementById('conn-declared');
+  list.innerHTML = '';
+  if (!declaredVoiceConfig || !flat.length) {
+    list.hidden = true;
+    syncDirection();
+    return;
+  }
+  for (const [k, v] of flat) {
+    const dt = document.createElement('dt');
+    dt.textContent = k;
+    const dd = document.createElement('dd');
+    dd.textContent = declaredLabel(v);
+    if (v === null || v === undefined || v === '') dd.classList.add('declared-empty');
+    dd.title = typeof v === 'string' ? v : '';
+    list.append(dt, dd);
+  }
+  list.hidden = false;
+  syncDirection();
+}
+syncDirection();
 
 // Per-call identity for a callable system_prompt. Hidden unless the server
 // reports TIMBAL_VOICE_ALLOW_CLIENT_CALL_CONTEXT — otherwise it would be a
@@ -1205,107 +1604,6 @@ ttsSelect.onchange = () => {
 ttsModelSelect.onchange = () => {
   localStorage.setItem(TTS_MODEL_STORAGE_KEY, ttsModelSelect.value);
 };
-
-const modelSelect = document.getElementById('model-select');
-const modelProviderSelect = document.getElementById('model-provider-select');
-const modelCountEl = document.getElementById('model-count');
-const MODEL_STORAGE_KEY = 'timbal-voice-llm-model';
-const PROVIDER_LABELS = {
-  anthropic: 'Anthropic',
-  openai: 'OpenAI',
-  google: 'Google',
-  togetherai: 'Together AI',
-  xai: 'xAI',
-  groq: 'Groq',
-  fireworks: 'Fireworks',
-  xiaomi: 'Xiaomi',
-  byteplus: 'BytePlus',
-  cerebras: 'Cerebras',
-  sambanova: 'SambaNova',
-  moonshot: 'Moonshot',
-};
-/** @type {{id: string, provider: string, display_name: string}[]} */
-let MODEL_CATALOG = [];
-
-function providerLabel(p) {
-  return PROVIDER_LABELS[p] || (p ? p.charAt(0).toUpperCase() + p.slice(1) : p);
-}
-
-function initModelPicker(models, agentDefault) {
-  MODEL_CATALOG = Array.isArray(models) ? models : [];
-  const providers = [...new Set(MODEL_CATALOG.map((m) => m.provider))].sort((a, b) =>
-    providerLabel(a).localeCompare(providerLabel(b)),
-  );
-  modelProviderSelect.innerHTML = '<option value="">All providers</option>';
-  for (const p of providers) {
-    const opt = document.createElement('option');
-    opt.value = p;
-    opt.textContent = providerLabel(p);
-    modelProviderSelect.appendChild(opt);
-  }
-
-  const stored = localStorage.getItem(MODEL_STORAGE_KEY) || '';
-  if (stored && stored.includes('/')) {
-    modelProviderSelect.value = stored.split('/', 1)[0];
-  }
-  renderModelOptions(stored, agentDefault);
-
-  modelProviderSelect.onchange = () => {
-    renderModelOptions(modelSelect.value, agentDefault);
-  };
-  modelSelect.onchange = () => {
-    localStorage.setItem(MODEL_STORAGE_KEY, modelSelect.value);
-    // Sync provider step when a concrete model is chosen.
-    if (modelSelect.value && modelSelect.value.includes('/')) {
-      const p = modelSelect.value.split('/', 1)[0];
-      if (modelProviderSelect.value && modelProviderSelect.value !== p) {
-        modelProviderSelect.value = p;
-        renderModelOptions(modelSelect.value, agentDefault);
-      }
-    }
-  };
-}
-
-function renderModelOptions(preferred, agentDefault) {
-  const provider = modelProviderSelect.value;
-  let list = MODEL_CATALOG;
-  if (provider) list = list.filter((m) => m.provider === provider);
-
-  const defaultLabel = agentDefault
-    ? `Agent default (${agentDefault})`
-    : 'Agent default';
-  modelSelect.innerHTML = '';
-  const defOpt = document.createElement('option');
-  defOpt.value = '';
-  defOpt.textContent = defaultLabel;
-  modelSelect.appendChild(defOpt);
-
-  for (const m of list) {
-    const opt = document.createElement('option');
-    opt.value = m.id;
-    // When browsing all providers, prefix so names don't collide visually.
-    opt.textContent = provider ? m.display_name : `${providerLabel(m.provider)} · ${m.display_name}`;
-    opt.title = m.id;
-    modelSelect.appendChild(opt);
-  }
-
-  // Preserve selection: preferred → stored → empty. Unknown ids stay selectable.
-  const want = preferred || '';
-  if (want && ![...modelSelect.options].some((o) => o.value === want)) {
-    const opt = document.createElement('option');
-    opt.value = want;
-    opt.textContent = want;
-    opt.title = want;
-    modelSelect.appendChild(opt);
-  }
-  modelSelect.value = [...modelSelect.options].some((o) => o.value === want) ? want : '';
-  if (modelCountEl) {
-    const total = MODEL_CATALOG.length;
-    modelCountEl.textContent = provider
-      ? `${list.length} of ${total} models`
-      : `${total} models`;
-  }
-}
 
 // --- Agent target (standalone mode) ---------------------------------------
 // Embedded pages keep dialing their own origin exactly as before. Standalone
@@ -1601,7 +1899,7 @@ function truncateMiddle(s, max) {
   return s.slice(0, front) + '…' + s.slice(s.length - back);
 }
 
-/** Render the runnable strip + model picker from a meta blob (injected or fetched); null clears both. */
+/** Render the runnable strip + declared voice_config from a meta blob (injected or fetched); null clears both. */
 function applyMeta(meta) {
   const strip = document.getElementById('conn-strip');
   const verEl = document.getElementById('conn-version');
@@ -1613,14 +1911,14 @@ function applyMeta(meta) {
   // it — an unreachable server (null meta) or an older one reports nothing.
   callContextSection.hidden = !(meta && meta.allow_client_call_context);
   if (!meta) {
-    initModelPicker([], '');
+    applyDeclaredVoiceConfig(null);
     verEl.textContent = '';
     verEl.hidden = true;
     wrap.hidden = true;
     strip.hidden = true; // no bare "Timbal" + no stacked border with TARGET
     return;
   }
-  initModelPicker(meta.models || [], (meta.model || '').trim());
+  applyDeclaredVoiceConfig(meta.voice_config || null);
   const v = (meta.version || '').trim();
   verEl.textContent = v;
   verEl.hidden = !v;
@@ -2168,7 +2466,21 @@ function sessionConfigPayload() {
   if (sttSelect.value) cfg.stt_provider = sttSelect.value;
   if (ttsSelect.value) cfg.tts_provider = ttsSelect.value;
   if (ttsModelSelect.value) cfg.tts_model = ttsModelSelect.value;
-  if (modelSelect.value) cfg.model = modelSelect.value;
+  if (sttModelInput.value.trim()) cfg.stt_model = sttModelInput.value.trim();
+  if (languageInput.value.trim()) cfg.language = languageInput.value.trim();
+  if (voiceInput.value.trim()) cfg.voice = voiceInput.value.trim();
+  const sttExtra = jsonObjectOrNull(sttExtraInput);
+  if (sttExtra) cfg.stt_extra = sttExtra;
+  const ttsExtra = jsonObjectOrNull(ttsExtraInput);
+  if (ttsExtra) cfg.tts_extra = ttsExtra;
+  if (vadSelect.value) cfg.vad_endpointing = vadSelect.value === 'on';
+  const turnTimeout = numOrNull(turnTimeoutInput, { min: 0 });
+  if (turnTimeout !== null && turnTimeout > 0) cfg.turn_timeout_secs = turnTimeout;
+  if (turnFallbackSelect.value === 'off') {
+    cfg.turn_timeout_fallback = ''; // '' = cancel the turn silently
+  } else if (turnFallbackSelect.value === 'custom' && turnFallbackText.value.trim()) {
+    cfg.turn_timeout_fallback = turnFallbackText.value.trim();
+  }
   if (fillerSelect.value === 'off') {
     cfg.filler = { enabled: false };
   } else if (fillerSelect.value === 'on') {
@@ -2176,27 +2488,26 @@ function sessionConfigPayload() {
     // fields keep the server's (or the built-in) values.
     cfg.filler = { enabled: true };
     if (fillerPrompt.value.trim()) cfg.filler.system_prompt = fillerPrompt.value.trim();
-    const delay = parseFloat(fillerDelay.value);
-    if (Number.isFinite(delay) && delay >= 0) cfg.filler.delay_secs = delay;
-    const repeat = parseFloat(fillerRepeat.value);
-    if (Number.isFinite(repeat) && repeat > 0) cfg.filler.repeat_secs = repeat;
-    const maxPerTurn = parseInt(fillerMax.value, 10);
-    if (Number.isFinite(maxPerTurn) && maxPerTurn >= 1) cfg.filler.max_per_turn = maxPerTurn;
+    const delay = numOrNull(fillerDelay, { min: 0 });
+    if (delay !== null) cfg.filler.delay_secs = delay;
+    const repeat = numOrNull(fillerRepeat, { min: 0 });
+    if (repeat !== null && repeat > 0) cfg.filler.repeat_secs = repeat;
+    const maxPerTurn = numOrNull(fillerMax, { min: 1, integer: true });
+    if (maxPerTurn !== null) cfg.filler.max_per_turn = maxPerTurn;
+    const timeout = numOrNull(fillerTimeout, { min: 0 });
+    if (timeout !== null && timeout > 0) cfg.filler.timeout_secs = timeout;
+    if (fillerModel.value.trim().includes('/')) cfg.filler.model = fillerModel.value.trim();
   }
-  if (greetingSelect.value === 'off') {
-    // '' is the only spelling that subtracts a nested server default.
-    cfg.greeting = '';
-  } else if (greetingSelect.value === 'on') {
-    // Deep-merged over the server's greeting, so empty fields keep its values.
-    // A server with no greeting configured needs text or instructions here,
-    // otherwise the block fails validation and the server keeps its default.
-    cfg.greeting = {};
-    if (greetingText.value.trim()) cfg.greeting.text = greetingText.value.trim();
-    if (greetingInstructions.value.trim()) cfg.greeting.instructions = greetingInstructions.value.trim();
-    if (greetingInterruptible.value) cfg.greeting.interruptible = greetingInterruptible.value === 'yes';
-    const greetDelay = parseInt(greetingDelay.value, 10);
-    if (Number.isFinite(greetDelay) && greetDelay >= 0) cfg.greeting.delay_ms = greetDelay;
-  }
+  // Both openers travel; `direction` tells the server which one this call
+  // uses (greeting_for_direction). The inbound block is also the outbound
+  // fallback, so it is never redundant to send.
+  cfg.direction = directionSelect.value === 'outbound' ? 'outbound' : 'inbound';
+  const greetingPayload = greeting.payload();
+  if (greetingPayload !== undefined) cfg.greeting = greetingPayload;
+  const outboundPayload = outbound.payload();
+  if (outboundPayload !== undefined) cfg.outbound_greeting = outboundPayload;
+  const idlePayload = userIdlePayload();
+  if (idlePayload !== undefined) cfg.user_idle = idlePayload;
   if (!callContextSection.hidden) {
     const callContext = callContextPayload();
     if (callContext) cfg.call_context = callContext;
@@ -2390,6 +2701,7 @@ function handleServerMessage(msg) {
         void applyAmbience();
         {
           const bits = [];
+          if (msg.direction) bits.push(msg.direction === 'outbound' ? 'outbound call' : 'inbound call');
           if (msg.model) bits.push(msg.model);
           if (msg.stt_provider) bits.push(`STT ${msg.stt_provider}${msg.stt_model ? `/${msg.stt_model}` : ''}`);
           if (msg.tts_provider) bits.push(`TTS ${msg.tts_provider}`);

--- a/python/timbal/server/voice.html
+++ b/python/timbal/server/voice.html
@@ -764,7 +764,6 @@
         </div>
       </section>
       <section id="agent-section" class="panel-section panel-section--top" aria-label="Agent">
-        <h3 id="agent-section-title" class="panel-section-title" hidden>Agent</h3>
         <div id="conn-strip" class="conn-strip" hidden>
           <span id="conn-version" class="conn-version" hidden></span>
           <div id="conn-agent" class="conn-agent" hidden>
@@ -1910,14 +1909,17 @@ function applyMeta(meta) {
   // Only offer the call-context field where the server will actually honour
   // it — an unreachable server (null meta) or an older one reports nothing.
   callContextSection.hidden = !(meta && meta.allow_client_call_context);
+  const section = document.getElementById('agent-section');
   if (!meta) {
     applyDeclaredVoiceConfig(null);
     verEl.textContent = '';
     verEl.hidden = true;
     wrap.hidden = true;
     strip.hidden = true; // no bare "Timbal" + no stacked border with TARGET
+    section.hidden = true; // standalone: nothing answered yet — no empty section under TARGET
     return;
   }
+  section.hidden = false;
   applyDeclaredVoiceConfig(meta.voice_config || null);
   const v = (meta.version || '').trim();
   verEl.textContent = v;
@@ -3328,9 +3330,10 @@ async function initStandalone() {
   targetSection.hidden = false;
   targetSection.classList.add('panel-section--top');
   document.getElementById('target-heading').className = 'panel-title';
-  const agentSection = document.getElementById('agent-section');
-  agentSection.classList.remove('panel-section--top'); // restore the section rule
-  document.getElementById('agent-section-title').hidden = false;
+  // The agent section has no heading of its own: the runnable strip and the
+  // declared voice_config *are* the content, and the section (with its rule)
+  // only shows once a server has answered (see applyMeta).
+  document.getElementById('agent-section').classList.remove('panel-section--top');
   targetModeSelect.value = localStorage.getItem(TGT_KEY('mode')) || 'local';
   if (!targetModeSelect.value) targetModeSelect.value = 'local';
   localUrlInput.value = localStorage.getItem(TGT_KEY('local-url')) || '';

--- a/python/timbal/server/voice.py
+++ b/python/timbal/server/voice.py
@@ -37,6 +37,7 @@ from ..voice.config import (
     RecordingConfig,
     UserIdleConfig,
     VoiceConfig,
+    greeting_for_direction,
 )
 from .capacity import acquire_session_slot, release_session_slot
 
@@ -315,7 +316,36 @@ CLIENT_SETTABLE_VOICE_FIELDS = frozenset({
     # the LiveKit hello both arrive through this allowlist, and "what this call
     # opens with" is per-call by nature (an outbound campaign sets it per dial).
     "greeting",
+    "outbound_greeting",
+    # Silence policy is per-call tuning too (a voicemail-heavy campaign wants a
+    # short hang-up; a support line wants patient re-engagement).
+    "user_idle",
 })
+
+#: Hello keys the transport reads directly — not ``VoiceConfig`` fields, so
+#: they must not be logged as "ignored" by the override merge.
+_HELLO_TRANSPORT_KEYS = frozenset({"turn_detector", "call_context", "parent_id", "direction"})
+
+
+def client_call_direction(config: dict[str, Any]) -> str | None:
+    """``"inbound"`` / ``"outbound"`` from the hello, or ``None`` when unsaid.
+
+    The session never knows who placed the call; the host that did tells it
+    here so :func:`greeting_for_direction` can pick the opener. On telephony
+    that host is the webhook / dial that minted the client config; in the
+    playground it is the browser, simulating either side. It selects between
+    two openers the agent already declared, nothing more — so unlike
+    ``call_context`` it needs no gate.
+    """
+    raw = config.get("direction")
+    if not isinstance(raw, str):
+        return None
+    d = raw.strip().lower()
+    if d in ("inbound", "outbound"):
+        return d
+    if d:
+        logger.info("voice_client_direction_ignored", value=raw[:40])
+    return None
 
 # Keys a client may set *inside* ``stt_extra`` / ``tts_extra``. Tuning only.
 #
@@ -404,12 +434,12 @@ def merge_client_voice_overrides(server_defaults: VoiceConfig, client: dict[str,
     :data:`CLIENT_TUNING_TTS_EXTRA` — a caller never picks the provider host.
     """
     updates = {k: v for k, v in client.items() if k in CLIENT_SETTABLE_VOICE_FIELDS and v is not None}
-    # ``turn_detector``, ``call_context`` and ``parent_id`` are read straight
-    # off the hello by the transport, not through VoiceConfig — reporting them
-    # as ignored would be a lie in both directions.
+    # ``turn_detector``, ``call_context``, ``parent_id`` and ``direction`` are
+    # read straight off the hello by the transport, not through VoiceConfig —
+    # reporting them as ignored would be a lie in both directions.
     ignored = sorted(
         k for k, v in client.items()
-        if v is not None and k not in CLIENT_SETTABLE_VOICE_FIELDS and k not in ("turn_detector", "call_context", "parent_id")
+        if v is not None and k not in CLIENT_SETTABLE_VOICE_FIELDS and k not in _HELLO_TRANSPORT_KEYS
     )
     if ignored:
         logger.info("voice_client_config_ignored", keys=ignored)
@@ -428,12 +458,19 @@ def merge_client_voice_overrides(server_defaults: VoiceConfig, client: dict[str,
             logger.info("voice_client_filler_invalid", value=repr(updates["filler"]))
             del updates["filler"]
     if "greeting" in updates:
-        _merge_client_greeting(server_defaults, updates)
+        _merge_client_greeting(server_defaults, updates, "greeting")
+    if "outbound_greeting" in updates:
+        _merge_client_greeting(server_defaults, updates, "outbound_greeting")
+    if "user_idle" in updates:
+        _merge_client_user_idle(server_defaults, updates)
+    # ``model_copy`` marks every update key as set, so a client ``""`` on
+    # ``outbound_greeting`` reads as "declared: silence" in
+    # :func:`greeting_for_direction`, exactly like the agent's own ``""``.
     return server_defaults.model_copy(update=updates)
 
 
-def _merge_client_greeting(server_defaults: VoiceConfig, updates: dict[str, Any]) -> None:
-    """Resolve the client's ``greeting`` override in place.
+def _merge_client_greeting(server_defaults: VoiceConfig, updates: dict[str, Any], field: str) -> None:
+    """Resolve the client's ``greeting`` / ``outbound_greeting`` override in place.
 
     ``model_copy`` below runs no validators, so the coercion the ``VoiceConfig``
     field does for a bare string has to happen here too — and a bare string is
@@ -441,13 +478,19 @@ def _merge_client_greeting(server_defaults: VoiceConfig, updates: dict[str, Any]
     treated as a *text* override so the server keeps owning policy
     (``interruptible``, ``delay_ms``); ``""`` switches the opener off for this
     call, which is the one way a client can subtract a nested default.
+
+    An ``outbound_greeting`` patch merges over the opener outbound would
+    otherwise use — the agent's ``outbound_greeting`` when declared, else its
+    ``greeting`` — so a client tweaking one field keeps the rest of it.
     """
-    base = server_defaults.greeting
+    base = getattr(server_defaults, field)
+    if field == "outbound_greeting" and "outbound_greeting" not in server_defaults.model_fields_set:
+        base = server_defaults.greeting
     base_data = base.model_dump(include=base.model_fields_set) if base is not None else {}
-    raw = updates["greeting"]
+    raw = updates[field]
     if isinstance(raw, str):
         if not raw.strip():
-            updates["greeting"] = None
+            updates[field] = None
             return
         patch: Any = {"text": raw}
     elif isinstance(raw, GreetingConfig):
@@ -455,14 +498,41 @@ def _merge_client_greeting(server_defaults: VoiceConfig, updates: dict[str, Any]
     else:
         patch = raw
     if not isinstance(patch, dict):
-        logger.info("voice_client_greeting_invalid", value=repr(raw))
-        del updates["greeting"]
+        logger.info("voice_client_greeting_invalid", field=field, value=repr(raw))
+        del updates[field]
         return
     try:
-        updates["greeting"] = GreetingConfig.model_validate({**base_data, **patch})
+        updates[field] = GreetingConfig.model_validate({**base_data, **patch})
     except ValidationError:
-        logger.info("voice_client_greeting_invalid", value=repr(raw))
-        del updates["greeting"]
+        logger.info("voice_client_greeting_invalid", field=field, value=repr(raw))
+        del updates[field]
+
+
+def _merge_client_user_idle(server_defaults: VoiceConfig, updates: dict[str, Any]) -> None:
+    """Resolve the client's ``user_idle`` override in place.
+
+    Same contract as the greeting: a dict deep-merges over the server's block
+    and is validated (invalid → keep the server's); ``""`` switches the idle
+    watcher off for this call — ``UserIdleConfig`` has no ``enabled`` flag and
+    ``None`` cannot cross the override merge.
+    """
+    base = server_defaults.user_idle
+    base_data = base.model_dump(include=base.model_fields_set) if base is not None else {}
+    raw = updates["user_idle"]
+    if isinstance(raw, str) and not raw.strip():
+        updates["user_idle"] = None
+        return
+    if isinstance(raw, UserIdleConfig):
+        raw = raw.model_dump(include=raw.model_fields_set)
+    if not isinstance(raw, dict):
+        logger.info("voice_client_user_idle_invalid", value=repr(raw))
+        del updates["user_idle"]
+        return
+    try:
+        updates["user_idle"] = UserIdleConfig.model_validate({**base_data, **raw})
+    except ValidationError:
+        logger.info("voice_client_user_idle_invalid", value=repr(raw))
+        del updates["user_idle"]
 
 
 def runnable_meta_for_voice_page(runnable: Any, import_spec: str) -> dict[str, Any]:
@@ -476,23 +546,15 @@ def runnable_meta_for_voice_page(runnable: Any, import_spec: str) -> dict[str, A
         kind = type(runnable).__name__
     model = getattr(runnable, "model", None)
     model_s = str(model).strip() if isinstance(model, str) else ""
-    # Slim catalog for the playground model picker (from models.yaml via codegen).
-    from ..codegen.model_discovery import get_models
-
-    models = [
-        {
-            "id": m["id"],
-            "provider": m["provider"],
-            "display_name": m.get("display_name") or m["id"].split("/", 1)[-1],
-        }
-        for m in get_models()
-    ]
     return {
         "name": name,
         "kind": kind,
         "import_spec": (import_spec or "").strip(),
         "model": model_s,
-        "models": models,
+        # What the agent's own ``voice_config`` declares (same wire form as
+        # ``GET /voice_config``): the page shows these as the "server default"
+        # behind each knob instead of an opaque label.
+        "voice_config": declared_voice_config(runnable),
         # Lets the page enable its call-context field instead of offering a
         # control the server would silently drop.
         "allow_client_call_context": client_call_context_allowed(),
@@ -986,6 +1048,10 @@ def build_voice_session(
     raw_model = merged.model
     model_override = raw_model.strip() if isinstance(raw_model, str) and "/" in raw_model.strip() else None
     llm_model = model_override or (str(runnable.model) if isinstance(getattr(runnable, "model", None), str) else None)
+    # The opener depends on who placed the call, which only the host knows
+    # (``direction`` on the hello / dial config). Unsaid → inbound rules.
+    direction = client_call_direction(client_config)
+    greeting = greeting_for_direction(merged, outbound=direction == "outbound")
     logger.info(
         "voice_session_config",
         stt=type(stt).__name__,
@@ -997,14 +1063,16 @@ def build_voice_session(
         model=llm_model,
         turn_detector=turn_detector_label,
         vad_endpointing="auto" if vad_endpointing is None else vad_endpointing,
-        greeting=(None if merged.greeting is None else ((merged.greeting.text or "")[:80] or "<generated>")),
+        direction=direction,
+        greeting=(None if greeting is None else ((greeting.text or "")[:80] or "<generated>")),
+        user_idle=merged.user_idle is not None,
     )
 
     session_kwargs: dict[str, Any] = {}
     if merged.filler is not None and merged.filler.enabled:
         session_kwargs["filler"] = merged.filler
-    if merged.greeting is not None:
-        session_kwargs["greeting"] = merged.greeting
+    if greeting is not None:
+        session_kwargs["greeting"] = greeting
     if merged.user_idle is not None:
         session_kwargs["user_idle"] = merged.user_idle
     if merged.turn_timeout_secs is not None:
@@ -1077,6 +1145,7 @@ def build_voice_session(
         "tts_provider": tts_provider,
         "model": llm_model,
         "turn_detector": turn_detector_label,
+        "direction": direction,
         # Server config, not client-settable. Phase 1: the browser mixes this
         # locally (fetch /voice/ambience/current); nothing is mixed server-side.
         "ambient": (

--- a/python/timbal/server/voice.py
+++ b/python/timbal/server/voice.py
@@ -35,6 +35,7 @@ from ..voice.config import (
     FillerConfig,
     GreetingConfig,
     RecordingConfig,
+    UserIdleConfig,
     VoiceConfig,
 )
 from .capacity import acquire_session_slot, release_session_slot
@@ -154,6 +155,7 @@ _SPARSE_NESTED: tuple[tuple[str, type], ...] = (
     ("filler", FillerConfig),
     ("greeting", GreetingConfig),
     ("outbound_greeting", GreetingConfig),
+    ("user_idle", UserIdleConfig),
     ("ambient", AmbientAudioConfig),
 )
 
@@ -230,7 +232,7 @@ def declared_voice_config(runnable: Any) -> dict[str, Any]:
         return {}
     if ambient is not None:
         out["ambient"] = ambient
-    for nested in ("filler", "greeting", "outbound_greeting"):
+    for nested in ("filler", "greeting", "outbound_greeting", "user_idle"):
         block = out.get(nested)
         if isinstance(block, dict) and "model" in block and not isinstance(block["model"], str):
             block.pop("model")
@@ -1003,6 +1005,8 @@ def build_voice_session(
         session_kwargs["filler"] = merged.filler
     if merged.greeting is not None:
         session_kwargs["greeting"] = merged.greeting
+    if merged.user_idle is not None:
+        session_kwargs["user_idle"] = merged.user_idle
     if merged.turn_timeout_secs is not None:
         try:
             session_kwargs["turn_timeout_secs"] = float(merged.turn_timeout_secs)

--- a/python/timbal/server/voice.py
+++ b/python/timbal/server/voice.py
@@ -153,6 +153,7 @@ def _normalize_declared_voice_config(runnable: Any) -> dict[str, Any] | None:
 _SPARSE_NESTED: tuple[tuple[str, type], ...] = (
     ("filler", FillerConfig),
     ("greeting", GreetingConfig),
+    ("outbound_greeting", GreetingConfig),
     ("ambient", AmbientAudioConfig),
 )
 
@@ -229,7 +230,7 @@ def declared_voice_config(runnable: Any) -> dict[str, Any]:
         return {}
     if ambient is not None:
         out["ambient"] = ambient
-    for nested in ("filler", "greeting"):
+    for nested in ("filler", "greeting", "outbound_greeting"):
         block = out.get(nested)
         if isinstance(block, dict) and "model" in block and not isinstance(block["model"], str):
             block.pop("model")
@@ -250,11 +251,17 @@ def merge_voice_config(runnable: Any) -> VoiceConfig:
     vc = _normalize_declared_voice_config(runnable)
     if vc is None:
         return base
-    skip = frozenset({"stt_extra", "tts_extra", "filler", "greeting"})
+    skip = frozenset({"stt_extra", "tts_extra", "filler", "greeting", "outbound_greeting"})
     data = {
-        **base.model_dump(),
+        # ``outbound_greeting`` is tri-state and read via ``model_fields_set``
+        # (unset → inherit ``greeting``; ``""`` → silence; block → opener), so it
+        # must only be present here when the agent actually declared it — a
+        # dumped ``None`` from the env base would read as "declared: silence".
+        **base.model_dump(exclude={"outbound_greeting"}),
         **{k: v for k, v in vc.items() if v is not None and k not in skip},
     }
+    if "outbound_greeting" in vc:
+        data["outbound_greeting"] = vc["outbound_greeting"]
     if isinstance(vc.get("stt_extra"), dict):
         data["stt_extra"] = {**base.stt_extra, **vc["stt_extra"]}
     if isinstance(vc.get("tts_extra"), dict):

--- a/python/timbal/voice/__init__.py
+++ b/python/timbal/voice/__init__.py
@@ -5,6 +5,7 @@ from .config import (
     FillerConfig,
     GreetingConfig,
     RecordingConfig,
+    UserIdleConfig,
     VoiceConfig,
 )
 from .endpointing import (
@@ -163,6 +164,7 @@ __all__ = [
     "TurnMetrics",
     "TurnMetricsEvent",
     "TurnState",
+    "UserIdleConfig",
     "VadEndpointer",
     "VoiceConfig",
     "VoiceSession",

--- a/python/timbal/voice/config.py
+++ b/python/timbal/voice/config.py
@@ -112,6 +112,18 @@ class GreetingConfig(BaseModel):
     """Silence held before speaking. Telephony connects the media stream the
     moment the carrier answers, which can be before the callee has the handset
     to their ear; a beat here keeps the opener from landing under their "hello?"."""
+    after_user_silence_secs: float | None = Field(default=None, gt=0.0)
+    """Let the other side speak first; fall back to the opener if they don't.
+
+    Unset → speak the opener as soon as ``delay_ms`` has elapsed (the caller
+    dialled in and is waiting to hear who this is). Set → hold the opener and
+    listen: if the other side says anything within this many seconds, there is
+    no opener — their words open turn one and the agent answers *them* (on a
+    call we placed, "hello?" / "yes?" is the normal pickup). If the line stays
+    silent that long — a hesitant callee, a voicemail beep, a bad first second
+    of audio — speak the opener anyway rather than sit in mutual silence.
+    Retell's ``begin_after_user_silence_ms``, ElevenLabs' ``initial_wait_time``.
+    Counted from the end of ``delay_ms``."""
     model: Any = None
     """Generator LLM for ``instructions`` ("provider/model", or a TestModel in
     tests). None → the session's LLM. Unused by the ``text`` path."""
@@ -123,6 +135,76 @@ class GreetingConfig(BaseModel):
         if not (self.text or "").strip() and not (self.instructions or "").strip():
             raise ValueError("greeting needs 'text' or 'instructions'")
         return self
+
+
+DEFAULT_USER_IDLE_SYSTEM_PROMPT = (
+    "The other person on this live call has gone quiet after your last sentence. Say ONE short "
+    "spoken line to check they are still there or to gently move the conversation on — matching the "
+    "language of the conversation so far. Reply with only the words to say out loud; no quotes, no "
+    "stage directions."
+)
+
+
+class UserIdleConfig(BaseModel):
+    """What to do when the user stops talking mid-call.
+
+    A ``VoiceSession`` is reactive: after a reply it waits for the next
+    utterance, indefinitely. On a phone that is the difference between a call
+    that ends cleanly and one that burns ten minutes of STT on a caller who
+    walked away — or, just as common, a transcriber that missed what they said
+    so the agent *thinks* it is waiting. Every telephony stack re-engages after
+    a few seconds (Vapi ``idleMessages``, Retell ``reminder_trigger_ms``,
+    ElevenLabs ``turn_timeout``, Pipecat ``user_idle_timeout``) and hangs up
+    after a longer silence.
+
+    The clock starts once the agent has *finished being heard* (playback
+    drained, no turn in flight, no tool running) and is reset by any user
+    speech. After ``timeout_secs`` the agent speaks a prompt — ``text`` (one
+    line, or a list to rotate through) or an LLM-authored line from
+    ``instructions`` — at most ``max_count`` times per call. With
+    ``hangup_after_secs`` set, that long without a word from the user ends the
+    session; the agent's own prompts do not reset it.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    timeout_secs: float = Field(default=8.0, gt=0.0)
+    """Seconds of user silence, measured from when the agent's last audio has
+    drained, before a prompt is spoken. Re-arms after each prompt."""
+    text: str | list[str] | None = None
+    """The line(s) to say. A list rotates in order; wraps around."""
+    instructions: str | None = None
+    """Brief for an LLM-authored line, in the agent's own voice and language.
+    Ignored when ``text`` is set."""
+    max_count: int = Field(default=2, ge=0)
+    """Prompts per call, then silence (until ``hangup_after_secs``, if set).
+    ``0`` → never prompt; only the hang-up applies."""
+    hangup_after_secs: float | None = Field(default=None, gt=0.0)
+    """Seconds since the user's last word (or since the call started, if they
+    never spoke) after which the session ends. Not reset by our own prompts.
+    Unset → never hang up on silence."""
+    model: Any = None
+    """Generator LLM for ``instructions``. None → the session's LLM."""
+
+    @model_validator(mode="after")
+    def _has_something_to_do(self) -> UserIdleConfig:
+        has_line = bool(self.instructions and self.instructions.strip()) or bool(
+            self.text if isinstance(self.text, str) and self.text.strip() else [t for t in (self.text or []) if str(t).strip()]
+        )
+        if self.max_count > 0 and not has_line:
+            raise ValueError("user_idle needs 'text' or 'instructions' (or max_count=0 with hangup_after_secs)")
+        if self.max_count == 0 and self.hangup_after_secs is None:
+            raise ValueError("user_idle with max_count=0 does nothing without hangup_after_secs")
+        return self
+
+    def line_for(self, count: int) -> str | None:
+        """The static line for the ``count``-th prompt (0-based), or ``None`` to generate."""
+        if isinstance(self.text, str):
+            return self.text.strip() or None
+        lines = [str(t).strip() for t in (self.text or []) if str(t).strip()]
+        if not lines:
+            return None
+        return lines[count % len(lines)]
 
 
 def coerce_greeting(value: Any) -> GreetingConfig | None:
@@ -223,6 +305,8 @@ class VoiceConfig(BaseModel):
     """None → no background audio."""
     filler: FillerConfig | None = None
     """None → no spoken tool-call fillers. ``{}`` enables with defaults."""
+    user_idle: UserIdleConfig | None = None
+    """None → wait for the user forever (status quo). See :class:`UserIdleConfig`."""
     greeting: GreetingConfig | None = None
     """None → the session stays reactive (waits for the user to speak first).
     A bare string is shorthand for ``{"text": ...}``; ``""`` means no greeting.

--- a/python/timbal/voice/config.py
+++ b/python/timbal/voice/config.py
@@ -225,9 +225,31 @@ class VoiceConfig(BaseModel):
     """None → no spoken tool-call fillers. ``{}`` enables with defaults."""
     greeting: GreetingConfig | None = None
     """None → the session stays reactive (waits for the user to speak first).
-    A bare string is shorthand for ``{"text": ...}``; ``""`` means no greeting."""
+    A bare string is shorthand for ``{"text": ...}``; ``""`` means no greeting.
+    This is the opener for calls the *other side* started (inbound PSTN, a
+    browser joining) and the fallback for outbound — see ``outbound_greeting``."""
+    outbound_greeting: GreetingConfig | None = None
+    """Opener for calls *we* placed (outbound PSTN), where "thanks for calling"
+    is the wrong sentence. Unset → ``greeting`` applies to both directions;
+    ``""`` → speak nothing on outbound and wait for the callee's "hello"; a
+    string / block → that opener on outbound only. Only a host that knows the
+    call direction can apply it (:func:`greeting_for_direction`); the session
+    itself never sees a direction."""
 
-    @field_validator("greeting", mode="before")
+    @field_validator("greeting", "outbound_greeting", mode="before")
     @classmethod
     def _coerce_greeting(cls, v: Any) -> Any:
         return coerce_greeting(v)
+
+
+def greeting_for_direction(config: VoiceConfig, *, outbound: bool) -> GreetingConfig | None:
+    """The opener this call should use, given who placed it.
+
+    Inbound (and anything that is not a phone call we dialled) → ``greeting``.
+    Outbound → ``outbound_greeting`` when the agent set it — including an
+    explicit ``None`` from ``""``, which is how it says "stay quiet" — else
+    ``greeting``.
+    """
+    if outbound and "outbound_greeting" in config.model_fields_set:
+        return config.outbound_greeting
+    return config.greeting

--- a/python/timbal/voice/elevenlabs.py
+++ b/python/timbal/voice/elevenlabs.py
@@ -146,10 +146,16 @@ class ElevenLabsRealtimeSTT(SpeechToText):
         if config.language:
             params["language_code"] = config.language
         for k, v in extra.items():
-            if v is not None and not k.startswith("_"):
-                params[k] = v
+            if v is None or k.startswith("_"):
+                continue
+            # Booleans go on the wire as ``true`` / ``false``, not ``True``.
+            params[k] = str(v).lower() if isinstance(v, bool) else v
 
-        query = urlencode(params)
+        # ``doseq``: list-valued knobs (``keyterms``, ``secondary_languages``)
+        # become repeated parameters — ``keyterms=Acme&keyterms=Timbal`` — which
+        # is the only spelling Scribe accepts. Without it a list is stringified
+        # into one bogus term (``keyterms=%5B%27Acme%27...``).
+        query = urlencode(params, doseq=True)
         uri = f"wss://{host}/v1/speech-to-text/realtime?{query}"
         self._ws = await ws_connect(
             uri,

--- a/python/timbal/voice/endpointing.py
+++ b/python/timbal/voice/endpointing.py
@@ -266,6 +266,19 @@ class VadEndpointer:
         pending endpoint is now stale."""
         self._cancel_pending()
 
+    def last_speech_at(self) -> float | None:
+        """Monotonic time of the last frame Silero called speech, or ``None``.
+
+        ``None`` when the VAD has no recent evidence (not started, starved, or
+        no speech yet) — same caveat as :meth:`speech_secs_in_window`. The
+        session uses this as the user's end-of-speech stamp for STT latency.
+        """
+        if not self._started or not self._recent_speech:
+            return None
+        if time.monotonic() - self._last_frame_at > 1.0:
+            return None
+        return self._recent_speech[-1]
+
     def speech_secs_in_window(self, window_secs: float) -> float | None:
         """Total Silero speech seconds in the trailing ``window_secs``.
 

--- a/python/timbal/voice/metrics.py
+++ b/python/timbal/voice/metrics.py
@@ -27,6 +27,15 @@ class TurnMetrics(BaseModel):
     run_id: str | None = None
     """Id of the agent run this turn produced, to join metrics against the trace."""
     user_text_chars: int
+    speech_end_to_transcript_ms: float | None = None
+    """The user's ASR latency: their last speech -> the STT's committed
+    transcript arriving. This is the time the user spends waiting on the
+    transcriber, before any ``eou_to_*`` clock starts. ``None`` when there was
+    no end-of-speech evidence to measure from."""
+    speech_end_source: Literal["vad", "partial"] | None = None
+    """What stamped the end of speech: the local Silero VAD's last speech frame
+    (``vad``), or — without a local VAD — the STT's last interim transcript
+    (``partial``), a later and coarser stand-in."""
     eou_to_llm_first_token_ms: float | None = None
     """Committed transcript -> first LLM text delta."""
     eou_to_tts_first_byte_ms: float | None = None

--- a/python/timbal/voice/session.py
+++ b/python/timbal/voice/session.py
@@ -342,6 +342,13 @@ class VoiceSession:
         self._idle_task: asyncio.Task[None] | None = None
         self._idle_prompt_count = 0
         self._idle_prompt_speaking = False
+        # The prompt's ``[text, bytes]`` TTS record, its transcript entry and
+        # the played-bytes origin it started from — what ``interrupt()`` needs
+        # to rewrite the prompt to the heard prefix on barge-in. Kept apart from
+        # the greeting's so the two never overwrite each other.
+        self._idle_record: list | None = None
+        self._idle_entry: TranscriptEntry | None = None
+        self._idle_played_baseline = 0
         self._idle_since: float | None = None
         # Monotonic time of the last thing the user did (partial or commit).
         # Starts at run(); the hang-up clock is measured from here.
@@ -723,6 +730,8 @@ class VoiceSession:
         # rewrites what was left unheard, ``close()`` leaves the transcript alone.
         if was_active and truncate_completed and self._greeting_record is not None:
             self._truncate_greeting()
+        if was_active and truncate_completed and self._idle_record is not None:
+            self._truncate_idle_prompt()
         self._is_speaking = False
         if was_active:
             self.playback.on_interrupted()
@@ -1510,7 +1519,11 @@ class VoiceSession:
         if self._closed:
             return
         self._commit_event_at = time.monotonic()
-        self._pending_stt_latency = self._measure_stt_latency(self._commit_event_at)
+        # Measured now (the VAD / partial stamps are freshest here) but only
+        # published once the commit is *accepted* below: a noise commit the
+        # detector ignores mid-HOLD, or a late duplicate, must not overwrite the
+        # measurement of the utterance that actually opens the turn.
+        stt_latency = self._measure_stt_latency(self._commit_event_at)
         # Any commit (endpointer-forced or provider debounce) makes a pending
         # VAD endpoint stale — the STT segment it targeted is already closed.
         if self._endpointer is not None:
@@ -1600,6 +1613,10 @@ class VoiceSession:
             return
 
         final_text = decision.text or text
+        # Accepted (HOLD / NEW_TURN / CONTINUE): this is the commit whose ASR
+        # wait the turn should report. A HOLD keeps it until expiry; a later
+        # accepted commit that merges or continues replaces it with its own.
+        self._pending_stt_latency = stt_latency
         logger.info(
             "stt_committed_accepted",
             action=decision.action.value,
@@ -2620,22 +2637,85 @@ class VoiceSession:
             logger.warning("user_idle_watch_failed", error=str(e), exc_info=True)
 
     async def _speak_idle_prompt(self, text: str) -> None:
-        """Say ``text`` outside any turn: interruptible, transcribed, not a turn metric."""
+        """Say ``text`` outside any turn: interruptible, transcribed, not a turn metric.
+
+        Same shape as an interruptible opener, with its own bookkeeping:
+
+        * ``_is_speaking`` is raised for the duration so ``interrupt()`` sees
+          the prompt as active from the first synthesized byte, not only once
+          the client reports playback — a callee answering "are you still
+          there?" barges in either way.
+        * The prompt is in ``_tts_tasks``, so ``interrupt()`` cancels it; the
+          cancel path seals the client's bubble with what was heard
+          (``_truncate_idle_prompt`` ran inside ``interrupt()`` first).
+        * It only ever starts once the previous reply has fully drained
+          (``_agent_busy``), so that reply has nothing left to truncate:
+          ``_turn_finalized_ok`` is cleared so a barge-in here is attributed to
+          the prompt, never re-run against the finished turn.
+        """
         self._idle_prompt_speaking = True
-        self._transcript.append(TranscriptEntry(role="assistant", text=text))
+        self._is_speaking = True
+        self._turn_finalized_ok = False
+        self._idle_played_baseline = self.playback.played_bytes
+        self._idle_entry = TranscriptEntry(role="assistant", text=text)
+        self._transcript.append(self._idle_entry)
         await self._emit(AgentTextDelta(text=text))
-        speak_task = asyncio.create_task(self._speak(text, greeting=True))
+        speak_task = asyncio.create_task(self._speak(text, idle=True))
         self._tts_tail = speak_task
         self._tts_tasks.add(speak_task)
         speak_task.add_done_callback(lambda t: self._tts_tasks.discard(t))
         try:
             await speak_task
         except asyncio.CancelledError:
-            # Barged in — ``interrupt()`` already cleared the client buffer.
+            # Barged in. ``interrupt()`` has mapped the played bytes to the heard
+            # prefix and rewritten (or dropped) the transcript entry; seal the
+            # client's open bubble the same way the opener does.
+            await self._emit(AgentTextDone(text=self._last_interruption_heard_text or ""))
             return
         finally:
             self._idle_prompt_speaking = False
+            self._is_speaking = False
+            self._idle_record = None
+            self._idle_entry = None
         await self._emit(AgentTextDone(text=text))
+
+    def _truncate_idle_prompt(self) -> None:
+        """Align the idle prompt's transcript entry with what the caller heard.
+
+        Called from ``interrupt()`` before the client's buffer is cleared, like
+        :meth:`_truncate_greeting`. The prompt is not the session's first audio,
+        so heard bytes are measured from the played-bytes origin it started at.
+        """
+        record = self._idle_record
+        self._idle_record = None
+        if record is None or self._idle_entry is None:
+            return
+        full = str(record[0])
+        played = max(0, self.playback.played_bytes - self._idle_played_baseline)
+        heard = map_played_bytes_to_text([(full, int(record[1]))], played)
+        if self._recorder is not None:
+            self._recorder.drop_agent_tail(max(0, int(record[1]) - played))
+        # By construction the prompt is the newest thing said (it only starts
+        # when nothing else is), so SessionInterrupted — and the cancelled
+        # speak task's AgentTextDone — describe it, heard in full or not.
+        self._last_interruption_heard_text = heard
+        if heard == full:
+            return
+        index = next((i for i, e in enumerate(self._transcript) if e is self._idle_entry), None)
+        if index is None:
+            return
+        logger.info(
+            "user_idle_prompt_truncation",
+            heard_chars=len(heard),
+            prompt_chars=len(full),
+            **_trace_debug_fields(),
+        )
+        if heard:
+            self._idle_entry = TranscriptEntry(role="assistant", text=heard)
+            self._transcript[index] = self._idle_entry
+        else:
+            self._transcript.pop(index)
+            self._idle_entry = None
 
     async def _generate_idle_prompt(self) -> str | None:
         """One-shot LLM line for ``user_idle.instructions`` — same shape as the greeting generator."""
@@ -3067,20 +3147,30 @@ class VoiceSession:
             except (asyncio.CancelledError, Exception):
                 pass
 
-    async def _speak(self, text: str, *, filler: bool = False, greeting: bool = False) -> None:
+    async def _speak(self, text: str, *, filler: bool = False, greeting: bool = False, idle: bool = False) -> None:
+        """Synthesize ``text`` and emit its audio.
+
+        ``greeting`` / ``idle`` mark speech that belongs to no turn (the opener,
+        a user-idle prompt): it is kept out of the turn's segment list and
+        timings, ignores the per-turn cancel flag (stopping it is
+        ``interrupt()``'s job, by cancelling the task) and keeps its own
+        ``[text, bytes]`` record for barge-in truncation.
+        """
         text = _strip_markdown(text)
+        turnless = greeting or idle
         logger.debug(
             "turn_tts_synthesize_begin",
             text_chars=len(text),
             text_preview=text[:120],
             filler=filler,
             greeting=greeting,
+            idle=idle,
             cancel_turn_set=self._cancel_turn.is_set(),
             **_trace_debug_fields(),
         )
         chunk_count = 0
         total_bytes = 0
-        if not greeting:
+        if not turnless:
             if self._turn_tts_started_at is None:
                 self._turn_tts_started_at = time.monotonic()
             self._turn_tts_segments += 1
@@ -3094,14 +3184,16 @@ class VoiceSession:
             # TTS timings. Keep a direct handle so its byte count stays
             # readable after the first turn rebinds the record list.
             self._greeting_record = segment_record
+        elif idle:
+            self._idle_record = segment_record
         else:
             self._turn_tts_segment_records.append(segment_record)
         try:
             async for chunk in self.tts.synthesize(text):
-                # The opener predates every turn, so the per-turn cancel flag says
-                # nothing about it: stopping it is ``interrupt()``'s job, by
-                # cancelling this task, and only when it is interruptible.
-                if self._cancel_turn.is_set() and not greeting:
+                # Turnless speech predates / sits outside every turn, so the
+                # per-turn cancel flag says nothing about it: stopping it is
+                # ``interrupt()``'s job, by cancelling this task.
+                if self._cancel_turn.is_set() and not turnless:
                     # INFO on purpose: explains truncated audio_bytes in metrics.
                     logger.info(
                         "turn_tts_synthesize_break",
@@ -3113,7 +3205,7 @@ class VoiceSession:
                     break
                 chunk_count += 1
                 total_bytes += len(chunk)
-                if not greeting:
+                if not turnless:
                     if self._turn_first_audio_at is None:
                         self._turn_first_audio_at = time.monotonic()
                     self._turn_audio_bytes += len(chunk)
@@ -3147,7 +3239,7 @@ class VoiceSession:
                 **_trace_debug_fields(),
             )
         finally:
-            if not greeting:
+            if not turnless:
                 self._turn_tts_ended_at = time.monotonic()
 
     # -- Internal: interruption truncation ------------------------------------

--- a/python/timbal/voice/session.py
+++ b/python/timbal/voice/session.py
@@ -292,6 +292,10 @@ class VoiceSession:
         # committed transcript within a short window is attributed to it.
         self._endpoint_commit_sent_at: float | None = None
         self._turn_vad_endpointed = False
+        # (ms, "vad" | "partial") — the user's ASR wait for this turn's
+        # transcript; measured when the commit arrives, consumed by the turn.
+        self._pending_stt_latency: tuple[float, str] | None = None
+        self._turn_stt_latency: tuple[float, str] | None = None
         self._llm_warmup_task: asyncio.Task[None] | None = None
         # Tool-call filler: an LLM-generated phrase masks tool dead air (see
         # FillerConfig). The generator Agent is built lazily on first use.
@@ -1459,6 +1463,8 @@ class VoiceSession:
             logger.debug("stt_turn_dropped_session_closed", text_preview=final_text[:80])
             return
         self._turn_vad_endpointed = vad_endpointed
+        self._turn_stt_latency = self._pending_stt_latency
+        self._pending_stt_latency = None
         self._last_commit_at = time.monotonic()
         if replace_user_entry and self._transcript and self._transcript[-1].role == "user":
             self._transcript[-1] = TranscriptEntry(role="user", text=final_text)
@@ -1475,10 +1481,36 @@ class VoiceSession:
             **_trace_debug_fields(),
         )
 
+    def _measure_stt_latency(self, transcript_at: float) -> tuple[float, str] | None:
+        """The user's ASR wait: last speech → this committed transcript, in ms.
+
+        End of speech comes from the local Silero VAD when it is running (its
+        last speech frame); without one, the STT's last interim transcript is
+        the coarser stand-in — it already includes some provider latency, so
+        the number reads low. ``None`` when there is nothing to measure from,
+        or the gap is not a plausible latency (a stale stamp from a previous
+        utterance).
+        """
+        speech_end: float | None = None
+        source = ""
+        last_speech_at = getattr(self._endpointer, "last_speech_at", None)
+        if callable(last_speech_at):
+            speech_end = last_speech_at()
+            source = "vad"
+        if speech_end is None and self._last_partial_at > self._last_commit_at:
+            speech_end, source = self._last_partial_at, "partial"
+        if speech_end is None:
+            return None
+        gap = transcript_at - speech_end
+        if gap < 0 or gap > 10.0:
+            return None
+        return round(gap * 1000, 1), source
+
     async def _handle_committed(self, text: str) -> None:
         if self._closed:
             return
         self._commit_event_at = time.monotonic()
+        self._pending_stt_latency = self._measure_stt_latency(self._commit_event_at)
         # Any commit (endpointer-forced or provider debounce) makes a pending
         # VAD endpoint stale — the STT segment it targeted is already closed.
         if self._endpointer is not None:
@@ -3242,10 +3274,13 @@ class VoiceSession:
         eou = self._turn_eou_at or None
         eou_to_first_audio = _ms(eou, self._turn_first_audio_at)
         ctx = get_run_context()
+        stt = self._turn_stt_latency
         return TurnMetrics(
             turn_index=self._turn_index,
             run_id=ctx.id if ctx is not None else None,
             user_text_chars=len(user_text),
+            speech_end_to_transcript_ms=stt[0] if stt else None,
+            speech_end_source=stt[1] if stt else None,  # type: ignore[arg-type]
             eou_to_llm_first_token_ms=_ms(eou, self._turn_first_token_at),
             eou_to_tts_first_byte_ms=eou_to_first_audio,
             eou_to_first_audio_ms=eou_to_first_audio,

--- a/python/timbal/voice/session.py
+++ b/python/timbal/voice/session.py
@@ -38,8 +38,10 @@ from ..types.events.delta import DeltaEvent, Text, TextDelta, ToolUse
 from ..types.message import Message
 from .config import (
     DEFAULT_GREETING_SYSTEM_PROMPT,
+    DEFAULT_USER_IDLE_SYSTEM_PROMPT,
     FillerConfig,
     GreetingConfig,
+    UserIdleConfig,
     coerce_greeting,
 )
 from .events import (
@@ -241,6 +243,7 @@ class VoiceSession:
         model: str | None = None,
         filler: FillerConfig | dict[str, Any] | None = None,
         greeting: GreetingConfig | dict[str, Any] | str | None = None,
+        user_idle: UserIdleConfig | dict[str, Any] | None = None,
         call_context: dict[str, str] | None = None,
         parent_run_id: str | None = None,
     ):
@@ -323,6 +326,22 @@ class VoiceSession:
         # live so a barge-in can map played bytes back to heard words and the
         # first turn can account for audio still queued ahead of its reply.
         self._greeting_record: list | None = None
+
+        # User-idle re-engagement (see UserIdleConfig). A watchdog task started
+        # from run(); speaks a prompt after ``timeout_secs`` of user silence
+        # once the agent has drained, at most ``max_count`` times, and ends the
+        # session after ``hangup_after_secs`` without a word from the user.
+        self.user_idle: UserIdleConfig | None = (
+            user_idle if isinstance(user_idle, UserIdleConfig) or user_idle is None else UserIdleConfig.model_validate(user_idle)
+        )
+        self._idle_agent: Agent | None = None
+        self._idle_task: asyncio.Task[None] | None = None
+        self._idle_prompt_count = 0
+        self._idle_prompt_speaking = False
+        self._idle_since: float | None = None
+        # Monotonic time of the last thing the user did (partial or commit).
+        # Starts at run(); the hang-up clock is measured from here.
+        self._last_user_activity_at: float | None = None
         # The opener's transcript entry, held by identity so a barge-in can
         # rewrite it to the heard prefix after later entries have piled on top.
         self._greeting_entry: TranscriptEntry | None = None
@@ -614,6 +633,10 @@ class VoiceSession:
             audio_task = asyncio.create_task(self._forward_audio(audio_in))
             stt_task = asyncio.create_task(self._process_stt_events())
             sweep_task = asyncio.create_task(self._sweep_stale_partials())
+            self._last_user_activity_at = time.monotonic()
+            if self.user_idle is not None:
+                self._idle_task = asyncio.create_task(self._user_idle_watch())
+            background = [t for t in (audio_task, stt_task, sweep_task, self._idle_task) if t is not None]
 
             try:
                 while True:
@@ -622,10 +645,10 @@ class VoiceSession:
                         break
                     yield event
             finally:
-                for task in (audio_task, stt_task, sweep_task):
+                for task in background:
                     if not task.done():
                         task.cancel()
-                await asyncio.gather(audio_task, stt_task, sweep_task, return_exceptions=True)
+                await asyncio.gather(*background, return_exceptions=True)
 
         except Exception as e:
             logger.error("voice_session_error", error=str(e), exc_info=True)
@@ -2448,13 +2471,32 @@ class VoiceSession:
             return False
         return True
 
+    def _user_has_spoken(self) -> bool:
+        """Any user speech at all this session — a partial counts, a commit counts."""
+        return self._last_partial_at > 0 or self._last_commit_at > 0
+
     async def _greeting_flow(self) -> None:
-        """Hold ``delay_ms``, resolve the line, speak it."""
+        """Hold ``delay_ms``, optionally give the other side first go, resolve the line, speak it."""
         try:
             if self.greeting.delay_ms:
                 await asyncio.sleep(self.greeting.delay_ms / 1000)
                 if not self._greeting_still_wanted():
                     return
+            if self.greeting.after_user_silence_secs:
+                # Wait-for-pickup: the callee's "hello?" opens turn one and the
+                # agent answers *that*; only a silent line gets the opener.
+                deadline = time.monotonic() + self.greeting.after_user_silence_secs
+                while time.monotonic() < deadline:
+                    if self._closed or self._user_has_spoken():
+                        logger.info("greeting_skipped", reason="user_spoke_first")
+                        return
+                    await asyncio.sleep(0.05)
+                if not self._greeting_still_wanted():
+                    return
+                logger.info(
+                    "greeting_after_user_silence",
+                    waited_secs=self.greeting.after_user_silence_secs,
+                )
             # Static text wins when both are set: ~300ms to first audio against
             # ~1.5s for a generated line, and the wording is known in advance.
             text = (self.greeting.text or "").strip()
@@ -2469,6 +2511,127 @@ class VoiceSession:
             # Silence at the top of the call is the status quo, not something to
             # surface to the caller as a session error.
             logger.warning("greeting_failed", error=str(e), exc_info=True)
+
+    # -- Internal: user-idle re-engagement ------------------------------------
+
+    def _agent_busy(self) -> bool:
+        """Anything that means "it is not the user's silence we are looking at"."""
+        if self._is_speaking or self._greeting_speaking or self._idle_prompt_speaking:
+            return True
+        if self._current_turn_task is not None and not self._current_turn_task.done():
+            return True
+        if self._greeting_task is not None and not self._greeting_task.done():
+            return True  # opener still pending (delay_ms / after_user_silence window)
+        if self._held_user_text is not None:
+            return True  # a commit is being held for the user to finish
+        if self._last_partial_at > self._last_commit_at:
+            return True  # the user is mid-utterance
+        return self.playback.is_playing or self._greeting_pending_bytes() > 0
+
+    def _user_last_active_at(self) -> float:
+        return max(self._last_partial_at, self._last_commit_at, self._last_user_activity_at or 0.0)
+
+    async def _user_idle_watch(self) -> None:
+        """Speak a prompt after ``timeout_secs`` of user silence; hang up after ``hangup_after_secs``.
+
+        Polls rather than hooking every state transition: the states that count
+        as "busy" live in five places (turn, greeting, filler, playback drain,
+        held commit) and a 100ms poll is invisible against an 8s timeout.
+        """
+        cfg = self.user_idle
+        if cfg is None:
+            return
+        try:
+            while not self._closed:
+                await asyncio.sleep(0.1)
+                if self._closed:
+                    return
+                now = time.monotonic()
+                if cfg.hangup_after_secs is not None and not self._agent_busy():
+                    silent_for = now - self._user_last_active_at()
+                    if silent_for >= cfg.hangup_after_secs:
+                        logger.info(
+                            "user_idle_hangup",
+                            silent_secs=round(silent_for, 1),
+                            prompts_spoken=self._idle_prompt_count,
+                        )
+                        await self.close()
+                        return
+                if self._agent_busy():
+                    self._idle_since = None
+                    continue
+                if self._idle_since is None:
+                    self._idle_since = now
+                    continue
+                if self._idle_prompt_count >= cfg.max_count:
+                    continue
+                if now - self._idle_since < cfg.timeout_secs:
+                    continue
+                text = cfg.line_for(self._idle_prompt_count) or (await self._generate_idle_prompt() or "").strip()
+                if not text or self._agent_busy() or self._closed:
+                    # The user spoke while we were generating — no prompt.
+                    self._idle_since = None
+                    continue
+                self._idle_prompt_count += 1
+                logger.info(
+                    "user_idle_prompt",
+                    count=self._idle_prompt_count,
+                    max_count=cfg.max_count,
+                    idle_secs=round(now - self._idle_since, 1),
+                    text_preview=text[:120],
+                )
+                await self._speak_idle_prompt(text)
+                self._idle_since = None
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # a re-engagement nicety must never end the call
+            logger.warning("user_idle_watch_failed", error=str(e), exc_info=True)
+
+    async def _speak_idle_prompt(self, text: str) -> None:
+        """Say ``text`` outside any turn: interruptible, transcribed, not a turn metric."""
+        self._idle_prompt_speaking = True
+        self._transcript.append(TranscriptEntry(role="assistant", text=text))
+        await self._emit(AgentTextDelta(text=text))
+        speak_task = asyncio.create_task(self._speak(text, greeting=True))
+        self._tts_tail = speak_task
+        self._tts_tasks.add(speak_task)
+        speak_task.add_done_callback(lambda t: self._tts_tasks.discard(t))
+        try:
+            await speak_task
+        except asyncio.CancelledError:
+            # Barged in — ``interrupt()`` already cleared the client buffer.
+            return
+        finally:
+            self._idle_prompt_speaking = False
+        await self._emit(AgentTextDone(text=text))
+
+    async def _generate_idle_prompt(self) -> str | None:
+        """One-shot LLM line for ``user_idle.instructions`` — same shape as the greeting generator."""
+        cfg = self.user_idle
+        instructions = (cfg.instructions or "").strip() if cfg else ""
+        if not instructions:
+            return None
+        parts = [p for p in (await self._agent_system_prompt(), DEFAULT_USER_IDLE_SYSTEM_PROMPT, instructions) if p]
+        if self._idle_agent is None:
+            self._idle_agent = Agent(
+                name="voice_user_idle",
+                model=cfg.model or self.model or self.agent.model,
+                system_prompt="\n\n".join(parts),
+                max_tokens=96,
+                tracing_provider=None,
+            )
+        recent = " / ".join(e.text for e in self._transcript[-4:] if e.text)[-600:]
+        prompt = f"Conversation so far: {recent}\n\nThe user has gone quiet. Say your line." if recent else "Say your line."
+        ambient_ctx = get_run_context()
+        set_run_context(None)
+        try:
+            out = await self._idle_agent(prompt=prompt).collect()
+        finally:
+            set_run_context(ambient_ctx)
+        if out.status.code != "success" or out.output is None:
+            logger.warning("user_idle_generation_failed", status=out.status.code, error=out.error)
+            return None
+        return out.output.collect_text().strip().strip('"').strip() or None
 
     def _claim_greeting(self, text: str) -> asyncio.Task[None]:
         """Stake the TTS chain for the opener and start synthesizing it.


### PR DESCRIPTION
## Why

`greeting` is the inbound opener ("thanks for calling…"). On a call *we* placed that sentence is wrong, and an agent had no way to say so in `voice_config`. Pulling that thread surfaced the rest of what every telephony stack has for the *edges* of a call and we didn't: waiting for the callee to pick up before opening, re-engaging a caller who went quiet, hanging up on a dead line — and a playground that could actually exercise any of it.

## What

### Openers by direction

```python
voice_config={
    "greeting": "Northwind Dental, this is Sam. How can I help?",                        # inbound
    "outbound_greeting": {                                                               # calls we place
        "text": "Hi, it's Sam from Northwind Dental about your appointment — got a minute?",
        "after_user_silence_secs": 2.0,   # let them say "hello?" first; open only if they don't
    },
}
```

- `VoiceConfig.outbound_greeting: GreetingConfig | None`, same coercion as `greeting`. Tri-state: **unset** → `greeting` serves both directions; **`""`** → silence on outbound (wait for the callee); **string/block** → that opener on outbound.
- `greeting_for_direction(config, *, outbound)` resolves it. The session never knows the direction — the host that dialled or answered does, and now tells it: **`direction: "inbound" | "outbound"`** on the hello / LiveKit dial `client_config` / telephony `<Parameter>`. `build_voice_session` applies it; `session_started` echoes it. So the platform's outbound SIP path just says `direction: outbound` rather than resolving the opener itself.
- `GreetingConfig.after_user_silence_secs` — hold the opener and listen; their words open turn one, silence that long gets the opener anyway (voicemail, hesitation). Retell `begin_after_user_silence_ms`, ElevenLabs `initial_wait_time`.

### `user_idle` — silence handling

```python
"user_idle": {"timeout_secs": 6, "text": ["Still there?", "Take your time."], "max_count": 2, "hangup_after_secs": 40}
```

Clock starts once the agent has drained (no turn, tool, queued audio or held commit); any user speech resets it. Speaks `text` (rotating list) or an LLM-authored line from `instructions`, at most `max_count` times; `hangup_after_secs` since the user's last word ends the session and our own prompts don't reset it. Prompts are transcribed, interruptible, not turns. Vapi `idleMessages`, Retell `reminder_trigger_ms`, Pipecat `user_idle_timeout`. `None` → wait forever, as before.

### `TurnMetrics.speech_end_to_transcript_ms`

Per-user-message ASR latency: last speech (Silero VAD frame, else last interim) → committed transcript. `speech_end_source` = `"vad" | "partial"`. Only published for *accepted* commits — an IGNOREd noise commit mid-HOLD no longer overwrites the held utterance's measurement.

### Client-settable surface

`outbound_greeting` and `user_idle` join `greeting` / `filler` in `CLIENT_SETTABLE_VOICE_FIELDS` with the same rules: deep-merge over the server's block, validate (invalid → keep server's), `""` switches the block off for the call. `direction` is read by the transport like `turn_detector`.

### Playground (`voice.html`)

Was behind the config — no `outbound_greeting`, `user_idle`, `after_user_silence_secs`, `language`, `voice`, `vad_endpointing`, turn timeout, extras — and carried an LLM model picker that is an agent override, not voice config. Now:

- Every client-settable knob, grouped: Pipeline · Turn taking · Greeting · Outbound greeting · Filler · User idle · Ambience · Advanced (`stt_model`, `stt_extra`/`tts_extra` JSON).
- **Simulate: Inbound / Outbound** sends `direction`; the inactive opener block dims and says why.
- Model picker removed. The Agent panel lists what the agent's own `voice_config` declares (`/voice/meta` → `voice_config`, same wire form as `GET /voice_config`), and every field's placeholder shows that value as its "server default".
- `examples/voice_playground_agents.py` — `plain` / `thinking` / `tools` / `outbound` / `bare` on Groq, one per configuration shape. `--import_spec examples/voice_playground_agents.py::outbound`.

### Fixes along the way

- Idle prompts barge in like an interruptible opener: own TTS record, active from the first byte, cut to the heard prefix, bubble sealed. Previously invisible to `interrupt()` until playback acked and clobbered `_greeting_record`.
- ElevenLabs Scribe query: list extras (`keyterms`, `secondary_languages`) were stringified into one bogus term; now repeated params (`doseq=True`), booleans spelled `true`/`false`.
- Two CI timing flakes widened (`user_speech_resets_the_clock`, `followup_generation_sees_previous_phrases`).

## Tests

`python/tests/server` + `python/tests/voice`: 1200+ passing. New: direction/outbound merge (`TestClientOutboundGreetingAndDirection`), client `user_idle` overrides, idle-prompt barge-in (`TestUserIdlePromptBargeIn`), accepted-only ASR latency, Scribe query encoding. Playground verified headless against a live server.

Follow-up to #169–#171.
